### PR TITLE
- VM 생성시 전달 받은 vNic Id가 있으면 Attach하도록 기능 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
@@ -48,11 +48,11 @@ func createVM() {
 	//maxCount := aws.Int64(config.Aws.MaxCount)
 
 	vmReqInfo := irs.VMReqInfo{
-		VMName:           config.Aws.BaseName,
-		ImageId:          config.Aws.ImageID,
-		VirtualNetworkId: config.Aws.SubnetID,
-		//NetworkInterfaceId:
-		PublicIPId: "eipalloc-0e95789a23e6d0c6f",
+		VMName:             config.Aws.BaseName,
+		ImageId:            config.Aws.ImageID,
+		VirtualNetworkId:   config.Aws.SubnetID,
+		NetworkInterfaceId: "eni-00befb6d8c3a87b24",
+		PublicIPId:         "eipalloc-0e95789a23e6d0c6f",
 		//SecurityGroupIds: []string{"sg-0df1c209ea1915e4b"},
 		SecurityGroupIds: []string{config.Aws.SecurityGroupID},
 		VMSpecId:         config.Aws.InstanceType,
@@ -61,12 +61,13 @@ func createVM() {
 
 	vmInfo, err := vmHandler.StartVM(vmReqInfo)
 	if err != nil {
-		panic(err)
+		//panic(err)
 		cblogger.Error(err)
+	} else {
+		cblogger.Info("VM 생성 완료!!", vmInfo)
+		spew.Dump(vmInfo)
 	}
-	cblogger.Info("VM 생성 완료!!", vmInfo)
 	//cblogger.Info(vm)
-	spew.Dump(vmInfo)
 
 	cblogger.Info("Finish Create VM")
 }


### PR DESCRIPTION
- VM 생성시 전달 받은 vNic Id가 있으면 Attach하도록 기능 추가
--> 향후 CB인터페이스 변경 및 VNetworkHandler.go와 VMHandler.go간의 기능 파악이 용이하도록
     VM 생성 시 vNic Id가 전달되면 생성된 VM에 전달 받은 vNic을 추가하는 로직 추가 함.
     **[이슈]** 이 형태로 지원할 경우 CB Interface의 경우 **PrivateIP 필드는 배열이 아닌 단순 string으로 문자열이지만...**
     **vNic을 전달 받아서 추가할 경우 최소한 vNic이 2개 이상이 되기 때문에 응답도 Array가됨.**
     Array 타입으로 변경하거나 Array를 일일이 String으로 변환해서 CB응답으로 리턴해도되지만
     아직 미정인 부분이라 Array를 String으로 변환하지 않고 기존 로직 그대로 첫 번째 IP만 리턴하도록했음.
     따라서, vNic Id가 있을 때와 없을 때의 차이는 AWS Console에서 생성된 VM의 Private IP쪽을 체크하면 됨.(또는 AWS 콘솔의 네트워크인터페이스 관리 페이지에서 체크해도 됨)