### PR TITLE
[Cloudit] VPC 개선 cb-store 저장 및 활용

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
@@ -105,6 +105,12 @@ func testVPCHandler(config ResourceConfig) {
 		},
 		IPv4_CIDR: addSubnet.IPv4_CIDR,
 	}
+	removeSubnet := config.Cloudit.Resources.VpcIID.RemoveSubnet
+	removeSubnetInfo := irs.SubnetInfo{
+		IId: irs.IID{
+			NameId: removeSubnet.SubnetIID.NameId,
+		},
+	}
 	//deleteVpcid := irs.IID{
 	//	NameId: "bcr02a.tok02.774",
 	//}
@@ -163,21 +169,10 @@ Loop:
 				res_cblogger.Info("Finish AddSubnet()")
 			case 6:
 				res_cblogger.Info("Start RemoveSubnet() ...")
-				vpcInfo, err := vpcHandler.GetVPC(vpcIID)
-				if err != nil {
+				if vpcInfo, err := vpcHandler.RemoveSubnet(vpcIID, removeSubnetInfo.IId); err != nil {
 					res_cblogger.Error(err)
-				}
-				if vpcInfo.SubnetInfoList != nil && len(vpcInfo.SubnetInfoList) > 0 {
-					firstSubnet := vpcInfo.SubnetInfoList[0]
-					res_cblogger.Info(fmt.Sprintf("RemoveSubnet : %s %s", firstSubnet.IId.NameId, firstSubnet.IPv4_CIDR))
-					result, err := vpcHandler.RemoveSubnet(vpcIID, firstSubnet.IId)
-					if err != nil {
-						res_cblogger.Error(err)
-					} else {
-						spew.Dump(result)
-					}
 				} else {
-					res_cblogger.Error("not exist subnet")
+					spew.Dump(vpcInfo)
 				}
 				res_cblogger.Info("Finish RemoveSubnet()")
 			case 7:
@@ -746,6 +741,12 @@ type ResourceConfig struct {
 					} `yaml:"SubnetIID"`
 					IPv4_CIDR string `yaml:"IPv4_CIDR"`
 				} `yaml:"AddSubnet"`
+				RemoveSubnet struct {
+					SubnetIID struct {
+						NameId   string `yaml:"nameId"`
+						SystemId string `yaml:"systemId"`
+					} `yaml:"SubnetIID"`
+				} `yaml:"RemoveSubnet"`
 			} `yaml:"VpcIID"`
 			SecurityGroup struct {
 				NameId   string `yaml:"nameId"`

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml.sample
@@ -61,3 +61,6 @@ cloudit:
         SubnetIID:
           nameId: mcb-test-vpc-subnet3
         IPv4_CIDR: 10.0.16.0/22
+      RemoveSubnet:
+        SubnetIID:
+          nameId: mcb-test-vpc-subnet0

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/CommonClouditFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/CommonClouditFunc.go
@@ -27,6 +27,7 @@ const (
 	CBVMUser      = "cb-user"
 	CBKeyPairPath = "/meta_db/.ssh-cloudit/"
 	ClouditRegion = "ClouditRegion"
+	ClouditVPCREGISTER = "VPC-REGISTER"
 )
 
 var once sync.Once
@@ -104,6 +105,16 @@ func ListVNic(authHeader map[string]string, reqClient *client.RestClient, vmId s
 // KeyPair 해시 생성 함수
 func CreateHashString(credentialInfo idrv.CredentialInfo) (string, error) {
 	keyString := credentialInfo.IdentityEndpoint + credentialInfo.AuthToken + credentialInfo.TenantId
+	hasher := md5.New()
+	_, err := io.WriteString(hasher, keyString)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+func CreateVPCHashString(credentialInfo idrv.CredentialInfo) (string, error) {
+	keyString := credentialInfo.IdentityEndpoint + credentialInfo.AuthToken + credentialInfo.TenantId + ClouditVPCREGISTER
 	hasher := md5.New()
 	_, err := io.WriteString(hasher, keyString)
 	if err != nil {


### PR DESCRIPTION
[Cloudit] VPC 개선 cb-store 저장 및 활용 (이슈 #576)
   - VPC 단일 생성 기능 제공
   - VPC 내 서브넷 관리를 위한 cb-store 데이터 & CSP 데이터 조합 
     - 서브넷관리를 위해 cb-store에 데이터 저장 
     - 콘솔 등의 환경에서 subnet 삭제등으로  cb-store와 실데이터 싱크를 위해 실제 subnet 존재 확인등의 로직 추가
   - VPC 서브넷 생성 시 CIDR 값의 실패시 생성가능한 서브넷 리스트 제공