### PR TITLE
Azure, OpenStack, Cloudit 드라이버 NameId 기반 쉘 스크립트 테스트 적용

### DIFF
--- a/api-runtime/rest-runtime/test/azure/image/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/image/get-test.sh
@@ -1,3 +1,7 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vmimage/Canonical:UbuntuServer:18.04-LTS:latest?connection_name=azure-config01
+# Azure에서 제공하는 마켓플레이스 퍼블릭 이미지의 경우 URN 형태의 ID 제공 (Publisher:Offer:SKU:Version)
+# URN 형태의 Image ID를 기준으로 이미지 정보 조회
+
+IMAGE_ID=Canonical:UbuntuServer:18.04-LTS:latest
+curl -X GET http://$RESTSERVER:1024/vmimage/$IMAGE_ID?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/keypair/create-test.sh
+++ b/api-runtime/rest-runtime/test/azure/keypair/create-test.sh
@@ -1,3 +1,6 @@
 RESTSERVER=localhost
 
+# Azure에서 별도로 KeyPair 기능을 제공하지 않기 때문에 내부적으로 keypair 생성 후 해당 keypair 반환
+# CB-KeyPair 이름으로 키페어 생성 및 반환 처리
+
 curl -X POST http://$RESTSERVER:1024/keypair?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-KeyPair" }' |json_pp

--- a/api-runtime/rest-runtime/test/azure/keypair/delete-test.sh
+++ b/api-runtime/rest-runtime/test/azure/keypair/delete-test.sh
@@ -1,3 +1,4 @@
 RESTSERVER=localhost
 
-curl -X DELETE http://$RESTSERVER:1024/keypair/CB-KeyPair?connection_name=azure-config01 |json_pp
+KEY_NAME=CB-KeyPair
+curl -X DELETE http://$RESTSERVER:1024/keypair/$KEY_NAME?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/keypair/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/keypair/get-test.sh
@@ -1,3 +1,4 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/keypair/CB-KeyPair?connection_name=azure-config01 |json_pp
+KEY_NAME=CB-KeyPair
+curl -X GET http://$RESTSERVER:1024/keypair/$KEY_NAME?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/keypair/list-test.sh
+++ b/api-runtime/rest-runtime/test/azure/keypair/list-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/keypair?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/keypair?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/publicip/create-test.sh
+++ b/api-runtime/rest-runtime/test/azure/publicip/create-test.sh
@@ -1,3 +1,5 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/publicip?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-PublicIP" }'
+# CB-PublicIP 이름으로 퍼블릭 IP 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/publicip?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-PublicIP" }' |json_pp

--- a/api-runtime/rest-runtime/test/azure/publicip/delete-test.sh
+++ b/api-runtime/rest-runtime/test/azure/publicip/delete-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X DELETE http://$RESTSERVER:1024/publicip/CB-PublicIP?connection_name=azure-config01
+PUBLICIP_NAME=CB-PublicIP
+curl -X DELETE http://$RESTSERVER:1024/publicip/$PUBLICIP_NAME?connection_name=azure-config01

--- a/api-runtime/rest-runtime/test/azure/publicip/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/publicip/get-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/publicip/CB-PublicIP?connection_name=azure-config01
+PUBLICIP_NAME=CB-PublicIP
+curl -X GET http://$RESTSERVER:1024/publicip/$PUBLICIP_NAME?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/publicip/list-test.sh
+++ b/api-runtime/rest-runtime/test/azure/publicip/list-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/publicip?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/publicip?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/security/create-test.sh
+++ b/api-runtime/rest-runtime/test/azure/security/create-test.sh
@@ -1,3 +1,11 @@
 RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-SecGroup", "SecurityRules": [{"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"}] }'
+# CB-SecGroup 이름으로 보안그룹 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{
+ "Name": "CB-SecGroup",
+ "SecurityRules": [
+    {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"},
+    {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "outbound"}
+    ]
+}' |json_pp

--- a/api-runtime/rest-runtime/test/azure/security/delete-test.sh
+++ b/api-runtime/rest-runtime/test/azure/security/delete-test.sh
@@ -1,3 +1,4 @@
 RESTSERVER=node12
 
