### PR TITLE
GCP/Alibaba/Tencent RootDisk 및 사이즈 변경 기능 지원 (이슈 #348)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -850,14 +850,20 @@ func handleVM() {
 					ImageIID: irs.IID{SystemId: "ubuntu_18_04_x64_20G_alibase_20210420.vhd"},
 					//VpcIID:    irs.IID{SystemId: "vpc-0jl4l19l51gn2exrohgci"},
 					//SubnetIID: irs.IID{SystemId: "vsw-0jlj155cbwhjumtipnm6d"},
-					SubnetIID: irs.IID{SystemId: "vsw-6we8tac8w7dzqbxbyhj9o"}, //없는 Subnet 테스트
+					SubnetIID: irs.IID{SystemId: "vsw-6we8tac8w7dzqbxbyhj9o"}, //Tokyo Zone B
 					//SecurityGroupIIDs: []irs.IID{{SystemId: "sg-6we0rxnoai067qbkdkgw"}, {SystemId: "sg-6weeb9xaodr65g7bq10c"}},
 					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-6we7156yw8c8xbzi9f7v"}},
 					//VMSpecName:        "ecs.t5-lc2m1.nano",
-					VMSpecName: "ecs.g6.large", //cn-wulanchabu 리전
+					//VMSpecName: "ecs.g6.large", //cn-wulanchabu 리전
+					VMSpecName: "ecs.t5-lc2m1.nano", //도쿄리전
 					KeyPairIID: irs.IID{SystemId: "cb-japan"},
 					//VMUserId:          "root", //root만 가능
 					//VMUserPasswd: "Cbuser!@#", //대문자 소문자 모두 사용되어야 함. 그리고 숫자나 특수 기호 중 하나가 포함되어야 함.
+
+					RootDiskType: "cloud_efficiency", //cloud / cloud_efficiency / cloud_ssd / cloud_essd
+					RootDiskSize: "default",
+					//RootDiskType: "cloud_ssd", //cloud / cloud_efficiency / cloud_ssd / cloud_essd
+					//RootDiskSize: "22",
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -973,11 +979,11 @@ func main() {
 	cblogger.Debug("Debug mode")
 
 	//handleVPC() //VPC
-	handleVMSpec()
+	//handleVMSpec()
 	//handleImage() //AMI
 	//handleSecurity()
 	//handleKeyPair()
-	//handleVM()
+	handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
@@ -156,6 +156,29 @@ func (vmHandler *AlibabaVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 	//PayByBandwidth : 대역폭 사용료는 구독 기반이고 ECS 인스턴스 사용료에 포함 됨.
 	request.InternetChargeType = "PayByBandwidth"           //Public Ip요금 방식을 1시간 단위(PayByBandwidth) 요금으로 설정 / PayByTraffic(기본값) : 1GB단위 시간당 트래픽 요금 청구
 	request.InternetMaxBandwidthOut = requests.Integer("5") // 0보다 크면 Public IP가 할당 됨 - 최대 아웃 바운드 공용 대역폭 단위 : Mbit / s 유효한 값 : 0 ~ 100
+
+	//=============================
+	// Root Disk Type 변경
+	//=============================
+	if vmReqInfo.RootDiskType == "" {
+		//디스크 정보가 없으면 건드리지 않음.
+	} else {
+		request.SystemDiskCategory = vmReqInfo.RootDiskType
+	}
+
+	//=============================
+	// Root Disk Size 변경
+	//=============================
+	if vmReqInfo.RootDiskSize == "" {
+		//디스크 정보가 없으면 건드리지 않음.
+	} else {
+		if strings.EqualFold(vmReqInfo.RootDiskSize, "default") {
+			request.SystemDiskSize = "40"
+		} else {
+			request.SystemDiskSize = vmReqInfo.RootDiskSize
+		}
+	}
+
 	spew.Dump(request)
 
 	//=============================

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -884,6 +884,11 @@ func handleVM() {
 					VMSpecName:        "f1-micro",
 					KeyPairIID:        irs.IID{SystemId: "cb-keypairtest123123"},
 					VMUserId:          "cb-user",
+
+					//RootDiskType: "pd-ssd",      //pd-standard/pd-balanced/pd-ssd/pd-extreme
+					RootDiskType: "pd-balanced", //pd-standard/pd-balanced/pd-ssd/pd-extreme
+					//RootDiskSize: "12",     //최소 10GB 이상이어야 함.
+					RootDiskSize: "default", //10GB
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -998,11 +1003,11 @@ func handleVM() {
 func main() {
 	cblogger.Info("GCP Resource Test")
 	//handleVPC()
-	handleVMSpec()
+	//handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
 	//handleSecurity()
-	//handleVM()
+	handleVM()
 	//cblogger.Info(filepath.Join("a/b", "\\cloud-driver-libs\\.ssh-gcp\\"))
 	//cblogger.Info(filepath.Join("\\cloud-driver-libs\\.ssh-gcp\\", "/b/c/d"))
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
@@ -652,6 +652,8 @@ func handleVM() {
 					KeyPairIID:        irs.IID{SystemId: "skey-lk66iuyh"}, //cb_user_test
 					//VMUserId:          "root", //root만 가능
 					//VMUserPasswd: "Cbuser!@#", //대문자 소문자 모두 사용되어야 함. 그리고 숫자나 특수 기호 중 하나가 포함되어야 함.
+					RootDiskType: "CLOUD_PREMIUM", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
+					RootDiskSize: "30",
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -767,8 +769,8 @@ func main() {
 	//handleVMSpec()
 	//handleSecurity()
 	//handleImage() //AMI
-	handleKeyPair()
-	//handleVM()
+	//handleKeyPair()
+	handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleVNic() //Lancard

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
@@ -653,7 +653,9 @@ func handleVM() {
 					//VMUserId:          "root", //root만 가능
 					//VMUserPasswd: "Cbuser!@#", //대문자 소문자 모두 사용되어야 함. 그리고 숫자나 특수 기호 중 하나가 포함되어야 함.
 					RootDiskType: "CLOUD_PREMIUM", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
-					RootDiskSize: "30",
+					//RootDiskType: "CLOUD_SSD", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
+					//RootDiskSize: "60", //Image Size 보다 작으면 에러 남
+					RootDiskSize: "Default", //Image Size 보다 작으면 에러 남
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/conf/Test_Config.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/conf/Test_Config.go
@@ -12,7 +12,6 @@ package TencentTestConfig
 
 import (
 	"io/ioutil"
-	"os"
 
 	tdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/tencent"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -44,10 +43,8 @@ type Config struct {
 //환경변수 CBSPIDER_PATH 설정 후 해당 폴더 하위에 /config/configTencent.yaml 파일 생성해야 함.
 func ReadConfigFile() Config {
 	// Set Environment Value of Project Root Path
-	//rootpath := "D:/Workspace/mcloud-barista-config"
 	// /mnt/d/Workspace/mcloud-barista-config/config/config.yaml
-
-	//testFilePath := os.Getenv("CBSPIDER_PATH") + "/config/configTencent.yaml" //혹시 모를 키 노출 대비 시스템 외부에 존재
+	//testFilePath := os.Getenv("CBSPIDER_PATH") + "/config/configTencent.yaml" //혹시 모를 키 노출 대비 시스템 외부에 존재(개발용용)
 	testFilePath := "./conf/testConfigTencent.yaml"
 
 	cblogger.Debugf("Test Data 설정파일 : [%]", testFilePath)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/conf/Test_Config.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/conf/Test_Config.go
@@ -46,7 +46,6 @@ func ReadConfigFile() Config {
 	// /mnt/d/Workspace/mcloud-barista-config/config/config.yaml
 	//testFilePath := os.Getenv("CBSPIDER_PATH") + "/config/configTencent.yaml" //혹시 모를 키 노출 대비 시스템 외부에 존재(개발용용)
 	testFilePath := "./conf/testConfigTencent.yaml"
-
 	cblogger.Debugf("Test Data 설정파일 : [%]", testFilePath)
 
 	data, err := ioutil.ReadFile(testFilePath)

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -13,7 +13,8 @@ AWS:
 GCP:
   region: Region Zone
   credential: PrivateKey ProjectID ClientEmail
-
+  rookdisktype: pd-standard/pd-balanced/pd-ssd/pd-extreme
+  
 AZURE:
   region: location ResourceGroup
   credential: ClientId ClientSecret TenantId SubscriptionId

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -31,6 +31,7 @@ ALIBABA:
 TENCENT:
   region: Region Zone
   credential: ClientId ClientSecret
+  rookdisktype: LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
 
 IBM:
   region: Region Zone

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -25,6 +25,8 @@ OPENSTACK:
 ALIBABA:
   region: Region Zone
   credential: ClientId ClientSecret
+  rookdisktype: cloud/cloud_efficiency/cloud_ssd/cloud_essd
+
 
 TENCENT:
   region: Region Zone

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -14,7 +14,7 @@ GCP:
   region: Region Zone
   credential: PrivateKey ProjectID ClientEmail
   rookdisktype: pd-standard/pd-balanced/pd-ssd/pd-extreme
-  
+
 AZURE:
   region: location ResourceGroup
   credential: ClientId ClientSecret TenantId SubscriptionId
@@ -26,13 +26,13 @@ OPENSTACK:
 ALIBABA:
   region: Region Zone
   credential: ClientId ClientSecret
-  rookdisktype: cloud/cloud_efficiency/cloud_ssd/cloud_essd
+  rookdisktype: cloud_efficiency/cloud/cloud_ssd/cloud_essd
 
 
 TENCENT:
   region: Region Zone
   credential: ClientId ClientSecret
-  rookdisktype: LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
+  rookdisktype: CLOUD_PREMIUM/LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD
 
 IBM:
   region: Region Zone


### PR DESCRIPTION
개선 기능및 이슈 #348에 의한 RootDisk 및 사이즈 변경 기능 지원
- GCP / Alibaba / Tencent RootDisk 설정 기능 추가
- 사이즈에 "default"로 설정되면 각 CSP별 고정된 값으로 셋팅(GCP:10GB / Alibaba:40GB / Tencent:50GB)
- Type이 지정되지 않으면  CSP 기본 옵션으로 생성 (디스크 관련 옵션 설정하지 않음)
- Size가 지정되지 않으면 CSP 기본 옵션으로 생성 (디스크 관련 옵션 설정하지 않음)
- 전달 받은 Type이 있으면 디스크 타입을 해당 값으로 설정
- 전달 받은 Size가 있으면 디스크 사이즈를 해당 값으로 설정


GCP - RootDisk 설정 기능 추가
---
GCP는 디스크 타입 지정 없이 사이즈만 지정도 가능
사용 가능 디스크 타입 : **pd-standard/pd-balanced/pd-ssd/pd-extreme**
Default 스토리지 : 10GB / 스토리지 지정 시 최소 10GB 이상이어야 함.
asia-northeast3-a 존에서 f1-micro 스펙으로 테스트 완료

RootDiskSize: "12", 

RootDiskType: "pd-ssd",
RootDiskSize: "12", 

RootDiskType: "pd-balanced",
RootDiskSize: "Default", //10GB



Alibaba - RootDisk 설정 기능 추가
---
알리바바는 디스크 타입 지정 없이 사이즈만 지정 가능
사용 가능 디스크 타입  : **cloud/cloud_efficiency/cloud_ssd/cloud_essd**
Default 스토리지 : 40GB
도코리전 - ZoneB에서 ecs.t5-lc2m1.nano 스펙으로 cloud_efficiency / cloud_ssd 및 default & 22 지정 사이즈로 테스트 완료

RootDiskSize: "default",

RootDiskSize: "22",

RootDiskType: "cloud_efficiency",
RootDiskSize: "default",

RootDiskType: "cloud_efficiency",
RootDiskSize: "22",

RootDiskType: "cloud_ssd",
RootDiskSize: "default",


Tencent - RootDisk 설정 기능 추가
---
사용 가능 디스크 타입  : **LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM**
Default 스토리지 : 50GB / 스토리지 지정 시 Image Size 보다 작으면 에러 남.
ap-tokyo-2 Zone에서 S5.SMALL1 스펙으로 테스트 완료

RootDiskType: "CLOUD_PREMIUM", 
RootDiskSize: "Default",

RootDiskType: "CLOUD_PREMIUM", 
RootDiskSize: "30", //Image Size 보다 작으면 에러 남

RootDiskType: "CLOUD_PREMIUM", 
RootDiskSize: "60",

RootDiskType: "CLOUD_SSD", 
RootDiskSize: "60",

