### PR TITLE
Update grpc_conf.yaml and Remove protobuf struct from cbadm

### DIFF
--- a/api-runtime/grpc-runtime/common/cbconnection.go
+++ b/api-runtime/grpc-runtime/common/cbconnection.go
@@ -34,7 +34,7 @@ type CBConnection struct {
 // ===== [ Public Functions ] =====
 
 // NewCBConnection - 초기화된 grpc 클라이언트의 인스턴스 생성
-func NewCBConnection(serverAddr string, gConf *config.GrpcClientConfig) (*CBConnection, io.Closer, error) {
+func NewCBConnection(gConf *config.GrpcClientConfig) (*CBConnection, io.Closer, error) {
 
 	var (
 		tracer opentracing.Tracer = nil
@@ -45,7 +45,7 @@ func NewCBConnection(serverAddr string, gConf *config.GrpcClientConfig) (*CBConn
 		return nil, nil, errors.New("grpc connection config is null")
 	}
 
-	if serverAddr == "" {
+	if gConf.ServerAddr == "" {
 		return nil, nil, errors.New("server addr is empty")
 	}
 
@@ -93,7 +93,7 @@ func NewCBConnection(serverAddr string, gConf *config.GrpcClientConfig) (*CBConn
 
 	opts = append(opts, grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryIntercepters...)))
 	opts = append(opts, grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(streamIntercepters...)))
-	conn, err := grpc.Dial(serverAddr, opts...)
+	conn, err := grpc.Dial(gConf.ServerAddr, opts...)
 
 	return &CBConnection{Conn: conn}, closer, err
 }

--- a/api-runtime/grpc-runtime/config/config.go
+++ b/api-runtime/grpc-runtime/config/config.go
@@ -40,6 +40,7 @@ type GrpcServerConfig struct {
 
 // GrpcClientConfig - CB-GRPC 클라이언트 설정 구조
 type GrpcClientConfig struct {
+	ServerAddr   string              `mapstructure:"server_addr"`
 	Timeout      time.Duration       `mapstructure:"timeout"`
 	TLS          *TLSConfig          `mapstructure:"tls"`
 	Interceptors *InterceptorsConfig `mapstructure:"interceptors"`

--- a/interface/grpc_conf.yaml
+++ b/interface/grpc_conf.yaml
@@ -1,8 +1,7 @@
 version: 1
 grpc:
-  spidersrv:
-    addr: 127.0.0.1:50251  
   spidercli:
+    server_addr: 127.0.0.1:50251
     timeout: 90s
     #tls:
     #  tls_ca: $CBSPIDER_ROOT/certs/ca.crt


### PR DESCRIPTION
- 클라이언트의 grpc_conf.yaml 에서 서버주소 정보 위치 변경
  - spidercli 아래에 server_addr 항목에서 설정
- cbadm connect-infos 정보 출력에서 protobuf struct 대신에 map 을 사용하여 protobuf 와의 관계를 제거함