### PR TITLE
GCP VM핸들러 & Image핸들러 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -768,8 +768,9 @@ func handleVM() {
 				vmReqInfo := irs.VMReqInfo{
 					IId: irs.IID{NameId: "mcloud-barista-vm-test"},
 					ImageIID: irs.IID{
-						SystemId: "ubuntu-minimal-1804-bionic-v20200415",
-						//SystemId: "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190204",
+						NameId: "Test",
+						//SystemId: "ubuntu-minimal-1804-bionic-v20200415",
+						SystemId: "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190204",
 
 						//NameId:   "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
 						//SystemId: "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024",

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -284,8 +284,11 @@ func handleImage() {
 	//imageReqInfo := irs2.ImageReqInfo{
 	imageReqInfo := irs.ImageReqInfo{
 		IId: irs.IID{
-			NameId:   "Test OS Image",
-			SystemId: "vmsg02-asia-northeast1-b",
+			//NameId: "Test OS Image",
+			//SystemId: "vmsg02-asia-northeast1-b",
+			//SystemId: "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
+			//SystemId: "2076268724445164462", //centos-7-v20190204
+			SystemId: "ubuntu-minimal-1804-bionic-v20200415",
 		},
 	}
 
@@ -765,8 +768,13 @@ func handleVM() {
 				vmReqInfo := irs.VMReqInfo{
 					IId: irs.IID{NameId: "mcloud-barista-vm-test"},
 					ImageIID: irs.IID{
-						NameId:   "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
-						SystemId: "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
+						SystemId: "ubuntu-minimal-1804-bionic-v20200415",
+						//SystemId: "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190204",
+
+						//NameId:   "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
+						//SystemId: "projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024",
+						//SystemId: "2076268724445164462",	//에러
+						//SystemId: "ubuntu-minimal-1804-bionic-v20191024",
 						//NameId:   "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
 						//SystemId: "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415",
 					},

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -407,7 +407,7 @@ func (imageHandler *GCPImageHandler) FindImageInfo(projectId string, reqImageNam
 }
 */
 
-//@TODO : 이미지 ID확인할 것
+//@TODO : 나중에 시스템아이디 값 변경해야 함.(현재 이미지 핸들러는 이름 기반으로 변경되어 있기 때문...)
 func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 	//lArr := strings.Split(imageInfo.Licenses[0], "/")
 	//os := lArr[len(lArr)-1]
@@ -417,12 +417,12 @@ func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 
 	imageList := irs.ImageInfo{
 		IId: irs.IID{
-			NameId:   imageInfo.Name,
-			SystemId: imageInfo.Name, //자체 기능 구현을 위해 Name 기반으로 리턴함.
+			NameId: imageInfo.Name,
+			//SystemId: imageInfo.Name, //자체 기능 구현을 위해 Name 기반으로 리턴함. - 2020-05-14 다음 버전에 적용 예정
+			SystemId: imageInfo.SelfLink, //2020-05-14 카푸치노는 VM 생성시 URL 방식을 사용하기 때문에 임의로 맞춤(이미지 핸들러의 다른 함수에는 적용 못함)
 			//SystemId: strconv.FormatUint(imageInfo.Id, 10), //이 값으로는 VM생성 안됨.
 
 			//SystemId: imageInfo.SourceImage, //imageInfo.SourceImage의 경우 공백("")인 경우가 있음
-			//SystemId: imageInfo.SelfLink,
 		},
 		//Id:      strconv.FormatUint(imageInfo.Id, 10),
 		//Id:      imageInfo.SelfLink,

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	cblog "github.com/cloud-barista/cb-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -60,6 +61,8 @@ func (imageHandler *GCPImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) 
 	return irs.ImageInfo{}, errors.New("Feature not implemented.")
 }
 
+/*
+//리스트의 경우 Name 기반으로 조회해서 처리하기에는 너무 느리기 때문에 직접 컨버팅함.
 func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 
 	//projectId := imageHandler.Credential.ProjectID
@@ -77,28 +80,169 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 		imageList = append(imageList, &info)
 	}
 
-	spew.Dump(imageList)
+	//spew.Dump(imageList)
+	return imageList, nil
+}
+*/
+
+//리스트의 경우 Name 기반으로 조회해서 처리하기에는 너무 느리기 때문에 직접 컨버팅함.
+func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
+	cblogger.Info("전체 이미지 조회")
+
+	//https://cloud.google.com/compute/docs/images?hl=ko
+	arrImageProjectList := []string{
+		"gce-uefi-images", // 보안 VM을 지원하는 이미지
+
+		//보안 VM을 지원하지 않는 이미지들
+		"centos-cloud",
+		"cos-cloud",
+		"coreos-cloud",
+		"debian-cloud",
+		"rhel-cloud",
+		"rhel-sap-cloud",
+		"suse-cloud",
+		"suse-sap-cloud",
+		"ubuntu-os-cloud",
+		"windows-cloud",
+		"windows-sql-cloud",
+	}
+
+	var imageList []*irs.ImageInfo
+
+	cnt := 0
+	nextPageToken := ""
+	var req *compute.ImagesListCall
+	var res *compute.ImageList
+	var err error
+	for _, projectId := range arrImageProjectList {
+		cblogger.Infof("[%s] 프로젝트 소유의 이미지 목록 처리", projectId)
+
+		//첫번째 호출
+		req = imageHandler.Client.Images.List(projectId)
+		res, err = req.Do()
+		if err != nil {
+			cblogger.Errorf("[%s] 프로젝트 소유의 이미지 목록 조회 실패!", projectId)
+			cblogger.Error(err)
+			return nil, err
+		}
+
+		nextPageToken = res.NextPageToken
+		cblogger.Info("NestPageToken : ", nextPageToken)
+
+		//현재 페이지부터 마지막 페이지까지 조회
+		for {
+			for _, item := range res.Items {
+				cnt++
+				info := mappingImageInfo(item)
+				imageList = append(imageList, &info)
+			} // for : 페이지 데이터 추출
+
+			//다음 페이지가 존재하면 호출
+			if nextPageToken != "" {
+				res, err = req.PageToken(nextPageToken).Do()
+				nextPageToken = res.NextPageToken
+				cblogger.Info("NestPageToken : ", nextPageToken)
+			} else {
+				break
+			}
+		} // for : 멀티 페이지 처리
+	}
+
+	//spew.Dump(imageList)
 	return imageList, nil
 }
 
-func (imageHandler *GCPImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, error) {
-	//projectId := imageHandler.Credential.ProjectID
-	projectId := "gce-uefi-images"
+//Name 기반으로 VM생성에 필요한 URL및 Image API 호출과 CB 리턴 정보 조회용
+type GcpImageInfo struct {
+	ImageUrl string //for CB(VM Start)
+	Name     string //for CB
+	GuestOS  string //for CB (Item.Family)
+	Status   string //for CB
 
-	image, err := imageHandler.Client.Images.Get(projectId, imageIID.SystemId).Do()
+	ProjectId string //for image api call
+	//Id        uint64 //for image api call
+	Id string
+
+	SourceType  string //for keyValue
+	SourceImage string //for keyValue
+	SelfLink    string //for keyValue
+	Family      string //for keyValue
+}
+
+//GCP 호출을 줄이기 위해 조회된 정보를 CB형태로 직접 변환해서 전달 함.
+func (imageHandler *GCPImageHandler) ConvertGcpImageInfoToCbImageInfo(imageInfo GcpImageInfo) irs.ImageInfo {
+	cblogger.Info(imageInfo)
+	spew.Dump(imageInfo)
+
+	cbImageInfo := irs.ImageInfo{
+		IId: irs.IID{
+			NameId:   imageInfo.Name,
+			SystemId: imageInfo.Name,
+		},
+		GuestOS: imageInfo.GuestOS,
+		Status:  imageInfo.Status,
+
+		KeyValueList: []irs.KeyValue{
+			{"Name", imageInfo.Name},
+			//{"Id", strconv.FormatUint(imageInfo.Id, 10)},
+			{"Id", imageInfo.Id},
+			{"ImageUrl", imageInfo.ImageUrl},
+			{"SourceImage", imageInfo.SourceImage}, // VM생성 시에는 SourceImage나 SelfLink 값을 이용해야 함.
+			{"SourceType", imageInfo.SourceType},
+			{"SelfLink", imageInfo.SelfLink},
+			{"Family", imageInfo.Family},
+			{"ProjectId", imageInfo.ProjectId},
+		},
+	}
+
+	return cbImageInfo
+}
+
+func (imageHandler *GCPImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, error) {
+	cblogger.Info(imageIID)
+
+	//이미지 명을 기반으로 이미지 정보를 조회함.
+	gcpImageInfo, err := imageHandler.FindImageInfo(imageIID.SystemId)
+	//return irs.ImageInfo{IId: irs.IID{SystemId: gcpImageInfo.Url}}, err
 	if err != nil {
 		cblogger.Error(err)
 		return irs.ImageInfo{}, err
 	}
-	imageInfo := mappingImageInfo(image)
-	return imageInfo, nil
+	cblogger.Info(gcpImageInfo)
+	//return irs.ImageInfo{}, nil
+	return imageHandler.ConvertGcpImageInfoToCbImageInfo(gcpImageInfo), nil
+
+	/*
+		//projectId := imageHandler.Credential.ProjectID
+		projectId := "gce-uefi-images"
+
+		image, err := imageHandler.Client.Images.Get(projectId, imageIID.SystemId).Do()
+		if err != nil {
+			cblogger.Error(err)
+			return irs.ImageInfo{}, err
+		}
+		imageInfo := mappingImageInfo(image)
+		return imageInfo, nil
+	*/
 }
 
+// public Image 는 지울 수 없는데 어떻게 해야 하는가?
 func (imageHandler *GCPImageHandler) DeleteImage(imageIID irs.IID) (bool, error) {
-	// public Image 는 지울 수 없는데 어떻게 해야 하는가?
-	projectId := imageHandler.Credential.ProjectID
 
-	res, err := imageHandler.Client.Images.Delete(projectId, imageIID.SystemId).Do()
+	//이미지 명을 기반으로 이미지 정보를 조회함.
+	gcpImageInfo, err := imageHandler.FindImageInfo(imageIID.SystemId)
+	//return irs.ImageInfo{IId: irs.IID{SystemId: gcpImageInfo.Url}}, err
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
+
+	//projectId := imageHandler.Credential.ProjectID
+	projectId := gcpImageInfo.ProjectId
+	imageId := gcpImageInfo.Id
+
+	//res, err := imageHandler.Client.Images.Delete(projectId, imageIID.SystemId).Do()
+	res, err := imageHandler.Client.Images.Delete(projectId, imageId).Do()
 	if err != nil {
 		cblogger.Error(err)
 		return false, err
@@ -107,14 +251,178 @@ func (imageHandler *GCPImageHandler) DeleteImage(imageIID irs.IID) (bool, error)
 	return true, err
 }
 
+//사용의 편의를 위해 이미지 이름을 전달 받아서 URL 링크로 리턴 함.
+//https://cloud.google.com/compute/docs/images?hl=ko
+//@TODO : 효율을 위해서 최소한 ProjectId 정보를 입력 받아야 하지만 현재는 이미지 명만 전달 받기 때문에 하나로 통합해 놓음.
+func (imageHandler *GCPImageHandler) FindImageInfo(reqImageName string) (GcpImageInfo, error) {
+	cblogger.Infof("[%s] 이미지 정보 찾기 ", reqImageName)
+
+	//https://cloud.google.com/compute/docs/images?hl=ko
+	arrImageProjectList := []string{
+		//"ubuntu-os-cloud",
+
+		"gce-uefi-images", // 보안 VM을 지원하는 이미지
+
+		//보안 VM을 지원하지 않는 이미지들
+		"centos-cloud",
+		"cos-cloud",
+		"coreos-cloud",
+		"debian-cloud",
+		"rhel-cloud",
+		"rhel-sap-cloud",
+		"suse-cloud",
+		"suse-sap-cloud",
+		"ubuntu-os-cloud",
+		"windows-cloud",
+		"windows-sql-cloud",
+	}
+
+	cnt := 0
+	curImageLink := ""
+	imageInfo := GcpImageInfo{}
+	nextPageToken := ""
+	var req *compute.ImagesListCall
+	var res *compute.ImageList
+	var err error
+	for _, projectId := range arrImageProjectList {
+		cblogger.Infof("[%s] 프로젝트 소유의 이미지 목록 조회 처리", projectId)
+
+		//첫번째 호출
+		req = imageHandler.Client.Images.List(projectId)
+		req.Filter("name=" + reqImageName)
+		res, err = req.Do()
+		if err != nil {
+			cblogger.Errorf("[%s] 프로젝트 소유의 이미지 목록 조회 실패!", projectId)
+			cblogger.Error(err)
+			return GcpImageInfo{}, err
+		}
+
+		nextPageToken = res.NextPageToken
+		cblogger.Info("NestPageToken : ", nextPageToken)
+
+		//현재 페이지부터 마지막 페이지까지 조회
+		for {
+			/*
+				//list, err := imageHandler.Client.Images.List(projectId).Do() // 1000 // 500
+				req := imageHandler.Client.Images.List(projectId)
+				ret, err := req.Do()
+				cblogger.Info("First -------------> ", ret.NextPageToken)
+				list, err := req.PageToken(ret.NextPageToken).Do()
+				cblogger.Info("Second -------------> ", list.NextPageToken)
+			*/
+
+			//데이터 찾기
+			for _, item := range res.Items {
+				cnt++
+
+				//curImageLink = imageInfo.SourceImage //보통은 SelfLink에 정보가 있는데 혹시 몰라서 SourceImage 정보와 함께 비교 함. // SourceImage는 Name과 동일할 때가 있음.
+				cblogger.Debugf(" SourceImage : [%s]", curImageLink)
+
+				//SourceImage 정보가 없으면 SelfLink 정보를 이용함.
+				//SelfLink: [Output Only] Server-defined URL for the resource.
+				//if curImageLink == "" {
+
+				arrLink := strings.Split(item.SelfLink, "/")
+				if len(arrLink) > 0 {
+					curImageLink = arrLink[len(arrLink)-1]
+				}
+				cblogger.Debugf("  [%d] : [%s] : [%s]", item.Id, item.SelfLink, curImageLink)
+				cblogger.Debug("")
+				//}
+
+				if strings.EqualFold(reqImageName, item.Name) || strings.EqualFold(reqImageName, curImageLink) {
+					//cblogger.Debug("=====************** 찾았다!!! *********======")
+					cblogger.Infof("=====************** [%d]번째에 찾았다!!! *********======", cnt)
+					if item.SelfLink == "" {
+						cblogger.Errorf("요청 받은 [%s] 이미지의 정보를 찾았지만 Image URL[SelfLink]정보가 없습니다.", reqImageName)
+						return GcpImageInfo{}, errors.New("Not Found : [" + reqImageName + "] Image information does not contain URL information.")
+					}
+					//imageInfo.Id = item.Id
+					imageInfo.Id = strconv.FormatUint(item.Id, 10)
+					imageInfo.ImageUrl = item.SelfLink //item.SourceImage에 URL이 아닌 item.Name이 나와서 SelfLink만 이용함.
+
+					imageInfo.GuestOS = item.Family
+					imageInfo.Status = item.Status
+
+					imageInfo.Name = item.Name
+					imageInfo.SourceImage = item.SourceImage
+					imageInfo.SourceType = item.SourceType
+					imageInfo.SelfLink = item.SelfLink
+					imageInfo.Family = item.Family
+					imageInfo.ProjectId = projectId
+
+					cblogger.Info("최종 이미지 정보")
+					spew.Dump(imageInfo)
+					return imageInfo, nil
+				}
+			} // for : 조회 결과에서 일치하는 데이터 찾기
+
+			//다음 페이지가 존재하면 호출
+			if nextPageToken != "" {
+				res, err = req.PageToken(nextPageToken).Do()
+				nextPageToken = res.NextPageToken
+				cblogger.Info("NestPageToken : ", nextPageToken)
+			} else {
+				break
+			}
+		} // for : 멀티 페이지 처리
+	}
+
+	cblogger.Errorf("요청 받은 [%s] 이미지에 대한 정보를 찾지 못 했습니다. - 총 이미지 체크 갯수 : [%d]", reqImageName, cnt)
+	return GcpImageInfo{}, errors.New("Not Found : [" + reqImageName + "] Image information not found")
+}
+
+/*
+//향후 필요하면 프로젝트Id를 입력 받도로 구현
+//이미지 설명 : https://cloud.google.com/compute/docs/images?hl=ko
+func (imageHandler *GCPImageHandler) FindImageInfo(projectId string, reqImageName string) (GcpImageInfo, error) {
+	cblogger.Infof("[%s] 프로젝트에서 [%s] 이미지 정보 찾기 ", projectId, reqImageName)
+
+	list, err := imageHandler.Client.Images.List(projectId).Do()
+	if err != nil {
+		cblogger.Error(err)
+		return GcpImageInfo{}, err
+	}
+
+	imageInfo := GcpImageInfo{}
+	curImageLink := ""
+	for _, item := range list.Items {
+		curImageLink = ""
+		arrLink := strings.Split(item.SelfLink, "/")
+		if len(arrLink) > 0 {
+			curImageLink = arrLink[len(arrLink)-1]
+		}
+		cblogger.Infof("  [%s] : [%s] : [%s]", item.Id, item.SelfLink, curImageLink)
+
+		if strings.EqualFold(reqImageName, item.Name) || strings.EqualFold(reqImageName, curImageLink) {
+			imageInfo.Id = item.Id
+			imageInfo.Url = curImageLink
+			return imageInfo, nil
+		}
+	}
+
+	cblogger.Errorf("요청 받은 [%s] 이미지에 대한 정보를 찾지 못 했습니다.", reqImageName)
+	return GcpImageInfo{}, errors.New("Not Found : [" + reqImageName + "] Image information not found")
+	//return GcpImageInfo{},nil
+}
+*/
+
+//@TODO : 이미지 ID확인할 것
 func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 	//lArr := strings.Split(imageInfo.Licenses[0], "/")
 	//os := lArr[len(lArr)-1]
 
+	//cblogger.Info("===================================")
+	//spew.Dump(imageInfo)
+
 	imageList := irs.ImageInfo{
 		IId: irs.IID{
 			NameId:   imageInfo.Name,
-			SystemId: strconv.FormatUint(imageInfo.Id, 10),
+			SystemId: imageInfo.Name, //자체 기능 구현을 위해 Name 기반으로 리턴함.
+			//SystemId: strconv.FormatUint(imageInfo.Id, 10), //이 값으로는 VM생성 안됨.
+
+			//SystemId: imageInfo.SourceImage, //imageInfo.SourceImage의 경우 공백("")인 경우가 있음
+			//SystemId: imageInfo.SelfLink,
 		},
 		//Id:      strconv.FormatUint(imageInfo.Id, 10),
 		//Id:      imageInfo.SelfLink,
@@ -122,9 +430,11 @@ func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 		GuestOS: imageInfo.Family,
 		Status:  imageInfo.Status,
 		KeyValueList: []irs.KeyValue{
+			{"Name", imageInfo.Name},
+			{"SourceImage", imageInfo.SourceImage}, // VM생성 시에는 SourceImage나 SelfLink 값을 이용해야 함.
 			{"SourceType", imageInfo.SourceType},
 			{"SelfLink", imageInfo.SelfLink},
-			{"GuestOsFeature", imageInfo.GuestOsFeatures[0].Type},
+			//{"GuestOsFeature", imageInfo.GuestOsFeatures[0].Type},	//Data가 없는 경우가 있어서 필요한 경우 체크해야 함.
 			{"Family", imageInfo.Family},
 			{"DiskSizeGb", strconv.FormatInt(imageInfo.DiskSizeGb, 10)},
 		},

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -50,11 +50,10 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	// email을 어디다가 넣지? 이것또한 문제넹
 	clientEmail := vmHandler.Credential.ClientEmail
 
+	/* // 2020-05-15 Name 기반 로직을 임의로 막아 놓음 - 다음 버전에 적용 예정. 현재는 URL 방식
 	//이미지 URL처리
 	cblogger.Infof("[%s] Image Name에 해당하는 Image Url 정보를 조회합니다.", vmReqInfo.ImageIID.SystemId)
 	imageHandler := GCPImageHandler{Credential: vmHandler.Credential, Region: vmHandler.Region, Client: vmHandler.Client}
-
-	//VPCHandler := AwsVPCHandler{Client: securityHandler.Client}
 
 	imageInfo, errImage := imageHandler.FindImageInfo(vmReqInfo.ImageIID.SystemId)
 	if errImage != nil {
@@ -63,6 +62,7 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 
 	cblogger.Infof("ImageName: [%s] ---> ImageUrl : [%s]", vmReqInfo.ImageIID.SystemId, imageInfo.ImageUrl)
 	imageURL = imageInfo.ImageUrl
+	*/
 
 	//PublicIP처리
 	// var publicIPAddress string
@@ -605,6 +605,7 @@ func (vmHandler *GCPVMHandler) mappingServerInfo(server *compute.Instance) irs.V
 }
 
 //이미지 URL 방식 대신 이름을 사용하도록 변경 중
+//@TODO : 2020-05-15 카푸치노 버전에서는 이름 대신 URL을 사용하기로 했음.
 func (vmHandler *GCPVMHandler) getImageInfo(diskname string) irs.IID {
 	projectID := vmHandler.Credential.ProjectID
 	zone := vmHandler.Region.Zone
@@ -623,23 +624,22 @@ func (vmHandler *GCPVMHandler) getImageInfo(diskname string) irs.IID {
 		cblogger.Error(err)
 		return irs.IID{}
 	}
-	//iArr := strings.Split(info.SourceImage, "/")
+
+	/* 2020-05-14 카푸치노 다음 버전에서 사용 예정
 	arrImageUrl := strings.Split(info.SourceImage, "/")
 	imageName := ""
 	if len(arrImageUrl) > 0 {
 		imageName = arrImageUrl[len(arrImageUrl)-1]
 	}
-
-	/*
-		iId := irs.IID{
-			NameId:   info.SourceImage,
-			SystemId: info.SourceImage,
-		}
-	*/
-
 	iId := irs.IID{
 		NameId:   imageName,
 		SystemId: imageName,
+	}
+	*/
+
+	iId := irs.IID{
+		NameId:   info.SourceImage, //2020-05-14 NameId는 사용자가 사용한 이름도 있기 때문에 리턴하지 않도록 수정
+		SystemId: info.SourceImage,
 	}
 
 	/*

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -50,6 +50,20 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	// email을 어디다가 넣지? 이것또한 문제넹
 	clientEmail := vmHandler.Credential.ClientEmail
 
+	//이미지 URL처리
+	cblogger.Infof("[%s] Image Name에 해당하는 Image Url 정보를 조회합니다.", vmReqInfo.ImageIID.SystemId)
+	imageHandler := GCPImageHandler{Credential: vmHandler.Credential, Region: vmHandler.Region, Client: vmHandler.Client}
+
+	//VPCHandler := AwsVPCHandler{Client: securityHandler.Client}
+
+	imageInfo, errImage := imageHandler.FindImageInfo(vmReqInfo.ImageIID.SystemId)
+	if errImage != nil {
+		return irs.VMInfo{}, nil
+	}
+
+	cblogger.Infof("ImageName: [%s] ---> ImageUrl : [%s]", vmReqInfo.ImageIID.SystemId, imageInfo.ImageUrl)
+	imageURL = imageInfo.ImageUrl
+
 	//PublicIP처리
 	// var publicIPAddress string
 	// cblogger.Info("PublicIp 처리 시작")
@@ -95,9 +109,18 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 
 	cblogger.Info("keypairInfo 정보")
 	spew.Dump(keypairInfo)
+
+	/*
+		type GCPImageHandler struct {
+			Region     idrv.RegionInfo
+			Ctx        context.Context
+			Client     *compute.Service
+			Credential idrv.CredentialInfo
+		}
+	*/
+
 	// Security Group Tags
 	var securityTags []string
-
 	for _, item := range vmReqInfo.SecurityGroupIIDs {
 		//securityTags = append(securityTags, item.NameId)
 		securityTags = append(securityTags, item.SystemId)
@@ -201,6 +224,9 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		cblogger.Error(errVmInfo)
 		return irs.VMInfo{}, errVmInfo
 	}
+
+	//ImageIId의 NameId는 사용자가 요청한 값으로 리턴
+	vmInfo.ImageIId.NameId = vmReqInfo.ImageIID.NameId
 	return vmInfo, nil
 
 	/* 2020-05-13 Start & Get 요청 시의 리턴 정보 통일을 위해 기존 로직 임시 제거
@@ -577,6 +603,8 @@ func (vmHandler *GCPVMHandler) mappingServerInfo(server *compute.Instance) irs.V
 
 	return vmInfo
 }
+
+//이미지 URL 방식 대신 이름을 사용하도록 변경 중
 func (vmHandler *GCPVMHandler) getImageInfo(diskname string) irs.IID {
 	projectID := vmHandler.Credential.ProjectID
 	zone := vmHandler.Region.Zone
@@ -596,10 +624,24 @@ func (vmHandler *GCPVMHandler) getImageInfo(diskname string) irs.IID {
 		return irs.IID{}
 	}
 	//iArr := strings.Split(info.SourceImage, "/")
-	iId := irs.IID{
-		NameId:   info.SourceImage,
-		SystemId: info.SourceImage,
+	arrImageUrl := strings.Split(info.SourceImage, "/")
+	imageName := ""
+	if len(arrImageUrl) > 0 {
+		imageName = arrImageUrl[len(arrImageUrl)-1]
 	}
+
+	/*
+		iId := irs.IID{
+			NameId:   info.SourceImage,
+			SystemId: info.SourceImage,
+		}
+	*/
+
+	iId := irs.IID{
+		NameId:   imageName,
+		SystemId: imageName,
+	}
+
 	/*
 		iId := irs.IID{
 			NameId: info.Name,


### PR DESCRIPTION
**[VM 핸들러]**
- StartVM의 리턴 정보중 ImageIId.NameId는 사용자가 요청한 NameId를 그대로 리턴하도록 변경
- Req ImageIId를 Image Name을 이용하도록 수정
  --> Image Name을 기준으로 제공되는 모든 프로젝트의 전체 이미지를 검색해서 처음 만나는 이미지의 URL 정보를 이용함.

**[Image 핸들러]**
- Image 고유 Id 기반에서 Image Name 기반으로 변경
  --> 전달 받은 Image Name을 기준으로 제공되는 모든 프로젝트의 전체 이미지를 검색해서 처음 만나는 이미지의 ID 정보를 조회후 Image API를 호출 함.
- Image 핸들러의 목록의 Key를 Image Name이 되도록 수정
