### PR TITLE
PublicIPHandler.go 2차 인터페이스 반영 완료

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -115,18 +115,10 @@ func handlePublicIP() {
 	handler := ResourceHandler.(irs.PublicIPHandler)
 
 	config := readConfigFile()
-	/*
-		publicIPReqInfo := irs.PublicIPReqInfo{
-			Id: config.Aws.VmID,
-		}
-	*/
-
 	//reqGetPublicIP := "13.124.140.207"
 	reqPublicIP := config.Aws.PublicIP
-	reqVmID := config.Aws.VmID
-
+	//reqPublicIP = "eipalloc-0231a3e16ec42e869"
 	cblogger.Info("reqPublicIP : ", reqPublicIP)
-	cblogger.Info("reqVmID : ", reqVmID)
 	//handler.CreatePublicIP(publicIPReqInfo)
 	//handler.ListPublicIP()
 	//handler.GetPublicIP("13.124.140.207")
@@ -175,12 +167,12 @@ func handlePublicIP() {
 
 			case 3:
 				fmt.Println("Start CreatePublicIP() ...")
-				reqInfo := irs.PublicIPReqInfo{Id: reqVmID}
+				reqInfo := irs.PublicIPReqInfo{Name: "mcloud-barista-eip-test"}
 				result, err := handler.CreatePublicIP(reqInfo)
 				if err != nil {
 					cblogger.Error("PublicIP 생성 실패 : ", err)
 				} else {
-					cblogger.Info("키 페어 생성 성공 ", result)
+					cblogger.Info("PublicIP 생성 성공 ", result)
 					spew.Dump(result)
 				}
 				fmt.Println("Finish CreatePublicIP()")
@@ -553,8 +545,8 @@ func handleVNic() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-	handleKeyPair()
-	//handlePublicIP() // PublicIP 생성 후 conf
+	//handleKeyPair()
+	handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
 	//handleImage() //AMI

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -1,0 +1,51 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by powerkim@etri.re.kr, 2019.06.
+
+package resources
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/davecgh/go-spew/spew"
+)
+
+// AssociationId 대신 PublicIP로도 가능 함.
+func AssociatePublicIP(client *ec2.EC2, allocationId string, instanceId string) (bool, error) {
+	cblogger.Infof("EC2에 퍼블릭 IP할당 - AllocationId : [%s], InstanceId : [%s]", allocationId, instanceId)
+
+	// EC2에 할당.
+	// Associate the new Elastic IP address with an existing EC2 instance.
+	assocRes, err := client.AssociateAddress(&ec2.AssociateAddressInput{
+		AllocationId: aws.String(allocationId),
+		InstanceId:   aws.String(instanceId),
+	})
+
+	spew.Dump(assocRes)
+	cblogger.Infof("[%s] EC2에 EIP(AllocationId : [%s]) 할당 완료 - AssociationId Id : [%s]", instanceId, allocationId, *assocRes.AssociationId)
+
+	if err != nil {
+		cblogger.Errorf("Unable to associate IP address with %s, %v", instanceId, err)
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Errorf(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Errorf(err.Error())
+		}
+		return false, err
+	}
+
+	cblogger.Info(assocRes)
+	return true, nil
+}

--- a/cloud-control-manager/cloud-driver/interfaces/new-resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/new-resources/PublicIPHandler.go
@@ -20,7 +20,7 @@ type PublicIPInfo  struct {
      OwnedVMID   string 
      Status string
      
-     keyValueList []KeyValue
+     KeyValueList []KeyValue
 }
 
 type PublicIPHandler interface {


### PR DESCRIPTION
PublicIPHandler.go 2차 인터페이스 반영 완료
개정안에 맞게 Public**IP 기반에서** PublicIP **ID**("**AllocationId**") 기반으로 로직 변경
- PublicIP 생성 시 Name 태그 설정 로직 반영
- PublicIP 생성 로직에서 생성된 IP를 VM에 할당하는 기능 제거
→ VM 생성 시 전달 받은  PublicIP ID를 이용해서 할당하는 방식으로 변경 됨

[참고] PublicIPInfo 구조체에서 Id string 필드가 사라져서 Key&Value의 “AssociationId”키에 값을 저장해서 리턴 함.
**VM 생성 요청 시 PublicIPID 값으로 Key&Value의 AssociationId Key에 저장된 값을 전달해야 함.**


**[사용 예시]**
Public IP 생성
reqInfo := irs.PublicIPReqInfo{Name: "mcloud-barista-eip-test"}
result, err := handler.CreatePublicIP(reqInfo)

목록 조회
result, err := handler.ListPublicIP()

정보 조회
result, err := handler.GetPublicIP("eipalloc-06a67a15fda999ad7")

PublicIP 삭제
result, err := handler.DeletePublicIP("eipalloc-06a67a15fda999ad7")