### PR TITLE
SecurityHandler.go 2차 로직 반영 완료

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -47,50 +47,52 @@ func handleSecurity() {
 	handler := ResourceHandler.(irs.SecurityHandler)
 
 	config := readConfigFile()
-
 	securityId := config.Aws.SecurityGroupID
 	cblogger.Infof(securityId)
-	//securityId = "sg-0fe21e070f09db954"
+	//securityId = "sg-0254f00ef99e40a3c"
 
-	//result, err := handler.GetSecurity(securityId)
-	//result, err := handler.GetSecurity("sg-0320a99e0c1bfcefc")
+	result, err := handler.GetSecurity(securityId)
+	//result, err := handler.GetSecurity("sg-0d4d11c090c4814e8")
 	//result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
 
 	securityReqInfo := irs.SecurityReqInfo{
-		GroupName:   "sgtest2-mcloub-barista",
-		Description: "this is desc",
-		VpcId:       "vpc-5a837e31",
-		IPPermissions: []*irs.SecurityRuleInfo{ //인바운드 정책 설정
+		Name: "sgtest2-mcloub-barista",
+		SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
 			{
-				FromPort:   80,
-				ToPort:     80,
+				FromPort:   "80",
+				ToPort:     "80",
 				IPProtocol: "tcp",
-				Cidr:       "0.0.0.0/0",
+				Direction:  "inbound",
 			},
 			{
-				FromPort:   8080,
-				ToPort:     8080,
+				FromPort:   "8080",
+				ToPort:     "8080",
 				IPProtocol: "tcp",
-				Cidr:       "0.0.0.0/0",
-			},
-		},
-		IPPermissionsEgress: []*irs.SecurityRuleInfo{ //아웃바운드 정책 설정
-			{
-				FromPort:   443,
-				ToPort:     443,
-				IPProtocol: "tcp",
-				Cidr:       "0.0.0.0/0",
+				Direction:  "inbound",
 			},
 			{
-				FromPort:   9443,
-				ToPort:     9443,
+				FromPort:   "443",
+				ToPort:     "443",
 				IPProtocol: "tcp",
-				Cidr:       "0.0.0.0/0",
+				Direction:  "outbound",
+			},
+			{
+				FromPort:   "8443",
+				ToPort:     "9999",
+				IPProtocol: "tcp",
+				Direction:  "outbound",
+			},
+			{
+				//FromPort:   "8443",
+				//ToPort:     "9999",
+				IPProtocol: "-1", // 모두 허용 (포트 정보 없음)
+				Direction:  "inbound",
 			},
 		},
 	}
 
-	result, err := handler.CreateSecurity(securityReqInfo)
+	cblogger.Info(securityReqInfo)
+	//result, err := handler.CreateSecurity(securityReqInfo)
 
 	//result, err := handler.DeleteSecurity(securityId)
 	//result, err := handler.ListSecurity()
@@ -546,12 +548,12 @@ func handleVNic() {
 func main() {
 	cblogger.Info("AWS Resource Test")
 	//handleKeyPair()
-	handlePublicIP() // PublicIP 생성 후 conf
+	//handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	//handleSecurity()
+	handleSecurity()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -11,12 +11,199 @@
 package resources
 
 import (
+	"reflect"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/davecgh/go-spew/spew"
 )
 
+type AwsCBNetworkInfo struct {
+	VpcName   string
+	VpcId     string
+	CidrBlock string
+	IsDefault bool
+	State     string
+
+	SubnetName string
+	SubnetId   string
+}
+
+const CBDefaultVNetName string = "CB-VNet"          // CB Default Virtual Network Name
+const CBDefaultSubnetName string = "CB-VNet-Subnet" // CB Default Subnet Name
+const CBDefaultCidrBlock string = "192.168.0.0/16"  // CB Default CidrBlock
+
+func GetCBDefaultVNetName() string {
+	return CBDefaultVNetName
+}
+
+func GetCBDefaultSubnetName() string {
+	return CBDefaultSubnetName
+}
+
+func GetCBDefaultCidrBlock() string {
+	return CBDefaultCidrBlock
+}
+
+//VPC & Subnet이 존재하는 경우 정보를 리턴하고 없는 경우 Default VPC & Subnet을 생성 후 정보를 리턴 함.
+func GetCreateAutoCBNetworkInfo(client *ec2.EC2) (AwsCBNetworkInfo, error) {
+	var awsCBNetworkInfo AwsCBNetworkInfo
+	awsVpcInfo, err := GetVpc(client)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return AwsCBNetworkInfo{}, err
+	}
+
+	//기존 정보가 존재하면...
+	if awsVpcInfo.Id != "" {
+		//return awsVpcInfo.Id, nil
+		awsCBNetworkInfo.VpcId = awsVpcInfo.Id
+		awsCBNetworkInfo.VpcName = awsVpcInfo.Name
+		awsCBNetworkInfo.CidrBlock = awsVpcInfo.CidrBlock
+	} else {
+		cblogger.Infof("기본 VPC[%s]가 없어서 CIDR[%s] 범위의 VPC를 자동으로 생성합니다.", GetCBDefaultVNetName(), GetCBDefaultCidrBlock())
+		awsVpcReqInfo := AwsVpcReqInfo{
+			Name:      GetCBDefaultVNetName(),
+			CidrBlock: GetCBDefaultCidrBlock(),
+		}
+
+		result, errVpc := CreateVpc(client, awsVpcReqInfo)
+		if errVpc != nil {
+			cblogger.Error(errVpc)
+			return AwsCBNetworkInfo{}, errVpc
+		}
+		cblogger.Infof("CB Default VPC[%s] 생성 완료 - CIDR : [%s]", GetCBDefaultVNetName(), result.CidrBlock)
+		cblogger.Info(result)
+		spew.Dump(result)
+
+		awsCBNetworkInfo.VpcId = awsVpcInfo.Id
+		awsCBNetworkInfo.VpcName = awsVpcInfo.Name
+		awsCBNetworkInfo.CidrBlock = result.CidrBlock
+
+		//return result.Id, nil
+	}
+
+	return awsCBNetworkInfo, nil
+}
+
+func GetVpc(client *ec2.EC2) (AwsVpcInfo, error) {
+	cblogger.Info("VPC Name : ", GetCBDefaultVNetName())
+
+	input := &ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:Name"), // vpc-id , dhcp-options-id
+				Values: []*string{
+					aws.String(GetCBDefaultVNetName()),
+				},
+			},
+		},
+	}
+
+	result, err := client.DescribeVpcs(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return AwsVpcInfo{}, err
+	}
+
+	cblogger.Info(result)
+	//spew.Dump(result)
+
+	if !reflect.ValueOf(result.Vpcs).IsNil() {
+		awsVpcInfo := ExtractVpcDescribeInfo(result.Vpcs[0])
+		return awsVpcInfo, nil
+	} else {
+		return AwsVpcInfo{}, nil
+	}
+}
+
+// FindOrCreateMcloudBaristaDefaultVPC()에서 호출됨. - 이 곳은 나중을 위해 전달 받은 정보는 이용함
+// 기본 VPC 생성이 필요하면 FindOrCreateMcloudBaristaDefaultVPC()를 호출할 것
+func CreateVpc(client *ec2.EC2, awsVpcReqInfo AwsVpcReqInfo) (AwsVpcInfo, error) {
+	cblogger.Info(awsVpcReqInfo)
+
+	input := &ec2.CreateVpcInput{
+		CidrBlock: aws.String(awsVpcReqInfo.CidrBlock),
+	}
+
+	spew.Dump(input)
+	result, err := client.CreateVpc(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(err.Error())
+		}
+		return AwsVpcInfo{}, err
+	}
+
+	cblogger.Info(result)
+	spew.Dump(result)
+	awsVpcInfo := ExtractVpcDescribeInfo(result.Vpc)
+
+	//VPC Name 태깅
+	tagInput := &ec2.CreateTagsInput{
+		Resources: []*string{
+			aws.String(*result.Vpc.VpcId),
+		},
+		Tags: []*ec2.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: aws.String(awsVpcReqInfo.Name),
+			},
+		},
+	}
+	spew.Dump(tagInput)
+
+	_, errTag := client.CreateTags(tagInput)
+	if errTag != nil {
+		//@TODO : Name 태깅 실패시 생성된 VPC를 삭제할지 Name 태깅을 하라고 전달할지 결정해야 함. - 일단, 바깥에서 처리 가능하도록 생성된 VPC 정보는 전달 함.
+		if aerr, ok := errTag.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			// Print the error, cast err to awserr.Error to get the Code and
+			// Message from an error.
+			cblogger.Error(errTag.Error())
+		}
+		return awsVpcInfo, errTag
+	}
+
+	awsVpcInfo.Name = awsVpcReqInfo.Name
+
+	return awsVpcInfo, nil
+}
+
+//
+// 현재는 VM 생성 시에만 사용하므로 일단 VMHandler에 구현해 놨음.
+//
+/*
 // AssociationId 대신 PublicIP로도 가능 함.
 func AssociatePublicIP(client *ec2.EC2, allocationId string, instanceId string) (bool, error) {
 	cblogger.Infof("EC2에 퍼블릭 IP할당 - AllocationId : [%s], InstanceId : [%s]", allocationId, instanceId)
@@ -49,3 +236,4 @@ func AssociatePublicIP(client *ec2.EC2, allocationId string, instanceId string) 
 	cblogger.Info(assocRes)
 	return true, nil
 }
+*/

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
@@ -12,6 +12,7 @@ package resources
 
 import (
 	"reflect"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -32,71 +33,143 @@ func (securityHandler *AwsSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 	cblogger.Infof("securityReqInfo : ", securityReqInfo)
 	spew.Dump(securityReqInfo)
 
+	awsCBNetworkInfo, errVpc := GetCreateAutoCBNetworkInfo(securityHandler.Client)
+	if errVpc != nil {
+		return irs.SecurityInfo{}, nil
+	}
+
+	cblogger.Infof("==> [%s] CB Default VPC 정보 찾음", awsCBNetworkInfo.VpcId)
+	vpcId := awsCBNetworkInfo.VpcId
+
 	// Create the security group with the VPC, name and description.
-	createRes, err := securityHandler.Client.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
-		GroupName:   aws.String(securityReqInfo.GroupName),
-		Description: aws.String(securityReqInfo.Description),
-		VpcId:       aws.String(securityReqInfo.VpcId),
-	})
+	//createRes, err := securityHandler.Client.CreateSecurityGroup(&ec2.CreateSecurityGroupInput{
+	input := ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(securityReqInfo.Name),
+		Description: aws.String(securityReqInfo.Name),
+		//		VpcId:       aws.String(securityReqInfo.VpcId),awsCBNetworkInfo
+		VpcId: aws.String(vpcId),
+	}
+	cblogger.Infof("보안 그룹 생성 요청 정보", input)
+	createRes, err := securityHandler.Client.CreateSecurityGroup(&input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case "InvalidVpcID.NotFound":
-				cblogger.Errorf("Unable to find VPC with ID %q.", securityReqInfo.VpcId)
+				cblogger.Errorf("Unable to find VPC with ID %q.", vpcId)
 				return irs.SecurityInfo{}, err
 			case "InvalidGroup.Duplicate":
-				cblogger.Errorf("Security group %q already exists.", securityReqInfo.GroupName)
+				cblogger.Errorf("Security group %q already exists.", securityReqInfo.Name)
 				return irs.SecurityInfo{}, err
 			}
 		}
