### PR TITLE
이슈 #231 처리

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -59,6 +59,7 @@ func getVMClient(connectionInfo idrv.ConnectionInfo) (*ec2.EC2, error) {
 
 	// setup Region
 	fmt.Println("AwsDriver : getVMClient() - Region : [" + connectionInfo.RegionInfo.Region + "]")
+	fmt.Println("AwsDriver : getVMClient() - Zone : [" + connectionInfo.RegionInfo.Zone + "]")
 	//fmt.Println("전달 받은 커넥션 정보")
 	//spew.Dump(connectionInfo)
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1002,6 +1002,7 @@ func handleVMSpec() {
 				} else {
 					cblogger.Info("VMSpec 목록 조회 결과")
 					spew.Dump(result)
+					cblogger.Infof("전체 목록 개수 : [%d]", len(result))
 				}
 
 				fmt.Println("Finish ListVMSpec()")

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -534,10 +534,12 @@ func handleVPC() {
 				IId:       irs.IID{NameId: "New-CB-Subnet"},
 				IPv4_CIDR: "10.0.1.0/24",
 			},
-			{
-				IId:       irs.IID{NameId: "New-CB-Subnet2"},
-				IPv4_CIDR: "10.0.2.0/24",
-			},
+			/*
+				{
+					IId:       irs.IID{NameId: "New-CB-Subnet2"},
+					IPv4_CIDR: "10.0.2.0/24",
+				},
+			*/
 		},
 		//Id:   "subnet-044a2b57145e5afc5",
 		//Name: "CB-VNet-Subnet", // 웹 도구 등 외부에서 전달 받지 않고 드라이버 내부적으로 자동 구현때문에 사용하지 않음.
@@ -1073,11 +1075,11 @@ func main() {
 		}
 	*/
 
-	//handleVPC()
+	handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
-	handleVM()
+	//handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
@@ -1188,6 +1190,7 @@ func setVPCHandler() (irs.VPCHandler, error) {
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
+			Zone:   config.Aws.Zone,
 		},
 	}
 
@@ -1218,6 +1221,7 @@ type Config struct {
 		AawsAccessKeyID    string `yaml:"aws_access_key_id"`
 		AwsSecretAccessKey string `yaml:"aws_secret_access_key"`
 		Region             string `yaml:"region"`
+		Zone               string `yaml:"zone"`
 
 		ImageID string `yaml:"image_id"`
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1075,7 +1075,7 @@ func main() {
 		}
 	*/
 
-	handleVPC()
+	//handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
@@ -1083,7 +1083,7 @@ func main() {
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	//handleVMSpec()
+	handleVMSpec()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()
@@ -1117,6 +1117,7 @@ func getResourceHandler(handlerType string) (interface{}, error) {
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
+			Zone:   config.Aws.Zone,
 		},
 	}
 
@@ -1163,6 +1164,7 @@ func setKeyPairHandler() (irs.KeyPairHandler, error) {
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
+			Zone:   config.Aws.Zone,
 		},
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMSpecHandler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	"github.com/davecgh/go-spew/spew"
 )
 
 //https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DescribeInstanceTypes
