### PR TITLE
VNetworkHandler & SecurityHandler & VMHandler & ImageHandler 기능 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Vm.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Vm.go
@@ -40,7 +40,7 @@ func handleVM() {
 
 	handler := ResourceHandler.(irs.VMHandler)
 
-	VmID := "vm03"
+	VmID := "vmsg02"
 
 	for {
 		fmt.Println("VM Management")
@@ -69,12 +69,12 @@ func handleVM() {
 
 			case 1:
 				vmReqInfo := irs.VMReqInfo{
-					VMName: "vm03",
-					//ImageId:            config.Aws.ImageID,
+					VMName:           "vmsg02",
+					ImageId:          "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024",
 					VirtualNetworkId: "cb-vnet",
 					//NetworkInterfaceId: "eni-00befb6d8c3a87b24",
-					PublicIPId: "publicip-vm03",
-					//SecurityGroupIds: []string{"sg-0df1c209ea1915e4b"},
+					PublicIPId:       "publicip1",
+					SecurityGroupIds: []string{"sgvm02"},
 					//SecurityGroupIds: []string{config.Aws.SecurityGroupID},
 					VMSpecId: "f1-micro",
 					//KeyPairName:      config.Aws.KeyName,

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/CommonHandler.go
@@ -29,6 +29,30 @@ const (
 	CBKeyPairPath = "/cloud-driver-libs/.ssh-gcp/"
 )
 
+const CBDefaultVNetName string = "cb-vnet2"  // CB Default Virtual Network Name
+const CBDefaultSubnetName string = "cb-vnet" // CB Default Subnet Name
+
+type GcpCBNetworkInfo struct {
+	VpcName   string
+	VpcId     string
+	CidrBlock string
+	IsDefault bool
+	State     string
+
+	SubnetName string
+	SubnetId   string
+}
+
+//VPC
+func GetCBDefaultVNetName() string {
+	return CBDefaultVNetName
+}
+
+//Subnet
+func GetCBDefaultSubnetName() string {
+	return CBDefaultSubnetName
+}
+
 func GetKeyValueList(i map[string]interface{}) []irs.KeyValue {
 	var keyValueList []irs.KeyValue
 	for k, v := range i {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	cblog "github.com/cloud-barista/cb-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -58,14 +57,15 @@ name, sourceDisk(sourceImage),storageLocations(배열 ex : ["asia"])
 */
 
 func (imageHandler *GCPImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) (irs.ImageInfo, error) {
-
 	return irs.ImageInfo{}, errors.New("Feature not implemented.")
 }
 
 func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 
-	projectId := imageHandler.Credential.ProjectID
+	//projectId := imageHandler.Credential.ProjectID
+	projectId := "gce-uefi-images"
 
+	// list, err := imageHandler.Client.Images.List(projectId).Do()
 	list, err := imageHandler.Client.Images.List(projectId).Do()
 	if err != nil {
 		cblogger.Error(err)
@@ -82,7 +82,8 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 }
 
 func (imageHandler *GCPImageHandler) GetImage(imageID string) (irs.ImageInfo, error) {
-	projectId := imageHandler.Credential.ProjectID
+	//projectId := imageHandler.Credential.ProjectID
+	projectId := "gce-uefi-images"
 
 	image, err := imageHandler.Client.Images.Get(projectId, imageID).Do()
 	if err != nil {
@@ -94,6 +95,7 @@ func (imageHandler *GCPImageHandler) GetImage(imageID string) (irs.ImageInfo, er
 }
 
 func (imageHandler *GCPImageHandler) DeleteImage(imageID string) (bool, error) {
+	// public Image 는 지울 수 없는데 어떻게 해야 하는가?
 	projectId := imageHandler.Credential.ProjectID
 
 	res, err := imageHandler.Client.Images.Delete(projectId, imageID).Do()
@@ -106,17 +108,19 @@ func (imageHandler *GCPImageHandler) DeleteImage(imageID string) (bool, error) {
 }
 
 func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
-	lArr := strings.Split(imageInfo.Licenses[0], "/")
-	os := lArr[len(lArr)-1]
+	//lArr := strings.Split(imageInfo.Licenses[0], "/")
+	//os := lArr[len(lArr)-1]
 	imageList := irs.ImageInfo{
-		Id:      strconv.FormatUint(imageInfo.Id, 10),
+		//Id:      strconv.FormatUint(imageInfo.Id, 10),
+		Id:      imageInfo.SelfLink,
 		Name:    imageInfo.Name,
-		GuestOS: os,
+		GuestOS: imageInfo.Family,
 		Status:  imageInfo.Status,
 		KeyValueList: []irs.KeyValue{
 			{"SourceType", imageInfo.SourceType},
 			{"SelfLink", imageInfo.SelfLink},
 			{"GuestOsFeature", imageInfo.GuestOsFeatures[0].Type},
+			{"Family", imageInfo.Family},
 			{"DiskSizeGb", strconv.FormatInt(imageInfo.DiskSizeGb, 10)},
 		},
 	}


### PR DESCRIPTION
- VNetworkHandler 기능 변경
  -- 입력 받은 Name과 상관 없이 **"cb-vnet"으로만 생성**되도록 함.

- SecurityHandler 기능 변경
  -- VM에 보안그룹 할당및 보안그룹 태깅을 위해 "cb-vnet"에 태깅함.
  -- inboud / outboud를 INGRESS / EGRESS로 치환

- VMHandler 기능 변경
  -- ImageId를 입력 받도록 수정 (예:**projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024**) : ImageName을 조회해서 Id를 사용하는 로직 추가 예정(현재는 FullURL을 입력해야 동작함)
  -- VM 생성시 태깅에 보안 그룹 반영
  -- VM 정보 조회시 태깅 정보를 보안 그룹에 반영
  -- VM 정보 조회시 ImageId 정보 반영

- ImageHandler 기능 변경
  -- 공개이미지 목록 조회 기능 추가