-		cblogger.Errorf("Unable to create security group %q, %v", securityReqInfo.GroupName, err)
+		cblogger.Errorf("Unable to create security group %q, %v", securityReqInfo.Name, err)
 		return irs.SecurityInfo{}, err
 	}
-	cblogger.Debug("보안 그룹 생성완료")
+	cblogger.Infof("[%s] 보안 그룹 생성완료", aws.StringValue(createRes.GroupId))
 	spew.Dump(createRes)
 
-	cblogger.Infof("Created security group %s with VPC %s.\n",
-		aws.StringValue(createRes.GroupId), securityReqInfo.VpcId)
+	//cblogger.Infof("Created security group %s with VPC %s.\n", aws.StringValue(createRes.GroupId), securityReqInfo.VpcId)
 
 	//newGroupId = *createRes.GroupId
 
+	cblogger.Infof("인바운드 보안 정책 처리")
 	//Ingress 처리
 	var ipPermissions []*ec2.IpPermission
-	for _, ip := range securityReqInfo.IPPermissions {
+	for _, ip := range *securityReqInfo.SecurityRules {
+		//for _, ip := range securityReqInfo.IPPermissions {
+		if ip.Direction != "inbound" {
+			cblogger.Info("==> inbound가 아닌 보안 그룹 Skip : ", ip.Direction)
+			continue
+		}
+
 		ipPermission := new(ec2.IpPermission)
 		ipPermission.SetIpProtocol(ip.IPProtocol)
-		ipPermission.SetFromPort(ip.FromPort)
-		ipPermission.SetToPort(ip.ToPort)
+
+		if ip.FromPort != "" {
+			if n, err := strconv.ParseInt(ip.FromPort, 10, 64); err == nil {
+				ipPermission.SetFromPort(n)
+			} else {
+				cblogger.Error(ip.FromPort, "은 숫자가 아님!!")
+				return irs.SecurityInfo{}, err
+			}
+		} else {
+			//ipPermission.SetFromPort(0)
+		}
+
+		if ip.ToPort != "" {
+			if n, err := strconv.ParseInt(ip.ToPort, 10, 64); err == nil {
+				ipPermission.SetToPort(n)
+			} else {
+				cblogger.Error(ip.ToPort, "은 숫자가 아님!!")
+				return irs.SecurityInfo{}, err
+			}
+		} else {
+			//ipPermission.SetToPort(0)
+		}
+
 		ipPermission.SetIpRanges([]*ec2.IpRange{
 			(&ec2.IpRange{}).
-				SetCidrIp(ip.Cidr),
+				//SetCidrIp(ip.Cidr),
+				SetCidrIp("0.0.0.0/0"),
 		})
 		ipPermissions = append(ipPermissions, ipPermission)
 	}
 
 	// Add permissions to the security group
 	_, err = securityHandler.Client.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
-		GroupName:     aws.String(securityReqInfo.GroupName),
+		//GroupName:     aws.String(securityReqInfo.Name),
+		GroupId:       createRes.GroupId,
 		IpPermissions: ipPermissions,
 	})
 	if err != nil {
-		cblogger.Errorf("Unable to set security group %q ingress, %v", securityReqInfo.GroupName, err)
+		cblogger.Errorf("Unable to set security group %q ingress, %v", securityReqInfo.Name, err)
 		return irs.SecurityInfo{}, err
 	}
 
 	cblogger.Info("Successfully set security group ingress")
 
