### PR TITLE
SubnetIID & VpcIID 추가 적용및 VpcHandler 기능제거

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -57,10 +57,11 @@ func handleSecurity() {
 	//result, err := handler.GetSecurity("sg-0fd2d90b269ebc082") // sgtest-mcloub-barista
 	//result, err := handler.DeleteSecurity(irs.IID{SystemId: securityId})
 	//result, err := handler.DeleteSecurity(irs.IID{SystemId: "sg-0101df0e8d4f27fec"})
-	//result, err := handler.ListSecurity()
+	result, err := handler.ListSecurity()
 
 	securityReqInfo := irs.SecurityReqInfo{
-		IId: irs.IID{NameId: "cb-sgtest-mcloud-barista"},
+		IId:    irs.IID{NameId: "cb-sgtest2-mcloud-barista"},
+		VpcIID: irs.IID{NameId: "CB-VNet", SystemId: "vpc-0c23cb9c0e68c735a"},
 		SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
 			{
 				FromPort:   "20",
@@ -104,7 +105,7 @@ func handleSecurity() {
 	}
 
 	cblogger.Info(securityReqInfo)
-	result, err := handler.CreateSecurity(securityReqInfo)
+	//result, err := handler.CreateSecurity(securityReqInfo)
 
 	if err != nil {
 		cblogger.Infof("보안 그룹 조회 실패 : ", err)
@@ -696,7 +697,7 @@ func handleVM() {
 				vmReqInfo := irs.VMReqInfo{
 					IId:               irs.IID{NameId: "mcloud-barista-iid-vm-test"},
 					ImageIID:          irs.IID{SystemId: "ami-047f7b46bd6dd5d84"},
-					VirtualNetworkId:  irs.IID{SystemId: "subnet-012957090a923c498"},
+					SubnetIID:         irs.IID{SystemId: "subnet-012957090a923c498"},
 					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-013868663c85586f9"}},
 					VMSpecName:        "t2.micro",
 					KeyPairIID:        irs.IID{SystemId: "CB-KeyPairTest123123"},
@@ -929,13 +930,13 @@ func main() {
 	//handleVNetwork() //VPC
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
-	//handleSecurity()
+	handleSecurity()
 	//handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
 	//handleVMSpec()
-	handleVPC()
+	//handleVPC()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -118,7 +118,9 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		}
 		subnetID := subnetInfo.IId.SystemId
 	*/
-	subnetID := vmReqInfo.VirtualNetworkId.SystemId
+
+	subnetID := vmReqInfo.SubnetIID.SystemId
+	//subnetID := vmReqInfo.VirtualNetworkId.SystemId
 
 	/*
 		//=============================
@@ -596,7 +598,7 @@ func (vmHandler *AwsVMHandler) ExtractDescribeInstances(reservation *ec2.Reserva
 	if !reflect.ValueOf(reservation.Instances[0].NetworkInterfaces).IsNil() {
 		if !reflect.ValueOf(reservation.Instances[0].NetworkInterfaces[0].VpcId).IsNil() {
 			//vmInfo.VirtualNetworkId = *reservation.Instances[0].NetworkInterfaces[0].VpcId
-			vmInfo.VirtualNetworkIId = irs.IID{"", *reservation.Instances[0].NetworkInterfaces[0].VpcId}
+			vmInfo.VpcIID = irs.IID{"", *reservation.Instances[0].NetworkInterfaces[0].VpcId}
 			keyValueList = append(keyValueList, irs.KeyValue{Key: "VpcId", Value: *reservation.Instances[0].NetworkInterfaces[0].VpcId})
 		}
 

--- a/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -12,10 +12,10 @@
 package resources
 
 type SecurityReqInfo struct {
-        IId     IID       // {NameId, SystemId}
+	IId IID // {NameId, SystemId}
 
-        vpcIID  IID       // {NameId, SystemId}
-	Direction     string  // @todo used??
+	VpcIID        IID    // {NameId, SystemId}
+	Direction     string // @todo used??
 	SecurityRules *[]SecurityRuleInfo
 }
 
@@ -27,9 +27,9 @@ type SecurityRuleInfo struct {
 }
 
 type SecurityInfo struct {
-        IId   IID       // {NameId, SystemId}
+	IId IID // {NameId, SystemId}
 
-        vpcIID  IID       // {NameId, SystemId}
+	VpcIID        IID    // {NameId, SystemId}
 	Direction     string // @todo userd??
 	SecurityRules *[]SecurityRuleInfo
 

--- a/cloud-control-manager/cloud-driver/interfaces/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/VMHandler.go
@@ -16,22 +16,22 @@ import (
 )
 
 type VMReqInfo struct {
-        IId   IID       // {NameId, SystemId}
+	IId IID // {NameId, SystemId}
 
-	ImageIID           IID
-	vpcIID   	   IID
-	subnetIID   	   IID
-	SecurityGroupIIDs  []IID
+	ImageIID          IID
+	VpcIID            IID
+	SubnetIID         IID
+	SecurityGroupIIDs []IID
 
-	VMSpecName   string
-	KeyPairIID   IID
+	VMSpecName string
+	KeyPairIID IID
 
 	VMUserId     string
 	VMUserPasswd string
 }
 
 type VMStatusInfo struct {
-        IId   IID       // {NameId, SystemId}
+	IId      IID // {NameId, SystemId}
 	VmStatus VMStatus
 }
 
@@ -50,7 +50,7 @@ const (
 
 	Terminating VMStatus = "Terminating" // from running, suspended to terminated
 	Terminated  VMStatus = "Terminated"
-	NotExist  VMStatus = "NotExist" // VM does not exist
+	NotExist    VMStatus = "NotExist" // VM does not exist
 
 	Failed VMStatus = "Failed"
 )
@@ -61,26 +61,26 @@ type RegionInfo struct {
 }
 
 type VMInfo struct {
-        IId   IID       // {NameId, SystemId}
+	IId       IID       // {NameId, SystemId}
 	StartTime time.Time // Timezone: based on cloud-barista server location.
 
 	Region            RegionInfo //  ex) {us-east1, us-east1-c} or {ap-northeast-2}
 	ImageIId          IID
-	VMSpecName        string   //  instance type or flavour, etc... ex) t2.micro or f1.micro
-	vpcIID   	   IID
-	subnetIID   	   IID  // AWS, ex) subnet-8c4a53e4 
+	VMSpecName        string //  instance type or flavour, etc... ex) t2.micro or f1.micro
+	VpcIID            IID
+	SubnetIID         IID   // AWS, ex) subnet-8c4a53e4
 	SecurityGroupIIds []IID // AWS, ex) sg-0b7452563e1121bb6
 
-	KeyPairIId   IID 
+	KeyPairIId IID
 
 	VMUserId     string // ex) user1
 	VMUserPasswd string
 
-	NetworkInterface   string // ex) eth0
-	PublicIP           string 
-	PublicDNS          string 
-	PrivateIP          string 
-	PrivateDNS         string 
+	NetworkInterface string // ex) eth0
+	PublicIP         string
+	PublicDNS        string
+	PrivateIP        string
+	PrivateDNS       string
 
 	VMBootDisk  string // ex) /dev/sda1
 	VMBlockDisk string // ex)


### PR DESCRIPTION
[공통 인터페이스]
- VMHandler : 외부에서 접근 가능하도록 subnetIID와 vpcIID의 첫 Field명을 대문자로 변경
- SecurityHandler : 외부에서 접근 가능하도록 vpcIID --> VpcIID로 수정

[VMHandler]
- Subnet&VpcIID 반영

[SecurityHandler]
- VpcIID 전달 받는 방식으로 로직 변경
- 목록의 경우 CB-VNet에서만 조회했었으나 전체 VPC 영역에서 조회되도록 수정

[VPCHandler]
- 구현된 기능 없음