### PR TITLE
#255 / #258 예외 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1076,7 +1076,7 @@ func main() {
 		}
 	*/
 
-	handleVPC()
+	//handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
@@ -1084,7 +1084,7 @@ func main() {
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	//handleVMSpec()
+	handleVMSpec()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -33,7 +33,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("AWS Resource Test")
-	cblog.SetLevel("debug")
+	cblog.SetLevel("info")
 }
 
 func handleSecurity() {
@@ -1076,7 +1076,7 @@ func main() {
 		}
 	*/
 
-	//handleVPC()
+	handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
@@ -1084,7 +1084,7 @@ func main() {
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	handleVMSpec()
+	//handleVMSpec()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -287,7 +287,7 @@ func ConvertJsonString(v interface{}) (string, error) {
 //CB-KeyValue 등을 위해 String 타입으로 변환
 func ConvertToString(value interface{}) (string, error) {
 	if value == nil {
-		cblogger.Error("Nil Value")
+		cblogger.Warnf("Nil Value")
 		return "", errors.New("Nil. Value")
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -260,7 +260,7 @@ func ConvertJsonStringNoEscape(v interface{}) (string, error) {
 
 	//fmt.Println("After marshal", string(buffer.Bytes()))
 	//spew.Dump(string(buffer.Bytes()))
-	spew.Dump("\"TEST")
+	//spew.Dump("\"TEST")
 
 	jsonString := string(buffer.Bytes())
 	//jsonString = strings.Replace(jsonString, "\n", "", -1)
@@ -288,7 +288,7 @@ func ConvertJsonString(v interface{}) (string, error) {
 func ConvertToString(value interface{}) (string, error) {
 	if value == nil {
 		cblogger.Error("Nil Value")
-		return "", errors.New("NIL Value")
+		return "", errors.New("Nil. Value")
 	}
 
 	var result string
@@ -339,7 +339,8 @@ func ConvertKeyValueList(v interface{}) ([]irs.KeyValue, error) {
 		//value := fmt.Sprint(v)
 		value, errString := ConvertToString(v)
 		if errString != nil {
-			cblogger.Errorf("Key[%s]의 값은 변환 불가 - [%s]", k, errString)
+			//cblogger.Errorf("Key[%s]의 값은 변환 불가 - [%s]", k, errString)
+			cblogger.Warnf("Key[%s]의 값은 변환 불가 - [%s]", k, errString) //요구에 의해서 Error에서 Warn으로 낮춤
 			continue
 		}
 		keyValueList = append(keyValueList, irs.KeyValue{k, value})


### PR DESCRIPTION
- #255 AWS VPC 삭제 시 "InvalidRoute.NotFound"예외는 무시하도록 기능 변경
- #255 보완 작업으로 라우트 삭제전 0.0.0.0 설정 여부 조회하도록 로직 추가
- #258 예외의 경우 에러나 개선 사항은 아니며 특정 객체들의 필드 값을 문자열로 자동 맵핑시 이용하는 ConvertKeyValueList()에서 구조체나 배열을 비롯하여 NIL등 단일 String으로 단순 변환되지 않는 값들에 대해서는 변환이 불가능하기 때문에 향후 해당 필드들에 대한 참고를 위해 Error로 로그를 남기고 있으며,
cb의 경우 지정된 필드 외의 추가 정보들도 최대한 많이 남겨 달라고 요청이 있었기 때문에 AWS의 전체 오브젝트의 값을 단순 변환하기 때문에 위와 같은 현상들이 많이 발생하고 있음.
변환 함수 입장에서는 에러로 남기는게 향후에 찾기 무난하기 때문에 에러로 남기고 있으나 에러의 오해 소지가 있어서 요청에 의해 Warn으로 하향 조정했으며 필요시 Debug로 내려도 무관함.