### PR TITLE
로그레벨 일부 정리및 이미지 핸들러의 NameId 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -708,7 +708,7 @@ func handleImage() {
 					cblogger.Info("Image 목록 조회 결과")
 					cblogger.Info(result)
 					cblogger.Info("출력 결과 수 : ", len(result))
-					//spew.Dump(result)
+					spew.Dump(result)
 
 					//조회및 삭제 테스트를 위해 리스트의 첫번째 정보의 ID를 요청ID로 자동 갱신함.
 					if result != nil {
@@ -912,8 +912,8 @@ func handleVM() {
 func main() {
 	cblogger.Info("Alibaba Cloud Resource Test")
 	//handleVPC() //VPC
-	handleVMSpec()
-	//handleImage() //AMI
+	//handleVMSpec()
+	handleImage() //AMI
 	//handleKeyPair()
 	//handleSecurity()
 	//handleVM()

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ImageHandler.go
@@ -147,7 +147,7 @@ func ExtractImageDescribeInfo(image *ecs.Image) irs.ImageInfo {
 	cblogger.Infof("=====> ")
 	spew.Dump(image)
 	imageInfo := irs.ImageInfo{
-		IId: irs.IID{SystemId: image.ImageId},
+		IId: irs.IID{NameId: image.ImageId, SystemId: image.ImageId},
 		//Name:    image.ImageName,
 		Status:  image.Status,
 		GuestOS: image.OSNameEn,

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -664,7 +664,7 @@ func handleImage() {
 					cblogger.Info("Image 목록 조회 결과")
 					cblogger.Info(result)
 					cblogger.Info("출력 결과 수 : ", len(result))
-					//spew.Dump(result)
+					spew.Dump(result)
 
 					//조회및 삭제 테스트를 위해 리스트의 첫번째 정보의 ID를 요청ID로 자동 갱신함.
 					if result != nil {
@@ -1000,8 +1000,9 @@ func handleVMSpec() {
 				if err != nil {
 					cblogger.Error("VMSpec 목록 조회 실패 : ", err)
 				} else {
-					cblogger.Info("VMSpec 목록 조회 결과")
-					spew.Dump(result)
+					cblogger.Debug("VMSpec 목록 조회 결과")
+					//spew.Dump(result)
+					cblogger.Debug(result)
 					cblogger.Infof("전체 목록 개수 : [%d]", len(result))
 				}
 
@@ -1013,8 +1014,9 @@ func handleVMSpec() {
 				if err != nil {
 					cblogger.Error(reqVMSpec, " VMSpec 정보 조회 실패 : ", err)
 				} else {
-					cblogger.Infof("VMSpec[%s]  정보 조회 결과", reqVMSpec)
-					spew.Dump(result)
+					cblogger.Debugf("VMSpec[%s]  정보 조회 결과", reqVMSpec)
+					//spew.Dump(result)
+					cblogger.Debug(result)
 				}
 				fmt.Println("Finish GetVMSpec()")
 
@@ -1024,13 +1026,14 @@ func handleVMSpec() {
 				if err != nil {
 					cblogger.Error("VMSpec Org 목록 조회 실패 : ", err)
 				} else {
-					cblogger.Info("VMSpec Org 목록 조회 결과")
+					cblogger.Debug("VMSpec Org 목록 조회 결과")
 					//spew.Dump(result)
-					cblogger.Info(result)
+					cblogger.Debug(result)
 					//spew.Dump(result)
 					//fmt.Println(result)
 					//fmt.Println("=========================")
 					//fmt.Println(result)
+					cblogger.Infof("전체 목록 개수 : [%d]", len(result))
 				}
 
 				fmt.Println("Finish ListOrgVMSpec()")
@@ -1041,9 +1044,9 @@ func handleVMSpec() {
 				if err != nil {
 					cblogger.Error(reqVMSpec, " VMSpec Org 정보 조회 실패 : ", err)
 				} else {
-					cblogger.Infof("VMSpec[%s] Org 정보 조회 결과", reqVMSpec)
+					cblogger.Debugf("VMSpec[%s] Org 정보 조회 결과", reqVMSpec)
 					//spew.Dump(result)
-					cblogger.Info(result)
+					cblogger.Debug(result)
 					//fmt.Println(result)
 				}
 				fmt.Println("Finish GetOrgVMSpec()")
@@ -1082,9 +1085,9 @@ func main() {
 	//handleSecurity()
 	//handleVM()
 
-	//handleImage() //AMI
+	handleImage() //AMI
 	//handleVNic() //Lancard
-	handleVMSpec()
+	//handleVMSpec()
 
 	/*
 		KeyPairHandler, err := setKeyPairHandler()

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	"github.com/davecgh/go-spew/spew"
 )
 
 const CBDefaultVNetName string = "CB-VNet"          // CB Default Virtual Network Name
@@ -287,7 +286,7 @@ func ConvertJsonString(v interface{}) (string, error) {
 //CB-KeyValue 등을 위해 String 타입으로 변환
 func ConvertToString(value interface{}) (string, error) {
 	if value == nil {
-		cblogger.Warnf("Nil Value")
+		cblogger.Debugf("Nil Value")
 		return "", errors.New("Nil. Value")
 	}
 
@@ -312,8 +311,7 @@ func ConvertToString(value interface{}) (string, error) {
 
 //Cloud Object를 CB-KeyValue 형식으로 변환이 필요할 경우 이용
 func ConvertKeyValueList(v interface{}) ([]irs.KeyValue, error) {
-	spew.Dump(v)
-
+	//spew.Dump(v)
 	var keyValueList []irs.KeyValue
 	var i map[string]interface{}
 
@@ -340,7 +338,7 @@ func ConvertKeyValueList(v interface{}) ([]irs.KeyValue, error) {
 		value, errString := ConvertToString(v)
 		if errString != nil {
 			//cblogger.Errorf("Key[%s]의 값은 변환 불가 - [%s]", k, errString)
-			cblogger.Warnf("Key[%s]의 값은 변환 불가 - [%s]", k, errString) //요구에 의해서 Error에서 Warn으로 낮춤
+			cblogger.Debugf("Key[%s]의 값은 변환 불가 - [%s]", k, errString) //요구에 의해서 Error에서 Warn으로 낮춤
 			continue
 		}
 		keyValueList = append(keyValueList, irs.KeyValue{k, value})

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ImageHandler.go
@@ -94,14 +94,15 @@ func (imageHandler *AwsImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 func ExtractImageDescribeInfo(image *ec2.Image) irs.ImageInfo {
 	//spew.Dump(image)
 	imageInfo := irs.ImageInfo{
-		IId: irs.IID{*image.Name, *image.ImageId},
+		//IId: irs.IID{*image.Name, *image.ImageId},
+		IId: irs.IID{*image.ImageId, *image.ImageId},
 		//Id:     *image.ImageId,
 		//Name:   *image.Name,
 		Status: *image.State,
 	}
 
 	keyValueList := []irs.KeyValue{
-		{Key: "Name", Value: *image.Name},
+		//{Key: "Name", Value: *image.Name}, //20200723-Name이 없는 이미지 존재 - 예)ami-0008a301
 		{Key: "CreationDate", Value: *image.CreationDate},
 		{Key: "Architecture", Value: *image.Architecture},
 		{Key: "OwnerId", Value: *image.OwnerId},
@@ -112,6 +113,9 @@ func ExtractImageDescribeInfo(image *ec2.Image) irs.ImageInfo {
 	}
 
 	// 일부 이미지들은 아래 정보가 없어서 예외 처리 함.
+	if !reflect.ValueOf(image.Name).IsNil() {
+		keyValueList = append(keyValueList, irs.KeyValue{Key: "Name", Value: *image.Name})
+	}
 	if !reflect.ValueOf(image.Description).IsNil() {
 		keyValueList = append(keyValueList, irs.KeyValue{Key: "Description", Value: *image.Description})
 	}

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMSpecHandler.go
@@ -35,7 +35,7 @@ func ExtractGpuInfo(gpuDeviceInfo *ec2.GpuDeviceInfo) irs.GpuInfo {
 
 //인스턴스 스펙 정보를 추출함
 func ExtractVMSpecInfo(Region string, instanceTypeInfo *ec2.InstanceTypeInfo) irs.VMSpecInfo {
-	cblogger.Infof("ExtractVMSpecInfo : Region:[%s] / SpecName:[%s]", Region, *instanceTypeInfo.InstanceType)
+	cblogger.Debugf("ExtractVMSpecInfo : Region:[%s] / SpecName:[%s]", Region, *instanceTypeInfo.InstanceType)
 	//spew.Dump(instanceTypeInfo)
 
 	vCpuInfo := irs.VCpuInfo{}
@@ -148,7 +148,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpecI
 	cblogger.Infof("Start ListVMSpec(Region:[%s])", Region)
 
 	zoneId := vmSpecHandler.Region.Zone
-	cblogger.Infof("Zone : %s", zoneId)
+	cblogger.Infof("Request Zone : [%s]", zoneId)
 	if zoneId == "" {
 		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
 		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다.")
@@ -200,7 +200,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpecI
 		func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
 			pageNum++
 			//fmt.Println(page)
-			cblogger.Infof("PageNum : [%d] / Count : [%d] / lastPage : [%v]", pageNum, len(page.InstanceTypes), lastPage)
+			cblogger.Infof("PageNum : [%d] / Count : [%d] / isLastPage : [%v]", pageNum, len(page.InstanceTypes), lastPage)
 			//totCnt = totCnt + len(page.InstanceTypes)
 
 			for _, curInstance := range page.InstanceTypes {
@@ -209,7 +209,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpecI
 
 				_, exists := mapVmSpecIds[*curInstance.InstanceType]
 				if !exists {
-					cblogger.Infof("[%s] 스펙은 [%s] Zone에서 지원되지 않습니다.", *curInstance.InstanceType, zoneId)
+					cblogger.Debugf("[%s] 스펙은 [%s] Zone에서 지원되지 않습니다.", *curInstance.InstanceType, zoneId)
 					continue
 				}
 
@@ -324,7 +324,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListOrgVMSpec(Region string) (string, err
 		func(page *ec2.DescribeInstanceTypesOutput, lastPage bool) bool {
 			pageNum++
 			//fmt.Println(page)
-			cblogger.Infof("PageNum : [%d] / Count : [%d] / lastPage : [%v]", pageNum, len(page.InstanceTypes), lastPage)
+			cblogger.Infof("PageNum : [%d] / Count : [%d] / isLastPage : [%v]", pageNum, len(page.InstanceTypes), lastPage)
 			//totCnt = totCnt + len(page.InstanceTypes)
 
 			for _, curInstance := range page.InstanceTypes {
@@ -333,7 +333,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListOrgVMSpec(Region string) (string, err
 
 				_, exists := mapVmSpecIds[*curInstance.InstanceType]
 				if !exists {
-					cblogger.Infof("[%s] 스펙은 [%s] Zone에서 지원되지 않습니다.", *curInstance.InstanceType, zoneId)
+					cblogger.Debugf("[%s] 스펙은 [%s] Zone에서 지원되지 않습니다.", *curInstance.InstanceType, zoneId)
 					continue
 				}
 
@@ -379,7 +379,7 @@ func (vmSpecHandler *AwsVmSpecHandler) ListOrgVMSpecOld(Region string) (string, 
 	//cblogger.Info(resp)
 	//fmt.Println(resp)
 
-	//jsonString, errJson := ConvertJsonString(resp.InstanceTypes[0])
+	//00, errJson := ConvertJsonString(resp.InstanceTypes[0])
 	jsonString, errJson := ConvertJsonString(resp)
 	if errJson != nil {
 		cblogger.Error(errJson)

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -933,10 +933,10 @@ func main() {
 	cblogger.Info("GCP Resource Test")
 	//handleVPC()
 	//handleVMSpec()
-	//handleImage() //AMI
+	handleImage() //AMI
 	//handleKeyPair()
 	//handleSecurity()
-	handleVM()
+	//handleVM()
 	//cblogger.Info(filepath.Join("a/b", "\\cloud-driver-libs\\.ssh-gcp\\"))
 	//cblogger.Info(filepath.Join("\\cloud-driver-libs\\.ssh-gcp\\", "/b/c/d"))
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -198,6 +198,7 @@ func (imageHandler *GCPImageHandler) ConvertGcpImageInfoToCbImageInfo(imageInfo 
 	return cbImageInfo
 }
 
+//@TODO: URL기반에서 Name기반으로 조회하던 기능을 URL기반으로 원복해야 함.
 func (imageHandler *GCPImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, error) {
 	cblogger.Info(imageIID)
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -87,7 +87,7 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 
 //리스트의 경우 Name 기반으로 조회해서 처리하기에는 너무 느리기 때문에 직접 컨버팅함.
 func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
-	cblogger.Info("전체 이미지 조회")
+	cblogger.Debug("전체 이미지 조회")
 
 	//https://cloud.google.com/compute/docs/images?hl=ko
 	arrImageProjectList := []string{
@@ -127,7 +127,7 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 		}
 
 		nextPageToken = res.NextPageToken
-		cblogger.Info("NestPageToken : ", nextPageToken)
+		cblogger.Debug("NextPageToken : ", nextPageToken)
 
 		//현재 페이지부터 마지막 페이지까지 조회
 		for {
@@ -141,7 +141,7 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 			if nextPageToken != "" {
 				res, err = req.PageToken(nextPageToken).Do()
 				nextPageToken = res.NextPageToken
-				cblogger.Info("NestPageToken : ", nextPageToken)
+				cblogger.Debug("NextPageToken : ", nextPageToken)
 			} else {
 				break
 			}
@@ -417,7 +417,8 @@ func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 
 	imageList := irs.ImageInfo{
 		IId: irs.IID{
-			NameId: imageInfo.Name,
+			NameId: imageInfo.SelfLink,
+			//NameId: imageInfo.Name, //2020-07-23 이미지 핸들러는 아직 생성 기능을 지원하지 않기 때문에 NameId대신 SystemId로 통일
 			//SystemId: imageInfo.Name, //자체 기능 구현을 위해 Name 기반으로 리턴함. - 2020-05-14 다음 버전에 적용 예정
 			SystemId: imageInfo.SelfLink, //2020-05-14 카푸치노는 VM 생성시 URL 방식을 사용하기 때문에 임의로 맞춤(이미지 핸들러의 다른 함수에는 적용 못함)
 			//SystemId: strconv.FormatUint(imageInfo.Id, 10), //이 값으로는 VM생성 안됨.


### PR DESCRIPTION
- AlibabaCloud 이미지 핸들러의 리턴 정보에 NameId 추가
- AWS 스펙및 이미지 핸들러의 Log 정보를 줄이기 위해 Info에서 Debug로 낮춤.
- AWS 이미지 핸들러의 리턴 정보의 NameId값을 SystemId로 통일
- AWS 이미지 핸들러의 리턴 정보중 Name 태그가 없는 이미지들이 존재해서 예외추가
- GCP 이미지 핸들러의 목록 조회 결과 값의 NameId를 SystemId와 동일한 URL 값으로 변경
  *중요* GCP의 경우 이미지 조회는 NameId 기반으로 조회하도록 수정되어있는 상태라서 URL기반인 SystemId 기반으로 변경이 필요함.
  현재는 급하게 목록의 NameId만 URL 기반으로 우선 반영해놨음.
