### PR TITLE
존재하지 않는 키페어 검증 루틴 추가 (bug#37)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
@@ -150,12 +150,19 @@ func ExtractKeyPairDescribeInfo(keyPair *ec2.KeyPairInfo) irs.KeyPairInfo {
 }
 
 func (keyPairHandler *AwsKeyPairHandler) DeleteKey(keyName string) (bool, error) {
-	cblogger.Infof("DeleteKeyPaid : [%s]", keyName)
+	cblogger.Infof("삭제 요청된 키페어 : [%s]", keyName)
+
+	_, errGet := keyPairHandler.GetKey(keyName)
+	if errGet != nil {
+		return false, errGet
+	}
+
 	// Delete the key pair by name
-	_, err := keyPairHandler.Client.DeleteKeyPair(&ec2.DeleteKeyPairInput{
+	result, err := keyPairHandler.Client.DeleteKeyPair(&ec2.DeleteKeyPairInput{
 		KeyName: aws.String(keyName),
 	})
 
+	spew.Dump(result)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "InvalidKeyPair.Duplicate" {
 			cblogger.Error("Key pair %q does not exist.", keyName)


### PR DESCRIPTION
서버에 존재하지 않는 KeyPair 삭제 시 True대신 False 리턴을 희망해서
KeyPair 삭제전 삭제 할 KeyPair가 서버에 존재하는지 체크로직을 추가함.