### PR TITLE
Key 필드를 Id 기반에서 Name Tag 기반으로 로직 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -15,6 +15,8 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
+
 	awsdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 
@@ -49,16 +51,16 @@ func handleSecurity() {
 	config := readConfigFile()
 	securityId := config.Aws.SecurityGroupID
 	cblogger.Infof(securityId)
-	securityId = "sg-06c4523b969eaafc7"
+	//securityId = "sg-06c4523b969eaafc7"
+	securityId = "cb-sgtest-mcloud-barista"
 
-	result, err := handler.GetSecurity(securityId)
-	//result, err := handler.GetSecurity("sg-0d4d11c090c4814e8")
+	//result, err := handler.GetSecurity(securityId)
 	//result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
 	//result, err := handler.DeleteSecurity(securityId)
 	//result, err := handler.ListSecurity()
 
 	securityReqInfo := irs.SecurityReqInfo{
-		Name: "sgtest-mcloud-barista",
+		Name: securityId,
 		SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
 			{
 				FromPort:   "20",
@@ -102,7 +104,7 @@ func handleSecurity() {
 	}
 
 	cblogger.Info(securityReqInfo)
-	//result, err := handler.CreateSecurity(securityReqInfo)
+	result, err := handler.CreateSecurity(securityReqInfo)
 
 	if err != nil {
 		cblogger.Infof("보안 그룹 조회 실패 : ", err)
@@ -127,6 +129,7 @@ func handlePublicIP() {
 	config := readConfigFile()
 	//reqGetPublicIP := "13.124.140.207"
 	reqPublicIP := config.Aws.PublicIP
+	reqPublicIP = "mcloud-barista-eip-test"
 	//reqPublicIP = "eipalloc-0231a3e16ec42e869"
 	cblogger.Info("reqPublicIP : ", reqPublicIP)
 	//handler.CreatePublicIP(publicIPReqInfo)
@@ -189,19 +192,22 @@ func handlePublicIP() {
 
 			case 4:
 				fmt.Println("Start DeletePublicIP() ...")
-				fmt.Print("삭제할 PublicIP를 입력하세요 : ")
-				inputCnt, err := fmt.Scan(&reqDelIP)
-				if err != nil {
-					panic(err)
-				}
+				/*
+					fmt.Print("삭제할 PublicIP를 입력하세요 : ")
+					inputCnt, err := fmt.Scan(&reqDelIP)
+					if err != nil {
+						panic(err)
+					}
 
-				if inputCnt == 1 {
-					cblogger.Info("삭제할 PublicIP : ", reqDelIP)
-				} else {
-					fmt.Println("삭제할 Public IP만 입력하세요.")
-				}
+					if inputCnt == 1 {
+						cblogger.Info("삭제할 PublicIP : ", reqDelIP)
+					} else {
+						fmt.Println("삭제할 Public IP만 입력하세요.")
+					}
+					result, err := handler.DeletePublicIP(reqDelIP)
+				*/
 
-				result, err := handler.DeletePublicIP(reqDelIP)
+				result, err := handler.DeletePublicIP(reqPublicIP)
 				if err != nil {
 					cblogger.Error(reqDelIP, " PublicIP 삭제 실패 : ", err)
 				} else {
@@ -308,7 +314,7 @@ func handleVNetwork() {
 
 	vNetworkReqInfo := irs.VNetworkReqInfo{
 		//Id:   "subnet-044a2b57145e5afc5",
-		//Name: "CB-VNet-Subnet2",	// 웹 도구 등 외부에서 전달 받지 않고 드라이버 내부적으로 자동 구현때문에 사용하지 않음.
+		Name: "CB-VNet-Subnet", // 웹 도구 등 외부에서 전달 받지 않고 드라이버 내부적으로 자동 구현때문에 사용하지 않음.
 		//CidrBlock: "10.0.0.0/16",
 		//CidrBlock: "192.168.0.0/16",
 	}
@@ -555,15 +561,39 @@ func handleVNic() {
 	}
 }
 
+func testErr() error {
+	//return awserr.Error("")
+	//return errors.New("")
+	return awserr.New("504", "찾을 수 없음", nil)
+}
+
 func main() {
 	cblogger.Info("AWS Resource Test")
-	//handleKeyPair()
-	//handlePublicIP() // PublicIP 생성 후 conf
+	/*
+		err := testErr()
+		spew.Dump(err)
+		if err != nil {
+			cblogger.Info("에러 발생")
+			awsErr, ok := err.(awserr.Error)
+			spew.Dump(awsErr)
+			spew.Dump(ok)
+			if ok {
+				if "404" == awsErr.Code() {
+					cblogger.Info("404!!!")
+				} else {
+					cblogger.Info("404 아님")
+				}
+			}
+		}
+	*/
 
-	handleVNetwork() //VPC
+	//handleVNetwork() //VPC
+	//handleKeyPair()
+	handlePublicIP() // PublicIP 생성 후 conf
+	//handleSecurity()
+
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	//handleSecurity()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_VM.go
@@ -48,17 +48,31 @@ func createVM() {
 
 	//minCount := aws.Int64(int64(config.Aws.MinCount))
 	//maxCount := aws.Int64(config.Aws.MaxCount)
-
+	/*
+		vmReqInfo := irs.VMReqInfo{
+			VMName:             config.Aws.BaseName,
+			ImageId:            config.Aws.ImageID,
+			VirtualNetworkId:   config.Aws.SubnetID,
+			NetworkInterfaceId: "eni-00befb6d8c3a87b24",
+			PublicIPId:         "eipalloc-0e95789a23e6d0c6f",
+			//SecurityGroupIds: []string{"sg-0df1c209ea1915e4b"},
+			SecurityGroupIds: []string{config.Aws.SecurityGroupID},
+			VMSpecId:         config.Aws.InstanceType,
+			KeyPairName:      config.Aws.KeyName,
+		}
+	*/
 	vmReqInfo := irs.VMReqInfo{
-		VMName:             config.Aws.BaseName,
-		ImageId:            config.Aws.ImageID,
-		VirtualNetworkId:   config.Aws.SubnetID,
-		NetworkInterfaceId: "eni-00befb6d8c3a87b24",
-		PublicIPId:         "eipalloc-0e95789a23e6d0c6f",
-		//SecurityGroupIds: []string{"sg-0df1c209ea1915e4b"},
-		SecurityGroupIds: []string{config.Aws.SecurityGroupID},
-		VMSpecId:         config.Aws.InstanceType,
-		KeyPairName:      config.Aws.KeyName,
+		//VMName:           config.Aws.BaseName,
+		VMName:           "mcloud-barista-vnictest3",
+		ImageId:          config.Aws.ImageID,
+		VirtualNetworkId: "CB-VNet-Subnet",
+		//NetworkInterfaceId: "eni-00befb6d8c3a87b24",
+		PublicIPId:       "mcloud-barista-eip-test",
+		SecurityGroupIds: []string{"cb-sgtest-mcloud-barista"},
+		//SecurityGroupIds: []string{"cb-sgtest-mcloud-barista", "cb-sgtest-mcloud-barista2"},
+		//SecurityGroupIds: []string{config.Aws.SecurityGroupID},
+		VMSpecId:    config.Aws.InstanceType,
+		KeyPairName: config.Aws.KeyName,
 	}
 
 	vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -108,7 +122,7 @@ func handleVM() {
 	}
 	config := readConfigFile()
 	VmID := config.Aws.VmID
-	//VmID = "i-0612a67a63ddb8374"
+	VmID = "mcloud-barista-vnictest3"
 
 	for {
 		fmt.Println("VM Management")

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -33,6 +33,9 @@ type AwsCBNetworkInfo struct {
 	SubnetId   string
 }
 
+const CUSTOM_ERR_CODE_TOOMANY string = "600"  //awserr.New("600", "n개 이상의 xxxx 정보가 존재합니다.", nil)
+const CUSTOM_ERR_CODE_NOTFOUND string = "404" //awserr.New("404", "XXX 정보가 존재하지 않습니다.", nil)
+
 //VPC
 func GetCBDefaultVNetName() string {
 	return CBDefaultVNetName

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/SecurityHandler.go
@@ -28,6 +28,7 @@ type AwsSecurityHandler struct {
 	Client *ec2.EC2
 }
 
+//2019-11-16부로 CB-Driver 전체 로직이 NameId 기반으로 변경됨. (보안 그룹은 그룹명으로 처리 가능하기 때문에 Name 태깅시 에러는 무시함)
 //@TODO : 존재하는 보안 그룹에 정책 추가하는 기능 필요
 //VPC 생략 시 활성화된 세션의 기본 VPC를 이용 함.
 func (securityHandler *AwsSecurityHandler) CreateSecurity(securityReqInfo irs.SecurityReqInfo) (irs.SecurityInfo, error) {
@@ -218,7 +219,8 @@ func (securityHandler *AwsSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 		cblogger.Error(errTag)
 	}
 
-	securityInfo, _ := securityHandler.GetSecurity(*createRes.GroupId)
+	//securityInfo, _ := securityHandler.GetSecurity(*createRes.GroupId)
+	securityInfo, _ := securityHandler.GetSecurity(securityReqInfo.Name) //2019-11-16 NameId 기반으로 변경됨
 	return securityInfo, nil
 }
 
@@ -268,13 +270,26 @@ func (securityHandler *AwsSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 	return results, nil
 }
 
-func (securityHandler *AwsSecurityHandler) GetSecurity(securityID string) (irs.SecurityInfo, error) {
-	cblogger.Infof("securityID : [%s]", securityID)
+//2019-11-16부로 CB-Driver 전체 로직이 NameId 기반으로 변경됨.
+func (securityHandler *AwsSecurityHandler) GetSecurity(securityNameId string) (irs.SecurityInfo, error) {
+	cblogger.Infof("securityNameId : [%s]", securityNameId)
 	input := &ec2.DescribeSecurityGroupsInput{
-		GroupIds: []*string{
-			aws.String(securityID),
-		},
+		/*
+			GroupIds: []*string{
+				aws.String(securityID),
+			},
+		*/
 	}
+	input.Filters = ([]*ec2.Filter{
+		&ec2.Filter{
+			//Name: aws.String("tag:Name"), // subnet-id
+			Name: aws.String("group-name"), // subnet-id
+			Values: []*string{
+				aws.String(securityNameId),
+			},
+		},
+	})
+	cblogger.Info(input)
 
 	result, err := securityHandler.Client.DescribeSecurityGroups(input)
 	cblogger.Info("result : ", result)
@@ -297,7 +312,8 @@ func (securityHandler *AwsSecurityHandler) GetSecurity(securityID string) (irs.S
 		securityInfo := ExtractSecurityInfo(result.SecurityGroups[0])
 		return securityInfo, nil
 	} else {
-		return irs.SecurityInfo{}, errors.New("정보를 찾을 수 없습니다.")
+		//return irs.SecurityInfo{}, errors.New("[" + securityNameId + "] 정보를 찾을 수 없습니다.")
+		return irs.SecurityInfo{}, errors.New("InvalidSecurityGroup.NotFound: The security group '" + securityNameId + "' does not exist")
 	}
 }
 
@@ -416,8 +432,17 @@ func ExtractIpPermissions(ipPermissions []*ec2.IpPermission, direction string) [
 	return results
 }
 
-func (securityHandler *AwsSecurityHandler) DeleteSecurity(securityID string) (bool, error) {
-	cblogger.Infof("securityID : [%s]", securityID)
+//2019-11-16부로 CB-Driver 전체 로직이 NameId 기반으로 변경됨.
+func (securityHandler *AwsSecurityHandler) DeleteSecurity(securityNameId string) (bool, error) {
+	cblogger.Infof("securityNameId : [%s]", securityNameId)
+
+	securityInfo, errsecurityInfo := securityHandler.GetSecurity(securityNameId)
+	if errsecurityInfo != nil {
+		return false, errsecurityInfo
+	}
+	cblogger.Info(securityInfo)
+
+	securityID := securityInfo.Id
 
 	// Delete the security group.
 	_, err := securityHandler.Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -61,43 +61,124 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	cblogger.Info(vmReqInfo)
 	spew.Dump(vmReqInfo)
 
-	//imageID := vmReqInfo.ImageInfo.Id
-	//instanceType := vmReqInfo.SpecID // "t2.micro"
-	//keyName := vmReqInfo.KeyPairInfo.Name
-	//securityGroupID := vmReqInfo.SecurityInfo.Id // "sg-0df1c209ea1915e4b" - 미지정시 보안 그룹명이 "default"인 보안 그룹이 사용 됨.
-	//subnetID := vmReqInfo.VNetworkInfo.Id // "subnet-cf9ccf83" - 미지정시 기본 VPC의 기본 서브넷이 임의로 이용되며 PublicIP가 할당 됨.
-	//baseName := vmReqInfo.Name            //"mcloud-barista-VMHandlerTest"
+	//=============================================
+	// 동일한 이름을 사용하는 VM이 존재하는지 확인함.
+	//=============================================
+	cblogger.Infof("생성할 VM이 존재하는지 체크합니다.")
+	vmInfo, errVmInfo := vmHandler.GetVM(vmReqInfo.VMName)
+
+	if errVmInfo != nil {
+		awsErr, ok := errVmInfo.(awserr.Error)
+		//spew.Dump(awsErr)
+		if ok {
+			if CUSTOM_ERR_CODE_NOTFOUND == awsErr.Code() {
+				cblogger.Infof("존재하는 VM [%s]이 없기 때문에 생성을 시작합니다.", vmReqInfo.VMName)
+			} else { // 404 Not Found 외의 에러는 모두 에러임.
+				cblogger.Error(errVmInfo)
+				return irs.VMInfo{}, errVmInfo
+			}
+		} else { //코드를 같지 않는 에러들도 모두 에러임.
+			return irs.VMInfo{}, errVmInfo
+		}
+	} else { //에러 정보가 없는 경우 이미 해당 VM이 생성되어 있기 때문에 에러임.
+		if len(vmInfo.Name) > 0 {
+			cblogger.Errorf("이미 [%s] VM이 존재하기 때문에 생성하지 않고 기존 정보와 함께 에러를 리턴함.", vmReqInfo.VMName)
+			cblogger.Info(vmInfo)
+			return vmInfo, errors.New("InvalidVM.Duplicate: The VM '" + vmReqInfo.VMName + "' already exists.")
+		}
+	}
 
 	imageID := vmReqInfo.ImageId
 	instanceType := vmReqInfo.VMSpecId // "t2.micro"
 	minCount := aws.Int64(1)
 	maxCount := aws.Int64(1)
 	keyName := vmReqInfo.KeyPairName
-	subnetID := vmReqInfo.VirtualNetworkId // "subnet-cf9ccf83" - 미지정시 기본 VPC의 기본 서브넷이 임의로 이용되며 PublicIP가 할당 됨.
-	baseName := vmReqInfo.VMName           //"mcloud-barista-VMHandlerTest"
+	baseName := vmReqInfo.VMName //"mcloud-barista-VMHandlerTest"
 
+	//=============================
+	// Subnet 처리 - NameId 기반
+	//=============================
+	cblogger.Info("NameId 기반으로 처리하기 위해 Subnet 정보를 조회함.")
+	//사용자가 입력한 Subnet말고 기본으로 생성된 Subnet 정보를 조회함
+	//@TODO - 나중에 vNic 등의 핸들러가 없어지고 Subnet 정보가 필요한 곳에서 명시적으로 모두 입력 받을 수 있다면 사용자가 입력한 값으로 변경 가능
+	vNetworkHandler := AwsVNetworkHandler{
+		//Region: vmHandler.Region,
+		Client: vmHandler.Client,
+	}
+	cblogger.Info(vNetworkHandler)
+
+	subnetInfo, errSubnetInfo := vNetworkHandler.GetVNetwork(GetCBDefaultSubnetName())
+	if errSubnetInfo != nil {
+		return irs.VMInfo{}, errSubnetInfo
+	}
+	subnetID := subnetInfo.Id
+
+	//=============================
+	// 보안그룹 처리 - NameId 기반
+	//=============================
+	cblogger.Info("NameId 기반으로 처리하기 위해 Name 기반의 보안그룹 배열을 Id 기반 보안그룹 배열로 조회및 변환함.")
+	var newSecurityGroupIds []string
+	securityHandler := AwsSecurityHandler{
+		//Region: vmHandler.Region,
+		Client: vmHandler.Client,
+	}
+	cblogger.Info(securityHandler)
+
+	for _, sgName := range vmReqInfo.SecurityGroupIds {
+		cblogger.Infof("보안그룹 조회 : [%s]", sgName)
+		sgInfo, errSgInfo := securityHandler.GetSecurity(sgName)
+		if errSgInfo != nil {
+			return irs.VMInfo{}, errSgInfo
+		}
+		cblogger.Infof("보안그룹 변환 : [%s] ==> [%s]", sgName, sgInfo.Id)
+		newSecurityGroupIds = append(newSecurityGroupIds, sgInfo.Id)
+	}
+
+	cblogger.Info("보안그룹 변환 완료")
+	cblogger.Info(newSecurityGroupIds)
+
+	//=============================
+	// PublicIp 처리 - NameId 기반
+	//=============================
+	cblogger.Info("NameId 기반으로 처리하기 위해 PublicIp 정보를 조회함.")
+	publicIPHandler := AwsPublicIPHandler{
+		//Region: vmHandler.Region,
+		Client: vmHandler.Client,
+	}
+	cblogger.Info(publicIPHandler)
+
+	publicIPInfo, errPublicIPInfo := publicIPHandler.GetPublicIP(vmReqInfo.PublicIPId)
+	cblogger.Info(publicIPInfo)
+	if errPublicIPInfo != nil {
+		cblogger.Error(errPublicIPInfo)
+		return irs.VMInfo{}, errPublicIPInfo
+	}
+	publicIpId := publicIPInfo.Id
+	cblogger.Infof("PublicIP ID를 [%s]대신 [%s]로 사용합니다.", publicIPInfo.Id, publicIpId)
+
+	//=============================
+	// VM생성 처리
+	//=============================
 	cblogger.Info("Create EC2 Instance")
-
 	input := &ec2.RunInstancesInput{
 		ImageId:      aws.String(imageID),
 		InstanceType: aws.String(instanceType),
 		MinCount:     minCount,
 		MaxCount:     maxCount,
 		KeyName:      aws.String(keyName),
-
-		SecurityGroupIds: aws.StringSlice(vmReqInfo.SecurityGroupIds),
-
+		//SecurityGroupIds: aws.StringSlice(vmReqInfo.SecurityGroupIds),
+		SecurityGroupIds: aws.StringSlice(newSecurityGroupIds),
 		/*SecurityGroupIds: []*string{
-			aws.String(securityGroupID), // set a security group.
+			aws.String(securityGroupID), // "sg-0df1c209ea1915e4b" - 미지정시 보안 그룹명이 "default"인 보안 그룹이 사용 됨.
 		},*/
 
-		SubnetId: aws.String(subnetID), // set a subnet.
-
+		SubnetId: aws.String(subnetID), // "subnet-cf9ccf83" - 미지정시 기본 VPC의 기본 서브넷이 임의로 이용되며 PublicIP가 할당 됨.
 	}
 	cblogger.Info(input)
 
 	// Specify the details of the instance that you want to create.
 	runResult, err := vmHandler.Client.RunInstances(input)
+	cblogger.Info(runResult)
 	if err != nil {
 		cblogger.Errorf("EC2 인스턴스 생성 실패 : ", err)
 		return irs.VMInfo{}, err
@@ -107,6 +188,9 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		return irs.VMInfo{}, errors.New("AWS로부터 전달 받은 VM 정보가 없습니다.")
 	}
 
+	//=============================
+	// Name Tag 처리 - NameId 기반
+	//=============================
 	newVmId := *runResult.Instances[0].InstanceId
 	cblogger.Infof("[%s] VM이 생성되었습니다.", newVmId)
 	// Tag에 VM Name 설정
@@ -126,16 +210,16 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	}
 
 	//Public IP및 최신 정보 전달을 위해 부팅이 완료될 때까지 대기했다가 전달하는 것으로 변경 함.
-	cblogger.Info("Public IP 할당 및 최신 정보 획득을 위해 EC2가 Running 상태가 될때까지 대기")
+	cblogger.Info("Public IP 할당 및 VM의 최신 정보 획득을 위해 EC2가 Running 상태가 될때까지 대기")
 	WaitForRun(vmHandler.Client, newVmId)
 	cblogger.Info("EC2 Running 상태 완료 : ", runResult.Instances[0].State.Name)
 
 	//EC2에 EIP 할당 (펜딩 상태에서는 EIP 할당 불가)
-	cblogger.Infof("[%s] EC2에 [%s] IP 할당 시작", newVmId, vmReqInfo.PublicIPId)
-	assocRes, errIp := vmHandler.AssociatePublicIP(vmReqInfo.PublicIPId, newVmId)
+	cblogger.Infof("[%s] EC2에 [%s] IP 할당 시작", newVmId, publicIpId)
+	assocRes, errIp := vmHandler.AssociatePublicIP(publicIpId, newVmId)
 	if errIp != nil {
-		cblogger.Errorf("EC2[%s]에 Public IP Id[%s]를 할당 할 수 없습니다 - %v", newVmId, vmReqInfo.PublicIPId, err)
-		return irs.VMInfo{}, nil
+		cblogger.Errorf("EC2[%s]에 Public IP Id[%s]를 할당 할 수 없습니다 - %v", newVmId, publicIpId, err)
+		return irs.VMInfo{}, errIp
 	}
 
 	cblogger.Infof("[%s] EC2에 Public IP 할당 결과 : ", newVmId, assocRes)
@@ -148,13 +232,15 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		if errvNic != nil {
 			cblogger.Errorf("vNic [%s] 추가 실패!", vmReqInfo.NetworkInterfaceId)
 			cblogger.Error(errvNic)
+			return irs.VMInfo{}, errvNic
 		} else {
 			cblogger.Infof("vNic [%s] 추가 완료", vmReqInfo.NetworkInterfaceId)
 		}
 	}
 
 	//최신 정보 조회
-	vmInfo, _ := vmHandler.GetVM(newVmId)
+	//newVmInfo, _ := vmHandler.GetVM(newVmId)
+	newVmInfo, _ := vmHandler.GetVM(vmReqInfo.VMName)
 
 	/*
 		//빠른 생성을 위해 Running 상태를 대기하지 않고 최소한의 정보만 리턴 함.
@@ -172,7 +258,7 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		}
 	*/
 
-	return vmInfo, nil
+	return newVmInfo, nil
 }
 
 //VM이 Running 상태일때까지 대기 함.
@@ -191,8 +277,17 @@ func WaitForRun(svc *ec2.EC2, instanceID string) {
 	cblogger.Info("=========WaitForRun() 종료")
 }
 
-func (vmHandler *AwsVMHandler) ResumeVM(vmID string) (irs.VMStatus, error) {
+func (vmHandler *AwsVMHandler) ResumeVM(vmNameId string) (irs.VMStatus, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
+
+	vmInfo, errVmInfo := vmHandler.GetVM(vmNameId)
+	if errVmInfo != nil {
+		return irs.VMStatus("Failed"), errVmInfo
+	}
+	cblogger.Info(vmInfo)
+	vmID := vmInfo.Id
 	cblogger.Infof("vmID : [%s]", vmID)
+
 	input := &ec2.StartInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vmID),
@@ -225,14 +320,24 @@ func (vmHandler *AwsVMHandler) ResumeVM(vmID string) (irs.VMStatus, error) {
 	return irs.VMStatus("Resuming"), nil
 }
 
-func (vmHandler *AwsVMHandler) SuspendVM(vmID string) (irs.VMStatus, error) {
+func (vmHandler *AwsVMHandler) SuspendVM(vmNameId string) (irs.VMStatus, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
+
+	vmInfo, errVmInfo := vmHandler.GetVM(vmNameId)
+	if errVmInfo != nil {
+		return irs.VMStatus("Failed"), errVmInfo
+	}
+	cblogger.Info(vmInfo)
+	vmID := vmInfo.Id
 	cblogger.Infof("vmID : [%s]", vmID)
+
 	input := &ec2.StopInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vmID),
 		},
 		DryRun: aws.Bool(true),
 	}
+	cblogger.Info(input)
 	result, err := vmHandler.Client.StopInstances(input)
 	spew.Dump(result)
 	awsErr, ok := err.(awserr.Error)
@@ -254,8 +359,17 @@ func (vmHandler *AwsVMHandler) SuspendVM(vmID string) (irs.VMStatus, error) {
 	return irs.VMStatus("Suspending"), nil
 }
 
-func (vmHandler *AwsVMHandler) RebootVM(vmID string) (irs.VMStatus, error) {
+func (vmHandler *AwsVMHandler) RebootVM(vmNameId string) (irs.VMStatus, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
+
+	vmInfo, errVmInfo := vmHandler.GetVM(vmNameId)
+	if errVmInfo != nil {
+		return irs.VMStatus("Failed"), errVmInfo
+	}
+	cblogger.Info(vmInfo)
+	vmID := vmInfo.Id
 	cblogger.Infof("vmID : [%s]", vmID)
+
 	input := &ec2.RebootInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vmID),
@@ -293,8 +407,17 @@ func (vmHandler *AwsVMHandler) RebootVM(vmID string) (irs.VMStatus, error) {
 	return irs.VMStatus("Rebooting"), nil
 }
 
-func (vmHandler *AwsVMHandler) TerminateVM(vmID string) (irs.VMStatus, error) {
+func (vmHandler *AwsVMHandler) TerminateVM(vmNameId string) (irs.VMStatus, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
+
+	vmInfo, errVmInfo := vmHandler.GetVM(vmNameId)
+	if errVmInfo != nil {
+		return irs.VMStatus("Failed"), errVmInfo
+	}
+	cblogger.Info(vmInfo)
+	vmID := vmInfo.Id
 	cblogger.Infof("vmID : [%s]", vmID)
+
 	input := &ec2.TerminateInstancesInput{
 		//InstanceIds: instanceIds,
 		InstanceIds: []*string{
@@ -313,18 +436,28 @@ func (vmHandler *AwsVMHandler) TerminateVM(vmID string) (irs.VMStatus, error) {
 	return irs.VMStatus("Terminating"), nil
 }
 
-//- 보안그룹의 경우 멀티개 설정이 가능한데 현재는 1개만 입력 받음
-// @Todo : SecurityID에 보안그룹 Name을 할당하는게 맞는지 확인 필요
-func (vmHandler *AwsVMHandler) GetVM(vmID string) (irs.VMInfo, error) {
-	cblogger.Infof("vmID : [%s]", vmID)
-
+//2019-11-16부로 CB-Driver 전체 로직이 NameId 기반으로 변경됨.
+func (vmHandler *AwsVMHandler) GetVM(vmNameId string) (irs.VMInfo, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
 	input := &ec2.DescribeInstancesInput{
-		InstanceIds: []*string{
-			aws.String(vmID),
-		},
+		/*
+			InstanceIds: []*string{
+				aws.String(vmID),
+			},
+		*/
 	}
+	input.Filters = ([]*ec2.Filter{
+		&ec2.Filter{
+			Name: aws.String("tag:Name"),
+			Values: []*string{
+				aws.String(vmNameId),
+			},
+		},
+	})
+	cblogger.Info(input)
 
 	result, err := vmHandler.Client.DescribeInstances(input)
+	cblogger.Info(result)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
@@ -337,13 +470,15 @@ func (vmHandler *AwsVMHandler) GetVM(vmID string) (irs.VMInfo, error) {
 		}
 		return irs.VMInfo{}, err
 	}
+	//cblogger.Info(result)
+	cblogger.Infof("조회된 VM 정보 수 : [%d]", len(result.Reservations))
+	if len(result.Reservations) > 1 {
+		return irs.VMInfo{}, awserr.New("600", "1개 이상의 VM ["+vmNameId+"] 정보가 존재합니다.", nil)
+	} else if len(result.Reservations) == 0 {
+		cblogger.Errorf("VM [%s] 정보가 존재하지 않습니다.", vmNameId)
+		return irs.VMInfo{}, awserr.New("404", "VM ["+vmNameId+"] 정보가 존재하지 않습니다.", nil)
+	}
 
-	cblogger.Info("Success", result)
-
-	/*
-		- 보안그룹의 경우 멀티개 설정이 가능한데 현재는 1개만 입력 받음
-		- SecurityID에 보안그룹 Name을 할당하는게 맞는지 확인 필요
-	*/
 	vmInfo := irs.VMInfo{}
 	for _, i := range result.Reservations {
 		//vmInfo := ExtractDescribeInstances(result.Reservations[0])
@@ -474,6 +609,16 @@ func ExtractDescribeInstances(reservation *ec2.Reservation) irs.VMInfo {
 	return vmInfo
 }
 
+func ExtractVmName(Tags []*ec2.Tag) string {
+	for _, t := range Tags {
+		if *t.Key == "Name" {
+			cblogger.Info("  --> EC2 명칭 : ", *t.Key)
+			return *t.Value
+		}
+	}
+	return ""
+}
+
 func (vmHandler *AwsVMHandler) ListVM() ([]*irs.VMInfo, error) {
 	cblogger.Infof("Start")
 	var vmInfoList []*irs.VMInfo
@@ -500,10 +645,17 @@ func (vmHandler *AwsVMHandler) ListVM() ([]*irs.VMInfo, error) {
 
 	cblogger.Info("Success")
 
+	tmpVmName := ""
 	for _, i := range result.Reservations {
 		for _, vm := range i.Instances {
 			cblogger.Info("[%s] EC2 정보 조회", *vm.InstanceId)
-			vmInfo, _ := vmHandler.GetVM(*vm.InstanceId)
+			tmpVmName = ExtractVmName(vm.Tags)
+			if tmpVmName == "" {
+				cblogger.Errorf("VM Id[%s]에 해당하는 VM 이름을 찾을 수 없습니다!!!", *vm.InstanceId)
+				continue
+			}
+			vmInfo, _ := vmHandler.GetVM(tmpVmName)
+			//vmInfo, _ := vmHandler.GetVM(*vm.InstanceId)
 			vmInfoList = append(vmInfoList, &vmInfo)
 		}
 	}
@@ -542,7 +694,15 @@ func ConvertVMStatusString(vmStatus string) (irs.VMStatus, error) {
 }
 
 //SHUTTING-DOWN / TERMINATED
-func (vmHandler *AwsVMHandler) GetVMStatus(vmID string) (irs.VMStatus, error) {
+func (vmHandler *AwsVMHandler) GetVMStatus(vmNameId string) (irs.VMStatus, error) {
+	cblogger.Infof("vmNameId : [%s]", vmNameId)
+
+	vmInfo, errVmInfo := vmHandler.GetVM(vmNameId)
+	if errVmInfo != nil {
+		return irs.VMStatus("Failed"), errVmInfo
+	}
+	cblogger.Info(vmInfo)
+	vmID := vmInfo.Id
 	cblogger.Infof("vmID : [%s]", vmID)
 
 	//vmStatus := "pending"
@@ -608,14 +768,22 @@ func (vmHandler *AwsVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 
 	cblogger.Info("Success")
 
+	tmpVmName := ""
 	for _, i := range result.Reservations {
 		for _, vm := range i.Instances {
 			//*vm.State.Name
 			//*vm.InstanceId
 
 			vmStatus, _ := ConvertVMStatusString(*vm.State.Name)
+			tmpVmName = ExtractVmName(vm.Tags)
+			if tmpVmName == "" {
+				cblogger.Errorf("VM Id[%s]에 해당하는 VM 이름을 찾을 수 없습니다!!!", *vm.InstanceId)
+				continue
+			}
+
 			vmStatusInfo := irs.VMStatusInfo{
-				VmId: *vm.InstanceId,
+				VmId:   *vm.InstanceId,
+				VmName: tmpVmName,
 				//VmStatus: vmHandler.GetVMStatus(*vm.InstanceId),
 				//VmStatus: irs.VMStatus(strings.ToUpper(*vm.State.Name)),
 				VmStatus: vmStatus,

--- a/cloud-control-manager/cloud-driver/interfaces/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/PublicIPHandler.go
@@ -17,6 +17,7 @@ type PublicIPReqInfo struct {
 
 type PublicIPInfo struct {
 	Name      string // AWS : Name Tag대신 AllocationId를 리턴 함.(편의를 위해 Name 정보는 KeyValueList에 전달 함.), OpenStack : 381a10f8-5831-4822-8388-922673addde4(ID), Cloudit : 182.252.135.44(IP)
+	Id        string // AWS : Name에는 NameId가 설정되기 때문에 삭제를 위해 Id 필드 추가
 	PublicIP  string
 	OwnedVMID string
 	Status    string


### PR DESCRIPTION
VNetworkHandler
- CreateVNetwork() : Name 기반 적용 완료 - "CB-VNet-Subnet" 고정이름 사용 / 중복 생성 체크
- DeleteVNetwork() : Name 기반 적용 완료 - "CB-VNet-Subnet" 고정이름 사용
- GetVNetwork() : Name 기반 적용 완료 - "CB-VNet-Subnet" 고정이름 사용
- ListVNetwork() : Name 기반 적용 완료 / "CB-VNet-Subnet" 검색후 리턴

KeyPairHandler : Name 기반으로 동작

PublicIPHandler
- CreatePublicIP() : Name 기반 적용 완료 / 중복 생성 체크
- DeletePublicIP() : Name 기반 적용 완료
- GetPublicIP() : Name 기반 적용 완료 / ** 다중 Result 체크 안 함. - 가장 마지막 결과 리턴 **
  --> 공통 I/F의 PublicIPInfo 구조체에 Id string 필드 추가
- ListPublicIP() : Name 기반 적용 완료 / Name Tag없는 PublicIP는 목록에서 제외

SecurityHandler
- CreateSecurity() : Name 기반 적용 완료 / 보안그룹명 기반으로 동작
- DeleteSecurity() : Name 기반 적용 완료 / 보안그룹명 기반으로 동작
- GetSecurity() : Name 기반 적용 완료  / 보안그룹명 기반으로 동작
- ListSecurity() : Name 기반 적용 완료 / 보안그룹명 기반으로 동작

VMHandler
- GetVM() : Name 기반 적용 / Not Found 처리 / 중복 Name 에러 처리
- GetVMStatus() : Name 기반 적용 / 중복 Name 에러 처리
- ListVM() : Name 기반 적용 / Name기반으로 변경되면서 Name Tag가 없는 VM정보는 목록에서 제외함.
- ListVMStatus() : Name 기반 적용 / Name기반으로 변경되면서 Name Tag가 없는 VM정보는 목록에서 제외함.
- RebootVM() : Name 기반 적용 / 중복 Name 에러 처리
- ResumeVM() : Name 기반 적용 / 중복 Name 에러 처리
- StartVM() : Name 기반 적용 / 중복 Name 에러 처리
- SuspendVM() : Name 기반 적용 / 중복 Name 에러 처리
- TerminateVM() : Name 기반 적용 / 중복 Name 에러 처리

VNicHandler : NameId 적용 안 함.

**[이슈]**
필수 필드가 아닌 Name Tag를 Key 기반으로 구현하면서 결정해야할 사항들
- CSP의 콘솔 사용 시 Name Tag는 필수가 아닌 선택 사항이기 때문에 Name Tag가 없거나 중복되는 경우가 존재함.
  -- 목록 조회 시 Name Tag가 없는 Object(예:VM)의 정보를 버려야 할지 에러로 처리하고 중단해야 할지 결정 필요
  -- Object(예:VM) 생성 시 기존에 사용된 Name Tag가 존재하면 중복 방지를 위해 생성 불가
     ---> [참고] VM 삭제 시 실시간으로 삭제되지 않기 때문에 Terminated 상태가 완전히 사라지기전까지는 생성 불가
  -- CSP의 콘솔을 통해 생성된 Object 중 동일한 이름의 Name Tag가 2개 이상 존재할 경우 CB에서는 조회하지 않고 에러 처리함.
     ---> VMHandler에만 2개 이상의 Name에 대한 체크가 적용되어 있음.