### PR TITLE
AWS - 이미지 정보에 GuestOS및  Description KeyValue추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -690,7 +690,7 @@ func handleImage() {
 	handler := ResourceHandler.(irs.ImageHandler)
 
 	imageReqInfo := irs.ImageReqInfo{
-		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-0e82959d4ed12de3f"},
+		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-005ace3da56246b4c"},
 		//Id:   "ami-047f7b46bd6dd5d84",
 		//Name: "Test OS Image",
 	}


### PR DESCRIPTION
몇 개 이미지를 살펴 볼 경우 윈도우즈는 Platform("windows") 정보가 존재하며 리눅스 계열은 Platform정보는 없고 PlatformDetails("Linux/UNIX")만 존재하는 듯. - 
윈도우즈 계열은 PlatformDetails에는 "Windows with SQL Server Standard"처럼 세부 정보가 있어서 Platform 정보가 있으면 Platform 정보를 GuestOS에 할당하고
Platform정보가 없는 경우 PlatformDetails 항목의 값을 사용하도록 했음.

이미지에 대한 세부 내용을 참고할 수 있도록 KeyValue에 Description 정보도 추가함.