+	cblogger.Infof("아웃바운드 보안 정책 처리")
 	//Egress 처리
 	var ipPermissionsEgress []*ec2.IpPermission
-	for _, ip := range securityReqInfo.IPPermissionsEgress {
+	//for _, ip := range securityReqInfo.IPPermissionsEgress {
+	for _, ip := range *securityReqInfo.SecurityRules {
+		if ip.Direction != "outbound" {
+			cblogger.Info("==> outbound가 아닌 보안 그룹 Skip : ", ip.Direction)
+			continue
+		}
+
 		ipPermission := new(ec2.IpPermission)
 		ipPermission.SetIpProtocol(ip.IPProtocol)
-		ipPermission.SetFromPort(ip.FromPort)
-		ipPermission.SetToPort(ip.ToPort)
+		//ipPermission.SetFromPort(ip.FromPort)
+		//ipPermission.SetToPort(ip.ToPort)
+		if ip.FromPort != "" {
+			if n, err := strconv.ParseInt(ip.FromPort, 10, 64); err == nil {
+				ipPermission.SetFromPort(n)
+			} else {
+				cblogger.Error(ip.FromPort, "은 숫자가 아님!!")
+				return irs.SecurityInfo{}, err
+			}
+		} else {
+			//ipPermission.SetFromPort(0)
+		}
+
+		if ip.ToPort != "" {
+			if n, err := strconv.ParseInt(ip.ToPort, 10, 64); err == nil {
+				ipPermission.SetToPort(n)
+			} else {
+				cblogger.Error(ip.ToPort, "은 숫자가 아님!!")
+				return irs.SecurityInfo{}, err
+			}
+		} else {
+			//ipPermission.SetToPort(0)
+		}
+
 		ipPermission.SetIpRanges([]*ec2.IpRange{
 			(&ec2.IpRange{}).
-				SetCidrIp(ip.Cidr),
+				//SetCidrIp(ip.Cidr),
+				SetCidrIp("0.0.0.0/0"),
 		})
+		//ipPermissions = append(ipPermissions, ipPermission)
 		ipPermissionsEgress = append(ipPermissionsEgress, ipPermission)
 	}
 
@@ -106,7 +179,7 @@ func (securityHandler *AwsSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 		IpPermissions: ipPermissionsEgress,
 	})
 	if err != nil {
-		cblogger.Errorf("Unable to set security group %q egress, %v", securityReqInfo.GroupName, err)
+		cblogger.Errorf("Unable to set security group %q egress, %v", securityReqInfo.Name, err)
 		return irs.SecurityInfo{}, err
 	}
 
