### PR TITLE
2차 인터페이스 일부 적용완료

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -227,11 +227,11 @@ func handleKeyPair() {
 	if err != nil {
 		panic(err)
 	}
-	config := readConfigFile()
+	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	//keyPairName := "test123"
-	keyPairName := config.Aws.KeyName
+	keyPairName := "CB-KeyPairTest"
+	//keyPairName := config.Aws.KeyName
 
 	for {
 		fmt.Println("KeyPair Management")
@@ -272,6 +272,7 @@ func handleKeyPair() {
 					cblogger.Infof(keyPairName, " 키 페어 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] 키 페어 생성 결과 : [%s]", keyPairName, result)
+					spew.Dump(result)
 				}
 			case 3:
 				cblogger.Infof("[%s] 키 페어 조회 테스트", keyPairName)
@@ -552,12 +553,12 @@ func handleVNic() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-	//handleKeyPair()
+	handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
 	//handleImage() //AMI
-	handleVNic() //Lancard
+	//handleVNic() //Lancard
 	//handleSecurity()
 
 	/*

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -304,11 +304,12 @@ func handleVNetwork() {
 	}
 
 	vNetworkReqInfo := irs.VNetworkReqInfo{
-		Id:   "subnet-044a2b57145e5afc5",
-		Name: "CB-VNet-Subnet2",
+		//Id:   "subnet-044a2b57145e5afc5",
+		//Name: "CB-VNet-Subnet2",	// 웹 도구 등 외부에서 전달 받지 않고 드라이버 내부적으로 자동 구현때문에 사용하지 않음.
 		//CidrBlock: "10.0.0.0/16",
-		CidrBlock: "192.168.20.0/24",
+		//CidrBlock: "192.168.0.0/16",
 	}
+	reqSubnetId := ""
 
 	for {
 		fmt.Println("VNetworkHandler Management")
@@ -338,9 +339,10 @@ func handleVNetwork() {
 					//cblogger.Info(result)
 					spew.Dump(result)
 
+					// 내부적으로 1개만 존재함.
 					//조회및 삭제 테스트를 위해 리스트의 첫번째 서브넷 ID를 요청ID로 자동 갱신함.
 					if result != nil {
-						vNetworkReqInfo.Id = result[0].SubnetId // 조회 및 삭제를 위해 생성된 ID로 변경
+						reqSubnetId = result[0].Id // 조회 및 삭제를 위해 생성된 ID로 변경
 					}
 				}
 
@@ -349,30 +351,30 @@ func handleVNetwork() {
 				//vNetworkReqInfo := irs.VNetworkReqInfo{}
 				result, err := vNetworkHandler.CreateVNetwork(vNetworkReqInfo)
 				if err != nil {
-					cblogger.Infof(vNetworkReqInfo.Id, " VNetwork 생성 실패 : ", err)
+					cblogger.Infof(reqSubnetId, " VNetwork 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("VNetwork 생성 결과 : ", result)
-					vNetworkReqInfo.Id = result.SubnetId // 조회 및 삭제를 위해 생성된 ID로 변경
+					reqSubnetId = result.Id // 조회 및 삭제를 위해 생성된 ID로 변경
 					spew.Dump(result)
 				}
 
 			case 3:
-				cblogger.Infof("[%s] VNetwork 조회 테스트", vNetworkReqInfo.Id)
-				result, err := vNetworkHandler.GetVNetwork(vNetworkReqInfo.Id)
+				cblogger.Infof("[%s] VNetwork 조회 테스트", reqSubnetId)
+				result, err := vNetworkHandler.GetVNetwork(reqSubnetId)
 				if err != nil {
-					cblogger.Infof("[%s] VNetwork 조회 실패 : ", vNetworkReqInfo.Id, err)
+					cblogger.Infof("[%s] VNetwork 조회 실패 : ", reqSubnetId, err)
 				} else {
-					cblogger.Infof("[%s] VNetwork 조회 결과 : [%s]", vNetworkReqInfo.Id, result)
+					cblogger.Infof("[%s] VNetwork 조회 결과 : [%s]", reqSubnetId, result)
 					spew.Dump(result)
 				}
 
 			case 4:
-				cblogger.Infof("[%s] VNetwork 삭제 테스트", vNetworkReqInfo.Id)
-				result, err := vNetworkHandler.DeleteVNetwork(vNetworkReqInfo.Id)
+				cblogger.Infof("[%s] VNetwork 삭제 테스트", reqSubnetId)
+				result, err := vNetworkHandler.DeleteVNetwork(reqSubnetId)
 				if err != nil {
-					cblogger.Infof("[%s] VNetwork 삭제 실패 : ", vNetworkReqInfo.Id, err)
+					cblogger.Infof("[%s] VNetwork 삭제 실패 : ", reqSubnetId, err)
 				} else {
-					cblogger.Infof("[%s] VNetwork 삭제 결과 : [%s]", vNetworkReqInfo.Id, result)
+					cblogger.Infof("[%s] VNetwork 삭제 결과 : [%s]", reqSubnetId, result)
 				}
 			}
 		}
@@ -466,13 +468,96 @@ func handleImage() {
 	}
 }
 
+// Test VNic
+func handleVNic() {
+	cblogger.Debug("Start VNicHandler Resource Test")
+
+	ResourceHandler, err := getResourceHandler("VNic")
+	if err != nil {
+		panic(err)
+	}
+	handler := ResourceHandler.(irs.VNicHandler)
+	reqVnicID := "eni-093deb03ca6eb70eb"
+	vNicReqInfo := irs.VNicReqInfo{
+		Name: "TestCB-VNic",
+		SecurityGroupIds: []string{
+			"sg-0d4d11c090c4814e8", "sg-0dc15d050f8272e24",
+		},
+	}
+
+	for {
+		fmt.Println("VNicHandler Management")
+		fmt.Println("0. Quit")
+		fmt.Println("1. VNic List")
+		fmt.Println("2. VNic Create")
+		fmt.Println("3. VNic Get")
+		fmt.Println("4. VNic Delete")
+
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			panic(err)
+		}
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 0:
+				return
+
+			case 1:
+				result, err := handler.ListVNic()
+				if err != nil {
+					cblogger.Infof(" VNic 목록 조회 실패 : ", err)
+				} else {
+					cblogger.Info("VNic 목록 조회 결과")
+					spew.Dump(result)
+					if len(result) > 0 {
+						reqVnicID = result[0].Id // 조회 및 삭제 편의를 위해 목록의 첫번째 ID로 변경
+					}
+				}
+
+			case 2:
+				cblogger.Infof("[%s] VNic 생성 테스트", vNicReqInfo.Name)
+				result, err := handler.CreateVNic(vNicReqInfo)
+				if err != nil {
+					cblogger.Infof(reqVnicID, " VNic 생성 실패 : ", err)
+				} else {
+					cblogger.Infof("VNic 생성 결과 : ", result)
+					reqVnicID = result.Id // 조회 및 삭제를 위해 생성된 ID로 변경
+					spew.Dump(result)
+				}
+
+			case 3:
+				cblogger.Infof("[%s] VNic 조회 테스트", reqVnicID)
+				result, err := handler.GetVNic(reqVnicID)
+				if err != nil {
+					cblogger.Infof("[%s] VNic 조회 실패 : ", reqVnicID, err)
+				} else {
+					cblogger.Infof("[%s] VNic 조회 결과 : [%s]", reqVnicID, result)
+					spew.Dump(result)
+				}
+
+			case 4:
+				cblogger.Infof("[%s] VNic 삭제 테스트", reqVnicID)
+				result, err := handler.DeleteVNic(reqVnicID)
+				if err != nil {
+					cblogger.Infof("[%s] VNic 삭제 실패 : ", reqVnicID, err)
+				} else {
+					cblogger.Infof("[%s] VNic 삭제 결과 : [%s]", reqVnicID, result)
+				}
+			}
+		}
+	}
+}
+
 func main() {
 	cblogger.Info("AWS Resource Test")
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 
-	//handleVNetwork() //VPC
-	handleImage() //AMI
+	handleVNetwork() //VPC
+	//handleImage() //AMI
+	//handleVNic() //Lancard
 	//handleSecurity()
 
 	/*

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -555,9 +555,9 @@ func main() {
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 
-	handleVNetwork() //VPC
+	//handleVNetwork() //VPC
 	//handleImage() //AMI
-	//handleVNic() //Lancard
+	handleVNic() //Lancard
 	//handleSecurity()
 
 	/*

--- a/cloud-control-manager/cloud-driver/interfaces/new-resources/VNicHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/new-resources/VNicHandler.go
@@ -11,22 +11,22 @@
 package resources
 
 type VNicReqInfo struct {
-     Name string
-     VNetName string 
-     SecurityGroupIds []string
-     PublicIPid string 
+	Name             string
+	VNetName         string
+	SecurityGroupIds []string
+	PublicIPid       string
 }
 
 type VNicInfo struct {
-     Id   string 
-     Name   string 
-     PublicIP     string 
-     MacAdress    string 
-     OwnedVMID   string 
-     SecurityGroupIds []string
-     Status string
+	Id               string
+	Name             string
+	PublicIP         string
+	MacAdress        string
+	OwnedVMID        string
+	SecurityGroupIds []string
+	Status           string
 
-     keyValueList []KeyValue 
+	KeyValueList []KeyValue
 }
 
 type VNicHandler interface {

--- a/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -28,8 +28,8 @@ type SecurityRuleInfo struct {
 	//2차 인터페이스
 	FromPort   int64
 	ToPort     int64
-	IPProtocol string
-	Direction  string
+	IPProtocol string // tcp | udp | icmp | ...
+	Direction  string // inbound | outbound
 
 	// @todo - 삭제예정(1차 인터페이스 잔여 필드)
 	Cidr string

--- a/cloud-control-manager/cloud-driver/interfaces/resources/VNetworkHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/VNetworkHandler.go
@@ -21,8 +21,8 @@ type VNetworkReqInfo struct {
 
 type VNetworkInfo struct {
 	//2차 인터페이스
-	Id            string // AWS에서는 Vpc ID로 임의 대체
-	Name          string // AWS
+	Id            string
+	Name          string
 	AddressPrefix string
 	Status        string
 
@@ -36,11 +36,6 @@ type VNetworkInfo struct {
 	MapPublicIpOnLaunch     bool   // AWS(향후 Map으로 변환?)
 	AvailableIpAddressCount int64  // AWS(향후 Map으로 변환?)
 	AvailabilityZone        string // AWS(향후 Map으로 변환?)
-}
-
-const CBDefaultVNetName string = "CB-VNet" // CB Default Virtual Network Name
-func GetCBDefaultVNetName() string { // AWS
-	return CBDefaultVNetName
 }
 
 type VNetworkHandler interface {


### PR DESCRIPTION
2차 인터페이스 적용완료
- VNetworkHandler.go 적용 완료
  --> 내부적으로 CB전용 VPC와 Subnet을 생성&삭제함.
- ImageHandler.go 적용 완료
  --> amazon소유의 퍼블릭 AMI 목록과 Get만 구현(삭제 미구현)
- KeyPairHandler.go 적용 완료
  --> Test 샘플은 "CB-KeyPairTest" 키페어를 생성 & 조회 & 삭제 함.
- VNicHandler.go 2차 인터페이스 방식은 적용완료 …
  --> VPC와 Subnet 자동 조회&생성 로직 구현 필요해서 다른 곳에선 동작 안함
  --> Subnet 정보를 전달받지 않기 때문에 VNicHandler에서 VNetworkHandler와 연계해서
        VPC와 Subnet을 자동으로 가져오거나 생성하는 로직을 반영해야 함.
- 다른 핸들러들도 VNicHandler와 비슷하게 내부에서 VPC 정보를 자동으로 가져오는 기능을 넣어야 해서 잠시 보류
