### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,9 @@ COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/api-runtime/rest-
 ENV CBSPIDER_ROOT /root/go/src/github.com/cloud-barista/cb-spider
 ENV CBSTORE_ROOT /root/go/src/github.com/cloud-barista/cb-spider
 ENV CBLOG_ROOT /root/go/src/github.com/cloud-barista/cb-spider
+ENV LOCALHOST OFF
 ENV PLUGIN_SW OFF
+ENV MEERKAT OFF
 
 ENTRYPOINT [ "/root/go/src/github.com/cloud-barista/cb-spider/api-runtime/cb-spider" ]
 


### PR DESCRIPTION
- Resolves #363

```
❯ docker run fc7c4b2f0ee1
...
[CB-SPIDER].[INFO]: 2021-05-11 08:19:14 nutsdb-driver.go:35, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.initialize() - ######## dbfile: /root/go/src/github.com/cloud-barista/cb-spider/meta_db/dat 
[CB-SPIDER].[INFO]: 2021-05-11 08:19:14 nutsdb-driver.go:35, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.initialize() - ######## dbfile: /root/go/src/github.com/cloud-barista/cb-spider/meta_db/dat 

  <CB-Spider> Multi-Cloud Infrastructure Federation Framework
     - AdminWeb: http://129.254.75.178:1024/spider/adminweb
     - REST API: http://129.254.75.178:1024/spider
     - Go   API: grpc://129.254.75.178:2048
```

- CB-Spider 실행에 필요한 환경변수가 추가되면
`setup.env` 뿐만 아니라
CB-Spider repo의 `Dockerfile` 에도 추가가 필요하며
나아가서는 cb-operator repo의 `docker-compose.yaml` 과 `Helm chart` 에도 추가가 필요합니다. 😊
- 버그가 수정된 컨테이너 이미지 생성을 위해 CB-Spider 에 새로운 tag 를 찍어야 하겠습니다.
- 컨테이너 이미지 tag 중, 제대로 작동하지 않는 tag 는 삭제하는 방안도 있겠습니다.