### PR TITLE
Add vm control button for AdminWeb

### DIFF
--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -282,8 +282,8 @@ func RunServer() {
 		{"GET", "/vmstatus", ListVMStatus},
 		{"GET", "/vmstatus/:Name", GetVMStatus},
 
-		{"GET", "/controlvm/:Name", ControlVM},  // suspend, resume, reboot
-		{"POST", "/controlvm/:Name", ControlVM}, // suspend, resume, reboot
+		{"GET", "/controlvm/:Name", ControlVM}, // suspend, resume, reboot
+		{"PUT", "/controlvm/:Name", ControlVM}, // suspend, resume, reboot
 
 		//-------------------------------------------------------------------//
 		//----------SSH RUN

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-CCM.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-CCM.go
@@ -997,7 +997,7 @@ func makeVMControlFunc_js() string {
 												document.getElementById("vmcontrol-" + vmName).innerHTML = '<span style="color:red">Waiting...</span>';
 												setTimeout(function(){
 													var xhr = new XMLHttpRequest();
-													xhr.open("POST", "$$SPIDER_SERVER$$/spider/controlvm/" + vmName + "?action=" + action, false);
+													xhr.open("PUT", "$$SPIDER_SERVER$$/spider/controlvm/" + vmName + "?action=" + action, false);
 													xhr.setRequestHeader('Content-Type', 'application/json');
 													sendJson = '{ "ConnectionName": "' + connConfig + '"}'
 													xhr.send(sendJson);


### PR DESCRIPTION
resolve #477 

- XMLHttpRequest 의 HTTP GET 호출에서는 json body 를 포함하지 못하는 문제로 인하여 POST 방식의 "/controlvm/:Name" VM Handler 추가함
- mock 환경에서 테스트함 