### PR TITLE
Tidy markdown documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.5.0-Affogato (2021.12.16.)
+# v0.5.0 (Affogato, 2021.12.16.)
 
 ### API Change
 
@@ -8,14 +8,14 @@
 ### Feature
 - Add a common Validator and apply it to user's input arguments ([#394 (comment)](https://github.com/cloud-barista/cb-spider/issues/394#issuecomment-963167074))
 - Enhance the SSH Key management and insertion method of cb-user into VM ([#480](https://github.com/cloud-barista/cb-spider/issues/480) [#508](https://github.com/cloud-barista/cb-spider/pull/508) [v0.4.14](https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.14))
-- Add vm control button for AdminWeb ( [#483](https://github.com/cloud-barista/cb-spider/pull/483) )
+- Add vm control button for AdminWeb ([#483](https://github.com/cloud-barista/cb-spider/pull/483))
 - Enhance IID(Integrated ID) with IID2 ([v0.4.11](https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.11))
-- Add 'SERVER_ADDRESS' configuration to run in firewall or Kubernetes env. ([v0.4.4](https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.4))
-- Update the version info AdminWeb and spctl with 0.5.0
+- Add `SERVER_ADDRESS` configuration to run in firewall or Kubernetes env. ([v0.4.4](https://github.com/cloud-barista/cb-spider/releases/tag/v0.4.4))
+- Update the version info AdminWeb and spctl with `0.5.0`
 
 ***
 
-# v0.4.0-CafeMocha (2021.06.30.)
+# v0.4.0 (Cafe Mocha, 2021.06.30.)
 
 ### API Change
 
@@ -29,11 +29,11 @@
 - Support single VM User with cb-user ([#230](https://github.com/cloud-barista/cb-spider/issues/230))
 - Enhance the method of Call Log Elapsed time ([#359](https://github.com/cloud-barista/cb-spider/issues/359) [ref](https://github.com/cloud-barista/cb-spider/wiki/StartVM-and-TerminateVM-Main-Flow-of-Cloud-Drivers))
 - Change the OpenStack Go SDK for Improvement ([#368](https://github.com/cloud-barista/cb-spider/pull/368) [#370](https://github.com/cloud-barista/cb-spider/pull/370))
-  - github.com/rackspace/gophercloud => github.com/gophercloud/gophercloud
+  - `github.com/rackspace/gophercloud` => `github.com/gophercloud/gophercloud`
 - Update the CSP Go sdk package of cloud drivers ([#328](https://github.com/cloud-barista/cb-spider/issues/328) [ref](https://github.com/cloud-barista/cb-spider/wiki/What-is-the-CSP-SDK-API-Version-of-drivers))
 - Shorten the SG delimiter: `-delimiter-` => `-deli-`
 - Support Server Status and Endpoint info
-  - ./bin/endpoint-info.sh
+  - `./bin/endpoint-info.sh`
 - Add SecurityGroup Source filter with CIDR ([#355](https://github.com/cloud-barista/cb-spider/issues/355))
 - Integrate tencent driver with current state
 - Add REST Basic Auth ([#261](https://github.com/cloud-barista/cb-spider/issues/261) [#412](https://github.com/cloud-barista/cb-spider/pull/412))
@@ -78,7 +78,7 @@
 - 통합ID IID Manager 추가 ([#163](https://github.com/cloud-barista/cb-spider/pull/163) [#194](https://github.com/cloud-barista/cb-spider/pull/194))  
 - VPC/Subnet 기능 추가  ([#9](https://github.com/cloud-barista/cb-spider/pull/9) [#226](https://github.com/cloud-barista/cb-spider/pull/226)) 
 - VNic, PublicIP 자동 관리 기능으로 개선
-- Cloud Driver 및 Region 정보 자동 등록 지원 도구 추가 utils/import-info/*
+- Cloud Driver 및 Region 정보 자동 등록 지원 도구 추가 (`utils/import-info/*`)
 - Docker Driver 추가(Hetero Multi-IaaS 제어)
 - Android 운영 환경을 위한 plugin off mode 추가 ([3938ea0](https://github.com/cloud-barista/cb-spider/commit/3938ea0c70e69664a62eb3cee6611cfbf26ea4ea))  
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The CB-Spider Mission is to connect all the clouds with a single interface.
 
 ```
 [NOTE]
-CB-Spider is currently under development. (the latest version is 0.5.0 affogato)
+CB-Spider is currently under development. (The latest version is v0.5.0 (Affogato))
 So, we do not recommend using the current release in production.
 Please note that the functionalities of CB-Spider are not stable and secure yet.
 If you have any difficulties in using CB-Spider, please let us know.


### PR DESCRIPTION
`v0.3.0` 의 태그명은 `v0.3.0-espresso` 가 맞는데,
`v0.4.0` 부터는 태그명도 `v0.4.0` 라서
이를 Changelog에 반영하였으며
그 외에도 마크다운을 약간 업데이트 하였습니다. 😊