### PR TITLE
Fix 'ConnetcionName' to 'ConfigName' about spctl connection

### DIFF
--- a/cloud-control-manager/iid-manager/IIDManager.go
+++ b/cloud-control-manager/iid-manager/IIDManager.go
@@ -289,7 +289,7 @@ defer iidRWLock.rwMutex.Unlock()
 
 func checkParams(connectionName string, resourceType string, iId *resources.IID) error {
         if connectionName == "" {
-                return fmt.Errorf("ConfigName is empty!")
+                return fmt.Errorf("ConnectionName is empty!")
         }
         if resourceType == "" {
                 return fmt.Errorf("ResourceType is empty!")
@@ -305,7 +305,7 @@ func checkParams(connectionName string, resourceType string, iId *resources.IID)
 
 func checkParamsSystemId(connectionName string, resourceType string, iId *resources.IID) error {
         if connectionName == "" {
-                return fmt.Errorf("ConfigName is empty!")
+                return fmt.Errorf("ConnectionName is empty!")
         }
         if resourceType == "" {
                 return fmt.Errorf("ResourceType is empty!")
@@ -321,7 +321,7 @@ func checkParamsSystemId(connectionName string, resourceType string, iId *resour
 
 func checkParamsKeyword(connectionName string, resourceType string, keyword *string) error {
         if connectionName == "" {
-                return fmt.Errorf("ConfigName is empty!")
+                return fmt.Errorf("ConnectionName is empty!")
         }
         if resourceType == "" {
                 return fmt.Errorf("ResourceType is empty!")


### PR DESCRIPTION
fix #478 

- spctl의 Connection 생성하는 부분의 `ConnectionName is empty` 의 오류 메시지 출력 부분을 `ConfigName is empty` 로 수정 완료했습니다.