### PR TITLE
CB-Net 방식의 VNetworkHandler 구현 완료

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -302,9 +302,10 @@ func handleVNetwork() {
 	}
 
 	vNetworkReqInfo := irs.VNetworkReqInfo{
-		Id:        "vpc-0083ad27cff8bae1f",
-		Name:      "vpc-create-test-mcloud-barista",
-		CidrBlock: "10.0.0.0/16",
+		Id:   "subnet-044a2b57145e5afc5",
+		Name: "CB-VNet-Subnet2",
+		//CidrBlock: "10.0.0.0/16",
+		CidrBlock: "192.168.20.0/24",
 	}
 
 	for {
@@ -334,6 +335,11 @@ func handleVNetwork() {
 					cblogger.Info("VNetwork 목록 조회 결과")
 					//cblogger.Info(result)
 					spew.Dump(result)
+
+					//조회및 삭제 테스트를 위해 리스트의 첫번째 서브넷 ID를 요청ID로 자동 갱신함.
+					if result != nil {
+						vNetworkReqInfo.Id = result[0].SubnetId // 조회 및 삭제를 위해 생성된 ID로 변경
+					}
 				}
 
 			case 2:
@@ -344,7 +350,7 @@ func handleVNetwork() {
 					cblogger.Infof(vNetworkReqInfo.Id, " VNetwork 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("VNetwork 생성 결과 : ", result)
-					vNetworkReqInfo.Id = result.Id // 조회 및 삭제를 위해 생성된 ID로 변경
+					vNetworkReqInfo.Id = result.SubnetId // 조회 및 삭제를 위해 생성된 ID로 변경
 					spew.Dump(result)
 				}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
@@ -27,6 +27,20 @@ func (imageHandler *AwsImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) 
 }
 
 func (imageHandler *AwsImageHandler) ListImage() ([]*irs.ImageInfo, error) {
+	//DescribeImages
+	/*
+		input := ec2.DescribeImagesInput{
+			ImageIds: []*string{&ami},
+		}
+		output, err := service.DescribeImages(&input)
+		if len(output.Images) > 0 {
+			checkError(err)
+			image := output.Images[0]
+			log.Printf("Found image in account: %s, with name: %s\n", *image.OwnerId, *image.Name)
+			log.Printf("Tags: %v", image.Tags)
+			return image
+		}
+	*/
 	return nil, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
@@ -6,12 +6,18 @@
 //
 // This is Resouces interfaces of Cloud Driver.
 //
-// by powerkim@etri.re.kr, 2019.06.
+// by devunet@mz.co.kr
 
-//VPC 처리
+//VNetworkHandler는 서브넷을 처리하는 핸들러임.
+//VPC & Subnet 처리
+//Ver2 - <CB-Virtual Network> 개발 방안에 맞게 AWS의 VPC기능은 외부에 숨기고 Subnet을 Main으로 함.
+
 package resources
 
 import (
+	"reflect"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -25,7 +31,20 @@ type AwsVNetworkHandler struct {
 	Client *ec2.EC2
 }
 
-func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, error) {
+type AwsVpcReqInfo struct {
+	Name      string
+	CidrBlock string // AWS
+}
+
+type AwsVpcInfo struct {
+	Name      string
+	Id        string
+	CidrBlock string // AWS
+	IsDefault bool   // AWS
+	State     string // AWS
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) ListVpc() ([]*AwsVpcInfo, error) {
 	cblogger.Debug("Start")
 	result, err := vNetworkHandler.Client.DescribeVpcs(&ec2.DescribeVpcsInput{})
 	if err != nil {
@@ -42,10 +61,10 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 		return nil, err
 	}
 
-	var vNetworkInfoList []*irs.VNetworkInfo
+	var vNetworkInfoList []*AwsVpcInfo
 	for _, curVpc := range result.Vpcs {
-		cblogger.Info("[%s] VPC 정보 조회", *curVpc.VpcId)
-		vNetworkInfo := ExtractDescribeInfo(curVpc)
+		cblogger.Infof("[%s] VPC 정보 조회", *curVpc.VpcId)
+		vNetworkInfo := ExtractVpcDescribeInfo(curVpc)
 		vNetworkInfoList = append(vNetworkInfoList, &vNetworkInfo)
 	}
 
@@ -53,10 +72,162 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 	return vNetworkInfoList, nil
 }
 
-func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VNetworkReqInfo) (irs.VNetworkInfo, error) {
+//@TODO : 여러 VPC에 속한 Subnet 목록을 조회하게되는데... CB-Vnet의 서브넷만 조회해야할지 결정이 필요함. 현재는 1차 버전 문맥상 CB-Vnet으로 내부적으로 제한해서 구현했음.
+func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, error) {
+	cblogger.Debug("Start")
+	var vNetworkInfoList []*irs.VNetworkInfo
+
+	cblogger.Infof("조회 범위를 CBDefaultVPC[%s]로 제한합니다.", irs.GetCBDefaultVNetName())
+	//defaultVpcInfo := irs.VNetworkReqInfo{}
+	VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(irs.VNetworkReqInfo{})
+	cblogger.Info("CBDefaultVPC 조회 결과 : ", VpcId)
+	if errVpc != nil {
+		return nil, errVpc
+	}
+
+	//생성된 CB Default Virtual Network가 없는 경우 nil 리턴
+	if VpcId == "" {
+		return vNetworkInfoList, nil
+	}
+
+	//기본 CBVPC에 속한 서브넷만 조회
+	input := &ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("vpc-id"),
+				Values: []*string{
+					aws.String(VpcId),
+				},
+			},
+		},
+	}
+
+	result, err := vNetworkHandler.Client.DescribeSubnets(input)
+	//result, err := vNetworkHandler.Client.DescribeSubnets(&ec2.DescribeSubnetsInput{})	//전체 서브넷 조회
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return nil, err
+	}
+
+	for _, curSubnet := range result.Subnets {
+		cblogger.Infof("[%s] Subnet 정보 조회", *curSubnet.SubnetId)
+		vNetworkInfo := ExtractDescribeInfo(curSubnet)
+		vNetworkInfoList = append(vNetworkInfoList, &vNetworkInfo)
+	}
+
+	spew.Dump(vNetworkInfoList)
+	return vNetworkInfoList, nil
+}
+
+//@TODO : ListVNetwork()에서 호출되는 경우도 있기 때문에 필요하면 VPC조회와 생성을 별도의 Func으로 분리해야함.(일단은 큰 문제는 없어서 놔둠)
+//CB Default Virtual Network가 존재하지 않으면 생성하며, 존재하는 경우 Vpc ID를 리턴 함.
+func (vNetworkHandler *AwsVNetworkHandler) FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo irs.VNetworkReqInfo) (string, error) {
 	cblogger.Info(vNetworkReqInfo)
+
+	awsVpcInfo, err := vNetworkHandler.GetVpc(irs.GetCBDefaultVNetName())
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return "", err
+	}
+
+	if awsVpcInfo.Id != "" {
+		return awsVpcInfo.Id, nil
+	} else {
+		cblogger.Infof("기본 VPC[%s]가 없어서 Subnet 요청 정보를 기반으로 /16 범위의 VPC를 생성합니다.", irs.GetCBDefaultVNetName())
+		cblogger.Info("Subnet CIDR 요청 정보 : ", vNetworkReqInfo.CidrBlock)
+		if vNetworkReqInfo.CidrBlock == "" {
+			//VPC가 없는 최초 상태에서 List()에서 호출되었을 수 있기 때문에 에러 처리는 하지 않고 nil을 전달함.
+			cblogger.Infof("요청 정보에 CIDR 정보가 없어서 Default VPC[%s]를 생성하지 않음", irs.GetCBDefaultVNetName())
+			return "", nil
+		}
+
+		reqCidr := strings.Split(vNetworkReqInfo.CidrBlock, ".")
+		//cblogger.Info("CIDR 추출 정보 : ", reqCidr[0])
+		VpcCidrBlock := reqCidr[0] + "." + reqCidr[1] + ".0.0/16"
+		cblogger.Info("신규 VPC에 사용할 CIDR 정보 : ", VpcCidrBlock)
+
+		awsVpcReqInfo := AwsVpcReqInfo{
+			Name:      irs.GetCBDefaultVNetName(),
+			CidrBlock: VpcCidrBlock,
+		}
+
+		result, errVpc := vNetworkHandler.CreateVpc(awsVpcReqInfo)
+		if errVpc != nil {
+			cblogger.Error(errVpc)
+			return "", errVpc
+		}
+		cblogger.Infof("CB Default VPC[%s] 생성 완료 - CIDR : [%s]", irs.GetCBDefaultVNetName(), result.CidrBlock)
+		cblogger.Info(result)
+		spew.Dump(result)
+
+		return result.Id, nil
+	}
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) GetVpc(vpcName string) (AwsVpcInfo, error) {
+	cblogger.Info("VPC Name : ", vpcName)
+
+	input := &ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:Name"), // vpc-id , dhcp-options-id
+				Values: []*string{
+					aws.String(vpcName),
+				},
+			},
+		},
+	}
+
+	result, err := vNetworkHandler.Client.DescribeVpcs(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return AwsVpcInfo{}, err
+	}
+
+	cblogger.Info(result)
+	//spew.Dump(result)
+
+	if !reflect.ValueOf(result.Vpcs).IsNil() {
+		awsVpcInfo := ExtractVpcDescribeInfo(result.Vpcs[0])
+		return awsVpcInfo, nil
+	} else {
+		return AwsVpcInfo{}, nil
+	}
+
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) CreateVpc(awsVpcReqInfo AwsVpcReqInfo) (AwsVpcInfo, error) {
+	cblogger.Info(awsVpcReqInfo)
+
 	input := &ec2.CreateVpcInput{
-		CidrBlock: aws.String(vNetworkReqInfo.CidrBlock),
+		CidrBlock: aws.String(awsVpcReqInfo.CidrBlock),
 	}
 
 	spew.Dump(input)
@@ -72,18 +243,89 @@ func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VN
 			// Message from an error.
 			cblogger.Error(err.Error())
 		}
