### PR TITLE
Add another Swagger pilot codes

### DIFF
--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -34,6 +34,22 @@ import (
 
 var cblog *logrus.Logger
 
+// @title CB-Spider REST API
+// @version latest
+// @description CB-Spider REST API
+
+// @contact.name API Support
+// @contact.url http://cloud-barista.github.io
+// @contact.email contact-to-cloud-barista@googlegroups.com
+
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host localhost:1024
+// @BasePath /spider
+
+// @securityDefinitions.basic BasicAuth
+
 func init() {
 	cblog = config.Cblogger
 	currentTime := time.Now()
@@ -57,6 +73,11 @@ type StatusInfo struct {
 type route struct {
 	method, path string
 	function     echo.HandlerFunc
+}
+
+// JSON Simple message struct
+type SimpleMsg struct {
+	Message string `json:"message" example:"Any message"`
 }
 
 func getHostIPorName() string {

--- a/api-runtime/rest-runtime/CCMRest.go
+++ b/api-runtime/rest-runtime/CCMRest.go
@@ -225,21 +225,33 @@ func getOrgVMSpec(c echo.Context) error {
 	return c.String(http.StatusOK, result)
 }
 
-//================ VPC Handler
+type vpcCreateReq struct {
+	ConnectionName string
+	ReqInfo        struct {
+		Name           string
+		IPv4_CIDR      string
+		SubnetInfoList []struct {
+			Name      string
+			IPv4_CIDR string
+		}
+	}
+}
+
+// createVPC godoc
+// @Summary Create VPC
+// @Description Create VPC
+// @Tags [CCM] VPC management
+// @Accept  json
+// @Produce  json
+// @Param vpcCreateReq body vpcCreateReq true "Request body to create VPC"
+// @Success 200 {object} resources.VPCInfo
+// @Failure 404 {object} SimpleMsg
+// @Failure 500 {object} SimpleMsg
+// @Router /vpc [post]
 func createVPC(c echo.Context) error {
 	cblog.Info("call createVPC()")
 
-	var req struct {
-		ConnectionName string
-		ReqInfo        struct {
-			Name           string
-			IPv4_CIDR      string
-			SubnetInfoList []struct {
-				Name      string
-				IPv4_CIDR string
-			}
-		}
-	}
+	req := vpcCreateReq{}
 
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -484,19 +496,31 @@ func removeCSPSubnet(c echo.Context) error {
 	return c.JSON(http.StatusOK, &resultInfo)
 }
 
-//================ SecurityGroup Handler
+type securityGroupCreateReq struct {
+	ConnectionName string
+	ReqInfo        struct {
+		Name          string
+		VPCName       string
+		Direction     string
+		SecurityRules *[]cres.SecurityRuleInfo
+	}
+}
+
+/* // createSecurity godoc
+// @Summary Create Security Group
+// @Description Create Security Group
+// @Tags [CCM] Security Group management
+// @Accept  json
+// @Produce  json
+// @Param securityGroupCreateReq body securityGroupCreateReq true "Request body to create Security Group"
+// @Success 200 {object} resources.SecurityInfo
+// @Failure 404 {object} SimpleMsg
+// @Failure 500 {object} SimpleMsg
+// @Router /securitygroup [post] */
 func createSecurity(c echo.Context) error {
 	cblog.Info("call createSecurity()")
 
-	var req struct {
-		ConnectionName string
-		ReqInfo        struct {
-			Name          string
-			VPCName       string
-			Direction     string
-			SecurityRules *[]cres.SecurityRuleInfo
-		}
-	}
+	req := securityGroupCreateReq{}
 
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -649,16 +673,18 @@ func deleteCSPSecurity(c echo.Context) error {
 	return c.JSON(http.StatusOK, &resultInfo)
 }
 
-type keyPairCreateReq struct {
-	ConnectionName string
-	ReqInfo        struct {
-		Name string
-	}
-}
+// type keyPairCreateReq struct {
+// 	ConnectionName string
+// 	ReqInfo        struct {
+// 		Name string
+// 	}
+// }
 
-// JSON Simple message struct
-type SimpleMsg struct {
-	Message string `json:"message" example:"Any message"`
+// JSONResult's data field will be overridden by the specific type
+type JSONResult struct {
+	//Code    int          `json:"code" `
+	//Message string       `json:"message"`
+	//Data    interface{}  `json:"data"`
 }
 
 // createKey godoc
@@ -667,7 +693,7 @@ type SimpleMsg struct {
 // @Tags [CCM] Access key management
 // @Accept  json
 // @Produce  json
-// @Param keyPairCreateReq body keyPairCreateReq true "Request body to create key"
+// @Param keyPairCreateReq body JSONResult{ConnectionName=string,ReqInfo=JSONResult{Name=string}} true "Request body to create key"
 // @Success 200 {object} resources.KeyPairInfo
 // @Failure 404 {object} SimpleMsg
 // @Failure 500 {object} SimpleMsg
@@ -675,7 +701,12 @@ type SimpleMsg struct {
 func createKey(c echo.Context) error {
 	cblog.Info("call createKey()")
 
-	req := keyPairCreateReq{}
+	var req struct {
+		ConnectionName string
+		ReqInfo        struct {
+			Name string
+		}
+	}
 
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/api-runtime/rest-runtime/docs/docs.go
+++ b/api-runtime/rest-runtime/docs/docs.go
@@ -18,7 +18,15 @@ var doc = `{
     "info": {
         "description": "{{.Description}}",
         "title": "{{.Title}}",
-        "contact": {},
+        "contact": {
+            "name": "API Support",
+            "url": "http://cloud-barista.github.io",
+            "email": "contact-to-cloud-barista@googlegroups.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
@@ -44,7 +52,34 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/restruntime.keyPairCreateReq"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/restruntime.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "ConnectionName": {
+                                            "type": "string"
+                                        },
+                                        "ReqInfo": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/restruntime.JSONResult"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "Name": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 ],
@@ -53,6 +88,52 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/resources.KeyPairInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/vpc": {
+            "post": {
+                "description": "Create VPC",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[CCM] VPC management"
+                ],
+                "summary": "Create VPC",
+                "parameters": [
+                    {
+                        "description": "Request body to create VPC",
+                        "name": "vpcCreateReq",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.vpcCreateReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/resources.VPCInfo"
                         }
                     },
                     "404": {
@@ -123,6 +204,51 @@ var doc = `{
                 }
             }
         },
+        "resources.SubnetInfo": {
+            "type": "object",
+            "properties": {
+                "iid": {
+                    "description": "{NameId, SystemId}",
+                    "$ref": "#/definitions/resources.IID"
+                },
+                "ipv4_CIDR": {
+                    "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.KeyValue"
+                    }
+                }
+            }
+        },
+        "resources.VPCInfo": {
+            "type": "object",
+            "properties": {
+                "iid": {
+                    "description": "{NameId, SystemId}",
+                    "$ref": "#/definitions/resources.IID"
+                },
+                "ipv4_CIDR": {
+                    "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.KeyValue"
+                    }
+                },
+                "subnetInfoList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.SubnetInfo"
+                    }
+                }
+            }
+        },
+        "restruntime.JSONResult": {
+            "type": "object"
+        },
         "restruntime.SimpleMsg": {
             "type": "object",
             "properties": {
@@ -132,7 +258,7 @@ var doc = `{
                 }
             }
         },
-        "restruntime.keyPairCreateReq": {
+        "restruntime.vpcCreateReq": {
             "type": "object",
             "properties": {
                 "connectionName": {
@@ -141,12 +267,34 @@ var doc = `{
                 "reqInfo": {
                     "type": "object",
                     "properties": {
+                        "ipv4_CIDR": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
+                        },
+                        "subnetInfoList": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "ipv4_CIDR": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "BasicAuth": {
+            "type": "basic"
         }
     }
 }`
@@ -162,12 +310,12 @@ type swaggerInfo struct {
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = swaggerInfo{
-	Version:     "",
-	Host:        "",
-	BasePath:    "",
+	Version:     "latest",
+	Host:        "localhost:1024",
+	BasePath:    "/spider",
 	Schemes:     []string{},
-	Title:       "",
-	Description: "",
+	Title:       "CB-Spider REST API",
+	Description: "CB-Spider REST API",
 }
 
 type s struct{}

--- a/api-runtime/rest-runtime/docs/swagger.json
+++ b/api-runtime/rest-runtime/docs/swagger.json
@@ -1,8 +1,21 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "CB-Spider REST API",
+        "title": "CB-Spider REST API",
+        "contact": {
+            "name": "API Support",
+            "url": "http://cloud-barista.github.io",
+            "email": "contact-to-cloud-barista@googlegroups.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        },
+        "version": "latest"
     },
+    "host": "localhost:1024",
+    "basePath": "/spider",
     "paths": {
         "/keypair": {
             "post": {
@@ -24,7 +37,34 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/restruntime.keyPairCreateReq"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/restruntime.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "ConnectionName": {
+                                            "type": "string"
+                                        },
+                                        "ReqInfo": {
+                                            "allOf": [
+                                                {
+                                                    "$ref": "#/definitions/restruntime.JSONResult"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "Name": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 ],
@@ -33,6 +73,52 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/resources.KeyPairInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/vpc": {
+            "post": {
+                "description": "Create VPC",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[CCM] VPC management"
+                ],
+                "summary": "Create VPC",
+                "parameters": [
+                    {
+                        "description": "Request body to create VPC",
+                        "name": "vpcCreateReq",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/restruntime.vpcCreateReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/resources.VPCInfo"
                         }
                     },
                     "404": {
@@ -103,6 +189,51 @@
                 }
             }
         },
+        "resources.SubnetInfo": {
+            "type": "object",
+            "properties": {
+                "iid": {
+                    "description": "{NameId, SystemId}",
+                    "$ref": "#/definitions/resources.IID"
+                },
+                "ipv4_CIDR": {
+                    "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.KeyValue"
+                    }
+                }
+            }
+        },
+        "resources.VPCInfo": {
+            "type": "object",
+            "properties": {
+                "iid": {
+                    "description": "{NameId, SystemId}",
+                    "$ref": "#/definitions/resources.IID"
+                },
+                "ipv4_CIDR": {
+                    "type": "string"
+                },
+                "keyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.KeyValue"
+                    }
+                },
+                "subnetInfoList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/resources.SubnetInfo"
+                    }
+                }
+            }
+        },
+        "restruntime.JSONResult": {
+            "type": "object"
+        },
         "restruntime.SimpleMsg": {
             "type": "object",
             "properties": {
@@ -112,7 +243,7 @@
                 }
             }
         },
-        "restruntime.keyPairCreateReq": {
+        "restruntime.vpcCreateReq": {
             "type": "object",
             "properties": {
                 "connectionName": {
@@ -121,12 +252,34 @@
                 "reqInfo": {
                     "type": "object",
                     "properties": {
+                        "ipv4_CIDR": {
+                            "type": "string"
+                        },
                         "name": {
                             "type": "string"
+                        },
+                        "subnetInfoList": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "ipv4_CIDR": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     }
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "BasicAuth": {
+            "type": "basic"
         }
     }
 }

--- a/api-runtime/rest-runtime/docs/swagger.yaml
+++ b/api-runtime/rest-runtime/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /spider
 definitions:
   resources.IID:
     properties:
@@ -33,24 +34,75 @@ definitions:
       value:
         type: string
     type: object
+  resources.SubnetInfo:
+    properties:
+      iid:
+        $ref: '#/definitions/resources.IID'
+        description: '{NameId, SystemId}'
+      ipv4_CIDR:
+        type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/resources.KeyValue'
+        type: array
+    type: object
+  resources.VPCInfo:
+    properties:
+      iid:
+        $ref: '#/definitions/resources.IID'
+        description: '{NameId, SystemId}'
+      ipv4_CIDR:
+        type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/resources.KeyValue'
+        type: array
+      subnetInfoList:
+        items:
+          $ref: '#/definitions/resources.SubnetInfo'
+        type: array
+    type: object
+  restruntime.JSONResult:
+    type: object
   restruntime.SimpleMsg:
     properties:
       message:
         example: Any message
         type: string
     type: object
-  restruntime.keyPairCreateReq:
+  restruntime.vpcCreateReq:
     properties:
       connectionName:
         type: string
       reqInfo:
         properties:
+          ipv4_CIDR:
+            type: string
           name:
             type: string
+          subnetInfoList:
+            items:
+              properties:
+                ipv4_CIDR:
+                  type: string
+                name:
+                  type: string
+              type: object
+            type: array
         type: object
     type: object
+host: localhost:1024
 info:
-  contact: {}
+  contact:
+    email: contact-to-cloud-barista@googlegroups.com
+    name: API Support
+    url: http://cloud-barista.github.io
+  description: CB-Spider REST API
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  title: CB-Spider REST API
+  version: latest
 paths:
   /keypair:
     post:
@@ -63,7 +115,19 @@ paths:
         name: keyPairCreateReq
         required: true
         schema:
-          $ref: '#/definitions/restruntime.keyPairCreateReq'
+          allOf:
+          - $ref: '#/definitions/restruntime.JSONResult'
+          - properties:
+              ConnectionName:
+                type: string
+              ReqInfo:
+                allOf:
+                - $ref: '#/definitions/restruntime.JSONResult'
+                - properties:
+                    Name:
+                      type: string
+                  type: object
+            type: object
       produces:
       - application/json
       responses:
@@ -82,4 +146,37 @@ paths:
       summary: Create SSH Key
       tags:
       - '[CCM] Access key management'
+  /vpc:
+    post:
+      consumes:
+      - application/json
+      description: Create VPC
+      parameters:
+      - description: Request body to create VPC
+        in: body
+        name: vpcCreateReq
+        required: true
+        schema:
+          $ref: '#/definitions/restruntime.vpcCreateReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/resources.VPCInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/restruntime.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/restruntime.SimpleMsg'
+      summary: Create VPC
+      tags:
+      - '[CCM] VPC management'
+securityDefinitions:
+  BasicAuth:
+    type: basic
 swagger: "2.0"

--- a/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/SecurityHandler.go
@@ -19,6 +19,7 @@ type SecurityReqInfo struct {
 	SecurityRules *[]SecurityRuleInfo
 }
 
+// @definitionAlias cres.SecurityRuleInfo
 type SecurityRuleInfo struct {
 	FromPort   string
 	ToPort     string


### PR DESCRIPTION
[REST API - Request call 의 JSON body 예시를 표시하는 방법]

[옵션 1] - `func createKey` 참조
```Go
// JSONResult's data field will be overridden by the specific type
type JSONResult struct {
	//Code    int          `json:"code" `
	//Message string       `json:"message"`
	//Data    interface{}  `json:"data"`
}

// createKey godoc
// @Summary Create SSH Key
// @Description Create SSH Key
// @Tags [CCM] Access key management
// @Accept  json
// @Produce  json
// @Param keyPairCreateReq body JSONResult{ConnectionName=string,ReqInfo=JSONResult{Name=string}} true "Request body to create key"
// @Success 200 {object} resources.KeyPairInfo
// @Failure 404 {object} SimpleMsg
// @Failure 500 {object} SimpleMsg
// @Router /keypair [post]
func createKey(c echo.Context) error {
	cblog.Info("call createKey()")

	var req struct {
		ConnectionName string
		ReqInfo        struct {
			Name string
		}
	}
```

(Go annotations 중 `// @Param keyPairCreateReq body` 뒤에 수동으로 기재)

[결과]
![image](https://user-images.githubusercontent.com/46767780/122492423-afafd880-d020-11eb-90a5-ffe4cf431b62.png)
(수동으로 기재한 대로, 각 필드의 첫 글자가 대문자로 표시됨)

![image](https://user-images.githubusercontent.com/46767780/122492463-c0604e80-d020-11eb-9865-2c88a6f23611.png)
(`Models` 부분에 `keyPairCreateReq` 와 관련된 것이 표시되지 않음)

---

[옵션 2] - `func createVPC` 참조
```Go
type vpcCreateReq struct {
	ConnectionName string
	ReqInfo        struct {
		Name           string
		IPv4_CIDR      string
		SubnetInfoList []struct {
			Name      string
			IPv4_CIDR string
		}
	}
}

// createVPC godoc
// @Summary Create VPC
// @Description Create VPC
// @Tags [CCM] VPC management
// @Accept  json
// @Produce  json
// @Param vpcCreateReq body vpcCreateReq true "Request body to create VPC"
// @Success 200 {object} resources.VPCInfo
// @Failure 404 {object} SimpleMsg
// @Failure 500 {object} SimpleMsg
// @Router /vpc [post]
func createVPC(c echo.Context) error {
	cblog.Info("call createVPC()")

	req := vpcCreateReq{}
```
(`type vpcCreateReq struct` 에 해당하는 부분을 `createVPC` 함수의 바깥으로 빼고, 
이것을 `// @Param vpcCreateReq body` 뒤에 기재)

[결과]
![image](https://user-images.githubusercontent.com/46767780/122492749-4ed4d000-d021-11eb-89a0-e98fd8590044.png)
(각 필드의 첫 글자가 소문자로 표시됨. 
필요한 경우, 각 필드 옆에 `json:"ConnectionName"` 와 같이 기재하여 대문자로 표시할 수 있음)

![image](https://user-images.githubusercontent.com/46767780/122493436-a6277000-d022-11eb-9241-7ddd9b939127.png)
(`Models` 부분에 `vpcCreateReq` 가 표시됨)

---

[기타]
현 상태에서, `swag` 이 import alias 를 처리하지 못하는 문제가 있음

```Go
import (
	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
)

type securityGroupCreateReq struct {
	ConnectionName string
	ReqInfo        struct {
		Name          string
		VPCName       string
		Direction     string
		SecurityRules *[]cres.SecurityRuleInfo
	}
}
```

`func createSecurity` 위에 있는 Go annotations 의 block comment 를 해제하고 `make swag` 하면

```
❯ make swag
        [CB-Spider] build Swagger docs
2021/06/18 10:42:16 Generate swagger docs....
2021/06/18 10:42:16 Generate general API Info, search dir:./
2021/06/18 10:42:16 warning: failed to get package name in dir: ./, error: execute go list command, exit status 1, stdout:, stderr:no Go files in /home/jhseo/go/src/github.com/cloud-barista/cb-spider
2021/06/18 10:42:16 Generating restruntime.vpcCreateReq
2021/06/18 10:42:16 Generating resources.VPCInfo
2021/06/18 10:42:16 Generating resources.IID
2021/06/18 10:42:16 Generating resources.SubnetInfo
2021/06/18 10:42:16 Generating resources.KeyValue
2021/06/18 10:42:16 Generating restruntime.SimpleMsg
2021/06/18 10:42:16 Generating restruntime.securityGroupCreateReq
2021/06/18 10:42:16 ParseComment error in file api-runtime/rest-runtime/CCMRest.go :cannot find type definition: cres.SecurityRuleInfo
Makefile:30: recipe for target 'swag' failed
make: *** [swag] Error 1
```
