### PR TITLE
알리 클라우드 VM핸들러 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -791,6 +791,8 @@ func handleVM() {
 					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-6we0rxnoai067qbkdkgw"}, {SystemId: "sg-6weeb9xaodr65g7bq10c"}},
 					VMSpecName:        "ecs.t5-lc2m1.nano",
 					KeyPairIID:        irs.IID{SystemId: "CB-KeyPairTest123123"},
+					//VMUserId:          "root", //root만 가능
+					VMUserPasswd: "Cbuser!@#", //대문자 소문자 모두 사용되어야 함. 그리고 숫자나 특수 기호 중 하나가 포함되어야 함.
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)


### PR DESCRIPTION
- VM 정보 조회
  -  NetworkInterface  / VMUserId  내용 추가
 --> NetworkInterface 항목에 할당된 인터페이스 Id 설정
-->  VMUserId 항목에는 root 설정

- VM Start(생성) 시 전달 받은 VMUserPasswd 필드 기능 적용
  --> 알리의 경우 VM 생성 시 계정을 추가하는 기능은 없고, root 사용자의 비밀번호를 설정하는 기능은 있기 때문에 VM 생성 시 VMUserPasswd  의 값이 존재할 경우 root 사용자의 비밀번호를 요청된 값으로 설정 하며 VM 리턴 정보에 VMUserId 에는 root를 VMUserPasswd 에는 사용자가 설정한 값을 리턴하도록 기능 추가 함.
비밀번호는 8-30자로서 대문자, 소문자, 숫자 및/또는 특수 문자가 포함되어야 합니다.