### PR TITLE
Fix delete csp resource for mock driver

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/ImageHandler.go
@@ -11,50 +11,50 @@
 package resources
 
 import (
-        cblog "github.com/cloud-barista/cb-log"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"fmt"
+
+	cblog "github.com/cloud-barista/cb-log"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
 var imgInfoMap map[string][]*irs.ImageInfo
 
 type MockImageHandler struct {
-	MockName      string
+	MockName string
 }
 
 var PrepareImageInfoList []*irs.ImageInfo
 
 func init() {
-        // cblog is a global variable.
+	// cblog is a global variable.
 	imgInfoMap = make(map[string][]*irs.ImageInfo)
 }
 
 // Be called before using the User function.
 // Called in MockDriver
 func PrepareVMImage(mockName string) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called PrepareVMImage()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called PrepareVMImage()!")
 
-        if imgInfoMap[mockName] != nil {
-                return
-        }
+	if imgInfoMap[mockName] != nil {
+		return
+	}
 
-        PrepareImageInfoList = []*irs.ImageInfo{
+	PrepareImageInfoList = []*irs.ImageInfo{
 		{irs.IID{"mock-vmimage-01", "mock-vmimage-01"}, "TestGuestOS", "TestStatus", nil},
 		{irs.IID{"mock-vmimage-02", "mock-vmimage-02"}, "TestGuestOS", "TestStatus", nil},
 		{irs.IID{"mock-vmimage-03", "mock-vmimage-03"}, "TestGuestOS", "TestStatus", nil},
 		{irs.IID{"mock-vmimage-04", "mock-vmimage-04"}, "TestGuestOS", "TestStatus", nil},
 		{irs.IID{"mock-vmimage-05", "mock-vmimage-05"}, "TestGuestOS", "TestStatus", nil},
-        }
-        imgInfoMap[mockName] = PrepareImageInfoList
+	}
+	imgInfoMap[mockName] = PrepareImageInfoList
 }
