### PR TITLE
OpenStack VMStatus 매핑 적용

### DIFF
--- a/api-runtime/rest-runtime/test/openstack/vm/get-status-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/get-status-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
 curl -X GET http://$RESTSERVER:1024/vmstatus/$VM_ID?connection_name=openstack-config01

--- a/api-runtime/rest-runtime/test/openstack/vm/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/get-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
-curl -X GET http://$RESTSERVER:1024/vm/$VM_ID?connection_name=openstack-config01
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
+curl -X GET http://$RESTSERVER:1024/vm/$VM_ID?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/list-status-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/list-status-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vmstatus?connection_name=openstack-config01
+curl -X GET http://$RESTSERVER:1024/vmstatus?connection_name=openstack-config01  |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/list-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/list-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vm?connection_name=openstack-config01
+curl -X GET http://$RESTSERVER:1024/vm?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/reboot-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/reboot-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
 curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=reboot"

--- a/api-runtime/rest-runtime/test/openstack/vm/resume-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/resume-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
 curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=resume"

--- a/api-runtime/rest-runtime/test/openstack/vm/start-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/start-test.sh
@@ -1,13 +1,22 @@
 RESTSERVER=localhost
 
+# OpenStack VM 생성 테스트 시 리소스 이름 정보
+
+# ImageId = ubuntu16.04
+# VirtualNetworkId(서브넷 ID와 매핑) = CB-Subnet
+# SecurityGroupIds = CB-SecGroup
+# VMSpecId = m1.small
+# KeyPairName(Name이 ID 처럼 사용) =  CB-KeyPair
+# PublicIPId(IP가 ID 처럼 사용) = 182.252.135.78
+
 curl -X POST http://$RESTSERVER:1024/vm?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{
-    "VMName": "CB-VM",
-    "ImageId": "c430f613-2b0d-48c8-9983-cdbc6826cca5",
-    "VirtualNetworkId": "c430f613-2b0d-48c8-9983-cdbc6826cca5",
+    "VMName": "CBVm",
+    "ImageId": "c14a9728-eb03-4813-9e1a-8f57fe62b4fb",
+    "VirtualNetworkId": "bb64d667-6ac7-420e-a0a1-17a32951161d",
     "SecurityGroupIds": [
-        "fbcc9efc-feb7-4f55-a70d-7745c6880c14"
+        "38c71c09-f8d8-4197-afd8-1a067a760e24"
     ],
-    "VMSpecId": "2",
+    "VMSpecId": "ba7c426b-29b4-4e6f-833c-8c36b8566c37",
     "KeyPairName": "CB-KeyPair",
-    "PublicIPId": "1b61f689-dcd9-4037-9da7-dcb9a06c2c5e"
+    "PublicIPId": "182.252.135.78"
 }'

--- a/api-runtime/rest-runtime/test/openstack/vm/suspend-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/suspend-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
 curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=suspend"

--- a/api-runtime/rest-runtime/test/openstack/vm/terminate-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/terminate-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=f565d481-6209-4932-a422-04195d4215e0
+VM_ID=3cac5ef3-a338-411d-9614-c42b044fe19c
 curl -X DELETE http://$RESTSERVER:1024/vm/$VM_ID?connection_name=openstack-config01

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -191,6 +191,8 @@ func (vmHandler *AzureVMHandler) ResumeVM(vmID string) (irs.VMStatus, error) {
 		cblogger.Error(err)
 		return irs.Failed, err
 	}
+
+	// 자체생성상태 반환
 	return irs.Resuming, nil
 }
 
@@ -205,6 +207,8 @@ func (vmHandler *AzureVMHandler) RebootVM(vmID string) (irs.VMStatus, error) {
 		cblogger.Error(err)
 		return irs.Failed, err
 	}
+
+	// 자체생성상태 반환
 	return irs.Rebooting, nil
 }
 
@@ -254,6 +258,7 @@ func (vmHandler *AzureVMHandler) TerminateVM(vmID string) (irs.VMStatus, error) 
 		return irs.Failed, err
 	}
 
+	// 자체생성상태 반환
 	return irs.NotExist, nil
 }
 
@@ -335,9 +340,9 @@ func getVmStatus(instanceView compute.VirtualMachineInstanceView) irs.VMStatus {
 		statArr := strings.Split(*stat.Code, "/")
 
 		if statArr[0] == "PowerState" {
-			powerState = statArr[1]
+			powerState = strings.ToLower(statArr[1])
 		} else if statArr[0] == "ProvisioningState" {
-			provisioningState = statArr[1]
+			provisioningState = strings.ToLower(statArr[1])
 		}
 	}
 
@@ -358,6 +363,8 @@ func getVmStatus(instanceView compute.VirtualMachineInstanceView) irs.VMStatus {
 		resultStatus = "Suspended"
 	case "deleting":
 		resultStatus = "Terminating"
+	default:
+		resultStatus = "Failed"
 	}
 	return irs.VMStatus(resultStatus)
 }


### PR DESCRIPTION

- Azure VMStatus 예외처리 및 주석 추가
- OpenStack VMStatus 매핑 적용
- OpenStack StartVM 관련 bash 예제코드 추가 (start-test.sh)

-------

** OpenStack VM 생성 테스트 시 리소스 이름 정보

**-- ImageId = ubuntu16.04
-- VirtualNetworkId(서브넷 ID와 매핑) = CB-Subnet
-- SecurityGroupIds = CB-SecGroup
-- VMSpecId = m1.small
-- KeyPairName(Name이 ID 처럼 사용) =  CB-KeyPair
-- PublicIPId(IP가 ID 처럼 사용) = 182.252.135.78**

curl -X POST http://$RESTSERVER:1024/vm?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{
    "VMName": "CBVm",
    "ImageId": "c14a9728-eb03-4813-9e1a-8f57fe62b4fb",
    "VirtualNetworkId": "bb64d667-6ac7-420e-a0a1-17a32951161d",
    "SecurityGroupIds": [
        "38c71c09-f8d8-4197-afd8-1a067a760e24"
    ],
    "VMSpecId": "ba7c426b-29b4-4e6f-833c-8c36b8566c37",
    "KeyPairName": "CB-KeyPair",
    "PublicIPId": "182.252.135.78"
}'

-------

