### PR TITLE
Azure 리소스 핸들러 호출 시 ResourceGroup 존재 여부 체크 및 자동 생성 기능 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -14,7 +14,9 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
 	azcon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/azure/connect"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	icon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/connect"
@@ -46,6 +48,12 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
 	// 3. create CloudConnection Instance of "connect/TDA_CloudConnection".
 	// 4. return CloudConnection Interface of TDA_CloudConnection.
+
+	// Credentail에 등록된 ResourceGroup 존재 여부 체크 및 생성
+	err := checkResourceGroup(connectionInfo.CredentialInfo, connectionInfo.RegionInfo)
+	if err != nil {
+		return nil, err
+	}
 
 	Ctx, VMClient, err := getVMClient(connectionInfo.CredentialInfo)
 	if err != nil {
@@ -104,6 +112,33 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 		DiskClient:          DiskClient,
 	}
 	return &iConn, nil
+}
+
+func checkResourceGroup(credential idrv.CredentialInfo, region idrv.RegionInfo) error {
+	config := auth.NewClientCredentialsConfig(credential.ClientId, credential.ClientSecret, credential.TenantId)
+	authorizer, err := config.Authorizer()
+	if err != nil {
+		return nil
+	}
+
+	resourceClient := resources.NewGroupsClient(credential.SubscriptionId)
+	resourceClient.Authorizer = authorizer
+	ctx, _ := context.WithTimeout(context.Background(), 600*time.Second)
+
+	rg, err := resourceClient.Get(ctx, region.ResourceGroup)
+
+	// 해당 리소스 그룹이 없을 경우 생성
+	if rg.ID == nil {
+		rg, err = resourceClient.CreateOrUpdate(ctx, region.ResourceGroup,
+			resources.Group{
+				Name:     to.StringPtr(region.ResourceGroup),
+				Location: to.StringPtr(region.Region),
+			})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func getVMClient(credential idrv.CredentialInfo) (context.Context, *compute.VirtualMachinesClient, error) {


### PR DESCRIPTION


- Azure 리소스 핸들러 호출 시 (CRUD) ResourceGroup 존재 여부 체크 및 자동 생성 기능 추가

cim-insert-test.sh

curl -X POST http://$RESTSERVER:1024/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-region01","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"koreacentral"}, **{"Key":"ResourceGroup", "Value":"CB-GROUP2"}**]}'
