### PR TITLE
#56 Bug ToPort 버그 Fix

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
@@ -350,7 +350,7 @@ func ExtractIpPermissionCommon(ip *ec2.IpPermission, securityRuleInfo *irs.Secur
 
 	if !reflect.ValueOf(ip.ToPort).IsNil() {
 		//securityRuleInfo.ToPort = *ip.ToPort
-		securityRuleInfo.FromPort = strconv.FormatInt(*ip.ToPort, 10)
+		securityRuleInfo.ToPort = strconv.FormatInt(*ip.ToPort, 10)
 	}
 
 	securityRuleInfo.IPProtocol = *ip.IpProtocol


### PR DESCRIPTION
- #56 Bug: AWS driver does not handle `FromPort` and `ToPort` properly.