### PR TITLE
NCP driver - Plugin mode build 적용

### DIFF
--- a/utils/driver-build-docker/1.driver-build-container-run.sh
+++ b/utils/driver-build-docker/1.driver-build-container-run.sh
@@ -22,5 +22,5 @@ source ../../setup.env
 # setup HOME env. with host $HOME in container
 sudo docker run --rm -it -v $PWD/2.build:$HOME/2.build -v $HOME/go:$HOME/go -v $CBSPIDER_ROOT:$CBSPIDER_ROOT \
 	-e GOPATH=$HOME/go -e CBSPIDER_ROOT=$CBSPIDER_ROOT \
-	-e  HOME=$HOME -w $HOME --hostname driver-build --name cloud-twin-dev \
+	-e  HOME=$HOME -w $HOME --hostname driver-build --name driver-build \
 	golang:$GOVERSION /bin/bash

--- a/utils/driver-build-docker/2.build/ncp-build.sh
+++ b/utils/driver-build-docker/2.build/ncp-build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Build Scripts to build drivers with plugin mode.
+# The driver repos can be other repos.
+# cf) https://github.com/cloud-barista/cb-spider/issues/343
+#
+# The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+# The CB-Spider Mission is to connect all the clouds with a single interface.
+#
+#      * Cloud-Barista: https://github.com/cloud-barista
+#
+# by CB-Spider Team, 2021.05.
+
+
+# You have to run in driver build container.
+echo "\$HOME" path is $HOME
+echo "\$CBSPIDER_ROOT" path is $CBSPIDER_ROOT
+
+git clone https://github.com/cloud-barista/ncp.git $HOME/ncp;
+
+ln -s $HOME/ncp/ncp $CBSPIDER_ROOT/cloud-control-manager/cloud-driver/drivers;
+ln -s $HOME/ncp/ncp-plugin $CBSPIDER_ROOT/cloud-control-manager/cloud-driver/drivers;
+
+cd $CBSPIDER_ROOT/cloud-control-manager/cloud-driver/drivers/ncp-plugin;
+./build_driver_lib.sh
+
+rm $CBSPIDER_ROOT/cloud-control-manager/cloud-driver/drivers/ncp;
+rm $CBSPIDER_ROOT/cloud-control-manager/cloud-driver/drivers/ncp-plugin;
+


### PR DESCRIPTION
- Plugin용  NCP driver object 파일 생성을 위한 ncp-build.sh 작성
- Driver build 작업용 container 이름 변경 : cloud-twin-dev  -> driver-build