@@ -180,26 +253,29 @@ func (securityHandler *AwsSecurityHandler) GetSecurity(securityID string) (irs.S
 }
 
 func ExtractSecurityInfo(securityGroupResult *ec2.SecurityGroup) irs.SecurityInfo {
-	var ipPermissions []*irs.SecurityRuleInfo
-	var ipPermissionsEgress []*irs.SecurityRuleInfo
+	var ipPermissions []irs.SecurityRuleInfo
+	var ipPermissionsEgress []irs.SecurityRuleInfo
+	var securityRules []irs.SecurityRuleInfo
 
 	cblogger.Info("===[그룹아이디:%s]===", *securityGroupResult.GroupId)
-	ipPermissions = ExtractIpPermissions(securityGroupResult.IpPermissions)
-	cblogger.Info("InBouds : ", ipPermissions)
-	ipPermissionsEgress = ExtractIpPermissions(securityGroupResult.IpPermissionsEgress)
-	cblogger.Info("OutBounds : ", ipPermissionsEgress)
+	ipPermissions = ExtractIpPermissions(securityGroupResult.IpPermissions, "inbound")
+	cblogger.Debug("InBouds : ", ipPermissions)
+	ipPermissionsEgress = ExtractIpPermissions(securityGroupResult.IpPermissionsEgress, "outbound")
+	cblogger.Debug("OutBounds : ", ipPermissionsEgress)
 	//spew.Dump(ipPermissionsEgress)
+	securityRules = append(ipPermissions, ipPermissionsEgress...)
 
 	securityInfo := irs.SecurityInfo{
-		GroupName: *securityGroupResult.GroupName,
-		GroupID:   *securityGroupResult.GroupId,
+		Id: *securityGroupResult.GroupId,
+		//SecurityRules: &[]irs.SecurityRuleInfo{},
+		SecurityRules: &securityRules,
 
-		IPPermissions:       ipPermissions,       //AWS:InBounds
-		IPPermissionsEgress: ipPermissionsEgress, //AWS:OutBounds
-
-		Description: *securityGroupResult.Description,
-		VpcID:       *securityGroupResult.VpcId,
-		OwnerID:     *securityGroupResult.OwnerId,
+		KeyValueList: []irs.KeyValue{
+			{Key: "GroupName", Value: *securityGroupResult.GroupName},
+			{Key: "VpcID", Value: *securityGroupResult.VpcId},
+			{Key: "OwnerID", Value: *securityGroupResult.OwnerId},
+			{Key: "Description", Value: *securityGroupResult.Description},
+		},
 	}
 
 	//Name은 Tag의 "Name" 속성에만 저장됨
@@ -219,48 +295,57 @@ func ExtractSecurityInfo(securityGroupResult *ec2.SecurityGroup) irs.SecurityInf
 func ExtractIpPermissionCommon(ip *ec2.IpPermission, securityRuleInfo *irs.SecurityRuleInfo) {
 	//공통 정보
 	if !reflect.ValueOf(ip.FromPort).IsNil() {
-		securityRuleInfo.FromPort = *ip.FromPort
+		//securityRuleInfo.FromPort = *ip.FromPort
+		securityRuleInfo.FromPort = strconv.FormatInt(*ip.FromPort, 10)
 	}
 
 	if !reflect.ValueOf(ip.ToPort).IsNil() {
-		securityRuleInfo.ToPort = *ip.ToPort
+		//securityRuleInfo.ToPort = *ip.ToPort
+		securityRuleInfo.FromPort = strconv.FormatInt(*ip.ToPort, 10)
 	}
 
 	securityRuleInfo.IPProtocol = *ip.IpProtocol
 }
 
-func ExtractIpPermissions(ipPermissions []*ec2.IpPermission) []*irs.SecurityRuleInfo {
-
-	var results []*irs.SecurityRuleInfo
+func ExtractIpPermissions(ipPermissions []*ec2.IpPermission, direction string) []irs.SecurityRuleInfo {
+	var results []irs.SecurityRuleInfo
 
 	for _, ip := range ipPermissions {
 
 		//ipv4 처리
 		for _, ipv4 := range ip.IpRanges {
 			cblogger.Info("Inbound/Outbound 정보 조회 : ", *ip.IpProtocol)
-			securityRuleInfo := new(irs.SecurityRuleInfo)
-			securityRuleInfo.Cidr = *ipv4.CidrIp
+			securityRuleInfo := irs.SecurityRuleInfo{
+				Direction: direction, // "inbound | outbound"
+				//Cidr: *ipv4.CidrIp,
+			}
+			cblogger.Debug(*ipv4.CidrIp)
 
-			ExtractIpPermissionCommon(ip, securityRuleInfo)
+			ExtractIpPermissionCommon(ip, &securityRuleInfo) //IP & Port & Protocol 추출
 			results = append(results, securityRuleInfo)
 		}
 
 		//ipv6 처리
 		for _, ipv6 := range ip.Ipv6Ranges {
-			securityRuleInfo := new(irs.SecurityRuleInfo)
-			securityRuleInfo.Cidr = *ipv6.CidrIpv6
+			securityRuleInfo := irs.SecurityRuleInfo{
+				Direction: direction, // "inbound | outbound"
+				//Cidr: *ipv6.CidrIpv6,
+			}
+			cblogger.Debug(*ipv6.CidrIpv6)
 
-			ExtractIpPermissionCommon(ip, securityRuleInfo)
+			ExtractIpPermissionCommon(ip, &securityRuleInfo) //IP & Port & Protocol 추출
 			results = append(results, securityRuleInfo)
 		}
 
 		//ELB나 보안그룹 참조 방식 처리
 		for _, userIdGroup := range ip.UserIdGroupPairs {
-			securityRuleInfo := new(irs.SecurityRuleInfo)
-			securityRuleInfo.Cidr = *userIdGroup.GroupId
-			// *userIdGroup.GroupName / *userIdGroup.UserId
+			securityRuleInfo := irs.SecurityRuleInfo{
+				Direction: direction, // "inbound | outbound"
+				//Cidr: *userIdGroup.GroupId,
+			}
+			cblogger.Debug(*userIdGroup.UserId)
 
-			ExtractIpPermissionCommon(ip, securityRuleInfo)
+			ExtractIpPermissionCommon(ip, &securityRuleInfo) //IP & Port & Protocol 추출
 			results = append(results, securityRuleInfo)
 		}
 
@@ -277,45 +362,6 @@ func ExtractIpPermissions(ipPermissions []*ec2.IpPermission) []*irs.SecurityRule
 			}
 		}
 		*/
-	}
-
-	return results
-}
-
-//@TODO : CIDR이 없는 경우 구조처 처리해야 함.(예: 타겟이 ELB거나 다른 보안 그룹일 경우))
-//@TODO : InBound / OutBound의 배열 처리및 테스트해야 함.
-func _ExtractIpPermissions(ipPermissions []*ec2.IpPermission) []*irs.SecurityRuleInfo {
-
-	var results []*irs.SecurityRuleInfo
-
-	for _, ip := range ipPermissions {
-		cblogger.Info("Inbound/Outbound 정보 조회 : ", *ip.IpProtocol)
-		securityRuleInfo := new(irs.SecurityRuleInfo)
-
-		if !reflect.ValueOf(ip.FromPort).IsNil() {
-			securityRuleInfo.FromPort = *ip.FromPort
-		}
-
-		if !reflect.ValueOf(ip.ToPort).IsNil() {
-			securityRuleInfo.ToPort = *ip.ToPort
-		}
-
-		//IpRanges가 없고 UserIdGroupPairs가 있는 경우가 있음(ELB / 보안 그룹 참조 등)
-		securityRuleInfo.IPProtocol = *ip.IpProtocol
-
-		if !reflect.ValueOf(ip.IpRanges).IsNil() {
-			securityRuleInfo.Cidr = *ip.IpRanges[0].CidrIp
-		} else {
-			//ELB나 다른 보안그룹 참조처럼 IpRanges가 없고 UserIdGroupPairs가 있는 경우 처리
-			//https://docs.aws.amazon.com/ko_kr/elasticloadbalancing/latest/classic/elb-security-groups.html
-			if !reflect.ValueOf(ip.UserIdGroupPairs).IsNil() {
-				securityRuleInfo.Cidr = *ip.UserIdGroupPairs[0].GroupId
-			} else {
-				cblogger.Error("미지원 보안 그룹 형태 발견 - 구조 파악 필요 ", ip)
-			}
-		}
-
-		results = append(results, securityRuleInfo)
 	}
 
 	return results

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
@@ -23,12 +23,11 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+
+	//cbtool "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws/resources/tool"
+	//cbtool "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws/resources/tool"
 	"github.com/davecgh/go-spew/spew"
 )
