### PR TITLE
Replace jwt-go with currently-being-maintained ver

### DIFF
--- a/api-runtime/grpc-runtime/interceptors/authjwt/auth.go
+++ b/api-runtime/grpc-runtime/interceptors/authjwt/auth.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/cloud-barista/cb-spider/api-runtime/grpc-runtime/logger"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"

--- a/api-runtime/grpc-runtime/jwt-gen/jwt_gen.go
+++ b/api-runtime/grpc-runtime/jwt-gen/jwt_gen.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/containerd/containerd v1.4.3 // indirect
 	github.com/coreos/bbolt v1.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -33,6 +32,7 @@ require (
 	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gophercloud/gophercloud v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
- Replace jwt-go with currently-being-maintained ver
  - As-is: https://github.com/dgrijalva/jwt-go
  - To-be: https://github.com/golang-jwt/jwt
  - Related CB-Tumblebug issue: https://github.com/cloud-barista/cb-tumblebug/issues/656
  - Related CB-Tumblebug PR: https://github.com/cloud-barista/cb-tumblebug/pull/661
  - Related Dependabot alert: https://github.com/cloud-barista/cb-spider/security/dependabot/go.mod/github.com%2Fdgrijalva%2Fjwt-go/open
    
![image](https://user-images.githubusercontent.com/46767780/128139902-73a8baf9-4fc7-4d18-939c-8c5efd69792e.png)
