### PR TITLE
Alibaba VmSpecHandler의 MEM 규격을 MB로 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -912,10 +912,10 @@ func handleVM() {
 func main() {
 	cblogger.Info("Alibaba Cloud Resource Test")
 	//handleVPC() //VPC
-	//handleVMSpec()
+	handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
-	handleSecurity()
+	//handleSecurity()
 	//handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
@@ -64,7 +64,8 @@ func ExtractVMSpecInfo(Region string, instanceTypeInfo ecs.InstanceType) irs.VMS
 	//}
 
 	//if !reflect.ValueOf(&instanceTypeInfo.MemorySize).IsNil() {
-	vmSpecInfo.Mem = strconv.FormatFloat(instanceTypeInfo.MemorySize, 'f', 0, 64)
+	//vmSpecInfo.Mem = strconv.FormatFloat(instanceTypeInfo.MemorySize, 'f', 0, 64)
+	vmSpecInfo.Mem = strconv.FormatFloat(instanceTypeInfo.MemorySize*1024, 'f', 0, 64) // GB->MB로 변환
 	//}
 
 	//KeyValue 목록 처리


### PR DESCRIPTION
Alibaba VmSpecHandler의 MEM 규격을 GB에서 MB로 변경 ( GPU의 메모리 정보는 조회가 안되기 때문애 VM 메모리만 변경 함.)