### PR TITLE
NameId 기반의 로직에서 SystemId 기반으로 로직 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
@@ -101,6 +101,7 @@ func ExtractImageDescribeInfo(image *ec2.Image) irs.ImageInfo {
 	}
 
 	keyValueList := []irs.KeyValue{
+		{Key: "Name", Value: *image.Name},
 		{Key: "CreationDate", Value: *image.CreationDate},
 		{Key: "Architecture", Value: *image.Architecture},
 		{Key: "OwnerId", Value: *image.OwnerId},

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/KeyPairHandler.go
@@ -98,10 +98,10 @@ func (keyPairHandler *AwsKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 //혼선을 피하기 위해 keyPairID 대신 keyName으로 변경 함.
 func (keyPairHandler *AwsKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPairInfo, error) {
 	//keyPairID := keyName
-	cblogger.Infof("keyName : [%s]", keyIID.NameId)
+	cblogger.Infof("keyName : [%s]", keyIID.SystemId)
 	input := &ec2.DescribeKeyPairsInput{
 		KeyNames: []*string{
-			aws.String(keyIID.NameId),
+			aws.String(keyIID.SystemId),
 		},
 	}
 
@@ -155,7 +155,7 @@ func ExtractKeyPairDescribeInfo(keyPair *ec2.KeyPairInfo) irs.KeyPairInfo {
 }
 
 func (keyPairHandler *AwsKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error) {
-	cblogger.Infof("삭제 요청된 키페어 : [%s]", keyIID.NameId)
+	cblogger.Infof("삭제 요청된 키페어 : [%s]", keyIID.SystemId)
 
 	_, errGet := keyPairHandler.GetKey(keyIID)
 	if errGet != nil {
@@ -164,20 +164,20 @@ func (keyPairHandler *AwsKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error)
 
 	// Delete the key pair by name
 	result, err := keyPairHandler.Client.DeleteKeyPair(&ec2.DeleteKeyPairInput{
-		KeyName: aws.String(keyIID.NameId),
+		KeyName: aws.String(keyIID.SystemId),
 	})
 
 	spew.Dump(result)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "InvalidKeyPair.Duplicate" {
-			cblogger.Error("Key pair %q does not exist.", keyIID.NameId)
+			cblogger.Error("Key pair %q does not exist.", keyIID.SystemId)
 			return false, err
 		}
-		cblogger.Errorf("Unable to delete key pair: %s, %v.", keyIID.NameId, err)
+		cblogger.Errorf("Unable to delete key pair: %s, %v.", keyIID.SystemId, err)
 		return false, err
 	}
 
-	cblogger.Infof("Successfully deleted %q key pair\n", keyIID.NameId)
+	cblogger.Infof("Successfully deleted %q key pair\n", keyIID.SystemId)
 
 	return true, nil
 }


### PR DESCRIPTION
CommonAwsFunc.go
Default CB VPC(“CB-VNet”) & Default CB Subnet (“CB-VNet-Subnet”)
→ VPC와 Subnet은 1개만 허용하고 내부에서 자동으로 처리되기 때문에 NameId 기반으로 구현됨.

ImageHandler.go
GetImage() : SystemId 기반으로 조회
Image Name을 Return 정보의 NameId에 셋팅 함.

KeyPairHandler.go
KeyName을 사용하지만 IID에서 SystemId의 값을 이용하도록 수정.
ListKey() : KeyName을 사용하기 때문에 NameId & SystemId모두 동일한 값 리턴
Return : irs.IID{*keyPair.KeyName, *keyPair.KeyName}
CreateKey() : NameId로 생성
Return : IID.NameId에는 전달 받은 NameId를 IID.SystemId에는 생성된 KeyName 할당
GetKey() : keyIID.SystemId로 조회
DeleteKey() : keyIID.SystemId로 삭제

SecurityHandler.go
CreateSecurity()
→ 내부에서 자동으로 Default CB VPC(“CB-VNet”) ID를 찾아서 사용 함.
→ GroupName 필드에 securityReqInfo.IId.NameId 설정 함.
→ Name Tag에 securityReqInfo.IId.NameId 설정 함.
     Tag 실패시 에러 로그만 남기고 예외는 발생 시키지 않음.
ListSecurity()
→ 내부에서 자동으로 Default CB VPC(“CB-VNet”) ID를 찾아서 사용 함.
GetSecurity() : securityIID.SystemId로 조회
Return : Name Tag 값을 IId.NameId에 할당. IId.SystemId에 보안그룹 ID 할당
DeleteSecurity() : securityIID.SystemId로 삭제

VNetworkHandler.go
신규 방식으로 변경 예정

VMHandler.go
SuspendVM: SystemId 기반으로 변경 - vmIID.SystemId  사용
ResumeVM() : SystemId 기반으로 변경 - vmIID.SystemId  사용
GetVM() : SystemId 기반으로 변경 - vmIID.SystemId  사용
GetVMStatus() : SystemId 기반으로 변경 - vmIID.SystemId  사용
ListVMStatus() : Name이 없는 인스턴스도 포함하도록 변경
StartVM() : IID.SystemId 기반으로 변경
→ 동일한 Name을 사용하는 VM이 있는지 체크하는 로직 제거
→ SubnetId를 자동으로 찾지 않고 vmReqInfo.VirtualNetworkId.SystemId을 이용하도록 변경
→ 보안 그룹을 IID 기반 배열에서 SystemId 기반 배열로 변환
→ Name Tag 설정 실패 에러 무시