### PR TITLE
AWS/ALIBABA/TENCENT - 보안그룹에 CIDR 반영

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -339,9 +339,9 @@ func handleSecurity() {
 	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	securityName := "CB-SecurityTestIcmp"
+	securityName := "CB-SecurityTestCidr"
 	securityId := "sg-6wedru4yb4m6qqfvd3sj"
-	vpcId := "vpc-6wei16ufuimfcct41o0xh"
+	vpcId := "vpc-6we8we6do6m72xzzipur1"
 
 	for {
 		fmt.Println("Security Management")
@@ -381,44 +381,61 @@ func handleSecurity() {
 					IId:    irs.IID{NameId: securityName},
 					VpcIID: irs.IID{SystemId: vpcId},
 					SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
+						//CIDR 테스트
 						{
-							FromPort:   "20",
-							ToPort:     "22",
+							FromPort:   "30",
+							ToPort:     "30",
 							IPProtocol: "tcp",
 							Direction:  "inbound",
-						},
-
-						{
-							FromPort:   "80",
-							ToPort:     "80",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
+							CIDR:       "10.13.1.10/32",
 						},
 						{
-							FromPort:   "8080",
-							ToPort:     "8080",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-						},
-						{
-							FromPort:   "-1",
-							ToPort:     "-1",
-							IPProtocol: "icmp",
-							Direction:  "inbound",
-						},
-
-						{
-							FromPort:   "443",
-							ToPort:     "443",
+							FromPort:   "40",
+							ToPort:     "40",
 							IPProtocol: "tcp",
 							Direction:  "outbound",
+							CIDR:       "10.13.1.10/32",
 						},
-						{
-							FromPort:   "8443",
-							ToPort:     "9999",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-						},
+						/*
+							{
+								FromPort:   "20",
+								ToPort:     "22",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+
+							{
+								FromPort:   "80",
+								ToPort:     "80",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "8080",
+								ToPort:     "8080",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "-1",
+								ToPort:     "-1",
+								IPProtocol: "icmp",
+								Direction:  "inbound",
+							},
+
+							{
+								FromPort:   "443",
+								ToPort:     "443",
+								IPProtocol: "tcp",
+								Direction:  "outbound",
+							},
+							{
+								FromPort:   "8443",
+								ToPort:     "9999",
+								IPProtocol: "tcp",
+								Direction:  "outbound",
+							},
+						*/
 						/*
 							{
 								//FromPort:   "8443",
@@ -435,6 +452,7 @@ func handleSecurity() {
 					cblogger.Infof(securityName, " Security 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 생성 결과 : [%v]", securityName, result)
+					securityId = result.IId.SystemId
 					spew.Dump(result)
 				}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -50,7 +50,7 @@ func handleSecurity() {
 
 	securityName := "CB-SecurityTest1"
 	securityId := "sg-0d6a2bb960481ce68"
-	vpcId := "vpc-c0479cab"
+	vpcId := "vpc-0c4d36a3ac3924419"
 
 	for {
 		fmt.Println("Security Management")
@@ -91,43 +91,68 @@ func handleSecurity() {
 					IId:    irs.IID{NameId: securityName},
 					VpcIID: irs.IID{SystemId: vpcId},
 					SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
+						//CIDR 테스트
 						{
-							FromPort:   "20",
-							ToPort:     "22",
+							FromPort:   "30",
+							ToPort:     "30",
 							IPProtocol: "tcp",
 							Direction:  "inbound",
-						},
-
-						{
-							FromPort:   "80",
-							ToPort:     "80",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
+							CIDR:       "10.13.1.10/32",
 						},
 						{
-							FromPort:   "8080",
-							ToPort:     "8080",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-						},
-						{
-							FromPort:   "-1",
-							ToPort:     "-1",
-							IPProtocol: "icmp",
-							Direction:  "inbound",
-						},
-						{
-							FromPort:   "443",
-							ToPort:     "443",
+							FromPort:   "40",
+							ToPort:     "40",
 							IPProtocol: "tcp",
 							Direction:  "outbound",
+							CIDR:       "10.13.1.10/32",
 						},
-						{
-							FromPort:   "8443",
-							ToPort:     "9999",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-						},
+						// {
+						// 	FromPort:   "30",
+						// 	ToPort:     "30",
+						// 	IPProtocol: "tcp",
+						// 	Direction:  "outbound",
+						// 	CIDR:       "1.2.3.4/0",
+						// },
+						// {
+						// 	FromPort:   "20",
+						// 	ToPort:     "22",
+						// 	IPProtocol: "tcp",
+						// 	Direction:  "inbound",
+						// 	//CIDR:       "1.2.3.4/0",
+						// },
+						/*
+							{
+								FromPort:   "80",
+								ToPort:     "80",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+								CIDR:       "1.2.3.4/0",
+							},
+							{
+								FromPort:   "8080",
+								ToPort:     "8080",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "-1",
+								ToPort:     "-1",
+								IPProtocol: "icmp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "443",
+								ToPort:     "443",
+								IPProtocol: "tcp",
+								Direction:  "outbound",
+							},
+							{
+								FromPort:   "8443",
+								ToPort:     "9999",
+								IPProtocol: "tcp",
+								Direction:  "outbound",
+							},
+						*/
 						/*
 							{
 								//FromPort:   "8443",
@@ -144,6 +169,7 @@ func handleSecurity() {
 					cblogger.Infof(securityName, " Security 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 생성 결과 : [%v]", securityName, result)
+					securityId = result.IId.SystemId
 					spew.Dump(result)
 				}
 
@@ -1118,29 +1144,12 @@ func main() {
 	//handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
-	//handleSecurity()
-	handleVM()
+	handleSecurity()
+	//handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
 	//handleVMSpec()
-
-	/*
-		KeyPairHandler, err := setKeyPairHandler()
-		if err != nil {
-			panic(err)
-		}
-
-		keyPairName := "test123"
-		cblogger.Infof("[%s] 키 페어 조회 테스트", keyPairName)
-		result, err := KeyPairHandler.GetKey(keyPairName)
-		if err != nil {
-			cblogger.Infof(keyPairName, " 키 페어 조회 실패 : ", err)
-		} else {
-			cblogger.Infof("[%s] 키 페어 조회 결과")
-			spew.Dump(result)
-		}
-	*/
 }
 
 //handlerType : resources폴더의 xxxHandler.go에서 Handler이전까지의 문자열

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
@@ -181,31 +181,48 @@ func handleSecurity() {
 					IId:    irs.IID{NameId: securityName},
 					VpcIID: irs.IID{SystemId: vpcId},
 					SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
+						//CIDR 테스트
 						{
-							FromPort:   "20",
-							ToPort:     "22",
+							FromPort:   "30",
+							ToPort:     "",
 							IPProtocol: "tcp",
 							Direction:  "inbound",
+							CIDR:       "10.13.1.10/32",
 						},
+						{
+							FromPort:   "40",
+							ToPort:     "",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "10.13.1.10/32",
+						},
+						/*
+							{
+								FromPort:   "20",
+								ToPort:     "22",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
 
-						{
-							FromPort:   "80",
-							ToPort:     "",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-						},
-						{
-							FromPort:   "8080",
-							ToPort:     "",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-						},
-						{
-							FromPort:   "ALL",
-							ToPort:     "",
-							IPProtocol: "icmp",
-							Direction:  "inbound",
-						},
+							{
+								FromPort:   "80",
+								ToPort:     "",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "8080",
+								ToPort:     "",
+								IPProtocol: "tcp",
+								Direction:  "inbound",
+							},
+							{
+								FromPort:   "ALL",
+								ToPort:     "",
+								IPProtocol: "icmp",
+								Direction:  "inbound",
+							},
+						*/
 
 						// {
 						// 	FromPort:   "443",
@@ -235,6 +252,7 @@ func handleSecurity() {
 					cblogger.Infof(securityName, " Security 생성 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 생성 결과 : [%v]", securityName, result)
+					securityId = result.IId.SystemId
 					spew.Dump(result)
 				}
 
@@ -729,9 +747,9 @@ func main() {
 	cblogger.Info("Tencent Cloud Resource Test")
 	//handleVPC() //VPC
 	//handleKeyPair()
-	//handleSecurity()
+	handleSecurity()
 	//handleImage() //AMI
-	handleVMSpec()
+	//handleVMSpec()
 	//handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
@@ -58,7 +58,8 @@ func (securityHandler *TencentSecurityHandler) CreateSecurity(securityReqInfo ir
 	for _, curPolicy := range *securityReqInfo.SecurityRules {
 		securityGroupPolicy := new(vpc.SecurityGroupPolicy)
 		securityGroupPolicy.Protocol = common.StringPtr(curPolicy.IPProtocol)
-		securityGroupPolicy.CidrBlock = common.StringPtr("0.0.0.0/0")
+		//securityGroupPolicy.CidrBlock = common.StringPtr("0.0.0.0/0")
+		securityGroupPolicy.CidrBlock = common.StringPtr(curPolicy.CIDR)
 		securityGroupPolicy.Action = common.StringPtr("accept")
 
 		if curPolicy.ToPort != "" {
@@ -249,8 +250,8 @@ func (securityHandler *TencentSecurityHandler) ExtractPolicyGroups(policyGroups 
 				}
 
 				securityRuleInfo := irs.SecurityRuleInfo{
-					Direction: direction, // "inbound | outbound"
-					//Cidr:      *curPolicy.CidrBlock,
+					Direction:  direction, // "inbound | outbound"
+					CIDR:       *curPolicy.CidrBlock,
 					IPProtocol: *curPolicy.Protocol,
 					FromPort:   fromPort,
 					ToPort:     toPort,


### PR DESCRIPTION
AWS/ALIBABA/TENCENT의 경우 Inbound / Outbound에 대한 간단한 CIDR 테스트는 진행했음.

[참고사항1]
- AWS의 경우 CIDR에 123.456.789.123/**0** 처럼 /32가 아닌 /0으로 잘 못 입력할 경우 API에서 별도의 오류 없이 정상적으로 등록되며 실제 처리된 결과는 사용자가 입력한 CIDR이 아닌 AWS 자체적으로 0.0.0.0/0으로 등록되니 참고... 
- 다른 CSP도 동일한지 확인해 보지 않았으며 123.456.789.123/**32** 처럼 정상적인 경우만 테스트해 봤음.

[참고사항2 -GCP 이슈]
- GCP의 경우 이전 이슈가 해결되지 않은 상태로 있어서 논의가 필요하기에 별도로 작업후 커밋 예정
  --> GCP의 경우 보안 그룹 생성시 1개의 보안그룹 명에는 1개의 Inbound or Outbound만 셋팅할 수 있음.
        그래서 기존에는 SecurityReqInfo.Direction 정보를 이용했지만 Inbound와 Outbound를 동시에 요청할 경우와 SecurityRuleInfo 배열의 첫번째 요소의 값을 이용하거나 Name 정보를 추가하는 방안 중 결정되지 않은 상태임.
        현재는 SecurityReqInfo.Direction  값이 있으면 이용하고 없으면 가장 많이 사용되는 Inbound로 동작하도록 설정되어있음.

  --> 현재 CIDR의 경우에도 동일하게 각 Port마다 설정하는 방식이 아닌 보안 정책에 1개만 셋팅 가능함.
        즉, 1개의 정책(Inbound or Outbound 택1)에 여러 개의 Port 정보만 등록하는 방식이라 CIDR도 1개로 통일되어야 함.
        SecurityReqInfo.Direction 은 없어질(?) 항목이라 해당 항목에 CIDR을 추가할 것인지 SecurityRuleInfo 배열의 첫번째 정보 기반으로 처리할 것인지에 따라 구현후 커밋 예정이라 일단 GCP는 보류해 놓음.
        텀블벅 내부에서도 SecurityReqInfo.Direction 값은 이용하지 않을 것으로 추정되기에 임시로 SecurityRuleInfo 배열의 첫번째 값을 이용하고 웹도구에서는 GCP의 경우 모든 배열의 값을 공통으로 설정하도록 하는게 좋을지....
         유사한 다른 CSP가 있다면 배열이 아닌 명확하게 SecurityReqInfo.Direction / SecurityReqInfo.CIDR을 이용하는게 좋을지 결정은 필요할 듯.