### PR TITLE
[#43 Bug Fix] PublicIp 조회시 AWS API의 에러가 없는 경우 "PublicIP NotFound" 예외 메시지 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -224,7 +224,7 @@ func handleKeyPair() {
 	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	keyPairName := "CB-KeyPairTest"
+	keyPairName := "CB-KeyPairTest123123"
 	//keyPairName := config.Aws.KeyName
 
 	for {
@@ -477,7 +477,8 @@ func handleVNic() {
 	vNicReqInfo := irs.VNicReqInfo{
 		Name: "TestCB-VNic",
 		SecurityGroupIds: []string{
-			"sg-0d4d11c090c4814e8", "sg-0dc15d050f8272e24",
+			//"sg-0d4d11c090c4814e8", "sg-0dc15d050f8272e24",
+			"sg-06c4523b969eaafc7",
 		},
 	}
 
@@ -549,10 +550,10 @@ func handleVNic() {
 func main() {
 	cblogger.Info("AWS Resource Test")
 	//handleKeyPair()
-	//handlePublicIP() // PublicIP 생성 후 conf
+	handlePublicIP() // PublicIP 생성 후 conf
 
 	//handleVNetwork() //VPC
-	handleImage() //AMI
+	//handleImage() //AMI
 	//handleVNic() //Lancard
 	//handleSecurity()
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PublicIPHandler.go
@@ -11,6 +11,7 @@
 package resources
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -173,13 +174,14 @@ func (publicIpHandler *AwsPublicIPHandler) GetPublicIP(publicIPID string) (irs.P
 		},
 	})
 	if err != nil {
-		cblogger.Errorf("Unable to elastic IP address, %v", err)
+		cblogger.Error(err)
 		return irs.PublicIPInfo{}, err
 	}
 
 	// Printout the IP addresses if there are any.
 	if len(result.Addresses) == 0 {
-		cblogger.Infof("No elastic IPs for %s region\n", *publicIpHandler.Client.Config.Region)
+		cblogger.Errorf("Not found Elastic IP Information - Request allocation-id : [%s]", publicIPID)
+		return irs.PublicIPInfo{}, errors.New("PublicIP NotFound")
 	} else {
 		cblogger.Info("Elastic IPs")
 		for _, addr := range result.Addresses {


### PR DESCRIPTION
PublicIp 조회시 AWS API의 에러가 없는 경우 "PublicIP NotFound" 예외 메시지를 던지도록 기능 추가 (#43 Bug에 대한 조치)
#43 Bug: GET aws publicip with invalid `eipalloc` ID returns an empty JSON object, not an error message