### PR TITLE
Alibaba 이슈 #409에 의해 타임아웃 및 RetryTime 설정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/AlibabaDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/AlibabaDriver.go
@@ -22,6 +22,11 @@ import (
 	icon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/connect"
 	"github.com/davecgh/go-spew/spew"
 )
+import (
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
+)
 
 type AlibabaDriver struct{}
 
@@ -94,14 +99,27 @@ func getECSClient(connectionInfo idrv.ConnectionInfo) (*ecs.Client, error) {
 	*/
 
 	// Create a credential object
+	/* BaseCredential는 deprecated 되었음.
 	credential := &credentials.BaseCredential{
 		AccessKeyId:     connectionInfo.CredentialInfo.ClientId,
 		AccessKeySecret: connectionInfo.CredentialInfo.ClientSecret,
 	}
+	*/
 
-	escClient, err := ecs.NewClientWithAccessKey(connectionInfo.RegionInfo.Region, credential.AccessKeyId, credential.AccessKeySecret)
+	credential := &credentials.AccessKeyCredential{
+		AccessKeyId:     connectionInfo.CredentialInfo.ClientId,
+		AccessKeySecret: connectionInfo.CredentialInfo.ClientSecret,
+	}
 
-	//escClient, err := ecs.NewClientWithOptions(connectionInfo.RegionInfo.Region, config, credential)
+	config := sdk.NewConfig()
+	config.Timeout = time.Duration(30) * time.Second //time.Millisecond
+	config.AutoRetry = true
+	config.MaxRetryTime = 5
+	//sdk.Timeout(1000)
+
+	//escClient, err := ecs.NewClientWithAccessKey(connectionInfo.RegionInfo.Region, credential.AccessKeyId, credential.AccessKeySecret)
+
+	escClient, err := ecs.NewClientWithOptions(connectionInfo.RegionInfo.Region, config, credential)
 	if err != nil {
 		fmt.Println("Could not create alibaba's ecs service client", err)
 		spew.Dump(err)
@@ -137,13 +155,26 @@ func getVPCClient(connectionInfo idrv.ConnectionInfo) (*vpc.Client, error) {
 	*/
 
 	// Create a credential object
+	/* BaseCredential는 deprecated 되었음.
 	credential := &credentials.BaseCredential{
 		AccessKeyId:     connectionInfo.CredentialInfo.ClientId,
 		AccessKeySecret: connectionInfo.CredentialInfo.ClientSecret,
 	}
+	*/
 
-	vpcClient, err := vpc.NewClientWithAccessKey(connectionInfo.RegionInfo.Region, credential.AccessKeyId, credential.AccessKeySecret)
-	//vpcClient, err := vpc.NewClientWithOptions(connectionInfo.RegionInfo.Region, config, credential)
+	credential := &credentials.AccessKeyCredential{
+		AccessKeyId:     connectionInfo.CredentialInfo.ClientId,
+		AccessKeySecret: connectionInfo.CredentialInfo.ClientSecret,
+	}
+
+	config := sdk.NewConfig()
+	config.Timeout = time.Duration(30) * time.Second //time.Millisecond
+	config.AutoRetry = true
+	config.MaxRetryTime = 5
+	//sdk.Timeout(1000)
+
+	//vpcClient, err := vpc.NewClientWithAccessKey(connectionInfo.RegionInfo.Region, credential.AccessKeyId, credential.AccessKeySecret)
+	vpcClient, err := vpc.NewClientWithOptions(connectionInfo.RegionInfo.Region, config, credential)
 	if err != nil {
 		fmt.Println("Could not create alibaba's vpc service client", err)
 		return nil, err


### PR DESCRIPTION
- 이슈 #409  에 의해 API 클라이언트의 타임아웃을 30초로 설정함.
  자동 재시도 기능 활성화및 최대 재시도 횟수를 5회로 함게 설정함.
    config.Timeout = time.Duration(30) * time.Second //time.Millisecond
   config.AutoRetry = true
   config.MaxRetryTime = 5

- 기존에 사용하던 credentials.BaseCredential은 deprecated 되어서 credentials.AccessKeyCredential로 인증 방식을 변경함.