-
 
 // (1) create imageInfo object
 // (2) insert ImageInfo into global Map
 func (imageHandler *MockImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) (irs.ImageInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called CreateImage()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called CreateImage()!")
 
 	mockName := imageHandler.MockName
 	imageReqInfo.IId.SystemId = imageReqInfo.IId.NameId
@@ -65,15 +65,15 @@ func (imageHandler *MockImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo)
 	// (2) insert ImageInfo into global Map
 	imgInfoList, _ := imgInfoMap[mockName]
 	imgInfoList = append(imgInfoList, &imageInfo)
-	imgInfoMap[mockName]=imgInfoList
+	imgInfoMap[mockName] = imgInfoList
 
 	return imageInfo, nil
 }
 
 func (imageHandler *MockImageHandler) ListImage() ([]*irs.ImageInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called ListImage()!")
-	
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called ListImage()!")
+
 	mockName := imageHandler.MockName
 	imgInfoList, ok := imgInfoMap[mockName]
 	if !ok {
@@ -86,9 +86,8 @@ func (imageHandler *MockImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 }
 
 func (imageHandler *MockImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called GetImage()!")
-
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called GetImage()!")
 
 	imgInfoList, err := imageHandler.ListImage()
 	if err != nil {
@@ -97,31 +96,31 @@ func (imageHandler *MockImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo,
 	}
 
 	for _, info := range imgInfoList {
-		if((*info).IId.NameId == imageIID.NameId) {
+		if (*info).IId.NameId == imageIID.NameId {
 			return *info, nil
 		}
 	}
-	
+
 	return irs.ImageInfo{}, fmt.Errorf("%s image does not exist!!", imageIID.NameId)
 }
 
 func (imageHandler *MockImageHandler) DeleteImage(imageIID irs.IID) (bool, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called DeleteImage()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called DeleteImage()!")
 
-        imgInfoList, err := imageHandler.ListImage()
-        if err != nil {
-                cblogger.Error(err)
-                return false, err
-        }
+	imgInfoList, err := imageHandler.ListImage()
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
 
 	mockName := imageHandler.MockName
-        for idx, info := range imgInfoList {
-                if(info.IId.NameId == imageIID.NameId) {
+	for idx, info := range imgInfoList {
+		if info.IId.SystemId == imageIID.SystemId {
 			imgInfoList = append(imgInfoList[:idx], imgInfoList[idx+1:]...)
-			imgInfoMap[mockName]=imgInfoList
+			imgInfoMap[mockName] = imgInfoList
 			return true, nil
-                }
-        }
+		}
+	}
 	return false, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/KeyPairHandler.go
@@ -11,48 +11,49 @@
 package resources
 
 import (
-        _ "github.com/sirupsen/logrus"
-        cblog "github.com/cloud-barista/cb-log"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"fmt"
+
+	cblog "github.com/cloud-barista/cb-log"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	_ "github.com/sirupsen/logrus"
 )
 
 var keyPairInfoMap map[string][]*irs.KeyPairInfo
 
 type MockKeyPairHandler struct {
-	MockName      string
+	MockName string
 }
 
 func init() {
-        // cblog is a global variable.
+	// cblog is a global variable.
 	keyPairInfoMap = make(map[string][]*irs.KeyPairInfo)
 }
 
 // (1) create keyPairInfo object
 // (2) insert keyPairInfo into global Map
 func (keyPairHandler *MockKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReqInfo) (irs.KeyPairInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called CreateKey()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called CreateKey()!")
 
 	mockName := keyPairHandler.MockName
 	keyPairReqInfo.IId.SystemId = keyPairReqInfo.IId.NameId
 
 	// (1) create keyPairInfo object
 	keyPairInfo := irs.KeyPairInfo{keyPairReqInfo.IId,
-			"XXXXFingerprint", "XXXXPublicKey", "XXXXPrivateKey", "cb-user", nil}
+		"XXXXFingerprint", "XXXXPublicKey", "XXXXPrivateKey", "cb-user", nil}
 
 	// (2) insert KeyPairInfo into global Map
 	infoList, _ := keyPairInfoMap[mockName]
 	infoList = append(infoList, &keyPairInfo)
-	keyPairInfoMap[mockName]=infoList
+	keyPairInfoMap[mockName] = infoList
 
 	return keyPairInfo, nil
 }
 
 func (keyPairHandler *MockKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called ListKey()!")
-	
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called ListKey()!")
+
 	mockName := keyPairHandler.MockName
 	infoList, ok := keyPairInfoMap[mockName]
 	if !ok {
@@ -65,8 +66,8 @@ func (keyPairHandler *MockKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) 
 }
 
 func (keyPairHandler *MockKeyPairHandler) GetKey(iid irs.IID) (irs.KeyPairInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called GetKey()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called GetKey()!")
 
 	infoList, err := keyPairHandler.ListKey()
 	if err != nil {
@@ -75,31 +76,31 @@ func (keyPairHandler *MockKeyPairHandler) GetKey(iid irs.IID) (irs.KeyPairInfo, 
 	}
 
 	for _, info := range infoList {
-		if((*info).IId.NameId == iid.NameId) {
+		if (*info).IId.NameId == iid.NameId {
 			return *info, nil
 		}
 	}
-	
+
 	return irs.KeyPairInfo{}, fmt.Errorf("%s keypair does not exist!!", iid.NameId)
 }
 
 func (keyPairHandler *MockKeyPairHandler) DeleteKey(iid irs.IID) (bool, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called DeleteKey()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called DeleteKey()!")
 
-        infoList, err := keyPairHandler.ListKey()
-        if err != nil {
-                cblogger.Error(err)
-                return false, err
-        }
+	infoList, err := keyPairHandler.ListKey()
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
 
 	mockName := keyPairHandler.MockName
-        for idx, info := range infoList {
-                if(info.IId.NameId == iid.NameId) {
+	for idx, info := range infoList {
+		if info.IId.SystemId == iid.SystemId {
 			infoList = append(infoList[:idx], infoList[idx+1:]...)
-			keyPairInfoMap[mockName]=infoList
+			keyPairInfoMap[mockName] = infoList
 			return true, nil
-                }
-        }
+		}
+	}
 	return false, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/SecurityHandler.go
@@ -11,47 +11,48 @@
 package resources
 
 import (
-        cblog "github.com/cloud-barista/cb-log"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"fmt"
+
+	cblog "github.com/cloud-barista/cb-log"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
 var securityInfoMap map[string][]*irs.SecurityInfo
 
 type MockSecurityHandler struct {
-	MockName      string
+	MockName string
 }
 
 func init() {
-        // cblog is a global variable.
+	// cblog is a global variable.
 	securityInfoMap = make(map[string][]*irs.SecurityInfo)
 }
 
 // (1) create securityInfo object
 // (2) insert securityInfo into global Map
 func (securityHandler *MockSecurityHandler) CreateSecurity(securityReqInfo irs.SecurityReqInfo) (irs.SecurityInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called CreateSecurity()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called CreateSecurity()!")
 
 	mockName := securityHandler.MockName
 	securityReqInfo.IId.SystemId = securityReqInfo.IId.NameId
 	securityReqInfo.VpcIID.SystemId = securityReqInfo.VpcIID.NameId
 	// (1) create securityInfo object
 	securityInfo := irs.SecurityInfo{securityReqInfo.IId,
-			securityReqInfo.VpcIID,
-			securityReqInfo.Direction,
-			securityReqInfo.SecurityRules,
-			nil}
+		securityReqInfo.VpcIID,
+		securityReqInfo.Direction,
+		securityReqInfo.SecurityRules,
+		nil}
 
 	// (2) insert SecurityInfo into global Map
 	infoList, _ := securityInfoMap[mockName]
 	infoList = append(infoList, &securityInfo)
-	securityInfoMap[mockName]=infoList
+	securityInfoMap[mockName] = infoList
 
 	return CloneSecurityInfo(securityInfo), nil
 }
 
-func CloneSecurityInfoList(srcInfoList []*irs.SecurityInfo) ([]*irs.SecurityInfo) {
+func CloneSecurityInfoList(srcInfoList []*irs.SecurityInfo) []*irs.SecurityInfo {
 	clonedInfoList := []*irs.SecurityInfo{}
 	for _, srcInfo := range srcInfoList {
 		clonedInfo := CloneSecurityInfo(*srcInfo)
@@ -60,35 +61,35 @@ func CloneSecurityInfoList(srcInfoList []*irs.SecurityInfo) ([]*irs.SecurityInfo
 	return clonedInfoList
 }
 
-func CloneSecurityInfo(srcInfo irs.SecurityInfo) (irs.SecurityInfo) {
+func CloneSecurityInfo(srcInfo irs.SecurityInfo) irs.SecurityInfo {
 	/*
-	type SecurityInfo struct {
-		IId IID // {NameId, SystemId}
-		VpcIID        IID    // {NameId, SystemId}
-		Direction     string // @todo userd??
-		SecurityRules *[]SecurityRuleInfo
-		KeyValueList []KeyValue
-	}
+		type SecurityInfo struct {
+			IId IID // {NameId, SystemId}
+			VpcIID        IID    // {NameId, SystemId}
+			Direction     string // @todo userd??
+			SecurityRules *[]SecurityRuleInfo
+			KeyValueList []KeyValue
+		}
 	*/
 
 	// clone SecurityInfo
-	clonedInfo := irs.SecurityInfo {
-		IId: irs.IID{srcInfo.IId.NameId, srcInfo.IId.SystemId},
-		VpcIID: irs.IID{srcInfo.VpcIID.NameId, srcInfo.VpcIID.SystemId},
+	clonedInfo := irs.SecurityInfo{
+		IId:       irs.IID{srcInfo.IId.NameId, srcInfo.IId.SystemId},
+		VpcIID:    irs.IID{srcInfo.VpcIID.NameId, srcInfo.VpcIID.SystemId},
 		Direction: srcInfo.Direction,
 
 		// Need not clone
 		SecurityRules: srcInfo.SecurityRules,
-		KeyValueList: srcInfo.KeyValueList,
+		KeyValueList:  srcInfo.KeyValueList,
 	}
 
 	return clonedInfo
 }
 
 func (securityHandler *MockSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called ListSecurity()!")
-	
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called ListSecurity()!")
+
 	mockName := securityHandler.MockName
 	infoList, ok := securityInfoMap[mockName]
 	if !ok {
@@ -99,8 +100,8 @@ func (securityHandler *MockSecurityHandler) ListSecurity() ([]*irs.SecurityInfo,
 }
 
 func (securityHandler *MockSecurityHandler) GetSecurity(iid irs.IID) (irs.SecurityInfo, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called GetSecurity()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called GetSecurity()!")
 
 	infoList, err := securityHandler.ListSecurity()
 	if err != nil {
@@ -110,7 +111,7 @@ func (securityHandler *MockSecurityHandler) GetSecurity(iid irs.IID) (irs.Securi
 
 	// infoList is already cloned in ListSecurity()
 	for _, info := range infoList {
-		if(info.IId.NameId == iid.NameId) {
+		if info.IId.NameId == iid.NameId {
 			return *info, nil
 		}
 	}
@@ -119,22 +120,22 @@ func (securityHandler *MockSecurityHandler) GetSecurity(iid irs.IID) (irs.Securi
 }
 
 func (securityHandler *MockSecurityHandler) DeleteSecurity(iid irs.IID) (bool, error) {
-        cblogger := cblog.GetLogger("CB-SPIDER")
-        cblogger.Info("Mock Driver: called DeleteSecurity()!")
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called DeleteSecurity()!")
 
-        infoList, err := securityHandler.ListSecurity()
-        if err != nil {
-                cblogger.Error(err)
-                return false, err
-        }
+	infoList, err := securityHandler.ListSecurity()
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
 
 	mockName := securityHandler.MockName
-        for idx, info := range infoList {
-                if(info.IId.NameId == iid.NameId) {
+	for idx, info := range infoList {
+		if info.IId.SystemId == iid.SystemId {
 			infoList = append(infoList[:idx], infoList[idx+1:]...)
-			securityInfoMap[mockName]=infoList
+			securityInfoMap[mockName] = infoList
 			return true, nil
-                }
-        }
+		}
+	}
 	return false, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/VMHandler.go
@@ -325,7 +325,7 @@ func (vmHandler *MockVMHandler) ListVM() ([]*irs.VMInfo, error) {
 		return []*irs.VMInfo{}, nil
 	}
 
-	// cloning list of VM Status
+	// cloning list of VM
 	resultList := make([]*irs.VMInfo, len(infoList))
 	copy(resultList, infoList)
 	return resultList, nil

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/VMHandler.go
@@ -99,7 +99,7 @@ func (vmHandler *MockVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, er
 			return irs.VMInfo{}, fmt.Errorf(errMSG)
 		}
 	}
-	
+
 	// keypair validation
 	keyPairHandler := MockKeyPairHandler{mockName}
 	validatedKeyPairInfo, err := keyPairHandler.GetKey(vmReqInfo.KeyPairIID)
@@ -188,7 +188,7 @@ func (vmHandler *MockVMHandler) ResumeVM(iid irs.IID) (irs.VMStatus, error) {
 
 	statusInfoList, ok := vmStatusInfoMap[mockName]
 	if !ok {
-		
+
 		errMSG := mockName + " vm status does not exist!!"
 		cblogger.Error(errMSG)
 		return "", fmt.Errorf(errMSG)
@@ -263,14 +263,14 @@ func (vmHandler *MockVMHandler) TerminateVM(iid irs.IID) (irs.VMStatus, error) {
 
 	mockName := vmHandler.MockName
 	for idx, info := range infoList {
-		if info.IId.NameId == iid.NameId {
+		if info.IId.SystemId == iid.SystemId {
 			infoList = append(infoList[:idx], infoList[idx+1:]...)
 		}
 	}
 	vmInfoMap[mockName] = infoList
 
 	for idx, info := range statusInfoList {
-		if info.IId.NameId == iid.NameId {
+		if info.IId.SystemId == iid.SystemId {
 			statusInfoList = append(statusInfoList[:idx], statusInfoList[idx+1:]...)
 		}
 	}
@@ -325,7 +325,10 @@ func (vmHandler *MockVMHandler) ListVM() ([]*irs.VMInfo, error) {
 		return []*irs.VMInfo{}, nil
 	}
 
-	return infoList, nil
+	// cloning list of VM Status
+	resultList := make([]*irs.VMInfo, len(infoList))
+	copy(resultList, infoList)
+	return resultList, nil
 }
 
 func (vmHandler *MockVMHandler) GetVM(iid irs.IID) (irs.VMInfo, error) {

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/VPCHandler.go
@@ -105,7 +105,7 @@ func (vpcHandler *MockVPCHandler) DeleteVPC(iid irs.IID) (bool, error) {
 
 	mockName := vpcHandler.MockName
 	for idx, info := range infoList {
-		if info.IId.NameId == iid.NameId {
+		if info.IId.SystemId == iid.SystemId {
 			infoList = append(infoList[:idx], infoList[idx+1:]...)
 			vpcInfoMap[mockName] = infoList
 			return true, nil
@@ -148,7 +148,7 @@ func (vpcHandler *MockVPCHandler) RemoveSubnet(iid irs.IID, subnetIID irs.IID) (
 	for _, info := range infoList {
 		if (*info).IId.NameId == iid.NameId {
 			for idx, subInfo := range info.SubnetInfoList {
-				if subInfo.IId.NameId == subnetIID.NameId {
+				if subInfo.IId.SystemId == subnetIID.SystemId {
 					info.SubnetInfoList = append(info.SubnetInfoList[:idx], info.SubnetInfoList[idx+1:]...)
 					return true, nil
 				}

--- a/cloud-control-manager/cloud-driver/drivers/mock/test/image_test.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/test/image_test.go
@@ -9,29 +9,29 @@
 package mocktest
 
 import (
+	mockdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/mock"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	mockdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/mock"
 
-	"testing"
 	_ "fmt"
+	"testing"
 )
 
 var imageHandler irs.ImageHandler
 
 func init() {
-        cred := idrv.CredentialInfo{
-                MockName:      "MockDriver-01",
-        }
-	connInfo := idrv.ConnectionInfo {
-		CredentialInfo: cred, 
-		RegionInfo: idrv.RegionInfo{},
+	cred := idrv.CredentialInfo{
+		MockName: "MockDriver-01",
+	}
+	connInfo := idrv.ConnectionInfo{
+		CredentialInfo: cred,
+		RegionInfo:     idrv.RegionInfo{},
 	}
 	cloudConn, _ := (&mockdrv.MockDriver{}).ConnectCloud(connInfo)
 	imageHandler, _ = cloudConn.CreateImageHandler()
 }
 
-const BUILTIN_IMG_NUM  int = 5
+const BUILTIN_IMG_NUM int = 5
 
 var imageTestInfoList = []string{
 	"mock-user-image-Name01",
@@ -44,8 +44,8 @@ var imageTestInfoList = []string{
 func TestImageCreateList(t *testing.T) {
 	// create
 	for _, info := range imageTestInfoList {
-		reqInfo := irs.ImageReqInfo {
-			IId : irs.IID{info, ""},
+		reqInfo := irs.ImageReqInfo{
+			IId: irs.IID{info, ""},
 		}
 		_, err := imageHandler.CreateImage(reqInfo)
 		if err != nil {
@@ -69,41 +69,40 @@ func TestImageCreateList(t *testing.T) {
 		if imgName != one.IId.NameId {
 			t.Errorf("Image ID %s is not same %s", imgName, one.IId.NameId)
 		}
-//		fmt.Printf("\n\t%#v\n", info)
+		//		fmt.Printf("\n\t%#v\n", info)
 	}
 }
 
 func TestImageDeleteGet(t *testing.T) {
-        // Get & check the Value
-        info, err := imageHandler.GetImage(irs.IID{imageTestInfoList[0], ""})
-        if err != nil {
-                t.Error(err.Error())
-        }
-	if info.IId.SystemId != imageTestInfoList[0]{
+	// Get & check the Value
+	info, err := imageHandler.GetImage(irs.IID{imageTestInfoList[0], ""})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if info.IId.SystemId != imageTestInfoList[0] {
 		t.Errorf("System ID %s is not same %s", info.IId.SystemId, imageTestInfoList[0])
 	}
 
 	// delete all
 	infoList, err := imageHandler.ListImage()
-        if err != nil {
-                t.Error(err.Error())
-        }
-        for _, imgName := range imageTestInfoList {
-		ret, err := imageHandler.DeleteImage(irs.IID{imgName, ""})
-		if err!=nil {
-                        t.Error(err.Error())
+	if err != nil {
+		t.Error(err.Error())
+	}
+	for _, imgName := range imageTestInfoList {
+		ret, err := imageHandler.DeleteImage(irs.IID{"", imgName})
+		if err != nil {
+			t.Error(err.Error())
 		}
 		if !ret {
-                        t.Errorf("Return is not True!! %s", imgName)
+			t.Errorf("Return is not True!! %s", imgName)
 		}
-        }
+	}
 	// check the result of Delete Op
 	infoList, err = imageHandler.ListImage()
-        if err != nil {
-                t.Error(err.Error())
-        }
-	if len(infoList)>BUILTIN_IMG_NUM { // BUILTIN_IMG_NUM: built-in image (see MockDriver)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if len(infoList) > BUILTIN_IMG_NUM { // BUILTIN_IMG_NUM: built-in image (see MockDriver)
 		t.Errorf("The number of Infos is not %d. It is %d.", 0, len(infoList))
 	}
 }
-

--- a/cloud-control-manager/cloud-driver/drivers/mock/test/vpc_test.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/test/vpc_test.go
@@ -11,31 +11,31 @@ package mocktest
 import (
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	// icon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/connect"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	mockdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/mock"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
-	"testing"
 	_ "fmt"
+	"testing"
 )
 
 var vpcHandler irs.VPCHandler
 
 func init() {
-        cred := idrv.CredentialInfo{
-                MockName:      "MockDriver-01",
-        }
-	connInfo := idrv.ConnectionInfo {
-		CredentialInfo: cred, 
-		RegionInfo: idrv.RegionInfo{},
+	cred := idrv.CredentialInfo{
+		MockName: "MockDriver-01",
+	}
+	connInfo := idrv.ConnectionInfo{
+		CredentialInfo: cred,
+		RegionInfo:     idrv.RegionInfo{},
 	}
 	cloudConn, _ := (&mockdrv.MockDriver{}).ConnectCloud(connInfo)
 	vpcHandler, _ = cloudConn.CreateVPCHandler()
 }
 
 type VPCTestInfo struct {
-	IId string
-	VpcCIDR string
-	SubnetIID string
+	IId        string
+	VpcCIDR    string
+	SubnetIID  string
 	SubnetCIDR string
 }
 
@@ -48,23 +48,23 @@ var vpcTestInfoList = []VPCTestInfo{
 }
 
 type SubnetTestInfo struct {
-        VpcIID string
-        SubnetIID string
-        SubnetCIDR string
+	VpcIID     string
+	SubnetIID  string
+	SubnetCIDR string
 }
 
 var subnetTestInfoList = []SubnetTestInfo{
-        {"mock-vpc-name01", "mock-subnet-02", "10.0.2.0/24"},
-        {"mock-vpc-name01", "mock-subnet-03", "10.0.3.0/24"},
+	{"mock-vpc-name01", "mock-subnet-02", "10.0.2.0/24"},
+	{"mock-vpc-name01", "mock-subnet-03", "10.0.3.0/24"},
 }
 
 func TestVPCCreateList(t *testing.T) {
 	// create
 	for _, info := range vpcTestInfoList {
-		reqInfo := irs.VPCReqInfo {
-			IId : irs.IID{info.IId, ""},
-			IPv4_CIDR : info.VpcCIDR,
-			SubnetInfoList : []irs.SubnetInfo{ {IId: irs.IID{info.SubnetIID, ""}, IPv4_CIDR : info.SubnetCIDR}, },
+		reqInfo := irs.VPCReqInfo{
+			IId:            irs.IID{info.IId, ""},
+			IPv4_CIDR:      info.VpcCIDR,
+			SubnetInfoList: []irs.SubnetInfo{{IId: irs.IID{info.SubnetIID, ""}, IPv4_CIDR: info.SubnetCIDR}},
 		}
 		_, err := vpcHandler.CreateVPC(reqInfo)
 		if err != nil {
@@ -84,98 +84,96 @@ func TestVPCCreateList(t *testing.T) {
 		if info.IId.SystemId != vpcTestInfoList[i].IId {
 			t.Errorf("System ID %s is not same %s", info.IId.SystemId, vpcTestInfoList[i].IId)
 		}
-//		fmt.Printf("\n\t%#v\n", info)
+		//		fmt.Printf("\n\t%#v\n", info)
 	}
 }
 
 func TestVPCAddSubnet(t *testing.T) {
-        // add subnet
-        for _, info := range subnetTestInfoList {
-                subnetInfo := irs.SubnetInfo {
-                        IId : irs.IID{info.SubnetIID, ""},
-                        IPv4_CIDR : info.SubnetCIDR,
-                }
-                _, err := vpcHandler.AddSubnet(irs.IID{info.VpcIID, ""}, subnetInfo)
-                if err != nil {
-                        t.Error(err.Error())
-                }
-        }
+	// add subnet
+	for _, info := range subnetTestInfoList {
+		subnetInfo := irs.SubnetInfo{
+			IId:       irs.IID{info.SubnetIID, ""},
+			IPv4_CIDR: info.SubnetCIDR,
+		}
+		_, err := vpcHandler.AddSubnet(irs.IID{info.VpcIID, ""}, subnetInfo)
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
 
-        // check the result of two AddSubnet()
-        info, err := vpcHandler.GetVPC(irs.IID{subnetTestInfoList[0].VpcIID, ""})
-        if err != nil {
-                t.Error(err.Error())
-        }
-        // check the number of subnets after adding
+	// check the result of two AddSubnet()
+	info, err := vpcHandler.GetVPC(irs.IID{subnetTestInfoList[0].VpcIID, ""})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	// check the number of subnets after adding
 	subnetInfoList := info.SubnetInfoList
 	true_num := 3
-        if true_num != len(subnetInfoList) {
-                t.Errorf("The number of subnetInfo is not %d. It is %d.", true_num, len(subnetInfoList))
-        }
+	if true_num != len(subnetInfoList) {
+		t.Errorf("The number of subnetInfo is not %d. It is %d.", true_num, len(subnetInfoList))
+	}
 	// check the last value of subnet list
 	if subnetInfoList[2].IPv4_CIDR != subnetTestInfoList[1].SubnetCIDR {
 		t.Errorf("Subnet IPv4_CIDR %s is not same %s", subnetInfoList[2].IPv4_CIDR, subnetTestInfoList[1].SubnetCIDR)
-        }
+	}
 }
 
 func TestVPCRemoveSubnet(t *testing.T) {
-        // remove subnet
-        for _, info := range subnetTestInfoList {
-                _, err := vpcHandler.RemoveSubnet(irs.IID{info.VpcIID, ""}, irs.IID{info.SubnetIID, ""})
-                if err != nil {
-                        t.Error(err.Error())
-                }
-        }
+	// remove subnet
+	for _, info := range subnetTestInfoList {
+		_, err := vpcHandler.RemoveSubnet(irs.IID{info.VpcIID, ""}, irs.IID{"", info.SubnetIID})
+		if err != nil {
+			t.Error(err.Error())
+		}
+	}
 
-        // check the result of two RemoveSubnet()
-        info, err := vpcHandler.GetVPC(irs.IID{subnetTestInfoList[0].VpcIID, ""})
-        if err != nil {
-                t.Error(err.Error())
-        }
-        // check the number of subnets after removal
-        subnetInfoList := info.SubnetInfoList
+	// check the result of two RemoveSubnet()
+	info, err := vpcHandler.GetVPC(irs.IID{subnetTestInfoList[0].VpcIID, ""})
+	if err != nil {
+		t.Error(err.Error())
+	}
+	// check the number of subnets after removal
+	subnetInfoList := info.SubnetInfoList
 	true_num := 1
-        if true_num != len(subnetInfoList) {
-                t.Errorf("The number of subnetInfo is not %d. It is %d.", true_num, len(subnetInfoList))
-        }
-        // check the fist value of subnet list
-        if subnetInfoList[0].IPv4_CIDR != vpcTestInfoList[0].SubnetCIDR {
-                t.Errorf("Subnet IPv4_CIDR %s is not same %s", subnetInfoList[0].IPv4_CIDR, vpcTestInfoList[0].SubnetCIDR)
-        }
+	if true_num != len(subnetInfoList) {
+		t.Errorf("The number of subnetInfo is not %d. It is %d.", true_num, len(subnetInfoList))
+	}
+	// check the fist value of subnet list
+	if subnetInfoList[0].IPv4_CIDR != vpcTestInfoList[0].SubnetCIDR {
+		t.Errorf("Subnet IPv4_CIDR %s is not same %s", subnetInfoList[0].IPv4_CIDR, vpcTestInfoList[0].SubnetCIDR)
+	}
 }
 
-
 func TestVPCDeleteGet(t *testing.T) {
-        // Get & check the Value
-        info, err := vpcHandler.GetVPC(irs.IID{vpcTestInfoList[0].IId, ""})
-        if err != nil {
-                t.Error(err.Error())
-        }
+	// Get & check the Value
+	info, err := vpcHandler.GetVPC(irs.IID{vpcTestInfoList[0].IId, ""})
+	if err != nil {
+		t.Error(err.Error())
+	}
 	if info.IId.SystemId != vpcTestInfoList[0].IId {
 		t.Errorf("System ID %s is not same %s", info.IId.SystemId, vpcTestInfoList[0].IId)
 	}
 
 	// delete all
 	infoList, err := vpcHandler.ListVPC()
-        if err != nil {
-                t.Error(err.Error())
-        }
-        for _, info := range infoList {
+	if err != nil {
+		t.Error(err.Error())
+	}
+	for _, info := range infoList {
 		ret, err := vpcHandler.DeleteVPC(info.IId)
-		if err!=nil {
-                        t.Error(err.Error())
+		if err != nil {
+			t.Error(err.Error())
 		}
 		if !ret {
-                        t.Errorf("Return is not True!! %s", info.IId.NameId)
+			t.Errorf("Return is not True!! %s", info.IId.NameId)
 		}
-        }
+	}
 	// check the result of Delete Op
 	infoList, err = vpcHandler.ListVPC()
-        if err != nil {
-                t.Error(err.Error())
-        }
-	if len(infoList)>0 {
+	if err != nil {
+		t.Error(err.Error())
+	}
+	if len(infoList) > 0 {
 		t.Errorf("The number of Infos is not %d. It is %d.", 0, len(infoList))
 	}
 }
-


### PR DESCRIPTION
- DeleteCSPResource() 함수에서 리소스 삭제할 때 SystemId 를 이용하고 있음
- mock driver 에서 리소스 삭제할 때 NameId 를 사용하고 있어 SystemId 로 변경함
- MockVMHandler 의 ListVM() 에서 결과를 복사해서 리턴함