-curl -X DELETE http://$RESTSERVER:1024/securitygroup/CB-SecGroup?connection_name=azure-config01
+SECURITY_NAME=CB-SecGroup
+curl -X DELETE http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=azure-config01

--- a/api-runtime/rest-runtime/test/azure/security/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/security/get-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/securitygroup/CB-SecGroup?connection_name=azure-config01
+SECURITY_NAME=CB-SecGroup
+curl -X GET http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/security/list-test.sh
+++ b/api-runtime/rest-runtime/test/azure/security/list-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/securitygroup?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/vm/get-status-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/get-status-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vmstatus/CBVm?connection_name=azure-config01
+VM_NAME=CBVm
+curl -X GET http://$RESTSERVER:1024/vmstatus/$VM_NAME?connection_name=azure-config01

--- a/api-runtime/rest-runtime/test/azure/vm/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/get-test.sh
@@ -1,3 +1,4 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vm/CBVm?connection_name=azure-config01 |json_pp
+VM_NAME=CBVm
+curl -X GET http://$RESTSERVER:1024/vm/$VM_NAME?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/vm/list-status-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/list-status-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vmstatus?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/vmstatus?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/vm/list-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/list-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vm?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/vm?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/azure/vm/reboot-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/reboot-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET "http://$RESTSERVER:1024/controlvm/CBVm?connection_name=azure-config01&action=reboot"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=azure-config01&action=reboot"

--- a/api-runtime/rest-runtime/test/azure/vm/resume-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/resume-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET "http://$RESTSERVER:1024/controlvm/CBVm?connection_name=azure-config01&action=resume"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=azure-config01&action=resume"

--- a/api-runtime/rest-runtime/test/azure/vm/start-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/start-test.sh
@@ -1,5 +1,8 @@
 RESTSERVER=localhost
 
+# CBVm 이름으로 VM 생성 및 반환 처리
+# VM 생성 후 VMUserId에 설정한 "cb-user" 사용자 계정으로 CB-Keypair를 사용해서 SSH 접속 가능
+
 curl -X POST http://$RESTSERVER:1024/vm?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{
     "VMName": "CBVm",
     "ImageId": "Canonical:UbuntuServer:18.04-LTS:18.04.201804262",

--- a/api-runtime/rest-runtime/test/azure/vm/suspend-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/suspend-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET "http://$RESTSERVER:1024/controlvm/CBVm?connection_name=azure-config01&action=suspend"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=azure-config01&action=suspend"

--- a/api-runtime/rest-runtime/test/azure/vm/terminate-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vm/terminate-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X DELETE "http://$RESTSERVER:1024/vm/CBVm?connection_name=azure-config01"
+VM_NAME=CBVm
+curl -X DELETE "http://$RESTSERVER:1024/vm/$VM_NAME?connection_name=azure-config01"

--- a/api-runtime/rest-runtime/test/azure/vnetwork/create-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vnetwork/create-test.sh
@@ -1,3 +1,5 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}'
+# CB-Subnet 이름으로 네트워크 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=azure-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}' |json_pp

--- a/api-runtime/rest-runtime/test/azure/vnetwork/delete-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vnetwork/delete-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X DELETE http://$RESTSERVER:1024/vnetwork/CB-Subnet?connection_name=azure-config01
+VNETWORK_NAME=CB-Subnet
+curl -X DELETE http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=azure-config01

--- a/api-runtime/rest-runtime/test/azure/vnetwork/get-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vnetwork/get-test.sh
@@ -1,3 +1,4 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vnetwork/CB-Subnet?connection_name=azure-config01
+VNETWORK_NAME=CB-Subnet
+curl -X GET http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=azure-config01  |json_pp

--- a/api-runtime/rest-runtime/test/azure/vnetwork/list-test.sh
+++ b/api-runtime/rest-runtime/test/azure/vnetwork/list-test.sh
@@ -1,3 +1,3 @@
-RESTSERVER=node12
+RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vnetwork?connection_name=azure-config01
+curl -X GET http://$RESTSERVER:1024/vnetwork?connection_name=azure-config01 |json_pp

--- a/api-runtime/rest-runtime/test/cloudit/security/create-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/security/create-test.sh
@@ -1,3 +1,11 @@
 RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=cloudit-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-SecGroup", "SecurityRules": [{"FromPort": "22", "ToPort" : "22", "IPProtocol" : "tcp", "Direction" : "inbound"}] }' |json_pp &
