### PR TITLE
2차 인터페이스 반영 완료

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -41,7 +41,7 @@ func (AwsDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.VNetworkHandler = true
 	drvCapabilityInfo.SecurityHandler = true
 	drvCapabilityInfo.KeyPairHandler = true
-	drvCapabilityInfo.VNicHandler = false
+	drvCapabilityInfo.VNicHandler = true
 	drvCapabilityInfo.PublicIPHandler = true
 	drvCapabilityInfo.VMHandler = true
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -51,9 +51,11 @@ func handleSecurity() {
 	cblogger.Infof(securityId)
 	//securityId = "sg-0254f00ef99e40a3c"
 
-	result, err := handler.GetSecurity(securityId)
+	//result, err := handler.GetSecurity(securityId)
 	//result, err := handler.GetSecurity("sg-0d4d11c090c4814e8")
 	//result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
+	//result, err := handler.DeleteSecurity(securityId)
+	//result, err := handler.ListSecurity()
 
 	securityReqInfo := irs.SecurityReqInfo{
 		Name: "sgtest2-mcloub-barista",
@@ -92,10 +94,8 @@ func handleSecurity() {
 	}
 
 	cblogger.Info(securityReqInfo)
-	//result, err := handler.CreateSecurity(securityReqInfo)
+	result, err := handler.CreateSecurity(securityReqInfo)
 
-	//result, err := handler.DeleteSecurity(securityId)
-	//result, err := handler.ListSecurity()
 	if err != nil {
 		cblogger.Infof("보안 그룹 조회 실패 : ", err)
 	} else {
@@ -304,7 +304,8 @@ func handleVNetwork() {
 		//CidrBlock: "10.0.0.0/16",
 		//CidrBlock: "192.168.0.0/16",
 	}
-	reqSubnetId := ""
+	reqSubnetId := "subnet-071c95d03cc330550"
+	reqSubnetId = ""
 
 	for {
 		fmt.Println("VNetworkHandler Management")
@@ -548,12 +549,12 @@ func handleVNic() {
 func main() {
 	cblogger.Info("AWS Resource Test")
 	//handleKeyPair()
-	//handlePublicIP() // PublicIP 생성 후 conf
+	handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	handleSecurity()
+	//handleSecurity()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
@@ -48,20 +48,14 @@ func createVM() {
 	//maxCount := aws.Int64(config.Aws.MaxCount)
 
 	vmReqInfo := irs.VMReqInfo{
-		Name: config.Aws.BaseName,
-		ImageInfo: irs.ImageInfo{
-			Id: config.Aws.ImageID,
-		},
-		SpecID: config.Aws.InstanceType,
-		SecurityInfo: irs.SecurityInfo{
-			Id: config.Aws.SecurityGroupID,
-		},
-		KeyPairInfo: irs.KeyPairInfo{
-			Name: config.Aws.KeyName,
-		},
-		VNetworkInfo: irs.VNetworkInfo{
-			Id: config.Aws.SubnetID,
-		},
+		VMName:           config.Aws.BaseName,
+		ImageId:          config.Aws.ImageID,
+		VirtualNetworkId: config.Aws.SubnetID,
+		//NetworkInterfaceId:
+		PublicIPId:       "eipalloc-0e95789a23e6d0c6f",
+		SecurityGroupIds: []string{"sg-099702cf5647f77c2"},
+		VMSpecId:         config.Aws.InstanceType,
+		KeyPairName:      config.Aws.KeyName,
 	}
 
 	vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -110,6 +104,7 @@ func handleVM() {
 	}
 	config := readConfigFile()
 	VmID := config.Aws.VmID
+	VmID = "i-0612a67a63ddb8374"
 
 	for {
 		fmt.Println("VM Management")

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -11,13 +11,14 @@
 package resources
 
 import (
-	"reflect"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ec2"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/davecgh/go-spew/spew"
 )
+
+const CBDefaultVNetName string = "CB-VNet"          // CB Default Virtual Network Name
+const CBDefaultSubnetName string = "CB-VNet-Subnet" // CB Default Subnet Name
+const CBDefaultCidrBlock string = "192.168.0.0/16"  // CB Default CidrBlock
 
 type AwsCBNetworkInfo struct {
 	VpcName   string
@@ -30,14 +31,12 @@ type AwsCBNetworkInfo struct {
 	SubnetId   string
 }
 
-const CBDefaultVNetName string = "CB-VNet"          // CB Default Virtual Network Name
-const CBDefaultSubnetName string = "CB-VNet-Subnet" // CB Default Subnet Name
-const CBDefaultCidrBlock string = "192.168.0.0/16"  // CB Default CidrBlock
-
+//VPC
 func GetCBDefaultVNetName() string {
 	return CBDefaultVNetName
 }
 
+//Subnet
 func GetCBDefaultSubnetName() string {
 	return CBDefaultSubnetName
 }
@@ -46,10 +45,88 @@ func GetCBDefaultCidrBlock() string {
 	return CBDefaultCidrBlock
 }
 
+//이 함수는 VPC & Subnet이 존재하는 곳에서만 사용됨.
 //VPC & Subnet이 존재하는 경우 정보를 리턴하고 없는 경우 Default VPC & Subnet을 생성 후 정보를 리턴 함.
-func GetCreateAutoCBNetworkInfo(client *ec2.EC2) (AwsCBNetworkInfo, error) {
+func (vNetworkHandler *AwsVNetworkHandler) GetAutoCBNetworkInfo() (AwsCBNetworkInfo, error) {
 	var awsCBNetworkInfo AwsCBNetworkInfo
-	awsVpcInfo, err := GetVpc(client)
+
+	subNetId := vNetworkHandler.GetMcloudBaristaDefaultSubnetId()
+	if subNetId == "" {
+		//내부에서 VPC를 자동으로 생성후 Subnet을 생성함.
+		_, err := vNetworkHandler.CreateVNetwork(irs.VNetworkReqInfo{})
+		if err != nil {
+			cblogger.Error("Default VNetwork(VPC & Subnet) 자동 생성 실패")
+			cblogger.Error(err)
+			return AwsCBNetworkInfo{}, err
+		}
+	}
+
+	//VPC & Subnet을 생성했으므로 예외처리 없이 조회만 처리함.
+	awsVpcInfo, _ := vNetworkHandler.GetVpc(GetCBDefaultVNetName())
+	spew.Dump(awsVpcInfo)
+	awsCBNetworkInfo.VpcId = awsVpcInfo.Id
+	awsCBNetworkInfo.VpcName = awsVpcInfo.Name
+
+	awsSubnetInfo, _ := vNetworkHandler.GetVNetwork("")
+	spew.Dump(awsSubnetInfo)
+	awsCBNetworkInfo.SubnetId = awsSubnetInfo.Id
+	awsCBNetworkInfo.SubnetName = awsSubnetInfo.Name
+
+	spew.Dump(awsCBNetworkInfo)
+
+	return awsCBNetworkInfo, nil
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) GetMcloudBaristaDefaultVpcId() string {
+	awsVpcInfo, err := vNetworkHandler.GetVpc(GetCBDefaultVNetName())
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			cblogger.Error(err.Error())
+		}
+		return ""
+	}
+
+	//기존 정보가 존재하면...
+	if awsVpcInfo.Id != "" {
+		return awsVpcInfo.Id
+	} else {
+		return ""
+	}
+}
+
+func (vNetworkHandler *AwsVNetworkHandler) GetMcloudBaristaDefaultSubnetId() string {
+	awsSubnetInfo, err := vNetworkHandler.GetVNetwork("")
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			default:
+				cblogger.Error(aerr.Error())
+			}
+		} else {
+			cblogger.Error(err.Error())
+		}
+		return ""
+	}
+
+	//기존 정보가 존재하면...
+	if awsSubnetInfo.Id != "" {
+		return awsSubnetInfo.Id
+	} else {
+		return ""
+	}
+}
+
+//@TODO : ListVNetwork()에서 호출되는 경우도 있기 때문에 필요하면 VPC조회와 생성을 별도의 Func으로 분리해야함.(일단은 큰 문제는 없어서 놔둠)
+//CB Default Virtual Network가 존재하지 않으면 생성하며, 존재하는 경우 Vpc ID를 리턴 함.
+func (vNetworkHandler *AwsVNetworkHandler) FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo irs.VNetworkReqInfo) (string, error) {
+	cblogger.Info(vNetworkReqInfo)
+
+	awsVpcInfo, err := vNetworkHandler.GetVpc(GetCBDefaultVNetName())
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
@@ -61,179 +138,51 @@ func GetCreateAutoCBNetworkInfo(client *ec2.EC2) (AwsCBNetworkInfo, error) {
 			// Message from an error.
 			cblogger.Error(err.Error())
 		}
-		return AwsCBNetworkInfo{}, err
+		return "", err
 	}
 
 	//기존 정보가 존재하면...
 	if awsVpcInfo.Id != "" {
-		//return awsVpcInfo.Id, nil
-		awsCBNetworkInfo.VpcId = awsVpcInfo.Id
-		awsCBNetworkInfo.VpcName = awsVpcInfo.Name
-		awsCBNetworkInfo.CidrBlock = awsVpcInfo.CidrBlock
+		return awsVpcInfo.Id, nil
 	} else {
+		//@TODO : Subnet과 VPC모두 CSP별 고정된 값으로 드라이버가 내부적으로 자동으로 생성하도록 CB규약이 바뀌어서 서브넷 정보 기반의 로직은 모두 잠시 죽여 놓음 - 리스트 요청시에도 내부적으로 자동 생성하도록 변경 중
+		/*
+			cblogger.Infof("기본 VPC[%s]가 없어서 Subnet 요청 정보를 기반으로 /16 범위의 VPC를 생성합니다.", GetCBDefaultVNetName())
+			cblogger.Info("Subnet CIDR 요청 정보 : ", vNetworkReqInfo.CidrBlock)
+			if vNetworkReqInfo.CidrBlock == "" {
+				//VPC가 없는 최초 상태에서 List()에서 호출되었을 수 있기 때문에 에러 처리는 하지 않고 nil을 전달함.
+				cblogger.Infof("요청 정보에 CIDR 정보가 없어서 Default VPC[%s]를 생성하지 않음", GetCBDefaultVNetName())
+				return "", nil
+			}
+
+			reqCidr := strings.Split(vNetworkReqInfo.CidrBlock, ".")
+			//cblogger.Info("CIDR 추출 정보 : ", reqCidr[0])
+			VpcCidrBlock := reqCidr[0] + "." + reqCidr[1] + ".0.0/16"
+			cblogger.Info("신규 VPC에 사용할 CIDR 정보 : ", VpcCidrBlock)
+		*/
+
 		cblogger.Infof("기본 VPC[%s]가 없어서 CIDR[%s] 범위의 VPC를 자동으로 생성합니다.", GetCBDefaultVNetName(), GetCBDefaultCidrBlock())
 		awsVpcReqInfo := AwsVpcReqInfo{
-			Name:      GetCBDefaultVNetName(),
+			Name: GetCBDefaultVNetName(),
+			//CidrBlock: VpcCidrBlock,
 			CidrBlock: GetCBDefaultCidrBlock(),
 		}
 
-		result, errVpc := CreateVpc(client, awsVpcReqInfo)
+		result, errVpc := vNetworkHandler.CreateVpc(awsVpcReqInfo)
 		if errVpc != nil {
 			cblogger.Error(errVpc)
-			return AwsCBNetworkInfo{}, errVpc
+			return "", errVpc
 		}
 		cblogger.Infof("CB Default VPC[%s] 생성 완료 - CIDR : [%s]", GetCBDefaultVNetName(), result.CidrBlock)
 		cblogger.Info(result)
 		spew.Dump(result)
 
-		awsCBNetworkInfo.VpcId = awsVpcInfo.Id
-		awsCBNetworkInfo.VpcName = awsVpcInfo.Name
-		awsCBNetworkInfo.CidrBlock = result.CidrBlock
-
-		//return result.Id, nil
-	}
-
-	return awsCBNetworkInfo, nil
-}
-
-func GetVpc(client *ec2.EC2) (AwsVpcInfo, error) {
-	cblogger.Info("VPC Name : ", GetCBDefaultVNetName())
-
-	input := &ec2.DescribeVpcsInput{
-		Filters: []*ec2.Filter{
-			&ec2.Filter{
-				Name: aws.String("tag:Name"), // vpc-id , dhcp-options-id
-				Values: []*string{
-					aws.String(GetCBDefaultVNetName()),
-				},
-			},
-		},
-	}
-
-	result, err := client.DescribeVpcs(input)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				cblogger.Error(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			cblogger.Error(err.Error())
-		}
-		return AwsVpcInfo{}, err
-	}
-
-	cblogger.Info(result)
-	//spew.Dump(result)
-
-	if !reflect.ValueOf(result.Vpcs).IsNil() {
-		awsVpcInfo := ExtractVpcDescribeInfo(result.Vpcs[0])
-		return awsVpcInfo, nil
-	} else {
-		return AwsVpcInfo{}, nil
+		return result.Id, nil
 	}
 }
 
-// FindOrCreateMcloudBaristaDefaultVPC()에서 호출됨. - 이 곳은 나중을 위해 전달 받은 정보는 이용함
-// 기본 VPC 생성이 필요하면 FindOrCreateMcloudBaristaDefaultVPC()를 호출할 것
-func CreateVpc(client *ec2.EC2, awsVpcReqInfo AwsVpcReqInfo) (AwsVpcInfo, error) {
-	cblogger.Info(awsVpcReqInfo)
-
-	input := &ec2.CreateVpcInput{
-		CidrBlock: aws.String(awsVpcReqInfo.CidrBlock),
-	}
-
-	spew.Dump(input)
-	result, err := client.CreateVpc(input)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				cblogger.Error(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			cblogger.Error(err.Error())
-		}
-		return AwsVpcInfo{}, err
-	}
-
-	cblogger.Info(result)
-	spew.Dump(result)
-	awsVpcInfo := ExtractVpcDescribeInfo(result.Vpc)
-
-	//VPC Name 태깅
-	tagInput := &ec2.CreateTagsInput{
-		Resources: []*string{
-			aws.String(*result.Vpc.VpcId),
-		},
-		Tags: []*ec2.Tag{
-			{
-				Key:   aws.String("Name"),
-				Value: aws.String(awsVpcReqInfo.Name),
-			},
-		},
-	}
-	spew.Dump(tagInput)
-
-	_, errTag := client.CreateTags(tagInput)
-	if errTag != nil {
-		//@TODO : Name 태깅 실패시 생성된 VPC를 삭제할지 Name 태깅을 하라고 전달할지 결정해야 함. - 일단, 바깥에서 처리 가능하도록 생성된 VPC 정보는 전달 함.
-		if aerr, ok := errTag.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				cblogger.Error(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			cblogger.Error(errTag.Error())
-		}
-		return awsVpcInfo, errTag
-	}
-
-	awsVpcInfo.Name = awsVpcReqInfo.Name
-
-	return awsVpcInfo, nil
+//자동으로 생성된 VPC & Subnet을 삭제해도 되는가?
+//명시적으로 Subnet 삭제의 호출이 없기 때문에 시큐리티 그룹이나 vNic이 삭제되는 시점에 호출됨.
+func (vNetworkHandler *AwsVNetworkHandler) IsAvailableAutoCBNet() bool {
+	return false
 }
-
-//
-// 현재는 VM 생성 시에만 사용하므로 일단 VMHandler에 구현해 놨음.
-//
-/*
-// AssociationId 대신 PublicIP로도 가능 함.
-func AssociatePublicIP(client *ec2.EC2, allocationId string, instanceId string) (bool, error) {
-	cblogger.Infof("EC2에 퍼블릭 IP할당 - AllocationId : [%s], InstanceId : [%s]", allocationId, instanceId)
-
-	// EC2에 할당.
-	// Associate the new Elastic IP address with an existing EC2 instance.
-	assocRes, err := client.AssociateAddress(&ec2.AssociateAddressInput{
-		AllocationId: aws.String(allocationId),
-		InstanceId:   aws.String(instanceId),
-	})
-
-	spew.Dump(assocRes)
-	cblogger.Infof("[%s] EC2에 EIP(AllocationId : [%s]) 할당 완료 - AssociationId Id : [%s]", instanceId, allocationId, *assocRes.AssociationId)
-
-	if err != nil {
-		cblogger.Errorf("Unable to associate IP address with %s, %v", instanceId, err)
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				cblogger.Errorf(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			cblogger.Errorf(err.Error())
-		}
-		return false, err
-	}
-
-	cblogger.Info(assocRes)
-	return true, nil
-}
-*/

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
@@ -112,8 +112,6 @@ func extractPublicIpDescribeInfo(allocRes *ec2.Address) irs.PublicIPInfo {
 		{Key: "AllocationId", Value: *allocRes.AllocationId},
 	}
 
-	publicIPInfo.KeyValueList = keyValueList
-
 	spew.Dump(allocRes)
 	publicIPInfo.PublicIP = *allocRes.PublicIp
 	//publicIPInfo.Domain = *allocRes.Domain
@@ -149,6 +147,7 @@ func extractPublicIpDescribeInfo(allocRes *ec2.Address) irs.PublicIPInfo {
 		}
 	}
 
+	publicIPInfo.KeyValueList = keyValueList
 	return publicIPInfo
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VNetworkHandler.go
@@ -12,6 +12,9 @@
 //VPC & Subnet 처리
 //Ver2 - <CB-Virtual Network> 개발 방안에 맞게 AWS의 VPC기능은 외부에 숨기고 Subnet을 Main으로 함.
 
+//2019-10-17 충돌 방지및 CB-VNet을 감추기 위해 명시적으로 각 핸들러들의 Create나 Delete에서만 자동으로 처리하며,
+//           정확하지는 않아도 네트워크 범위를 id 기반에서 name기반으로 변경 함. (예) vpc-name / subnet-name
+//           *** Subnet은 1개만 생성되도록 제한 함..***
 package resources
 
 import (
@@ -80,18 +83,36 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 	cblogger.Debug("Start")
 	var vNetworkInfoList []*irs.VNetworkInfo
 
-	cblogger.Infof("조회 범위를 CBDefaultVPC[%s]로 제한합니다.", GetCBDefaultVNetName())
-	//defaultVpcInfo := irs.VNetworkReqInfo{}
-	VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(irs.VNetworkReqInfo{})
-	cblogger.Info("CBDefaultVPC 조회 결과 : ", VpcId)
-	if errVpc != nil {
-		return nil, errVpc
-	}
+	cblogger.Infof("조회 범위를 CBDefaultVPC[%s]와 CBDefaultSubnet[%s]으로 제한합니다.", GetCBDefaultVNetName(), GetCBDefaultSubnetName())
 
-	//생성된 CB Default Virtual Network가 없는 경우 nil 리턴
+	VpcId := vNetworkHandler.GetMcloudBaristaDefaultVpcId()
 	if VpcId == "" {
-		return vNetworkInfoList, nil
+		return nil, nil
 	}
+	/*
+		VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(irs.VNetworkReqInfo{})
+		cblogger.Info("CBDefaultVPC 조회 결과 : ", VpcId)
+		if errVpc != nil {
+			return nil, errVpc
+		}
+		if VpcId == "" {
+			return vNetworkInfoList, nil
+		}
+	*/
+
+	/*
+		awsCBNetworkInfo, errCBInfo := vNetworkHandler.GetAutoCBNetworkInfo()
+		if errCBInfo != nil {
+			return nil, errCBInfo
+		}
+
+		//생성된 CB Default Virtual Network가 없는 경우 nil 리턴
+		if awsCBNetworkInfo.VpcName == "" {
+			return vNetworkInfoList, nil
+		}
+
+		VpcId := awsCBNetworkInfo.VpcId
+	*/
 
 	//기본 CBVPC에 속한 서브넷만 조회
 	input := &ec2.DescribeSubnetsInput{
@@ -102,9 +123,16 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 					aws.String(VpcId),
 				},
 			},
+			{
+				Name: aws.String("tag:Name"),
+				Values: []*string{
+					aws.String(GetCBDefaultSubnetName()),
+				},
+			},
 		},
 	}
 
