### PR TITLE
PublicIP 핸들러의 정보조회 시 Name 필드에 Name Tag대신 AllocationId를 리턴 함.

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -548,8 +548,8 @@ func handleVNic() {
 
 func main() {
 	cblogger.Info("AWS Resource Test")
-	handleKeyPair()
-	//handlePublicIP() // PublicIP 생성 후 conf
+	//handleKeyPair()
+	handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
 	//handleImage() //AMI

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
@@ -138,11 +138,13 @@ func extractPublicIpDescribeInfo(allocRes *ec2.Address) irs.PublicIPInfo {
 		keyValueList = append(keyValueList, irs.KeyValue{Key: "PrivateIpAddress", Value: *allocRes.PrivateIpAddress})
 	}
 
+	publicIPInfo.Name = *allocRes.AllocationId //2019-10-21 Name 필드에 ID 값을 리턴하도록 변경 (만약을 위해 Key&Value 목록에 Name 정보 리턴)
 	//Name 태그 설정
 	for _, t := range allocRes.Tags {
 		if *t.Key == "Name" {
-			publicIPInfo.Name = *t.Value
-			cblogger.Debug("명칭 : ", publicIPInfo.Name)
+			//publicIPInfo.Name = *t.Value
+			//cblogger.Debug("명칭 : ", publicIPInfo.Name)
+			keyValueList = append(keyValueList, irs.KeyValue{Key: "Name", Value: *t.Value})
 			break
 		}
 	}

--- a/cloud-control-manager/cloud-driver/interfaces/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/PublicIPHandler.go
@@ -16,7 +16,7 @@ type PublicIPReqInfo struct {
 }
 
 type PublicIPInfo struct {
-	Name      string
+	Name      string // AWS : Name Tag대신 AllocationId를 리턴 함.(편의를 위해 Name 정보는 KeyValueList에 전달 함.)
 	PublicIP  string
 	OwnedVMID string
 	Status    string


### PR DESCRIPTION
출력된 정보에 Name 값이 없으면 불편 할 수 있어서 편의를 위해 Name 정보는 KeyValueList에 전달 함.