+# CB-SecGroup 이름으로 보안그룹 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=cloudit-config01 -H 'Content-Type: application/json' -d '{
+"Name": "CB-SecGroup",
+ "SecurityRules": [
+    {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"},
+    {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "outbound"}
+    ]
+}' |json_pp

--- a/api-runtime/rest-runtime/test/cloudit/security/delete-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/security/delete-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-SECURITY_ID=6a3bcb31-c172-43ba-a7d0-4ae17dcf74bd
-curl -X DELETE http://$RESTSERVER:1024/securitygroup/$SECURITY_ID?connection_name=cloudit-config01 | json_pp &
+SECURITY_NAME=CB-SecGroup
+curl -X DELETE http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=cloudit-config01 | json_pp

--- a/api-runtime/rest-runtime/test/cloudit/security/get-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/security/get-test.sh
@@ -1,5 +1,4 @@
 RESTSERVER=localhost
 
 SECURITY_NAME=CB-SecGroup
-#curl -X GET http://$RESTSERVER:1024/securitygroup/$SECURITY_ID?connection_name=cloudit-config01 | json_pp
 curl -X GET http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=cloudit-config01 | json_pp

--- a/api-runtime/rest-runtime/test/cloudit/vm/get-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/vm/get-test.sh
@@ -1,5 +1,4 @@
 RESTSERVER=localhost
 
 VM_NAME=CBVm
-#curl -X GET http://$RESTSERVER:1024/vm/$VM_ID?connection_name=cloudit-config01 | json_pp
 curl -X GET http://$RESTSERVER:1024/vm/$VM_NAME?connection_name=cloudit-config01 | json_pp

--- a/api-runtime/rest-runtime/test/cloudit/vnetwork/create-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/vnetwork/create-test.sh
@@ -1,3 +1,5 @@
 RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=cloudit-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}'
+# CB-Subnet 이름으로 네트워크 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=cloudit-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}' |json_pp

--- a/api-runtime/rest-runtime/test/cloudit/vnetwork/delete-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/vnetwork/delete-test.sh
@@ -3,5 +3,5 @@ RESTSERVER=localhost
 # [참고]
 # Cloudit에서 서브넷 조회 시 서브넷 CIDR를 기준으로 조회
 
-VNETWORK_ID=10.0.12.0
-curl -X DELETE http://$RESTSERVER:1024/vnetwork/$VNETWORK_ID?connection_name=cloudit-config01
+VNETWORK_NAME=CB-Subnet
+curl -X DELETE http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=cloudit-config01

--- a/api-runtime/rest-runtime/test/cloudit/vnetwork/get-test.sh
+++ b/api-runtime/rest-runtime/test/cloudit/vnetwork/get-test.sh
@@ -4,5 +4,4 @@ RESTSERVER=localhost
 # Cloudit에서 서브넷 조회 시 서브넷 CIDR를 기준으로 조회
 
 VNETWORK_NAME=CB-Subnet
-#curl -X GET http://$RESTSERVER:1024/vnetwork/$VNETWORK_ID?connection_name=cloudit-config01 | json_pp
 curl -X GET http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=cloudit-config01 | json_pp

--- a/api-runtime/rest-runtime/test/openstack/image/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/image/get-test.sh
@@ -1,4 +1,7 @@
 RESTSERVER=localhost
 
+# OpenStack의 경우 사용자가 등록한 이미지 정보를 조회
+# ubuntu16.04 이름을 기준으로 이미지 정보 조회
+
 IMAGE_ID=ubuntu16.04
 curl -X GET http://$RESTSERVER:1024/vmimage/$IMAGE_ID?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/keyPair/create-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/keyPair/create-test.sh
@@ -1,3 +1,5 @@
 RESTSERVER=localhost
 
-curl -X POST http://$RESTSERVER:1024/keypair?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-Keypair" }'
+# CB-KeyPair 이름으로 키페어 생성 및 반환 처리
+
+curl -X POST http://$RESTSERVER:1024/keypair?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{ "Name": "CB-Keypair" }' |json_pp

