### PR TITLE
CB-Spider에 driver 추가 반영

### DIFF
--- a/cloud-control-manager/CloudDriverHandler_dynamic.go
+++ b/cloud-control-manager/CloudDriverHandler_dynamic.go
@@ -208,6 +208,9 @@ func GetRegionNameByRegionInfo(rgnInfo *rim.RegionInfo) (string, string, error) 
 		regionName = getValue(rgnInfo.KeyValueInfoList, "Region")
 	case "MOCK":
 		regionName = getValue(rgnInfo.KeyValueInfoList, "Region")
+	case "TENCENT":
+		regionName = getValue(rgnInfo.KeyValueInfoList, "Region")
+		zoneName = getValue(rgnInfo.KeyValueInfoList, "Zone")
 	default:
 		errmsg := rgnInfo.ProviderName + " is not a valid ProviderName!!"
 		return "", "", fmt.Errorf(errmsg)

--- a/cloud-control-manager/cloud-driver/call-log/gen4test/gen_calllog.go
+++ b/cloud-control-manager/cloud-driver/call-log/gen4test/gen_calllog.go
@@ -62,8 +62,9 @@ var cloudOSList = []call.CLOUD_OS{
 	call.ALIBABA,
 	call.DOCKER,
 	call.CLOUDTWIN,
-	//call.NCP,
-	//call.NCPVPC,
+	call.TENCENT,
+	call.NCP,
+	call.NCPVPC,
 }
 
 var resTypeList = []call.RES_TYPE{


### PR DESCRIPTION
- CB-Spider에서 tencent driver 활용시 dynamic mode(plug-in mode) 지원을 위해 tencent driver 추가
- Call log 수집 대상 cloud OS에 tencent, NCP, NCP VPC driver 추가