### PR TITLE
[bugfix]드라이버 핸들러 에러 코드라인 표시

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
@@ -38,7 +38,6 @@ func InitLog() {
 }
 
 func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
-	cblogger.Error(err.Error())
 	hiscallInfo.ErrorMSG = err.Error()
 	calllogger.Info(call.String(hiscallInfo))
 }

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/ImageHandler.go
@@ -134,6 +134,7 @@ func (imageHandler *AzureImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 
 	publishers, err := imageHandler.VMImageClient.ListPublishers(context.TODO(), imageHandler.Region.Region)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -194,6 +195,7 @@ func (imageHandler *AzureImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo
 	// 이미지 URN 형식 검사
 	if len(imageArr) != 4 {
 		formatErr := errors.New("invalid format for image ID, imageId=" + imageIID.NameId)
+		cblogger.Error(formatErr.Error())
 		LoggingError(hiscallInfo, formatErr)
 		return irs.ImageInfo{}, formatErr
 	}
@@ -233,6 +235,7 @@ func (imageHandler *AzureImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo
 	start := call.Start()
 	vmImage, err := imageHandler.VMImageClient.Get(imageHandler.Ctx, imageHandler.Region.Region, imageArr[0], imageArr[1], imageArr[2], imageArr[3])
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -249,6 +252,7 @@ func (imageHandler *AzureImageHandler) DeleteImage(imageIID irs.IID) (bool, erro
 	start := call.Start()
 	future, err := imageHandler.Client.Delete(imageHandler.Ctx, imageHandler.Region.ResourceGroup, imageIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -256,6 +260,7 @@ func (imageHandler *AzureImageHandler) DeleteImage(imageIID irs.IID) (bool, erro
 
 	err = future.WaitForCompletionRef(imageHandler.Ctx, imageHandler.Client.Client)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -78,6 +78,7 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 	security, _ := securityHandler.Client.Get(securityHandler.Ctx, securityHandler.Region.ResourceGroup, securityReqInfo.IId.NameId, "")
 	if security.ID != nil {
 		createErr := errors.New(fmt.Sprintf("Security Group with name %s already exist", securityReqInfo.IId.NameId))
+		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.SecurityInfo{}, createErr
 	}
@@ -120,6 +121,7 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 	start := call.Start()
 	future, err := securityHandler.Client.CreateOrUpdate(securityHandler.Ctx, securityHandler.Region.ResourceGroup, securityReqInfo.IId.NameId, createOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -127,6 +129,7 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 
 	err = future.WaitForCompletionRef(securityHandler.Ctx, securityHandler.Client.Client)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -134,6 +137,7 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 	// 생성된 SecurityGroup 정보 리턴
 	securityInfo, err := securityHandler.GetSecurity(securityReqInfo.IId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -148,6 +152,7 @@ func (securityHandler *AzureSecurityHandler) ListSecurity() ([]*irs.SecurityInfo
 	start := call.Start()
 	result, err := securityHandler.Client.List(securityHandler.Ctx, securityHandler.Region.ResourceGroup)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -168,6 +173,7 @@ func (securityHandler *AzureSecurityHandler) GetSecurity(securityIID irs.IID) (i
 	start := call.Start()
 	security, err := securityHandler.Client.Get(securityHandler.Ctx, securityHandler.Region.ResourceGroup, securityIID.NameId, "")
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -184,11 +190,13 @@ func (securityHandler *AzureSecurityHandler) DeleteSecurity(securityIID irs.IID)
 	start := call.Start()
 	future, err := securityHandler.Client.Delete(securityHandler.Ctx, securityHandler.Region.ResourceGroup, securityIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
 	err = future.WaitForCompletionRef(securityHandler.Ctx, securityHandler.Client.Client)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMSpecHandler.go
@@ -43,6 +43,7 @@ func (vmSpecHandler *AzureVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpe
 	start := call.Start()
 	result, err := vmSpecHandler.Client.List(vmSpecHandler.Ctx, Region)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -62,6 +63,7 @@ func (vmSpecHandler *AzureVmSpecHandler) GetVMSpec(Region string, Name string) (
 	start := call.Start()
 	result, err := vmSpecHandler.Client.List(vmSpecHandler.Ctx, Region)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMSpecInfo{}, err
 	}
@@ -75,6 +77,7 @@ func (vmSpecHandler *AzureVmSpecHandler) GetVMSpec(Region string, Name string) (
 	}
 
 	getErr := errors.New(fmt.Sprintf("failed to get VM spec, err : %s", err))
+	cblogger.Error(getErr.Error())
 	LoggingError(hiscallInfo, getErr)
 	return irs.VMSpecInfo{}, getErr
 }
@@ -86,6 +89,7 @@ func (vmSpecHandler *AzureVmSpecHandler) ListOrgVMSpec(Region string) (string, e
 	start := call.Start()
 	result, err := vmSpecHandler.Client.List(vmSpecHandler.Ctx, Region)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -97,6 +101,7 @@ func (vmSpecHandler *AzureVmSpecHandler) ListOrgVMSpec(Region string) (string, e
 	jsonResult.Result = *result.Value
 	jsonBytes, err := json.Marshal(jsonResult)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -112,6 +117,7 @@ func (vmSpecHandler *AzureVmSpecHandler) GetOrgVMSpec(Region string, Name string
 	start := call.Start()
 	result, err := vmSpecHandler.Client.List(vmSpecHandler.Ctx, Region)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -122,6 +128,7 @@ func (vmSpecHandler *AzureVmSpecHandler) GetOrgVMSpec(Region string, Name string
 			jsonBytes, err := json.Marshal(spec)
 			if err != nil {
 				getErr := errors.New(fmt.Sprintf("failed to get VM spec, err : %s", err))
+				cblogger.Error(getErr.Error())
 				LoggingError(hiscallInfo, getErr)
 				return "", err
 			}
@@ -132,6 +139,7 @@ func (vmSpecHandler *AzureVmSpecHandler) GetOrgVMSpec(Region string, Name string
 	}
 
 	notFoundErr := errors.New("failed to get VM spec")
+	cblogger.Error(notFoundErr.Error())
 	LoggingError(hiscallInfo, notFoundErr)
 	return "", notFoundErr
 }

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/CommonClouditFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/CommonClouditFunc.go
@@ -41,7 +41,6 @@ func InitLog() {
 }
 
 func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
-	cblogger.Error(err.Error())
 	hiscallInfo.ErrorMSG = err.Error()
 	calllogger.Info(call.String(hiscallInfo))
 }

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/ImageHandler.go
@@ -59,6 +59,7 @@ func (imageHandler *ClouditImageHandler) CreateImage(imageReqInfo irs.ImageReqIn
 	start := call.Start()
 	image, err := image.Create(imageHandler.Client, &createOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -82,6 +83,7 @@ func (imageHandler *ClouditImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	start := call.Start()
 	imageList, err := image.List(imageHandler.Client, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -102,6 +104,7 @@ func (imageHandler *ClouditImageHandler) GetImage(imageIID irs.IID) (irs.ImageIn
 	start := call.Start()
 	imageInfo, err := imageHandler.getImageByName(imageIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -124,6 +127,7 @@ func (imageHandler *ClouditImageHandler) DeleteImage(imageIID irs.IID) (bool, er
 	start := call.Start()
 	err := image.Delete(imageHandler.Client, imageIID.SystemId, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/SecurityHandler.go
@@ -68,6 +68,7 @@ func (securityHandler *ClouditSecurityHandler) CreateSecurity(securityReqInfo ir
 	securityInfo, _ := securityHandler.getSecurityByName(securityReqInfo.IId.NameId)
 	if securityInfo != nil {
 		createErr := errors.New(fmt.Sprintf("SecurityGroup with name %s already exist", securityReqInfo.IId.NameId))
+		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.SecurityInfo{}, createErr
 	}
@@ -110,6 +111,7 @@ func (securityHandler *ClouditSecurityHandler) CreateSecurity(securityReqInfo ir
 	start := call.Start()
 	securityGroup, err := securitygroup.Create(securityHandler.Client, &createOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -133,6 +135,7 @@ func (securityHandler *ClouditSecurityHandler) ListSecurity() ([]*irs.SecurityIn
 	start := call.Start()
 	securityList, err := securitygroup.List(securityHandler.Client, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -165,6 +168,7 @@ func (securityHandler *ClouditSecurityHandler) GetSecurity(securityIID irs.IID) 
 	start := call.Start()
 	securityInfo, err := securityHandler.getSecurityByName(securityIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -180,6 +184,7 @@ func (securityHandler *ClouditSecurityHandler) GetSecurity(securityIID irs.IID) 
 	// SecurityGroup Rule 정보 가져오기
 	sgRules, err := securitygroup.ListRule(securityHandler.Client, securityInfo.ID, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -198,6 +203,7 @@ func (securityHandler *ClouditSecurityHandler) DeleteSecurity(securityIID irs.II
 	// 이름 기준 보안그룹 조회
 	securityInfo, err := securityHandler.getSecurityByName(securityIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -213,6 +219,7 @@ func (securityHandler *ClouditSecurityHandler) DeleteSecurity(securityIID irs.II
 	start := call.Start()
 	err = securitygroup.Delete(securityHandler.Client, securityInfo.ID, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMSpecHandler.go
@@ -60,6 +60,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) ListVMSpec(Region string) ([]*irs.VMS
 	list, err := specs.List(vmSpecHandler.Client, &requestOpts)
 	if err != nil {
 		getError := errors.New(fmt.Sprintf("failed to get VM spec list, err : %s", err.Error()))
+		cblogger.Error(getError.Error())
 		LoggingError(hiscallInfo, getError)
 		return nil, getError
 	}
@@ -80,6 +81,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) GetVMSpec(Region string, Name string)
 	specInfo, err := vmSpecHandler.GetVMSpecByName(Region, Name)
 	if err != nil {
 		notFoundErr := errors.New(fmt.Sprintf("failed to get VM spec, err : %s", err.Error()))
+		cblogger.Error(notFoundErr.Error())
 		LoggingError(hiscallInfo, notFoundErr)
 		return irs.VMSpecInfo{}, notFoundErr
 	}
@@ -103,6 +105,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) ListOrgVMSpec(Region string) (string,
 	list, err := specs.List(vmSpecHandler.Client, &requestOpts)
 	if err != nil {
 		getErr := errors.New(fmt.Sprintf("failed to get VM spec list, err : %s", err.Error()))
+		cblogger.Error(getErr.Error())
 		LoggingError(hiscallInfo, getErr)
 		return "", getErr
 	}
@@ -114,6 +117,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) ListOrgVMSpec(Region string) (string,
 	jsonResult.Result = *list
 	jsonBytes, err := json.Marshal(jsonResult)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -131,6 +135,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) GetOrgVMSpec(Region string, Name stri
 	specInfo, err := vmSpecHandler.GetVMSpecByName(Region, Name)
 	if err != nil {
 		notFoundErr := errors.New(fmt.Sprintf("failed to get VM spec, err : %s", err.Error()))
+		cblogger.Error(notFoundErr.Error())
 		LoggingError(hiscallInfo, notFoundErr)
 		return "", notFoundErr
 	}
@@ -138,6 +143,7 @@ func (vmSpecHandler *ClouditVMSpecHandler) GetOrgVMSpec(Region string, Name stri
 
 	jsonBytes, err := json.Marshal(specInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VPCHandler.go
@@ -54,6 +54,7 @@ func (vpcHandler *ClouditVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.V
 	for i, vpcSubnet := range vpcReqInfo.SubnetInfoList {
 		result, err := vpcHandler.CreateSubnet(vpcSubnet)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.VPCInfo{}, err
 		}
@@ -72,6 +73,7 @@ func (vpcHandler *ClouditVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	start := call.Start()
 	subnetList, err := vpcHandler.ListSubnet()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -89,6 +91,7 @@ func (vpcHandler *ClouditVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error)
 	start := call.Start()
 	vpcInfo, err := vpcHandler.ListVPC()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -103,6 +106,7 @@ func (vpcHandler *ClouditVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 
 	vpcInfo, err := vpcHandler.GetVPC(vpcIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -111,6 +115,7 @@ func (vpcHandler *ClouditVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	for _, subnetInfo := range vpcInfo.SubnetInfoList {
 		subnetList, err := vpcHandler.ListSubnet()
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
@@ -269,6 +274,7 @@ func (vpcHandler *ClouditVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 	checkSubnet, _ := vpcHandler.getSubnetByName(subnetInfo.IId.NameId)
 	if checkSubnet != nil {
 		createErr := errors.New(fmt.Sprintf("virtualNetwork with name %s already exist", subnetInfo.IId.NameId))
+		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.VPCInfo{}, createErr
 	}
@@ -283,11 +289,13 @@ func (vpcHandler *ClouditVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 		MoreHeaders: authHeader,
 	}
 	if creatableSubnetList, err := subnet.ListCreatableSubnet(vpcHandler.Client, &requestOpts); err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	} else {
 		if len(*creatableSubnetList) == 0 {
 			allocateErr := errors.New("there is no PublicIPs to allocate")
+			cblogger.Error(allocateErr.Error())
 			LoggingError(hiscallInfo, allocateErr)
 			return irs.VPCInfo{}, allocateErr
 		} else {
@@ -310,6 +318,7 @@ func (vpcHandler *ClouditVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 	start := call.Start()
 	_, err := subnet.Create(vpcHandler.Client, &createOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -317,6 +326,7 @@ func (vpcHandler *ClouditVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 
 	result, err := vpcHandler.GetVPC(vpcIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -330,6 +340,7 @@ func (vpcHandler *ClouditVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.
 
 	subnetInfo, err := vpcHandler.getSubnetByName(subnetIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -344,6 +355,7 @@ func (vpcHandler *ClouditVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.
 	start := call.Start()
 	err = subnet.Delete(vpcHandler.Client, subnetInfo.Addr, &requestOpts)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/CommonIbmFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/CommonIbmFunc.go
@@ -31,7 +31,6 @@ func InitLog() {
 }
 
 func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
-	cblogger.Error(err.Error())
 	hiscallInfo.ErrorMSG = err.Error()
 	calllogger.Info(call.String(hiscallInfo))
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/ImageHandler.go
@@ -24,6 +24,7 @@ func (imageHandler *IbmImageHandler) CreateImage(imageReqInfo irs.ImageReqInfo) 
 	hiscallInfo := GetCallLogScheme(imageHandler.Region, call.VMIMAGE, imageReqInfo.IId.NameId, "CreateImage()")
 	// start := call.Start()
 	err := errors.New(fmt.Sprintf("CreateImage Function Not Offer"))
+	cblogger.Error(err.Error())
 	LoggingError(hiscallInfo, err)
 	return irs.ImageInfo{}, errors.New(fmt.Sprintf("CreateImage Function Not Offer"))
 }
@@ -35,6 +36,7 @@ func (imageHandler *IbmImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	images, _, err := imageHandler.VpcService.ListImagesWithContext(imageHandler.Ctx, ListImagesOptions)
 
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -57,6 +59,7 @@ func (imageHandler *IbmImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 			}
 			images, _, err = imageHandler.VpcService.ListImagesWithContext(imageHandler.Ctx, ListImagesOptions2)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 
@@ -73,16 +76,19 @@ func (imageHandler *IbmImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, 
 
 	err := checkImageInfoIID(imageIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
 	image, err := getRawImage(imageIID, imageHandler.VpcService, imageHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
 	imageInfo, err := setImageInfo(&image)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -93,6 +99,7 @@ func (imageHandler *IbmImageHandler) DeleteImage(imageIID irs.IID) (bool, error)
 	hiscallInfo := GetCallLogScheme(imageHandler.Region, call.VMIMAGE, imageIID.NameId, "DeleteImage()")
 	// start := call.Start()
 	err := errors.New(fmt.Sprintf("DeleteImage Function Not Offer"))
+	cblogger.Error(err.Error())
 	LoggingError(hiscallInfo, err)
 	return false, err
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/KeyPairHandler.go
@@ -28,29 +28,34 @@ func (keyPairHandler *IbmKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 	//IID확인
 	err := checkValidKeyReqInfo(keyPairReqInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	//존재여부 확인
 	exist, err := keyPairHandler.existKey(keyPairReqInfo.IId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 
 	if exist {
 		err = errors.New(fmt.Sprintf("already exist VPC %s", keyPairReqInfo.IId.NameId))
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	start := call.Start()
 	keyPairPath := os.Getenv("CBSPIDER_ROOT") + CBKeyPairPath
 	if err := checkKeyPairFolder(keyPairPath); err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	hashString, err := CreateHashString(keyPairHandler.CredentialInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -60,23 +65,26 @@ func (keyPairHandler *IbmKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 	if _, err := os.Stat(savePrivateFileTo); err == nil {
 		errMsg := fmt.Sprintf("KeyPair with name %s already exist", keyPairReqInfo.IId.NameId)
 		createErr := errors.New(errMsg)
-
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.KeyPairInfo{}, createErr
 	}
 	privateKey, publicKey, err := keypair.GenKeyPair()
 
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	err = keypair.SaveKey(privateKey, savePrivateFileTo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	err = keypair.SaveKey(publicKey, savePublicFileTo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -86,6 +94,7 @@ func (keyPairHandler *IbmKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPairReq
 	options.SetPublicKey(string(publicKey))
 	key, _, err := keyPairHandler.VpcService.CreateKeyWithContext(keyPairHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -109,6 +118,7 @@ func (keyPairHandler *IbmKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
 	listKeysOptions := &vpcv1.ListKeysOptions{}
 	keys, _, err := keyPairHandler.VpcService.ListKeysWithContext(keyPairHandler.Ctx, listKeysOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -117,6 +127,7 @@ func (keyPairHandler *IbmKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
 		for _, key := range keys.Keys {
 			keyInfo, err := setKeyInfo(key, keyPairHandler.CredentialInfo)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				continue
 			}
@@ -129,6 +140,7 @@ func (keyPairHandler *IbmKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
 			}
 			keys, _, err = keyPairHandler.VpcService.ListKeysWithContext(keyPairHandler.Ctx, listKeysOptions)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 				//break
@@ -146,11 +158,13 @@ func (keyPairHandler *IbmKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPairInfo
 	start := call.Start()
 	key, err := getRawKey(keyIID, keyPairHandler.VpcService, keyPairHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
 	keyInfo, err := setKeyInfo(key, keyPairHandler.CredentialInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -163,6 +177,7 @@ func (keyPairHandler *IbmKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error)
 	start := call.Start()
 	key, err := getRawKey(keyIID, keyPairHandler.VpcService, keyPairHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -171,6 +186,7 @@ func (keyPairHandler *IbmKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error)
 	deleteKeyOptions.SetID(*key.ID)
 	response, err := keyPairHandler.VpcService.DeleteKeyWithContext(keyPairHandler.Ctx, deleteKeyOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -184,6 +200,7 @@ func (keyPairHandler *IbmKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error)
 		}
 		hashString, err := CreateHashString(keyPairHandler.CredentialInfo)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
@@ -193,17 +210,20 @@ func (keyPairHandler *IbmKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, error)
 
 		err = os.Remove(privateKeyPath)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
 		err = os.Remove(publicKeyPath)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
 		LoggingInfo(hiscallInfo, start)
 		return true, nil
 	} else {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
@@ -28,20 +28,24 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 	// req 체크
 	err := checkSecurityReqInfo(securityReqInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
 	exist, err := existSecurityGroup(securityReqInfo.IId, securityHandler.VpcService, securityHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	} else if exist {
 		err = errors.New(fmt.Sprintf("already exist %s", securityReqInfo.IId.NameId))
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
 	vpc, err := getRawVPC(securityReqInfo.VpcIID, securityHandler.VpcService, securityHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -52,6 +56,7 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 	options.SetName(securityReqInfo.IId.NameId)
 	securityGroup, _, err := securityHandler.VpcService.CreateSecurityGroupWithContext(securityHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -81,6 +86,7 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 					if deleteError != nil {
 						err = errors.New(err.Error() + deleteError.Error())
 					}
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return irs.SecurityInfo{}, err
 				}
@@ -103,6 +109,7 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 					if deleteError != nil {
 						err = errors.New(err.Error() + deleteError.Error())
 					}
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return irs.SecurityInfo{}, err
 				}
@@ -119,6 +126,7 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 		if deleteError != nil {
 			err = errors.New(err.Error() + deleteError.Error())
 		}
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -130,6 +138,7 @@ func (securityHandler *IbmSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 		if deleteError != nil {
 			err = errors.New(err.Error() + deleteError.Error())
 		}
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -143,6 +152,7 @@ func (securityHandler *IbmSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 	options := &vpcv1.ListSecurityGroupsOptions{}
 	securityGroups, _, err := securityHandler.VpcService.ListSecurityGroupsWithContext(securityHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -151,6 +161,7 @@ func (securityHandler *IbmSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 		for _, securityGroup := range securityGroups.SecurityGroups {
 			securityInfo, err := setSecurityGroupInfo(securityGroup)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 			}
@@ -163,6 +174,7 @@ func (securityHandler *IbmSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 			}
 			securityGroups, _, err = securityHandler.VpcService.ListSecurityGroupsWithContext(securityHandler.Ctx, options2)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 			}
@@ -180,16 +192,19 @@ func (securityHandler *IbmSecurityHandler) GetSecurity(securityIID irs.IID) (irs
 
 	err := checkSecurityGroupIID(securityIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
 	securityGroup, err := getRawSecurityGroup(securityIID, securityHandler.VpcService, securityHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
 	securityGroupInfo, err := setSecurityGroupInfo(securityGroup)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -204,11 +219,13 @@ func (securityHandler *IbmSecurityHandler) DeleteSecurity(securityIID irs.IID) (
 	err := checkSecurityGroupIID(securityIID)
 
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
 	securityGroup, err := getRawSecurityGroup(securityIID, securityHandler.VpcService, securityHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -216,6 +233,7 @@ func (securityHandler *IbmSecurityHandler) DeleteSecurity(securityIID irs.IID) (
 	options.SetID(*securityGroup.ID)
 	res, err := securityHandler.VpcService.DeleteSecurityGroupWithContext(securityHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -224,6 +242,7 @@ func (securityHandler *IbmSecurityHandler) DeleteSecurity(securityIID irs.IID) (
 		return true, nil
 	} else {
 		err = errors.New(res.String())
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMHandler.go
@@ -30,41 +30,50 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	// 1.Check VMReqInfo
 	err := checkVMReqInfo(vmReqInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	// 1-1 Exist Check
 	exist, err := existInstance(vmReqInfo.IId, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	} else if exist {
 		err = errors.New(fmt.Sprintf("already exist %s", vmReqInfo.IId.NameId))
+		cblogger.Error(err.Error())
+		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	// 1-2. Setup Req Resource IID
 	image, err := getRawImage(vmReqInfo.ImageIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	vpc, err := getRawVPC(vmReqInfo.VpcIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	vpcSubnet, err := getVPCRawSubnet(vpc, vmReqInfo.SubnetIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	key, err := getRawKey(vmReqInfo.KeyPairIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	spec, err := getRawSpec(vmReqInfo.VMSpecName, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
@@ -73,11 +82,13 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		for _, SecurityGroupIID := range vmReqInfo.SecurityGroupIIDs {
 			err := checkSecurityGroupIID(SecurityGroupIID)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
 			securityGroup, err := getRawSecurityGroup(SecurityGroupIID, vmHandler.VpcService, vmHandler.Ctx)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
@@ -89,6 +100,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	rootPath := os.Getenv("CBSPIDER_ROOT")
 	fileDataCloudInit, err := ioutil.ReadFile(rootPath + CBCloudInitFilePath)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
@@ -127,6 +139,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	})
 	createInstance, _, err := vmHandler.VpcService.CreateInstanceWithContext(vmHandler.Ctx, createInstanceOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
@@ -146,6 +159,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 						newErrText := err.Error() + deleteErr.Error()
 						err = errors.New(newErrText)
 					}
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return irs.VMInfo{}, err
 				}
@@ -173,9 +187,11 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				newErrText := err.Error() + deleteErr.Error()
 				err = errors.New(newErrText)
 			}
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.VMInfo{}, err
 		}
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
@@ -196,6 +212,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				newErrText := err.Error() + deleteErr.Error()
 				err = errors.New(newErrText)
 			}
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.VMInfo{}, err
 		}
@@ -217,6 +234,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
 				newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
 				err = errors.New(newErrText)
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
@@ -225,10 +243,12 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			if deleteErr != nil {
 				newErrText := err.Error() + deleteErr.Error()
 				err = errors.New(newErrText)
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
 			err = errors.New("failed to create VM")
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.VMInfo{}, err
 		}
@@ -242,6 +262,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 					// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
 					newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
 					err = errors.New(newErrText)
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return irs.VMInfo{}, err
 				}
@@ -250,10 +271,12 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				if deleteErr != nil {
 					newErrText := err.Error() + deleteErr.Error()
 					err = errors.New(newErrText)
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return irs.VMInfo{}, err
 				}
 				err = errors.New("failed to create VM")
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
@@ -271,6 +294,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
 				newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
 				err = errors.New(newErrText)
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
@@ -279,10 +303,12 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			if deleteErr != nil {
 				newErrText := err.Error() + deleteErr.Error()
 				err = errors.New(newErrText)
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VMInfo{}, err
 			}
 			err = errors.New("failed to create VM")
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.VMInfo{}, err
 		}
@@ -293,16 +319,19 @@ func (vmHandler *IbmVMHandler) SuspendVM(vmIID irs.IID) (irs.VMStatus, error) {
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	err = getSuspendVMCheck(*instance.Status)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -311,6 +340,7 @@ func (vmHandler *IbmVMHandler) SuspendVM(vmIID irs.IID) (irs.VMStatus, error) {
 	instanceActionOptions.SetType("stop")
 	_, _, err = vmHandler.VpcService.CreateInstanceActionWithContext(vmHandler.Ctx, instanceActionOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -322,16 +352,19 @@ func (vmHandler *IbmVMHandler) ResumeVM(vmIID irs.IID) (irs.VMStatus, error) {
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	err = getResumeVMCheck(*instance.Status)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -341,6 +374,7 @@ func (vmHandler *IbmVMHandler) ResumeVM(vmIID irs.IID) (irs.VMStatus, error) {
 	instanceActionOptions.SetForce(true)
 	_, _, err = vmHandler.VpcService.CreateInstanceActionWithContext(vmHandler.Ctx, instanceActionOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -352,16 +386,19 @@ func (vmHandler *IbmVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, error) {
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	err = getRebootCheck(*instance.Status)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -371,6 +408,7 @@ func (vmHandler *IbmVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, error) {
 	instanceActionOptions.SetForce(true)
 	_, _, err = vmHandler.VpcService.CreateInstanceActionWithContext(vmHandler.Ctx, instanceActionOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -382,21 +420,25 @@ func (vmHandler *IbmVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, error) 
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	err = removeFloatingIps(instance, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	err = deleteInstance(*instance.ID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -410,6 +452,7 @@ func (vmHandler *IbmVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 	options := &vpcv1.ListInstancesOptions{}
 	instances, _, err := vmHandler.VpcService.ListInstancesWithContext(vmHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -434,6 +477,7 @@ func (vmHandler *IbmVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 			}
 			instances, _, err = vmHandler.VpcService.ListInstancesWithContext(vmHandler.Ctx, listVpcsOptions2)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 			}
@@ -449,11 +493,13 @@ func (vmHandler *IbmVMHandler) GetVMStatus(vmIID irs.IID) (irs.VMStatus, error) 
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -467,6 +513,7 @@ func (vmHandler *IbmVMHandler) ListVM() ([]*irs.VMInfo, error) {
 	options := &vpcv1.ListInstancesOptions{}
 	instances, _, err := vmHandler.VpcService.ListInstancesWithContext(vmHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -475,6 +522,7 @@ func (vmHandler *IbmVMHandler) ListVM() ([]*irs.VMInfo, error) {
 		for _, instance := range instances.Instances {
 			vmInfo, err := vmHandler.setVmInfo(instance)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 			}
@@ -487,6 +535,7 @@ func (vmHandler *IbmVMHandler) ListVM() ([]*irs.VMInfo, error) {
 			}
 			instances, _, err = vmHandler.VpcService.ListInstancesWithContext(vmHandler.Ctx, listVpcsOptions2)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 				//break
@@ -504,17 +553,20 @@ func (vmHandler *IbmVMHandler) GetVM(vmIID irs.IID) (irs.VMInfo, error) {
 	start := call.Start()
 	err := checkVmIID(vmIID)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 	instance, err := getRawInstance(vmIID, vmHandler.VpcService, vmHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}
 
 	vmInfo, err := vmHandler.setVmInfo(instance)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMInfo{}, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VPCHandler.go
@@ -42,23 +42,27 @@ func (vpcHandler *IbmVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCIn
 	start := call.Start()
 	err := checkValidVpcReqInfo(vpcReqInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 
 	if vpcHandler.Region.Zone == "" {
 		err = errors.New("not exist Zone")
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 
 	exist, err := existVpc(vpcReqInfo.IId, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 	if exist {
 		err = errors.New(fmt.Sprintf("already exist VPC %s", vpcReqInfo.IId.NameId))
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -69,6 +73,7 @@ func (vpcHandler *IbmVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCIn
 	createVPCOptions.SetName(vpcReqInfo.IId.NameId)
 	vpc, _, err := vpcHandler.VpcService.CreateVPCWithContext(vpcHandler.Ctx, createVPCOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -87,6 +92,7 @@ func (vpcHandler *IbmVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCIn
 	_, _, err = vpcHandler.VpcService.CreateVPCAddressPrefixWithContext(vpcHandler.Ctx, createVPCAddressPrefixOptions)
 	// createVPCAddressPrefix error
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		_, delErr := vpcHandler.DeleteVPC(newVpcIId)
 		if delErr != nil {
@@ -103,6 +109,7 @@ func (vpcHandler *IbmVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCIn
 				if delErr != nil {
 					err = errors.New(err.Error() + delErr.Error())
 				}
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return irs.VPCInfo{}, err
 			}
@@ -114,6 +121,7 @@ func (vpcHandler *IbmVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VPCIn
 		if delErr != nil {
 			err = errors.New(err.Error() + delErr.Error())
 		}
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -127,6 +135,7 @@ func (vpcHandler *IbmVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	start := call.Start()
 	vpcs, _, err := vpcHandler.VpcService.ListVpcsWithContext(vpcHandler.Ctx, listVpcsOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -147,6 +156,7 @@ func (vpcHandler *IbmVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 			}
 			vpcs, _, err = vpcHandler.VpcService.ListVpcsWithContext(vpcHandler.Ctx, listVpcsOptions2)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return nil, err
 				//break
@@ -163,11 +173,13 @@ func (vpcHandler *IbmVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error) {
 	start := call.Start()
 	vpc, err := getRawVPC(vpcIID, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 	vpcInfo, err := setVPCInfo(vpc, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -179,6 +191,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	start := call.Start()
 	vpc, err := getRawVPC(vpcIID, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -186,6 +199,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	// Remove all Subnet
 	rawSubnets, err := getVPCRawSubnets(vpc, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -195,6 +209,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 			options.SetID(*subnet.ID)
 			_, err := vpcHandler.VpcService.DeleteSubnetWithContext(vpcHandler.Ctx, options)
 			if err != nil {
+				cblogger.Error(err.Error())
 				LoggingError(hiscallInfo, err)
 				return false, err
 			}
@@ -206,6 +221,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	for {
 		rawDeleteSubnets, err := getVPCRawSubnets(vpc, vpcHandler.VpcService, vpcHandler.Ctx)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
@@ -216,6 +232,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 		time.Sleep(1 * time.Second)
 		if curRetryCnt > maxRetryCnt {
 			err = errors.New("failed delete VPC - subnets delete TimeOut")
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
@@ -225,6 +242,7 @@ func (vpcHandler *IbmVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	deleteVpcOptions.SetID(*vpc.ID)
 	_, err = vpcHandler.VpcService.DeleteVPCWithContext(vpcHandler.Ctx, deleteVpcOptions)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -236,22 +254,26 @@ func (vpcHandler *IbmVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Subnet
 	start := call.Start()
 	vpc, err := getRawVPC(vpcIID, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 	err = attachSubnet(vpc, subnetInfo, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 	LoggingInfo(hiscallInfo, start)
 	vpc, err = getRawVPC(vpcIID, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
 	vpcInfo, err := setVPCInfo(vpc, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VPCInfo{}, err
 	}
@@ -265,6 +287,7 @@ func (vpcHandler *IbmVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.IID)
 		options.SetID(subnetIID.SystemId)
 		_, err := vpcHandler.VpcService.DeleteSubnetWithContext(vpcHandler.Ctx, options)
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return false, err
 		}
@@ -273,6 +296,7 @@ func (vpcHandler *IbmVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.IID)
 	}
 	vpc, err := getRawVPC(vpcIID, vpcHandler.VpcService, vpcHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
@@ -284,6 +308,7 @@ func (vpcHandler *IbmVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.IID)
 				options.SetID(*subnet.ID)
 				_, err := vpcHandler.VpcService.DeleteSubnetWithContext(vpcHandler.Ctx, options)
 				if err != nil {
+					cblogger.Error(err.Error())
 					LoggingError(hiscallInfo, err)
 					return false, err
 				}
@@ -293,6 +318,7 @@ func (vpcHandler *IbmVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.IID)
 		}
 	}
 	err = errors.New("not found subnet")
+	cblogger.Error(err.Error())
 	LoggingError(hiscallInfo, err)
 	return false, err
 

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VmSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VmSpecHandler.go
@@ -31,6 +31,7 @@ func (vmSpecHandler *IbmVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpecI
 	options := &vpcv1.ListInstanceProfilesOptions{}
 	profiles, _, err := vmSpecHandler.VpcService.ListInstanceProfilesWithContext(vmSpecHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -57,6 +58,7 @@ func (vmSpecHandler *IbmVmSpecHandler) GetVMSpec(Region string, Name string) (ir
 	start := call.Start()
 	if Name == "" {
 		err := errors.New("invalid Name")
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMSpecInfo{}, err
 	}
@@ -67,6 +69,7 @@ func (vmSpecHandler *IbmVmSpecHandler) GetVMSpec(Region string, Name string) (ir
 	//}
 	profile, err := getRawSpec(Name, vmSpecHandler.VpcService, vmSpecHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMSpecInfo{}, err
 	}
@@ -98,6 +101,7 @@ func (vmSpecHandler *IbmVmSpecHandler) ListOrgVMSpec(Region string) (string, err
 	options := &vpcv1.ListInstanceProfilesOptions{}
 	profiles, _, err := vmSpecHandler.VpcService.ListInstanceProfilesWithContext(vmSpecHandler.Ctx, options)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -118,6 +122,7 @@ func (vmSpecHandler *IbmVmSpecHandler) ListOrgVMSpec(Region string) (string, err
 	}
 	jsonBytes, err := json.Marshal(specList)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -130,6 +135,7 @@ func (vmSpecHandler *IbmVmSpecHandler) GetOrgVMSpec(Region string, Name string) 
 	start := call.Start()
 	if Name == "" {
 		err := errors.New("invalid Name")
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -140,6 +146,7 @@ func (vmSpecHandler *IbmVmSpecHandler) GetOrgVMSpec(Region string, Name string) 
 	//}
 	profile, err := getRawSpec(Name, vmSpecHandler.VpcService, vmSpecHandler.Ctx)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -157,6 +164,7 @@ func (vmSpecHandler *IbmVmSpecHandler) GetOrgVMSpec(Region string, Name string) 
 	}
 	jsonBytes, err := json.Marshal(vmSpecInfo)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/CommonOpenStackFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/CommonOpenStackFunc.go
@@ -39,7 +39,6 @@ func InitLog() {
 }
 
 func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
-	cblogger.Error(err.Error())
 	hiscallInfo.ErrorMSG = err.Error()
 	calllogger.Info(call.String(hiscallInfo))
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
@@ -75,6 +75,7 @@ func (imageHandler *OpenStackImageHandler) CreateImage(imageReqInfo irs.ImageReq
 	imageFilePath := fmt.Sprintf("%s/image/%s.iso", rootPath, reqInfo.Name)
 	if _, err := os.Stat(imageFilePath); os.IsNotExist(err) {
 		createErr := errors.New(fmt.Sprintf("Image files in path %s not exist", imageFilePath))
+		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.ImageInfo{}, createErr
 	}
@@ -83,6 +84,7 @@ func (imageHandler *OpenStackImageHandler) CreateImage(imageReqInfo irs.ImageReq
 	start := call.Start()
 	image, err := imgsvc.Create(imageHandler.ImageClient, createOpts).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -91,11 +93,13 @@ func (imageHandler *OpenStackImageHandler) CreateImage(imageReqInfo irs.ImageReq
 	// Upload Image file
 	imageBytes, err := ioutil.ReadFile(imageFilePath)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
 	result := imagedata.Upload(imageHandler.ImageClient, image.ID, bytes.NewReader(imageBytes))
 	if result.Err != nil {
+		cblogger.Error(result.Err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -122,6 +126,7 @@ func (imageHandler *OpenStackImageHandler) ListImage() ([]*irs.ImageInfo, error)
 	start := call.Start()
 	pager, err := images.ListDetail(imageHandler.Client, images.ListOpts{}).AllPages()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -129,6 +134,7 @@ func (imageHandler *OpenStackImageHandler) ListImage() ([]*irs.ImageInfo, error)
 
 	imageList, err := images.ExtractImages(pager)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -147,12 +153,14 @@ func (imageHandler *OpenStackImageHandler) GetImage(imageIID irs.IID) (irs.Image
 
 	imageId, err := imageHandler.IDFromName(imageHandler.Client, imageIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
 	start := call.Start()
 	image, err := images.Get(imageHandler.Client, imageId).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.ImageInfo{}, err
 	}
@@ -168,12 +176,14 @@ func (imageHandler *OpenStackImageHandler) DeleteImage(imageIID irs.IID) (bool, 
 
 	imageId, err := imageHandler.IDFromName(imageHandler.Client, imageIID.NameId)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
 	start := call.Start()
 	err = images.Delete(imageHandler.Client, imageId).ExtractErr()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/KeyPairHandler.go
@@ -41,6 +41,7 @@ func (keyPairHandler *OpenStackKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyP
 	start := call.Start()
 	keyPair, err := keypairs.Create(keyPairHandler.Client, create0pts).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -59,6 +60,7 @@ func (keyPairHandler *OpenStackKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, er
 	start := call.Start()
 	pager, err := keypairs.List(keyPairHandler.Client).AllPages()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -66,6 +68,7 @@ func (keyPairHandler *OpenStackKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, er
 
 	keypair, err := keypairs.ExtractKeyPairs(pager)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -85,6 +88,7 @@ func (keyPairHandler *OpenStackKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPa
 	start := call.Start()
 	keyPair, err := keypairs.Get(keyPairHandler.Client, keyIID.NameId).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.KeyPairInfo{}, err
 	}
@@ -101,6 +105,7 @@ func (keyPairHandler *OpenStackKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, 
 	start := call.Start()
 	err := keypairs.Delete(keyPairHandler.Client, keyIID.NameId).ExtractErr()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/SecurityHandler.go
@@ -84,12 +84,14 @@ func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo 
 	// Check SecurityGroup Exists
 	secGroupList, err := securityHandler.ListSecurity()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
 	for _, sg := range secGroupList {
 		if sg.IId.NameId == securityReqInfo.IId.NameId {
 			createErr := errors.New(fmt.Sprintf("Security Group with name %s already exist", securityReqInfo.IId.NameId))
+			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)
 			return irs.SecurityInfo{}, createErr
 		}
@@ -104,6 +106,7 @@ func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo 
 	start := call.Start()
 	group, err := secgroups.Create(securityHandler.Client, createOpts).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -145,6 +148,7 @@ func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo 
 
 		_, err := rules.Create(securityHandler.NetworkClient, createRuleOpts).Extract()
 		if err != nil {
+			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
 			return irs.SecurityInfo{}, err
 		}
@@ -153,6 +157,7 @@ func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo 
 	// 생성된 SecurityGroup 정보 리턴
 	securityInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: group.ID})
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -167,6 +172,7 @@ func (securityHandler *OpenStackSecurityHandler) ListSecurity() ([]*irs.Security
 	start := call.Start()
 	pager, err := secgroups.List(securityHandler.Client).AllPages()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -174,6 +180,7 @@ func (securityHandler *OpenStackSecurityHandler) ListSecurity() ([]*irs.Security
 
 	security, err := secgroups.ExtractSecurityGroups(pager)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -194,6 +201,7 @@ func (securityHandler *OpenStackSecurityHandler) GetSecurity(securityIID irs.IID
 	start := call.Start()
 	securityGroup, err := secgroups.Get(securityHandler.Client, securityIID.SystemId).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
@@ -210,6 +218,7 @@ func (securityHandler *OpenStackSecurityHandler) DeleteSecurity(securityIID irs.
 	start := call.Start()
 	result := secgroups.Delete(securityHandler.Client, securityIID.SystemId)
 	if result.Err != nil {
+		cblogger.Error(result.Err.Error())
 		LoggingError(hiscallInfo, result.Err)
 		return false, result.Err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMSpecHandler.go
@@ -41,6 +41,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) ListVMSpec(Region string) ([]*irs.V
 	start := call.Start()
 	pager, err := flavors.ListDetail(vmSpecHandler.Client, flavors.ListOpts{}).AllPages()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -48,6 +49,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) ListVMSpec(Region string) ([]*irs.V
 
 	list, err := flavors.ExtractFlavors(pager)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return nil, err
 	}
@@ -65,6 +67,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) GetVMSpec(Region string, Name strin
 
 	vmSpecId, err := vmSpecHandler.getIDFromName(vmSpecHandler.Client, Name)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMSpecInfo{}, err
 	}
@@ -72,6 +75,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) GetVMSpec(Region string, Name strin
 	start := call.Start()
 	vmSpec, err := flavors.Get(vmSpecHandler.Client, vmSpecId).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return irs.VMSpecInfo{}, err
 	}
@@ -88,6 +92,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) ListOrgVMSpec(Region string) (strin
 	start := call.Start()
 	pager, err := flavors.ListDetail(vmSpecHandler.Client, flavors.ListOpts{}).AllPages()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -95,6 +100,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) ListOrgVMSpec(Region string) (strin
 
 	list, err := flavors.ExtractFlavors(pager)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -105,6 +111,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) ListOrgVMSpec(Region string) (strin
 	jsonResult.Result = list
 	jsonBytes, err := json.Marshal(jsonResult)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -120,6 +127,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) GetOrgVMSpec(Region string, Name st
 
 	vmSpecId, err := vmSpecHandler.getIDFromName(vmSpecHandler.Client, Name)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -127,6 +135,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) GetOrgVMSpec(Region string, Name st
 	start := call.Start()
 	vmSpec, err := flavors.Get(vmSpecHandler.Client, vmSpecId).Extract()
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}
@@ -134,6 +143,7 @@ func (vmSpecHandler *OpenStackVMSpecHandler) GetOrgVMSpec(Region string, Name st
 
 	jsonBytes, err := json.Marshal(vmSpec)
 	if err != nil {
+		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
 		return "", err
 	}


### PR DESCRIPTION
관련 이슈 : #484

- 에러 발생 시 코드라인 불확실하게 표시되는 현상 수정
- 원인 : 각 핸들러의 commonFunc으로 loggingError 함수에서 Error를 시행해 해당 코드라인이 출력
- 해결 : cblogger.Error를 loggingError이 시행되는 지점에서 시행

