### PR TITLE
AWS 드라이버 #536 루트 디스크관련 이슈 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -690,7 +690,8 @@ func handleImage() {
 	handler := ResourceHandler.(irs.ImageHandler)
 
 	imageReqInfo := irs.ImageReqInfo{
-		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-0c068f008ea2bdaa1"},
+		//IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-0c068f008ea2bdaa1"}, //Microsoft Windows Server 2019
+		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-088da9557aae42f39"}, //Ubuntu Server 20.04 LTS (HVM), SSD Volume Type 64비트 x86
 		//Id:   "ami-047f7b46bd6dd5d84",
 		//Name: "Test OS Image",
 	}
@@ -898,14 +899,14 @@ func handleVM() {
 
 			case 1:
 				vmReqInfo := irs.VMReqInfo{
-					IId: irs.IID{NameId: "mcloud-barista-cb-user-test"},
+					IId: irs.IID{NameId: "mcloud-barista-cb-user-test-rootsize"},
 					//ImageIID:          irs.IID{SystemId: "ami-001b6f8703b50e077"}, //centos-stable-7.2003.13-ebs-202005201235
 					//ImageIID:          irs.IID{SystemId: "ami-059b6d3840b03d6dd"}, //Ubuntu Server 20.04 LTS (HVM)
 					//ImageIID:          irs.IID{SystemId: "ami-09e67e426f25ce0d7"}, //Ubuntu Server 20.04 LTS (HVM) - 버지니아 북부 리전
 					//ImageIID:          irs.IID{SystemId: "ami-059b6d3840b03d6dd"}, //Ubuntu Server 20.04 LTS (HVM)
 					ImageIID:          irs.IID{SystemId: "ami-0fe22bffdec36361c"}, //Ubuntu Server 18.04 LTS (HVM) - Japan 리전
 					SubnetIID:         irs.IID{SystemId: "subnet-0a6ca346752be1ca4"},
-					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-03685021f07b3ccd3"}},
+					SecurityGroupIIDs: []irs.IID{{SystemId: "sg-08c76d376b6e4e4ae"}},
 					VMSpecName:        "t2.micro",
 					KeyPairIID:        irs.IID{SystemId: "japan-test"},
 
@@ -913,7 +914,7 @@ func handleVM() {
 					//RootDiskType: "gp2", //gp2/standard/io1/io2/sc1/st1/gp3
 					//RootDiskType: "gp3", //gp2/standard/io1/io2/sc1/st1/gp3
 					//RootDiskSize: "60", //최소 8GB 이상이어야 함.
-					RootDiskSize: "1", //최소 8GB 이상이어야 함.
+					//RootDiskSize: "1", //최소 8GB 이상이어야 함.
 					//RootDiskSize: "Default", //8GB
 				}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -690,7 +690,7 @@ func handleImage() {
 	handler := ResourceHandler.(irs.ImageHandler)
 
 	imageReqInfo := irs.ImageReqInfo{
-		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-005ace3da56246b4c"},
+		IId: irs.IID{NameId: "Test OS Image", SystemId: "ami-0c068f008ea2bdaa1"},
 		//Id:   "ami-047f7b46bd6dd5d84",
 		//Name: "Test OS Image",
 	}
@@ -912,7 +912,8 @@ func handleVM() {
 					RootDiskType: "standard", //gp2/standard/io1/io2/sc1/st1/gp3
 					//RootDiskType: "gp2", //gp2/standard/io1/io2/sc1/st1/gp3
 					//RootDiskType: "gp3", //gp2/standard/io1/io2/sc1/st1/gp3
-					RootDiskSize: "60", //최소 8GB 이상이어야 함.
+					//RootDiskSize: "60", //최소 8GB 이상이어야 함.
+					RootDiskSize: "1", //최소 8GB 이상이어야 함.
 					//RootDiskSize: "Default", //8GB
 				}
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -60,7 +60,7 @@ func Connect(region string) *ec2.EC2 {
 
 // VM생성 시 사용할 루트 디스크의 최소 볼륨 사이즈 정보를 조회함
 // -1 : 정보 조회 실패
-func (vmHandler *AwsVMHandler) GetDiskInfo(ImageSystemId string) int64 {
+func (vmHandler *AwsVMHandler) GetDiskInfo(ImageSystemId string) (int64, error) {
 	cblogger.Debugf("ImageID : [%s]", ImageSystemId)
 
 	input := &ec2.DescribeImagesInput{
@@ -81,15 +81,15 @@ func (vmHandler *AwsVMHandler) GetDiskInfo(ImageSystemId string) int64 {
 		} else {
 			cblogger.Error(err.Error())
 		}
-		return -1
+		return -1, err
 	}
 
 	if len(result.Images) > 0 {
 		isize := aws.Int64(*result.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize)
-		return *isize
+		return *isize, nil
 	} else {
-		cblogger.Error("요청된 Image 정보를 찾을 수 없습니다.")
-		return -1 // errors.New("조회된 Image 정보가 없습니다.")
+		cblogger.Error("요청된 Image 정보[" + ImageSystemId + "]를 찾을 수 없습니다.")
+		return -1, errors.New("요청된 Image 정보[" + ImageSystemId + "]를 찾을 수 없습니다.")
 	}
 }
 
@@ -103,37 +103,38 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	}
 
 	//===============================
-	// Root Disk Size 검증 - 이슈#536
+	// Root Disk Size 사전 검증 - 이슈#536
 	//===============================
 	if vmReqInfo.RootDiskSize != "" {
-		//이미지의 볼륨 사이즈를 조회함.
-		imageVolumeSize := vmHandler.GetDiskInfo(vmReqInfo.ImageIID.SystemId)
-		if imageVolumeSize < 0 {
-			return irs.VMInfo{}, awserr.New(CUSTOM_ERR_CODE_BAD_REQUEST, "요청된 이미지의 기본 볼륨 사이즈 정보를 조회할 수 없습니다.", nil)
-		}
-
+		//default로 전달 받은 경우 아무것도 하지 않음 (default는 스파이더 상위에서 다른 값으로 바뀌어서 전달 받기 때문에 로직은 필요 없음)
 		if strings.EqualFold(vmReqInfo.RootDiskSize, "default") {
-			//default로 전달 받은 경우 이미지의 볼륨 사이즈로 설정 함.
-			vmReqInfo.RootDiskSize = strconv.FormatInt(imageVolumeSize, 10)
+			//default로 전달 받은 경우 이미지의 볼륨 사이즈로 설정 함. - 2022-03-03 혼동을 피하기 위해 로직 제거 함.
+			//vmReqInfo.RootDiskSize = strconv.FormatInt(imageVolumeSize, 10)
 		} else {
+			//이미지의 볼륨 사이즈를 조회함.
+			imageVolumeSize, err := vmHandler.GetDiskInfo(vmReqInfo.ImageIID.SystemId)
+			if err != nil {
+				cblogger.Error(err)
+				return irs.VMInfo{}, err
+			}
+
+			if imageVolumeSize < 0 {
+				return irs.VMInfo{}, awserr.New(CUSTOM_ERR_CODE_BAD_REQUEST, "요청된 이미지의 기본 볼륨 사이즈 정보를 조회할 수 없습니다.", nil)
+			}
+
+			//요청된 사이즈 체크
 			iChkDiskSize, err := strconv.ParseInt(vmReqInfo.RootDiskSize, 10, 64)
 			if err != nil {
 				cblogger.Error(err)
 				return irs.VMInfo{}, err
 			}
 
+			// 요청된 사이즈는 볼륨 사이즈 보다는 크거나 같아야 함.
 			if iChkDiskSize < imageVolumeSize {
 				cblogger.Errorf("루트볼륨은 %dGB보다 커야 합니다.", imageVolumeSize)
 				return irs.VMInfo{}, awserr.New(CUSTOM_ERR_CODE_BAD_REQUEST, "Root Disk Size must be at least the default size ("+strconv.FormatInt(imageVolumeSize, 10)+" GB).", nil)
 			}
-
-			//if iChkDiskSize < 8 {
-			//}
 		}
-	}
-
-	if 1 == 1 {
-		return irs.VMInfo{}, nil
 	}
 
 	imageID := vmReqInfo.ImageIID.SystemId
@@ -405,7 +406,7 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	newVmInfo, _ := vmHandler.GetVM(irs.IID{SystemId: newVmId})
 	newVmInfo.IId.NameId = vmReqInfo.IId.NameId // Tag 정보가 없을 수 있기 때문에 요청 받은 NameId를 전달 함.
 	//newVmInfo.RootDiskType = vmReqInfo.RootDiskType
-	newVmInfo.RootDiskSize = vmReqInfo.RootDiskSize // 조회시 사이즈는 나중에 블럭 디바이스 조회하는 기능 넣고 추가해야할 듯
+	//newVmInfo.RootDiskSize = vmReqInfo.RootDiskSize
 	//newVmInfo.RootDeviceName = newVmInfo.VMBootDisk
 
 	/*

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -85,8 +85,18 @@ func (vmHandler *AwsVMHandler) GetDiskInfo(ImageSystemId string) (int64, error) 
 	}
 
 	if len(result.Images) > 0 {
-		isize := aws.Int64(*result.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize)
-		return *isize, nil
+		if !reflect.ValueOf(result.Images[0].BlockDeviceMappings).IsNil() {
+			if !reflect.ValueOf(result.Images[0].BlockDeviceMappings[0].Ebs).IsNil() {
+				isize := aws.Int64(*result.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize)
+				return *isize, nil
+			} else {
+				cblogger.Error("BlockDeviceMappings에서 Ebs 정보를 찾을 수 없습니다.")
+				return -1, errors.New("BlockDeviceMappings에서 Ebs 정보를 찾을 수 없습니다.")
+			}
+		} else {
+			cblogger.Error("BlockDeviceMappings 정보를 찾을 수 없습니다.")
+			return -1, errors.New("BlockDeviceMappings 정보를 찾을 수 없습니다.")
+		}
 	} else {
 		cblogger.Error("요청된 Image 정보[" + ImageSystemId + "]를 찾을 수 없습니다.")
 		return -1, errors.New("요청된 Image 정보[" + ImageSystemId + "]를 찾을 수 없습니다.")


### PR DESCRIPTION
- AWS VM  생성 시 RootDisk 관련 정보는 사용자 요청과 상관 없이 생성된 VM 정보를 기반으로 리턴 하도록 변경
- 볼륨 사이즈 사전 체크 조건에 블럭디바이스 맵핑 정보에 있는 EBS의 볼륨 사이즈 정보로 비교하도록 로직 추가
   result.Images[0].BlockDeviceMappings[0].Ebs.VolumeSize
- 사용될 일은 없지만 혹시라도 "default" 사이즈가 요청 되었을 때 API 기본 값이 사용되도록 아무런 작업도 하지 않도록 수정