### PR TITLE
개선안 I및 이슈 #417 반영

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -28,7 +28,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("AlibabaCloud Resource Test")
-	cblog.SetLevel("debug")
+	cblog.SetLevel("info")
 }
 
 /*
@@ -973,10 +973,10 @@ func main() {
 	cblogger.Debug("Debug mode")
 
 	//handleVPC() //VPC
-	//handleVMSpec()
+	handleVMSpec()
 	//handleImage() //AMI
 	//handleSecurity()
-	handleKeyPair()
+	//handleKeyPair()
 	//handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
@@ -1,5 +1,6 @@
 package resources
 
+//20211104 개선안 I에 의해 Region 파라메터 대신 세션의 Region 정보로 대체함.
 import (
 	"errors"
 	"reflect"
@@ -78,8 +79,9 @@ func ExtractVMSpecInfo(Region string, instanceTypeInfo ecs.InstanceType) irs.VMS
 	return vmSpecInfo
 }
 
-func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMSpecInfo, error) {
-	cblogger.Infof("Start ListVMSpec(Region:[%s])", Region)
+func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec(RegionDel string) ([]*irs.VMSpecInfo, error) {
+	Region := vmSpecHandler.Region.Region
+	cblogger.Infof("Start ListVMSpec(Session Region:[%s])", Region)
 	var vMSpecInfoList []*irs.VMSpecInfo
 
 	request := ecs.CreateDescribeInstanceTypesRequest()
@@ -90,7 +92,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMS
 	callogger := call.GetLogger("HISCALL")
 	callLogInfo := call.CLOUDLOGSCHEMA{
 		CloudOS:      call.ALIBABA,
-		RegionZone:   vmSpecHandler.Region.Zone,
+		RegionZone:   Region,
 		ResourceType: call.VMSPEC,
 		ResourceName: "ListVMSpec()",
 		CloudOSAPI:   "DescribeInstanceTypes()",
@@ -123,8 +125,9 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec(Region string) ([]*irs.VMS
 	return vMSpecInfoList, nil
 }
 
-func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Region string, Name string) (irs.VMSpecInfo, error) {
-	cblogger.Infof("Start GetVMSpec(Region:[%s], Name:[%s])", Region, Name)
+func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(RegionDel string, Name string) (irs.VMSpecInfo, error) {
+	Region := vmSpecHandler.Region.Region
+	cblogger.Infof("Start GetVMSpec(Session Region:[%s], Name:[%s])", Region, Name)
 
 	request := ecs.CreateDescribeInstanceTypesRequest()
 	request.Scheme = "https"
@@ -135,7 +138,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Region string, Name string)
 	callogger := call.GetLogger("HISCALL")
 	callLogInfo := call.CLOUDLOGSCHEMA{
 		CloudOS:      call.ALIBABA,
-		RegionZone:   vmSpecHandler.Region.Zone,
+		RegionZone:   Region,
 		ResourceType: call.VMSPEC,
 		ResourceName: "Region:" + Region + "/ Name:" + Name,
 		CloudOSAPI:   "DescribeInstanceTypes()",
@@ -181,8 +184,9 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Region string, Name string)
 }
 
 // Alibaba Cloud의 정보 그대로를 가공 없이 JSON으로 리턴 함.
-func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec(Region string) (string, error) {
-	cblogger.Infof("Start ListOrgVMSpec(Region:[%s])", Region)
+func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec(RegionDel string) (string, error) {
+	Region := vmSpecHandler.Region.Region
+	cblogger.Infof("Start ListOrgVMSpec(Session Region:[%s])", Region)
 
 	request := ecs.CreateDescribeInstanceTypesRequest()
 	request.Scheme = "https"
@@ -192,7 +196,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec(Region string) (string,
 	callogger := call.GetLogger("HISCALL")
 	callLogInfo := call.CLOUDLOGSCHEMA{
 		CloudOS:      call.ALIBABA,
-		RegionZone:   vmSpecHandler.Region.Zone,
+		RegionZone:   Region,
 		ResourceType: call.VMSPEC,
 		ResourceName: "ListOrgVMSpec()",
 		CloudOSAPI:   "DescribeInstanceTypes()",
@@ -223,8 +227,9 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec(Region string) (string,
 }
 
 // AWS의 정보 그대로를 가공 없이 JSON으로 리턴 함.
-func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Region string, Name string) (string, error) {
-	cblogger.Infof("Start GetOrgVMSpec(Region:[%s], Name:[%s])", Region, Name)
+func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(RegionDel string, Name string) (string, error) {
+	Region := vmSpecHandler.Region.Region
+	cblogger.Infof("Start GetOrgVMSpec(Session Region:[%s], Name:[%s])", Region, Name)
 	request := ecs.CreateDescribeInstanceTypesRequest()
 	request.Scheme = "https"
 	request.RegionId = Region
@@ -233,7 +238,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Region string, Name stri
 	callogger := call.GetLogger("HISCALL")
 	callLogInfo := call.CLOUDLOGSCHEMA{
 		CloudOS:      call.ALIBABA,
-		RegionZone:   vmSpecHandler.Region.Zone,
+		RegionZone:   Region,
 		ResourceType: call.VMSPEC,
 		ResourceName: "Region:" + Region + "/ Name:" + Name,
 		CloudOSAPI:   "DescribeInstanceTypes()",

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1124,14 +1124,14 @@ func handleVMSpec() {
 func main() {
 	cblogger.Info("AWS Resource Test")
 	//handleVPC()
-	handleKeyPair()
+	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
 	//handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	//handleVMSpec()
+	handleVMSpec()
 }
 
 //handlerType : resources폴더의 xxxHandler.go에서 Handler이전까지의 문자열

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -998,10 +998,10 @@ func handleVM() {
 func main() {
 	cblogger.Info("GCP Resource Test")
 	//handleVPC()
-	//handleVMSpec()
+	handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
-	handleSecurity()
+	//handleSecurity()
 	//handleVM()
 	//cblogger.Info(filepath.Join("a/b", "\\cloud-driver-libs\\.ssh-gcp\\"))
 	//cblogger.Info(filepath.Join("\\cloud-driver-libs\\.ssh-gcp\\", "/b/c/d"))

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMSpecHandler.go
@@ -102,7 +102,7 @@ func (vmSpecHandler *GCPVMSpecHandler) GetVMSpec(Region string, Name string) (ir
 	callogger.Info(call.String(callLogInfo))
 
 	vmSpecInfo := irs.VMSpecInfo{
-		Region: Region,
+		Region: vmSpecHandler.Region.Region,
 		Name:   Name,
 		VCpu: irs.VCpuInfo{
 			Count: strconv.FormatInt(info.GuestCpus, 10),


### PR DESCRIPTION
**AWS** - Zone기반
- API는 Zone기반으로 구현되어 있으며 일부 로그 등에 사용된 파라메터의 Region 이용 부분을 세션의 Region으로 대체

**Alibaba**
- 파라메터의 Region 대신 세션의 Region으로 대체

**GCP** - Zone기반
- GetVMSpec()의 리턴 값에 사용된 파라메터의 Region 값 대신 세션의 Region 값으로 대체

**Tencent** - Zone 기반
- 이미 Zone기반으로 구현되어 있어서 변동 사항 없음