--- a/api-runtime/rest-runtime/test/openstack/keyPair/delete-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/keyPair/delete-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-KEYPAIR_ID=CB-Keypair
-curl -X DELETE http://$RESTSERVER:1024/keypair/$KEYPAIR_ID?connection_name=openstack-config01
+KEY_NAME=CB-KeyPair
+curl -X DELETE http://$RESTSERVER:1024/keypair/$KEY_NAME?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/keyPair/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/keyPair/get-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-KEYPAIR_ID=CB-Keypair
-curl -X GET http://$RESTSERVER:1024/keypair/$KEYPAIR_ID?connection_name=openstack-config01 |json_pp
+KEY_NAME=CB-KeyPair
+curl -X GET http://$RESTSERVER:1024/keypair/$KEY_NAME?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/keyPair/list-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/keyPair/list-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/keypair?connection_name=openstack-config01
+curl -X GET http://$RESTSERVER:1024/keypair?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/security/create-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/security/create-test.sh
@@ -1,12 +1,11 @@
 RESTSERVER=localhost
 
+# CB-SecGroup 이름으로 보안그룹 생성 및 반환 처리
+
 curl -X POST http://$RESTSERVER:1024/securitygroup?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{
-    "Name": "CB-SecGroup",
-    "SecurityRules": [
-        {
-            "FromPort": "22",
-            "ToPort" : "22",
-            "IPProtocol" : "tcp",
-            "Direction" : "inbound"
-        }
-    ]}'
+ "Name": "CB-SecGroup",
+ "SecurityRules": [
+    {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"},
+    {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "outbound"}
+    ]
+}' |json_pp

--- a/api-runtime/rest-runtime/test/openstack/security/delete-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/security/delete-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-SECURITYGROUP_ID=CB-SecGroup
-curl -X DELETE http://$RESTSERVER:1024/securitygroup/$SECURITYGROUP_ID?connection_name=openstack-config01
+SECURITY_NAME=CB-SecGroup
+curl -X DELETE http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=openstack-config01

--- a/api-runtime/rest-runtime/test/openstack/security/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/security/get-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-SECURITYGROUP_ID=CB-SecGroup
-curl -X GET http://$RESTSERVER:1024/securitygroup/$SECURITYGROUP_ID?connection_name=openstack-config01 |json_pp
+SECURITY_NAME=CB-SecGroup
+curl -X GET http://$RESTSERVER:1024/securitygroup/$SECURITY_NAME?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/security/list-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/security/list-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/securitygroup?connection_name=openstack-config01
+curl -X GET http://$RESTSERVER:1024/securitygroup?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/get-status-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/get-status-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X GET http://$RESTSERVER:1024/vmstatus/$VM_ID?connection_name=openstack-config01
+VM_NAME=CBVm
+curl -X GET http://$RESTSERVER:1024/vmstatus/$VM_NAME?connection_name=openstack-config01

--- a/api-runtime/rest-runtime/test/openstack/vm/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/get-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X GET http://$RESTSERVER:1024/vm/$VM_ID?connection_name=openstack-config01 |json_pp
+VM_NAME=CBVm
+curl -X GET http://$RESTSERVER:1024/vm/$VM_NAME?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/reboot-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/reboot-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=reboot"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=openstack-config01&action=reboot"

--- a/api-runtime/rest-runtime/test/openstack/vm/resume-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/resume-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=resume"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=openstack-config01&action=resume"

--- a/api-runtime/rest-runtime/test/openstack/vm/start-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/start-test.sh
@@ -16,4 +16,4 @@ curl -X POST http://$RESTSERVER:1024/vm?connection_name=openstack-config01 -H 'C
     ],
     "VMSpecId": "m1.small",
     "KeyPairName": "CB-KeyPair"
-}'
+}' |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vm/suspend-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/suspend-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_ID?connection_name=openstack-config01&action=suspend"
+VM_NAME=CBVm
+curl -X GET "http://$RESTSERVER:1024/controlvm/$VM_NAME?connection_name=openstack-config01&action=suspend"

--- a/api-runtime/rest-runtime/test/openstack/vm/terminate-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vm/terminate-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VM_ID=CBVm
-curl -X DELETE http://$RESTSERVER:1024/vm/$VM_ID?connection_name=openstack-config01
+VM_NAME=CBVm
+curl -X DELETE http://$RESTSERVER:1024/vm/$VM_NAME?connection_name=openstack-config01

