### PR TITLE
Azure VM 생성 파라미터 포맷 변경 및 SecurityGroup 옵션 변경

### DIFF
--- a/api-runtime/rest-runtime/test/azure/security/create-test.sh
+++ b/api-runtime/rest-runtime/test/azure/security/create-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-SecGroup", "SecurityRules": [{"FromPort": "22", "ToPort" : "22", "IPProtocol" : "tcp", "Direction" : "inbound"}] }'
+curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-SecGroup", "SecurityRules": [{"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"}] }'

--- a/api-runtime/rest-runtime/test/azure/vm/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/get-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vm/CBVm?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/vm/CBVm?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/vm/start-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/start-test.sh
@@ -1,3 +1,10 @@
 RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/vm?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "VMName": "CBVm", "ImageId": "Canonical:UbuntuServer:18.04-LTS:18.04.201804262", "NetworkInterfaceId": "/subscriptions/cb592624-b77b-4a8f-bb13-0e5a48cae40f/resourceGroups/CB-GROUP/providers/Microsoft.Network/networkInterfaces/CB-VNic", "SecurityGroupIds": ["/subscriptions/cb592624-b77b-4a8f-bb13-0e5a48cae40f/resourceGroups/CB-GROUP/providers/Microsoft.Network/networkSecurityGroups/CB-SecGroup"], "VMSpecId": "Standard_B1ls", "VMUserId": "cb-user", "VMUserPasswd": "cb-userCBUSER!@#"}'
+curl -X POST http://$RESTSERVER:1024/vm?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{
+    "VMName": "CBVm",
+    "ImageId": "Canonical:UbuntuServer:18.04-LTS:18.04.201804262",
+    "NetworkInterfaceId": "CB-VNic",
+    "VMSpecId": "Standard_B1ls",
+    "VMUserId": "cb-user",
+    "KeyPairName" : "CB-Keypair"
+}'

--- a/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
@@ -81,7 +81,7 @@ func (cloudConn *AzureCloudConnection) CreatePublicIPHandler() (irs.PublicIPHand
 
 func (cloudConn *AzureCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
 	cblogger.Info("Azure Cloud Driver: called CreateVMHandler()!")
-	vmHandler := azrs.AzureVMHandler{cloudConn.CredentialInfo, cloudConn.Region, cloudConn.Ctx, cloudConn.VMClient}
+	vmHandler := azrs.AzureVMHandler{cloudConn.CredentialInfo, cloudConn.Region, cloudConn.Ctx, cloudConn.VMClient, cloudConn.VNicClient, cloudConn.PublicIPClient}
 	return &vmHandler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
@@ -19,7 +19,7 @@ const (
 	CBVMUser             = "cb-user"
 	//CBKeyPairPath        = "/cloud-control-manager/cloud-driver/driver-libs/.ssh-azure/"
 	// by powerkim, 2019.10.30
-	CBKeyPairPath        = "/cloud-driver-libs/.ssh-azure/"
+	CBKeyPairPath = "/cloud-driver-libs/.ssh-azure/"
 )
 
 // 서브넷 CIDR 생성 (CIDR C class 기준 생성)
@@ -77,3 +77,32 @@ func GetPublicKey(credentialInfo idrv.CredentialInfo, keyPairName string) (strin
 	}
 	return string(publicKeyBytes), nil
 }
+
+// Private KeyPair 정보 가져오기
+/*func GetPrivateKey(credentialInfo idrv.CredentialInfo, keyPairName string) (string, error) {
+	keyPairPath := os.Getenv("CBSPIDER_ROOT") + CBKeyPairPath
+	hashString, err := CreateHashString(credentialInfo)
+	if err != nil {
+		return "", err
+	}
+
+	privateKeyPath := keyPairPath + hashString + "--" + keyPairName + ".ppk"
+	privateKeyBytes, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		return "", err
+	}
+	return string(privateKeyBytes), nil
+}*/
+
+func GetVNicIdByName(credentialInfo idrv.CredentialInfo, regionInfo idrv.RegionInfo, vNicName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s", credentialInfo.SubscriptionId, regionInfo.ResourceGroup, vNicName)
+}
+
+/*func GetSecGroupIdByName(credentialInfo idrv.CredentialInfo, regionInfo idrv.RegionInfo, publicIPName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s", credentialInfo.SubscriptionId, regionInfo.ResourceGroup, publicIPName)
+}*/
+
+/*func GetPublicIPIdByName(credentialInfo idrv.CredentialInfo, regionInfo idrv.RegionInfo, publicIPName string) string {
+	//"/subscriptions/cb592624-b77b-4a8f-bb13-0e5a48cae40f/resourceGroups/CB-GROUP/providers/Microsoft.Network/networkInterfaces/CB-VNic",
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/Microsoft.Network/networkInterfaces/%s", credentialInfo.SubscriptionId, regionInfo.ResourceGroup, publicIPName)
+}*/

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -56,9 +56,9 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 			Name: to.StringPtr(fmt.Sprintf("%s-rules-%d", securityReqInfo.Name, idx+1)),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				SourceAddressPrefix:      to.StringPtr("*"),
-				SourcePortRange:          to.StringPtr(rule.FromPort),
+				SourcePortRange:          to.StringPtr(rule.FromPort + "-" + rule.ToPort),
 				DestinationAddressPrefix: to.StringPtr("*"),
-				DestinationPortRange:     to.StringPtr(rule.ToPort),
+				DestinationPortRange:     to.StringPtr("*"),
 				Protocol:                 network.SecurityRuleProtocol(rule.IPProtocol),
 				Access:                   network.SecurityRuleAccess("Allow"),
 				Priority:                 to.Int32Ptr(priorityNum),


### PR DESCRIPTION

- Azure VM 생성 시 VNicId 파라미터 포맷 변경 (Id->Name)
curl -X POST http://$RESTSERVER:1024/vm?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{
    "VMName": "CBVm",
    "ImageId": "Canonical:UbuntuServer:18.04-LTS:18.04.201804262",
    **"NetworkInterfaceId": "CB-VNic",**
    "VMSpecId": "Standard_B1ls",
    "VMUserId": "cb-user",
    "KeyPairName" : "CB-Keypair"
}'

- Azure VM Mapping 정보 추가 (PrivateIP, PublicIP)

- Azure SecurityGroup 생성 시 파라미터 옵션 변경 (FromPort-ToPort)
curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{
 "Name": "CB-SecGroup",
 "SecurityRules": [
    **{"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"}**
    ]
}'
