### PR TITLE
개선 기능및 이슈 #348에 의한 AWS RootDisk 및 사이즈 변경 기능 지원및 Tencent 방식 개선

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -908,10 +908,11 @@ func handleVM() {
 					VMSpecName:        "t2.micro",
 					KeyPairIID:        irs.IID{SystemId: "japan-test"},
 
-					//RootDiskType: "pd-ssd",      //standard/io1/io2/gp2/sc1/st1/gp3
-					//RootDiskType: "pd-balanced", //pd-standard/pd-balanced/pd-ssd/pd-extreme
-					RootDiskSize: "15", //최소 10GB 이상이어야 함.
-					//RootDiskSize: "default", //10GB
+					RootDiskType: "standard", //gp2/standard/io1/io2/sc1/st1/gp3
+					//RootDiskType: "gp2", //gp2/standard/io1/io2/sc1/st1/gp3
+					//RootDiskType: "gp3", //gp2/standard/io1/io2/sc1/st1/gp3
+					RootDiskSize: "60", //최소 8GB 이상이어야 함.
+					//RootDiskSize: "Default", //8GB
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -921,6 +922,7 @@ func handleVM() {
 				} else {
 					cblogger.Info("VM 생성 완료!!", vmInfo)
 					spew.Dump(vmInfo)
+					VmID = vmInfo.IId
 				}
 				//cblogger.Info(vm)
 
@@ -1132,11 +1134,11 @@ func main() {
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleSecurity()
-	//handleVM()
+	handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard
-	handleVMSpec()
+	//handleVMSpec()
 }
 
 //handlerType : resources폴더의 xxxHandler.go에서 Handler이전까지의 문자열

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
@@ -646,16 +646,16 @@ func handleVM() {
 					//ImageIID: irs.IID{SystemId: "img-22trbn9x"}, //Ubuntu Server 20.04 LTS 64
 					ImageIID:          irs.IID{SystemId: "img-pi0ii46r"}, //Ubuntu Server 18.04.1 LTS 64
 					VpcIID:            irs.IID{SystemId: "vpc-2u04wg7k"},
-					SubnetIID:         irs.IID{SystemId: "subnet-ccawa5nz"},
+					SubnetIID:         irs.IID{SystemId: "subnet-ccawa5nz"}, //Zone2
 					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-3baxppe6"}},
-					VMSpecName:        "S5.SMALL1",
+					VMSpecName:        "C4.LARGE8",
 					KeyPairIID:        irs.IID{SystemId: "skey-lk66iuyh"}, //cb_user_test
 					//VMUserId:          "root", //root만 가능
 					//VMUserPasswd: "Cbuser!@#", //대문자 소문자 모두 사용되어야 함. 그리고 숫자나 특수 기호 중 하나가 포함되어야 함.
-					RootDiskType: "CLOUD_PREMIUM", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
-					//RootDiskType: "CLOUD_SSD", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
-					//RootDiskSize: "60", //Image Size 보다 작으면 에러 남
-					RootDiskSize: "Default", //Image Size 보다 작으면 에러 남
+					//RootDiskType: "CLOUD_PREMIUM", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
+					RootDiskType: "CLOUD_SSD", //LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
+					RootDiskSize: "60",        //Image Size 보다 작으면 에러 남
+					//RootDiskSize: "Default", //Image Size 보다 작으면 에러 남
 				}
 
 				vmInfo, err := vmHandler.StartVM(vmReqInfo)
@@ -768,11 +768,11 @@ func handleVM() {
 func main() {
 	cblogger.Info("Tencent Cloud Resource Test")
 	//handleVPC() //VPC
-	handleVMSpec()
+	//handleVMSpec()
 	//handleSecurity()
 	//handleImage() //AMI
 	//handleKeyPair()
-	//handleVM()
+	handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleVNic() //Lancard


### PR DESCRIPTION
개선 기능및 이슈 #348에 의한 AWS RootDisk 변경 기능 지원및 Tencent 지원 방식 개선
---
- AWS RootDisk RootDisk 설정기능 추가
- Tencent RootDisk 설정 방식도 다른 CSP와 동일하게 동작하도록 변경
- 사이즈에 "default"로 설정되면 각 CSP별 고정된 값으로 셋팅(AWS:8GB / Tencent:50GB)
- Type이 지정되지 않으면 CSP 기본 옵션으로 생성 (디스크 관련 옵션 설정하지 않음)
- Size가 지정되지 않으면 CSP 기본 옵션으로 생성 (디스크 관련 옵션 설정하지 않음)
- 전달 받은 Type이 있으면 디스크 타입을 해당 값으로 설정
- 전달 받은 Size가 있으면 디스크 사이즈를 해당 값으로 설정

AWS - RootDisk 설정 기능 추가
--
- 사용 가능 디스크 타입 : standard/io1/io2/gp2/sc1/st1/gp3
- Default 스토리지 : 8GB / 스토리지 지정 시 Image Size 보다 작으면 에러 남.
- 디스크 타입 및 디스크 사이즈 개별 지정 가능
- ap-northeast-1a리전에서 t2.micro 스펙으로 테스트 했음.


**[테스트 옵션및 결과]**
VMSpecName: "t2.micro"
RootDiskType: ""
RootDiskSize: ""
--> gp2, 8GB

VMSpecName: "t2.micro"
RootDiskType: "standard"
--> standard, 8GB

VMSpecName: "t2.micro"
RootDiskSize: "12"
--> gp2, 12GB

VMSpecName: "t2.micro"
RootDiskSize: "default"
--> gp2, 8GB

VMSpecName: "t2.micro"
RootDiskType: "gp3",
RootDiskSize: "Default",
--> gp3, 8GB

VMSpecName: "t2.micro"
RootDiskType: "standard",
RootDiskSize: "6", //Image Size(8GB) 보다 작으면 에러 남
--> Volume of size 6GB is smaller than  snapshot 'snap-095f9b3409e0b354e', expect size >= 8GB

VMSpecName: "t2.micro"
RootDiskType: "standard",
RootDiskSize: "60",
--> standard, 60GB


Tencent - 다른 CSP와 동작 방식 통일
--
- 사용 가능 디스크 타입 : LOCAL_BASIC/LOCAL_SSD/CLOUD_BASIC/CLOUD_SSD/CLOUD_PREMIUM
- Default 스토리지 : 50GB / 스토리지 지정 시 Image Size 보다 작으면 에러 남.
- **디스크 타입 및 디스크 사이즈 개별 지정 가능**
- ap-tokyo-2 Zone에서 M5.SMALL8 및 C4.LARGE8 스펙으로 테스트 완료

**[테스트 옵션및 결과]**
VMSpecName: "M5.SMALL8"
RootDiskType: ""
RootDiskSize: ""
--> Premium Cloud Storage，50GB

VMSpecName: "M5.SMALL8"
RootDiskType: "CLOUD_SSD"
--> SSD cloud disks，50GB

VMSpecName: "M5.SMALL8"
RootDiskSize: "70"
--> Premium Cloud Storage，70GB

VMSpecName: "C4.LARGE8"
RootDiskSize: "default"
--> Premium Cloud Storage，50GB

VMSpecName: "C4.LARGE8"
RootDiskType: "CLOUD_PREMIUM",
RootDiskSize: "Default",
--> Premium Cloud Storage，50GB

VMSpecName: "C4.LARGE8"
RootDiskType: "CLOUD_SSD",
RootDiskSize: "30", //Image Size 보다 작으면 에러 남
--> Image size cannot be larger than system disk size, please enlarge the system disk size or change another image.

VMSpecName: "C4.LARGE8"
RootDiskType: "CLOUD_SSD",
RootDiskSize: "60",
--> SSD cloud disks，60GB