@@ -20,9 +19,9 @@ type AwsVmSpecHandler struct {
 }
 
 func ExtractGpuInfo(gpuDeviceInfo *ec2.GpuDeviceInfo) irs.GpuInfo {
-	cblogger.Info(gpuDeviceInfo)
+	cblogger.Debug(gpuDeviceInfo)
 	//cblogger.Info("================")
-	spew.Dump(gpuDeviceInfo)
+	//spew.Dump(gpuDeviceInfo)
 
 	gpuInfo := irs.GpuInfo{
 		Count: strconv.FormatInt(*gpuDeviceInfo.Count, 10),
@@ -37,7 +36,7 @@ func ExtractGpuInfo(gpuDeviceInfo *ec2.GpuDeviceInfo) irs.GpuInfo {
 //인스턴스 스펙 정보를 추출함
 func ExtractVMSpecInfo(Region string, instanceTypeInfo *ec2.InstanceTypeInfo) irs.VMSpecInfo {
 	cblogger.Infof("ExtractVMSpecInfo : Region:[%s] / SpecName:[%s]", Region, *instanceTypeInfo.InstanceType)
-	spew.Dump(instanceTypeInfo)
+	//spew.Dump(instanceTypeInfo)
 
 	vCpuInfo := irs.VCpuInfo{}
 	gpuInfoList := []irs.GpuInfo{}
@@ -61,11 +60,11 @@ func ExtractVMSpecInfo(Region string, instanceTypeInfo *ec2.InstanceTypeInfo) ir
 	//GPU 정보가 있는 인스터스는 GPU 처리
 	if !reflect.ValueOf(instanceTypeInfo.GpuInfo).IsNil() {
 		for _, curGpu := range instanceTypeInfo.GpuInfo.Gpus {
-			cblogger.Infof("[%s] Gpu 스펙 정보 조회", *curGpu.Name)
+			cblogger.Debugf("[%s] Gpu 스펙 정보 조회", *curGpu.Name)
 			gpuInfo := ExtractGpuInfo(curGpu)
 			gpuInfoList = append(gpuInfoList, gpuInfo)
 		}
-		spew.Dump(gpuInfoList)
+		//spew.Dump(gpuInfoList)
 	}
 	vmSpecInfo.Gpu = gpuInfoList
 
@@ -79,8 +78,10 @@ func ExtractVMSpecInfo(Region string, instanceTypeInfo *ec2.InstanceTypeInfo) ir
 
 	//KeyValue 목록 처리
 	keyValueList, errKeyValue := ConvertKeyValueList(instanceTypeInfo)
-	cblogger.Errorf("[%]의 KeyValue 추출 실패", *instanceTypeInfo.InstanceType)
-	cblogger.Error(errKeyValue)
+	if errKeyValue != nil {
+		cblogger.Errorf("[%]의 KeyValue 추출 실패", *instanceTypeInfo.InstanceType)
+		cblogger.Error(errKeyValue)
+	}
 	/*
 		if errKeyValue != nil {
 			return irs.VMSpecInfo{}, errKeyValue

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VPCHandler.go
@@ -31,6 +31,13 @@ type AwsVPCHandler struct {
 func (VPCHandler *AwsVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCInfo, error) {
 	cblogger.Info(vpcReqInfo)
 
+	zoneId := VPCHandler.Region.Zone
+	cblogger.Infof("Zone : %s", zoneId)
+	if zoneId == "" {
+		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		return irs.VPCInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+	}
+
 	input := &ec2.CreateVpcInput{
 		CidrBlock: aws.String(vpcReqInfo.IPv4_CIDR),
 	}
@@ -218,6 +225,13 @@ func (VPCHandler *AwsVPCHandler) GetDefaultRouteTable(vpcId string) (string, err
 func (VPCHandler *AwsVPCHandler) CreateSubnet(vpcId string, reqSubnetInfo irs.SubnetInfo) (irs.SubnetInfo, error) {
 	cblogger.Info(reqSubnetInfo)
 
+	zoneId := VPCHandler.Region.Zone
+	cblogger.Infof("Zone : %s", zoneId)
+	if zoneId == "" {
+		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		return irs.SubnetInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+	}
+
 	vpcInfo, errVpcInfo := VPCHandler.GetSubnet(reqSubnetInfo.IId.SystemId)
 	if errVpcInfo == nil {
 		cblogger.Errorf("이미 [%S] Subnet이 존재하기 때문에 생성하지 않고 기존 정보와 함께 에러를 리턴함.", reqSubnetInfo.IId.SystemId)
@@ -229,6 +243,8 @@ func (VPCHandler *AwsVPCHandler) CreateSubnet(vpcId string, reqSubnetInfo irs.Su
 	input := &ec2.CreateSubnetInput{
 		CidrBlock: aws.String(reqSubnetInfo.IPv4_CIDR),
 		VpcId:     aws.String(vpcId),
+		//AvailabilityZoneId: aws.String(zoneId),	//use1-az1, use1-az2, use1-az3, use1-az4, use1-az5, use1-az6
+		AvailabilityZone: aws.String(zoneId),
 	}
 
 	cblogger.Info(input)


### PR DESCRIPTION
AWS 드라이버의 이슈 #231 처리 (Available Zone 관련 개선이 필요함)
- Connection 생성 시 Region의 Zone 정보 입력 필수
- VPC 생성 시 Subnet은 사용자가 Region 정보에 지정한 Zone에만 생성 됨. (Region.Zone)
- VMSpecHandler의 ListVMSpec() / ListOrgVMSpec()의 조회 범위를 Region에서 사용자가 Region 정보에 지정한 Zone 범위로 제한
- VMSpecHandler의 ListVMSpec() / ListOrgVMSpec()에 전체 페이지의 데이터를 가져오도록 페이징 처리 추가
   *참고, 페이징 처리에 따른 AWS 라이브러리 오류가 발생할 경우 최신 버전의 라이브러리를 사용할 것*
- VMSpecHandler.ExtractVMSpecInfo()의 spew.Dump()들 제거및 Log Level을 Info에서 Debug로 변경
