### PR TITLE
GCP 버그 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -341,7 +341,7 @@ func handleVPC() {
 	handler := ResourceHandler.(irs.VPCHandler)
 
 	vpcReqInfo := irs.VPCReqInfo{
-		IId: irs.IID{NameId: "cb-vpc2"},
+		IId: irs.IID{NameId: "cb-vpc"},
 		//IPv4_CIDR: "10.0.0.0/16",
 		SubnetInfoList: []irs.SubnetInfo{
 			{
@@ -855,11 +855,11 @@ func handleVM() {
 
 func main() {
 	cblogger.Info("GCP Resource Test")
-	handleVPC()
+	//handleVPC()
 	//handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
-	//handleSecurity()
+	handleSecurity()
 
 	//handleVM()
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -341,7 +341,7 @@ func handleVPC() {
 	handler := ResourceHandler.(irs.VPCHandler)
 
 	vpcReqInfo := irs.VPCReqInfo{
-		IId: irs.IID{NameId: "cb-vpc"},
+		IId: irs.IID{NameId: "cb-vpc2"},
 		//IPv4_CIDR: "10.0.0.0/16",
 		SubnetInfoList: []irs.SubnetInfo{
 			{
@@ -855,11 +855,11 @@ func handleVM() {
 
 func main() {
 	cblogger.Info("GCP Resource Test")
-	//handleVPC()
+	handleVPC()
 	//handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
 	//handleSecurity()
 
-	handleVM()
+	//handleVM()
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
@@ -173,8 +173,13 @@ func (securityHandler *GCPSecurityHandler) GetSecurity(securityIID irs.IID) (irs
 	vpcName := vpcArr[len(vpcArr)-1]
 	securityInfo := irs.SecurityInfo{
 		IId: irs.IID{
-			NameId:   security.Name,
-			SystemId: strconv.FormatUint(security.Id, 10),
+			NameId: security.Name,
+			//SystemId: strconv.FormatUint(security.Id, 10),
+			SystemId: security.Name,
+		},
+		VpcIID: irs.IID{
+			NameId:   vpcName,
+			SystemId: vpcName,
 		},
 
 		Direction: security.Direction,
@@ -182,7 +187,7 @@ func (securityHandler *GCPSecurityHandler) GetSecurity(securityIID irs.IID) (irs
 			{"Priority", strconv.FormatInt(security.Priority, 10)},
 			{"SourceRanges", security.SourceRanges[0]},
 			{"Allowed", security.Allowed[0].IPProtocol},
-			{"VpcName", vpcName},
+			{"Vpc", vpcName},
 		},
 		SecurityRules: &securityRules,
 	}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
@@ -269,18 +269,19 @@ func (vVPCHandler *GCPVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error) {
 func mappingSubnet(subnet *compute.Subnetwork) irs.SubnetInfo {
 	//str := subnet.SelfLink
 	str := strings.Split(subnet.SelfLink, "/")
-	vpcName := str[len(str)-1]
+	subnetName := str[len(str)-1]
 	regionStr := strings.Split(subnet.Region, "/")
 	region := regionStr[len(regionStr)-1]
 	subnetInfo := irs.SubnetInfo{
 		IId: irs.IID{
-			NameId:   subnet.Name,
-			SystemId: strconv.FormatUint(subnet.Id, 10),
+			NameId: subnet.Name,
+			//SystemId: strconv.FormatUint(subnet.Id, 10),
+			SystemId: subnet.Name,
 		},
 		IPv4_CIDR: subnet.IpCidrRange,
 		KeyValueList: []irs.KeyValue{
 			{"region", region},
-			{"vpc", vpcName},
+			{"subnet", subnetName},
 		},
 	}
 	return subnetInfo


### PR DESCRIPTION
GCP 버그 수정
VPC 리턴 정보 버그 수정
- Subnet의 SystemId의 값을 NameId로 통일
- Subnet의 KeyValue의 Key 값을 "vpc"에서 "subnet"으로 변경

보안그룹 리턴 정보 버그 수정
- SystemId의 값을 NameId로 통일
- VpcIID 정보 추가
- KeyValue의 "VpcName"을 "Vpc"로 변경