-		return irs.VNetworkInfo{}, err
+		return AwsVpcInfo{}, err
 	}
 
 	cblogger.Info(result)
 	spew.Dump(result)
-	//vNetworkInfo := irs.VNetworkInfo{}
-	vNetworkInfo := ExtractDescribeInfo(result.Vpc)
+	awsVpcInfo := ExtractVpcDescribeInfo(result.Vpc)
 
 	//VPC Name 태깅
 	tagInput := &ec2.CreateTagsInput{
 		Resources: []*string{
 			aws.String(*result.Vpc.VpcId),
+		},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(awsVpcReqInfo.Name),
+			},
+		},
+	}
+	spew.Dump(tagInput)
+
+	_, errTag := vNetworkHandler.Client.CreateTags(tagInput)
+	if errTag != nil {
+		//@TODO : Name 태깅 실패시 생성된 VPC를 삭제할지 Name 태깅을 하라고 전달할지 결정해야 함. - 일단, 바깥에서 처리 가능하도록 생성된 VPC 정보는 전달 함.
+		if aerr, ok := errTag.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(errTag.Error())
+		}
+		return awsVpcInfo, errTag
+	}
+
+	awsVpcInfo.Name = awsVpcReqInfo.Name
+
+	return awsVpcInfo, nil
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VNetworkReqInfo) (irs.VNetworkInfo, error) {
+	cblogger.Info(vNetworkReqInfo)
+
+	//최대 5개의 VPC 생성 제한이 있기 때문에 기본VPC 조회시 에러 처리를 해줌.
+	VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo)
+	cblogger.Info("CBDefaultVPC 조회 결과 : ", VpcId)
+	if errVpc != nil {
+		return irs.VNetworkInfo{}, errVpc
+	}
+
+	//서브넷 생성
+	input := &ec2.CreateSubnetInput{
+		CidrBlock: aws.String(vNetworkReqInfo.CidrBlock),
+		VpcId:     aws.String(VpcId),
+	}
+
+	cblogger.Info(input)
+	result, err := vNetworkHandler.Client.CreateSubnet(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return irs.VNetworkInfo{}, err
+	}
+	cblogger.Info(result)
+	spew.Dump(result)
+
+	//vNetworkInfo := irs.VNetworkInfo{}
+	vNetworkInfo := ExtractDescribeInfo(result.Subnet)
+
+	//Subnet Name 태깅
+	tagInput := &ec2.CreateTagsInput{
+		Resources: []*string{
+			aws.String(*result.Subnet.SubnetId),
 		},
 		Tags: []*ec2.Tag{
 			{
@@ -118,13 +360,13 @@ func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VN
 func (vNetworkHandler *AwsVNetworkHandler) GetVNetwork(vNetworkID string) (irs.VNetworkInfo, error) {
 	cblogger.Info("vNetworkID : [%s]", vNetworkID)
 
-	input := &ec2.DescribeVpcsInput{
-		VpcIds: []*string{
+	input := &ec2.DescribeSubnetsInput{
+		SubnetIds: []*string{
 			aws.String(vNetworkID),
 		},
 	}
 
-	result, err := vNetworkHandler.Client.DescribeVpcs(input)
+	result, err := vNetworkHandler.Client.DescribeSubnets(input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
@@ -141,14 +383,17 @@ func (vNetworkHandler *AwsVNetworkHandler) GetVNetwork(vNetworkID string) (irs.V
 
 	cblogger.Info(result)
 	//spew.Dump(result)
-
-	vNetworkInfo := ExtractDescribeInfo(result.Vpcs[0])
-	return vNetworkInfo, nil
+	if !reflect.ValueOf(result.Subnets).IsNil() {
+		vNetworkInfo := ExtractDescribeInfo(result.Subnets[0])
+		return vNetworkInfo, nil
+	} else {
+		return irs.VNetworkInfo{}, nil
+	}
 }
 
 //VPC 정보를 추출함
-func ExtractDescribeInfo(vpcInfo *ec2.Vpc) irs.VNetworkInfo {
-	vNetworkInfo := irs.VNetworkInfo{
+func ExtractVpcDescribeInfo(vpcInfo *ec2.Vpc) AwsVpcInfo {
+	awsVpcInfo := AwsVpcInfo{
 		Id:        *vpcInfo.VpcId,
 		CidrBlock: *vpcInfo.CidrBlock,
 		IsDefault: *vpcInfo.IsDefault,
@@ -159,8 +404,34 @@ func ExtractDescribeInfo(vpcInfo *ec2.Vpc) irs.VNetworkInfo {
 	cblogger.Debug("Name Tag 찾기")
 	for _, t := range vpcInfo.Tags {
 		if *t.Key == "Name" {
+			awsVpcInfo.Name = *t.Value
+			cblogger.Debug("VPC Name : ", awsVpcInfo.Name)
+			break
+		}
+	}
+
+	return awsVpcInfo
+}
+
+//Subnet 정보를 추출함
+func ExtractDescribeInfo(subnetInfo *ec2.Subnet) irs.VNetworkInfo {
+	vNetworkInfo := irs.VNetworkInfo{
+		SubnetId:  *subnetInfo.SubnetId,
+		CidrBlock: *subnetInfo.CidrBlock,
+		State:     *subnetInfo.State,
+
+		Id:                      *subnetInfo.VpcId,
+		MapPublicIpOnLaunch:     *subnetInfo.MapPublicIpOnLaunch,
+		AvailableIpAddressCount: *subnetInfo.AvailableIpAddressCount,
+		AvailabilityZone:        *subnetInfo.AvailabilityZone,
+	}
+
+	//Name은 Tag의 "Name" 속성에만 저장됨
+	cblogger.Debug("Name Tag 찾기")
+	for _, t := range subnetInfo.Tags {
+		if *t.Key == "Name" {
 			vNetworkInfo.Name = *t.Value
-			cblogger.Debug("VPC Name : ", vNetworkInfo.Name)
+			cblogger.Debug("Subnet Name : ", vNetworkInfo.Name)
 			break
 		}
 	}
@@ -168,10 +439,10 @@ func ExtractDescribeInfo(vpcInfo *ec2.Vpc) irs.VNetworkInfo {
 	return vNetworkInfo
 }
 
-func (vNetworkHandler *AwsVNetworkHandler) DeleteVNetwork(vNetworkID string) (bool, error) {
-	cblogger.Info("vNetworkID : [%s]", vNetworkID)
+func (vNetworkHandler *AwsVNetworkHandler) DeleteVpc(vpcId string) (bool, error) {
+	cblogger.Info("vpcId : [%s]", vpcId)
 	input := &ec2.DeleteVpcInput{
-		VpcId: aws.String(vNetworkID),
+		VpcId: aws.String(vpcId),
 	}
 
 	result, err := vNetworkHandler.Client.DeleteVpc(input)
@@ -191,4 +462,66 @@ func (vNetworkHandler *AwsVNetworkHandler) DeleteVNetwork(vNetworkID string) (bo
 	cblogger.Info(result)
 	spew.Dump(result)
 	return true, nil
+}
+
+//서브넷 삭제
+//마지막 서브넷인 경우 CB-Default Virtual Network도 함께 제거
+func (vNetworkHandler *AwsVNetworkHandler) DeleteVNetwork(vNetworkID string) (bool, error) {
+	cblogger.Info("vNetworkID : [%s]", vNetworkID)
+
+	input := &ec2.DeleteSubnetInput{
+		SubnetId: aws.String(vNetworkID),
+	}
+
+	_, err := vNetworkHandler.Client.DeleteSubnet(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return false, err
+	}
+
+	subnetList, _ := vNetworkHandler.ListVNetwork()
+
+	//서브넷이 존재하는경우 서브넷 삭제 결과 리턴
+	if subnetList != nil {
+		return true, nil
+	} else {
+		//서브넷이 없는 경우 기본 CBVPC도 삭제
+		VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(irs.VNetworkReqInfo{})
+		cblogger.Info("삭제할 CBDefaultVPC 조회 결과 : ", VpcId)
+		if errVpc != nil {
+			cblogger.Error("삭제할 CBDefaultVPC 조회 실패 : ", errVpc)
+			return false, errVpc
+		}
+
+		//발생할 경우가 없어 보이지만 삭제할 CB Default VPC가 없으면 종료
+		if VpcId == "" {
+			cblogger.Error("삭제할 CBDefaultVPC가 존재하지 않음")
+			return true, nil
+		}
+
+		cblogger.Info("CBDefaultVPC를 삭제 함.")
+		delVpc, errDelVpc := vNetworkHandler.DeleteVpc(VpcId)
+		if errDelVpc != nil {
+			cblogger.Error("CBDefaultVPC 삭제 실패 : ", errDelVpc)
+			return false, errDelVpc
+		}
+
+		if delVpc {
+			cblogger.Info("CBDefaultVPC를 삭제 완료.")
+			return true, nil
+		} else {
+			cblogger.Info("CBDefaultVPC를 삭제 실패.")
+			return false, nil //삭제 실패 이유를 모르는 경우
+		}
+
+	}
+
 }

--- a/cloud-control-manager/cloud-driver/interfaces/resources/VNetworkHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/VNetworkHandler.go
@@ -11,25 +11,34 @@
 package resources
 
 type VNetworkReqInfo struct {
-	Name string
+	Name string // AWS
 	Id   string
 	// @todo
 	CidrBlock string // AWS
 }
 
 type VNetworkInfo struct {
-	Name     string
-	Id       string
-	SubnetId string
+	Name     string // AWS
+	Id       string // AWS에서는 Vpc ID로 임의 대체
+	SubnetId string // AWS에서는 이 필드에 Subnet ID할당
+
 	// @todo
 	CidrBlock string // AWS
-	IsDefault bool   // AWS
 	State     string // AWS
+
+	MapPublicIpOnLaunch     bool   // AWS(향후 Map으로 변환?)
+	AvailableIpAddressCount int64  // AWS(향후 Map으로 변환?)
+	AvailabilityZone        string // AWS(향후 Map으로 변환?)
+}
+
+const CBDefaultVNetName string = "CB-VNet" // CB Default Virtual Network Name
+func GetCBDefaultVNetName() string { // AWS
+	return CBDefaultVNetName
 }
 
 type VNetworkHandler interface {
 	CreateVNetwork(vNetworkReqInfo VNetworkReqInfo) (VNetworkInfo, error)
-	ListVNetwork() ([]*VNetworkInfo, error)
+	ListVNetwork() ([]*VNetworkInfo, error) //@TODO : 여러 VPC에 속한 Subnet 목록을 조회하게되는데... 입력 아규먼트가 없고 맥락상 CB-Vnet의 서브넷만 조회해야할지 결정이 필요함. 현재는 1차 버전의 변경될 I/F 문맥상 CB-Vnet으로 내부적으로 제한해서 구현했음.
 	GetVNetwork(vNetworkID string) (VNetworkInfo, error)
 	DeleteVNetwork(vNetworkID string) (bool, error)
 }


### PR DESCRIPTION
- VPC는 외부에는 숨기고 내부에서 자동으로 CB Default Virtual Network("CB-VNet")을 생성및 삭제하는 방식의 변경될 개발 방안의 버전 적용
- VNetworkHandler I/F의 VNetworkInfo 구조체에 Id와 SubnetId가 존재해서 Id의 용도를 SubnetId가 아닌 VpcId로 사용했음.
- ListVNetwork() : 여러 개의 VPC에 속한 Subnet 목록을 조회할 것인지 CB-VNet에 속한 서브넷만 조회할 것인지 결정 필요. (메인이 서브넷이고 CB-VNet은 숨은 개념이라 구현은 CB-VNet하위만 조회하도록 했음.)
- CB Default Virtual Network를 자동으로 생성할 때 CIDR 정보는 Subnet 생성 요청 정보의 CIDR의 앞 16바이트로 생성하도록 구현 함.(AWS에서 사용 가능한 최대 서브넷 크기가 /16)
  (예) "192.168.100.1/24"로 서브넷 생성을 요청하면 CB-VNet이 없는 경우 "192.168.0.0/16"으로 VPC를 자동 생성함.
- 마지막 서브넷 삭제시 CB-Vnet 자동 삭제됨.
- Test_Resources.go의 handleVNetwork()에서 테스트 가능
  - 서브넷 생성 시 조회 & 삭제 테스트 편의를 위해 생성된 Subnet ID를 조회할 대상으로 자동 설정함.
  - 서브넷 목록 조회 시조회 & 삭제 테스트 편의를 위해 조회된 목록의 첫번째 Subnet ID를 조회할 대상으로 자동 설정함.
  - 서브넷 생성 테스트는 CIDR 범주가 있어서 실행시 마다 handleVNetwork()의 소스 코드에서 수정해야 함.