+	//spew.Dump(input)
 	result, err := vNetworkHandler.Client.DescribeSubnets(input)
 	//result, err := vNetworkHandler.Client.DescribeSubnets(&ec2.DescribeSubnetsInput{})	//전체 서브넷 조회
 	if err != nil {
@@ -121,6 +149,7 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 		return nil, err
 	}
 
+	spew.Dump(result)
 	for _, curSubnet := range result.Subnets {
 		cblogger.Infof("[%s] Subnet 정보 조회", *curSubnet.SubnetId)
 		vNetworkInfo := ExtractSubnetDescribeInfo(curSubnet)
@@ -129,66 +158,6 @@ func (vNetworkHandler *AwsVNetworkHandler) ListVNetwork() ([]*irs.VNetworkInfo, 
 
 	spew.Dump(vNetworkInfoList)
 	return vNetworkInfoList, nil
-}
-
-//@TODO : ListVNetwork()에서 호출되는 경우도 있기 때문에 필요하면 VPC조회와 생성을 별도의 Func으로 분리해야함.(일단은 큰 문제는 없어서 놔둠)
-//CB Default Virtual Network가 존재하지 않으면 생성하며, 존재하는 경우 Vpc ID를 리턴 함.
-func (vNetworkHandler *AwsVNetworkHandler) FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo irs.VNetworkReqInfo) (string, error) {
-	cblogger.Info(vNetworkReqInfo)
-
-	awsVpcInfo, err := vNetworkHandler.GetVpc(GetCBDefaultVNetName())
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				cblogger.Error(aerr.Error())
-			}
-		} else {
-			// Print the error, cast err to awserr.Error to get the Code and
-			// Message from an error.
-			cblogger.Error(err.Error())
-		}
-		return "", err
-	}
-
-	//기존 정보가 존재하면...
-	if awsVpcInfo.Id != "" {
-		return awsVpcInfo.Id, nil
-	} else {
-		//@TODO : Subnet과 VPC모두 CSP별 고정된 값으로 드라이버가 내부적으로 자동으로 생성하도록 CB규약이 바뀌어서 서브넷 정보 기반의 로직은 모두 잠시 죽여 놓음 - 리스트 요청시에도 내부적으로 자동 생성하도록 변경 중
-		/*
-			cblogger.Infof("기본 VPC[%s]가 없어서 Subnet 요청 정보를 기반으로 /16 범위의 VPC를 생성합니다.", GetCBDefaultVNetName())
-			cblogger.Info("Subnet CIDR 요청 정보 : ", vNetworkReqInfo.CidrBlock)
-			if vNetworkReqInfo.CidrBlock == "" {
-				//VPC가 없는 최초 상태에서 List()에서 호출되었을 수 있기 때문에 에러 처리는 하지 않고 nil을 전달함.
-				cblogger.Infof("요청 정보에 CIDR 정보가 없어서 Default VPC[%s]를 생성하지 않음", GetCBDefaultVNetName())
-				return "", nil
-			}
-
-			reqCidr := strings.Split(vNetworkReqInfo.CidrBlock, ".")
-			//cblogger.Info("CIDR 추출 정보 : ", reqCidr[0])
-			VpcCidrBlock := reqCidr[0] + "." + reqCidr[1] + ".0.0/16"
-			cblogger.Info("신규 VPC에 사용할 CIDR 정보 : ", VpcCidrBlock)
-		*/
-
-		cblogger.Infof("기본 VPC[%s]가 없어서 CIDR[%s] 범위의 VPC를 자동으로 생성합니다.", GetCBDefaultVNetName(), GetCBDefaultCidrBlock())
-		awsVpcReqInfo := AwsVpcReqInfo{
-			Name: GetCBDefaultVNetName(),
-			//CidrBlock: VpcCidrBlock,
-			CidrBlock: GetCBDefaultCidrBlock(),
-		}
-
-		result, errVpc := vNetworkHandler.CreateVpc(awsVpcReqInfo)
-		if errVpc != nil {
-			cblogger.Error(errVpc)
-			return "", errVpc
-		}
-		cblogger.Infof("CB Default VPC[%s] 생성 완료 - CIDR : [%s]", GetCBDefaultVNetName(), result.CidrBlock)
-		cblogger.Info(result)
-		spew.Dump(result)
-
-		return result.Id, nil
-	}
 }
 
 func (vNetworkHandler *AwsVNetworkHandler) GetVpc(vpcName string) (AwsVpcInfo, error) {
@@ -299,9 +268,16 @@ func (vNetworkHandler *AwsVNetworkHandler) CreateVpc(awsVpcReqInfo AwsVpcReqInfo
 func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VNetworkReqInfo) (irs.VNetworkInfo, error) {
 	cblogger.Info(vNetworkReqInfo)
 
+	vpcList, _ := vNetworkHandler.ListVNetwork()
+	if len(vpcList) > 0 {
+		cblogger.Error("이미 Default Subnet이 존재하기 때문에 생성하지 않고 기존 정보를 리턴함.")
+		cblogger.Info(vpcList)
+		return *vpcList[0], nil
+	}
+
 	//최대 5개의 VPC 생성 제한이 있기 때문에 기본VPC 조회시 에러 처리를 해줌.
-	VpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo)
-	cblogger.Info("CBDefaultVPC 조회 결과 : ", VpcId)
+	vpcId, errVpc := vNetworkHandler.FindOrCreateMcloudBaristaDefaultVPC(vNetworkReqInfo)
+	cblogger.Info("CBDefaultVPC 조회 결과 : ", vpcId)
 	if errVpc != nil {
 		return irs.VNetworkInfo{}, errVpc
 	}
@@ -311,7 +287,7 @@ func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VN
 	input := &ec2.CreateSubnetInput{
 		//CidrBlock: aws.String(vNetworkReqInfo.CidrBlock),
 		CidrBlock: aws.String(GetCBDefaultCidrBlock()), // VPC와 동일한 대역의 CB-Default Subnet을 생성 함.
-		VpcId:     aws.String(VpcId),
+		VpcId:     aws.String(vpcId),
 	}
 
 	cblogger.Info(input)
@@ -373,15 +349,35 @@ func (vNetworkHandler *AwsVNetworkHandler) CreateVNetwork(vNetworkReqInfo irs.VN
 	return vNetworkInfo, nil
 }
 
+//vNetworkID를 전달 받으면 해당 Subnet을 조회하고 / vNetworkID의 값이 없으면 CB Default Subnet을 조회함.
 func (vNetworkHandler *AwsVNetworkHandler) GetVNetwork(vNetworkID string) (irs.VNetworkInfo, error) {
 	cblogger.Infof("vNetworkID : [%s]", vNetworkID)
 
-	input := &ec2.DescribeSubnetsInput{
-		SubnetIds: []*string{
+	input := &ec2.DescribeSubnetsInput{}
+	//Subnet ID를 전달 받으면 해당 서브넷을 조회
+	if vNetworkID != "" {
+		input.SubnetIds = ([]*string{
 			aws.String(vNetworkID),
-		},
-	}
-
+		})
+	} else {
+		//그렇지 않으면 Default CB-Subnet 조회
+		input.Filters = ([]*ec2.Filter{
+			&ec2.Filter{
+				Name: aws.String("tag:Name"), // subnet-id
+				Values: []*string{
+					aws.String(GetCBDefaultSubnetName()),
+				},
+			},
+		})
+	} // end of if
+	/*
+		input := &ec2.DescribeSubnetsInput{
+			SubnetIds: []*string{
+				aws.String(vNetworkID),
+			},
+		}
+	*/
+	spew.Dump(input)
 	result, err := vNetworkHandler.Client.DescribeSubnets(input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
@@ -399,6 +395,7 @@ func (vNetworkHandler *AwsVNetworkHandler) GetVNetwork(vNetworkID string) (irs.V
 
 	cblogger.Info(result)
 	//spew.Dump(result)
+
 	if !reflect.ValueOf(result.Subnets).IsNil() {
 		vNetworkInfo := ExtractSubnetDescribeInfo(result.Subnets[0])
 		return vNetworkInfo, nil


### PR DESCRIPTION
- VNicHandler.go / VNetworkHandler.go / SecurityHandler.go에서 VPC & Subnet 정보가 필요한 경우
  자동으로 생성및 삭제하도록 구현 했지만 호출 상황에 따라서는 문제 소지가 있어서
  Createxxx 함수에서만 자동으로 생성하고 조회의 경우 생성하지 않도록 수정
  삭제의 경우도 비슷하게 체크 범주(VNic이 전부 삭제되어도 보안 그룹은 남아 있는지 함께 체크)가 커서 일단 VNetworkHandler.go의 삭제 요청이 있는 경우에만 VPC가 자동으로 삭제되도록 수정함.

[AWS VM핸들러 이슈]
- 사용자가 생성한 VPC는 기본적으로 외부와의 인터넷이 단절된 상태로 생성됨.
  즉, 사용자가 생성한 VPC에는 PublicIP를 할당할 수 없기 때문에
  PublicIP를 할당 할 수 있도록 외부와의 인터넷이 가능하도록 생성된 VPC의 라우팅 구성이 필요함.
  (예: 생성된 VPC에 인터넷게이트웨이를 생성 후 연결)

- VPC 생성시 IGW(인터넷게이트웨이) 생성및 연결 로직을 반영 예정이며...
  현재는 자동으로 생성된 CB-Net VPC에 수작업으로 IGW를 연결해야 VM 생성시 Public IP가 할당됨.