--- a/api-runtime/rest-runtime/test/openstack/vnetwork/create-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vnetwork/create-test.sh
@@ -1,7 +1,7 @@
 RESTSERVER=localhost
 
-# [참고]
 # 기본 네트워크인 CB-VNet 하위에 서브넷 생성
 # 서브넷 생성 시 자동으로 인터넷 게이트웨이 라우터 및 라우터 인터페이스 생성
+# CB-Subnet 이름으로 네트워크 생성 및 반환 처리
 
-curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}'
+curl -X POST http://$RESTSERVER:1024/vnetwork?connection_name=openstack-config01 -H 'Content-Type: application/json' -d '{"Name":"CB-Subnet"}' |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vnetwork/delete-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vnetwork/delete-test.sh
@@ -4,5 +4,5 @@ RESTSERVER=localhost
 # 기본 네트워크인 CB-VNet 하위에 서브넷 생성
 # 서브넷 삭제 시 자동으로 라우터 인터페이스 삭제
 
-VNETWORK_ID=CB-Subnet
-curl -X DELETE http://$RESTSERVER:1024/vnetwork/$VNETWORK_ID?connection_name=openstack-config01
+VNETWORK_NAME=CB-Subnet
+curl -X DELETE http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=openstack-config01

--- a/api-runtime/rest-runtime/test/openstack/vnetwork/get-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vnetwork/get-test.sh
@@ -1,4 +1,4 @@
 RESTSERVER=localhost
 
-VNETWORK_ID=CB-Subnet
-curl -X GET http://$RESTSERVER:1024/vnetwork/$VNETWORK_ID?connection_name=openstack-config01 |json_pp
+VNETWORK_NAME=CB-Subnet
+curl -X GET http://$RESTSERVER:1024/vnetwork/$VNETWORK_NAME?connection_name=openstack-config01 |json_pp

--- a/api-runtime/rest-runtime/test/openstack/vnetwork/list-test.sh
+++ b/api-runtime/rest-runtime/test/openstack/vnetwork/list-test.sh
@@ -1,3 +1,3 @@
 RESTSERVER=localhost
 
-curl -X GET http://$RESTSERVER:1024/vnetwork?connection_name=openstack-config01
+curl -X GET http://$RESTSERVER:1024/vnetwork?connection_name=openstack-config01 |json_pp

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -270,6 +270,8 @@ func (vmHandler *ClouditVMHandler) TerminateVM(vmNameID string) (irs.VMStatus, e
 		if ok, err := vmHandler.DisassociatePublicIP(reqOpts); !ok {
 			return irs.Failed, err
 		}
+
+		time.Sleep(5 * time.Second)
 	}
 
 	if err := server.Terminate(vmHandler.Client, vmInfo.Id, &requestOpts); err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -46,7 +46,7 @@ func (cloudConn *OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandle
 
 func (cloudConn OpenStackCloudConnection) CreateSecurityHandler() (irs.SecurityHandler, error) {
 	cblogger.Info("OpenStack Cloud Driver: called CreateSecurityHandler()!")
-	securityHandler := osrs.OpenStackSecurityHandler{cloudConn.Client}
+	securityHandler := osrs.OpenStackSecurityHandler{cloudConn.Client, cloudConn.NetworkClient}
 	return &securityHandler, nil
 }
 func (cloudConn *OpenStackCloudConnection) CreateKeyPairHandler() (irs.KeyPairHandler, error) {


### PR DESCRIPTION

- Azure 드라이버 NameId 기반 쉘 스크립트 적용
-- image
-- keypair
-- publicIp
-- security
-- vm
-- vnet

- OpenStack 드라이버 NameId 기반 쉘 스크립트 적용
-- image
-- keypair
-- publicIp (X, 내부 생성 및 내부 삭제 처리)
-- security
-- vm
-- vnet

- Cloudit 드라이버 NameId 기반 쉘 스크립트 적용
-- image
-- keypair (X, 해당 서비스 미제공으로 root 패스워드 기준 로그인)
-- publicIp (X, 내부 생성 및 내부 삭제 처리)
-- security
-- vm
-- vnet
