### PR TITLE
[openstack] RootDisk Size 지정(이슈 #348)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
@@ -39,7 +39,7 @@ func setterImage(image images.Image) *irs.ImageInfo {
 	for key, val := range image.Metadata {
 		metadata := irs.KeyValue{
 			Key:   key,
-			Value: val.(string),
+			Value: fmt.Sprintf("%v", val),
 		}
 		metadataList = append(metadataList, metadata)
 	}


### PR DESCRIPTION
- RootDisk Size 지정
   - RootDisk Size 지정을 위한 Volume Create 생성 옵션
   - RootDisk Volume의 타입 이원화로 Image 정보 metadata 내 지정 삽입
     - ImageName이라는 메타데이터가 웹 콘솔내에 보이지만 api에서 찾을 수 없음 => 사용자 지정 metadata로 삽입
- image metadata 파싱 에러
    - Image의 metadata => keyValueList 과정 중 string이 아닌 경우 파싱 에러 발견으로 코드 수정
