### PR TITLE
[Azure] go sdk 버전 업그레이드

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure-plugin/AzureDriver-lib.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure-plugin/AzureDriver-lib.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -14,9 +14,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
 
@@ -33,9 +33,8 @@ func (AzureDriver) GetDriverVersion() string {
 }
 
 const (
-        cspTimeout time.Duration = 6000
+	cspTimeout time.Duration = 6000
 )
-
 
 func (AzureDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	var drvCapabilityInfo idrv.DriverCapabilityInfo

--- a/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
@@ -12,8 +12,8 @@ package connect
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	cblog "github.com/cloud-barista/cb-log"
 	azrs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/azure/resources"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/ImageHandler.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMSpecHandler.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VPCHandler.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go v51.2.0+incompatible
+	github.com/Azure/azure-sdk-for-go v55.5.0+incompatible
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.7
 	github.com/Azure/go-autorest/autorest/to v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,10 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/azure-sdk-for-go v51.2.0+incompatible h1:qQNk//OOHK0GZcgMMgdJ4tZuuh0zcOeUkpTxjvKFpSQ=
+github.com/Azure/azure-sdk-for-go v51.2g.0+incompatible h1:qQNk//OOHK0GZcgMMgdJ4tZuuh0zcOeUkpTxjvKFpSQ=
 github.com/Azure/azure-sdk-for-go v51.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v55.5.0+incompatible h1:GToUAq2Qdrh6g2ITPXx95zQ2DGMFSIatf9QwFplUTmk=
+github.com/Azure/azure-sdk-for-go v55.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=


### PR DESCRIPTION
[go sdk version change]
  - 이전 : azure-sdk-for-go v51.2.0
  - 현재 :  azure-sdk-for-go v55.5.0
 

[go library import version change]
 1. compute
  - 이전 : github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute
  - 현재 : github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute
  - 이슈 : 새로운 버전에서 PowerOff 함수에 skipShutdown(강제종료옵션), Delete 함수에 forceDeletion(강제삭제옵션) 파라미터가 추가되어 default값인 false 전달
 
  2. network
  - 이전 : github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network
  - 현재 : github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network
  
  3. resources
  - 이전 : github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources
  - 현재 : github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources
