### PR TITLE
Fix grpc api

### DIFF
--- a/api-runtime/grpc-runtime/common/cbmessage.go
+++ b/api-runtime/grpc-runtime/common/cbmessage.go
@@ -107,9 +107,15 @@ func ConvertToOutput(outType string, obj interface{}) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		logger.Debug("json Marshal: \n", string(j))
+		outStr := string(j)
 
-		return string(j), nil
+		// json.Marshal 함수는  <,>, & 문자를 escape 함.. 다시 원래대로 변환
+		outStr = strings.Replace(outStr, "\\u003c", "<", -1)
+		outStr = strings.Replace(outStr, "\\u003e", ">", -1)
+		outStr = strings.Replace(outStr, "\\u0026", "&", -1)
+
+		logger.Debug("json Marshal: \n", outStr)
+		return outStr, nil
 	}
 
 	return "", nil

--- a/conf/grpc_conf.yaml
+++ b/conf/grpc_conf.yaml
@@ -10,7 +10,7 @@ grpc:
       #auth_jwt:
       #  jwt_key: your_secret_key
       #prometheus_metrics:
-      #  listen_port: 9092
+      #  listen_port: 9096
       #opentracing:
       #  jaeger:
       #    endpoint: localhost:6831

--- a/interface/cli/cbadm/cmd/gclient.go
+++ b/interface/cli/cbadm/cmd/gclient.go
@@ -139,8 +139,12 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if err != nil {
-		logger.Error("failed to run command: ", err)
+		if outType == "yaml" {
+			fmt.Fprintf(cmd.OutOrStdout(), "message: %v\n", err)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "{\"message\": \"%v\"}\n", err)
+		}
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", result)
 	}
-
-	fmt.Printf("%s\n", result)
 }

--- a/interface/cli/spider/cmd/gclient.go
+++ b/interface/cli/spider/cmd/gclient.go
@@ -273,8 +273,12 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if err != nil {
-		logger.Error("failed to run command: ", err)
+		if outType == "yaml" {
+			fmt.Fprintf(cmd.OutOrStdout(), "message: %v\n", err)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "{\"message\": \"%v\"}\n", err)
+		}
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", result)
 	}
-
-	fmt.Printf("%s\n", result)
 }

--- a/utils/grpc-support-docker/data/prometheus/prometheus.yaml
+++ b/utils/grpc-support-docker/data/prometheus/prometheus.yaml
@@ -27,4 +27,4 @@ scrape_configs:
   - job_name: 'cbspiderserver'
     scrape_interval: 10s
     static_configs:
-      - targets: ['192.168.201.207:9092']
+      - targets: ['192.168.201.207:9096']


### PR DESCRIPTION
- json.Marshal 함수는  <,>, & 문자를 escape 하고 있어 원래대로 다시 변환함
- CLI 에러 출력도 output format 으로 출력하게 함
- prometheus listening port 를 9092 에서 9096 으로 변경 (dragonfly port 와 충돌 해결 위해서)