-
-const CBDefaultVNetName string = "CB-VNet"          // CB Default Virtual Network Name
-const CBDefaultSubnetName string = "CB-VNet-Subnet" // CB Default Subnet Name
-const CBDefaultCidrBlock string = "192.168.0.0/16"  // CB Default CidrBlock
 
 type AwsVNetworkHandler struct {
 	Region idrv.RegionInfo
@@ -46,18 +45,6 @@ type AwsVpcInfo struct {
 	CidrBlock string // AWS
 	IsDefault bool   // AWS
 	State     string // AWS
-}
-
-func GetCBDefaultVNetName() string {
-	return CBDefaultVNetName
-}
-
-func GetCBDefaultSubnetName() string {
-	return CBDefaultSubnetName
-}
-
-func GetCBDefaultCidrBlock() string {
-	return CBDefaultCidrBlock
 }
 
 func (vNetworkHandler *AwsVNetworkHandler) ListVpc() ([]*AwsVpcInfo, error) {

--- a/cloud-control-manager/cloud-driver/interfaces/new-resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/new-resources/SecurityHandler.go
@@ -11,23 +11,23 @@
 package resources
 
 type SecurityReqInfo struct {
-     Name string
-     SecurityRules *[]SecurityRuleInfo
+	Name          string
+	SecurityRules *[]SecurityRuleInfo
 }
 
 type SecurityRuleInfo struct {
-        FromPort   string
-        ToPort     string
-        IPProtocol string
-        Direction string
+	FromPort   string
+	ToPort     string
+	IPProtocol string
+	Direction  string
 }
 
 type SecurityInfo struct {
-     Id string
-     Name string
-     SecurityRules *[]SecurityRuleInfo
+	Id            string
+	Name          string
+	SecurityRules *[]SecurityRuleInfo
 
-     keyValueList []KeyValue
+	KeyValueList []KeyValue
 }
 
 type SecurityHandler interface {

--- a/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -26,8 +26,8 @@ type SecurityReqInfo struct {
 
 type SecurityRuleInfo struct {
 	//2차 인터페이스
-	FromPort   int64
-	ToPort     int64
+	FromPort   string
+	ToPort     string
 	IPProtocol string // tcp | udp | icmp | ...
 	Direction  string // inbound | outbound
 


### PR DESCRIPTION
- 바뀔 2차 공통 인터페이스의 Port정보가 Int64가 아닌 string 타입이라서 1차 인터페이스 타입도 String 타입으로 변경했음. (interfaces/resources/**SecurityHandler.go**)
	FromPort   **string**
	ToPort     **string**

- 보안 그룹 생성 시 네트워크 정보는 내부에서 조회해서 사용하도록 수정 함. (VPC이름 : "CB-VNet")
  생성된 VPC가 없을 경우 자동으로 생성하지만 현재는 VPC까지만 자동생성하고 있음.
  **아직 서브넷은 자동으로 생성하지 않기 때문에 테스트를 위해선 "CB-VNet"이름의 VPC를 생성하고 서브넷을 하나 생성해줘야 함. ("CB-VNet-Subnet")**
  (편하게는 VNetworkHandler.go를 이용해서 생성해도 됨.)

**[사용 예시]**
**보안그룹 생성**
securityReqInfo := irs.SecurityReqInfo{
	Name: "sgtest2-mcloub-barista",
	SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
		{
			FromPort:   "80",
			ToPort:     "80",
			IPProtocol: "tcp",
			Direction:  "inbound",
		},
		{
			FromPort:   "8080",
			ToPort:     "8080",
			IPProtocol: "tcp",
			Direction:  "inbound",
		},
		{
			FromPort:   "443",
			ToPort:     "443",
			IPProtocol: "tcp",
			Direction:  "outbound",
		},
		{
			FromPort:   "8443",
			ToPort:     "9999",
			IPProtocol: "tcp",
			Direction:  "outbound",
		},
		{
			//FromPort:   "8443",
			//ToPort:     "9999",
			IPProtocol: "-1", // 모두 허용 (포트 정보 없음)
			Direction:  "inbound",
		},
	},
}
result, err := handler.CreateSecurity(securityReqInfo)

**보안그룹 목록조회**
result, err := handler.ListSecurity()

**보안그룹 조회**
result, err := handler.GetSecurity("sg-03cf7369ffa20f86b")

**보안그룹 삭제**
result, err := handler.DeleteSecurity("sg-03cf7369ffa20f86b")