### PR TITLE
[Cloudit] VM,SecurityGroup id 최대 길이값 버그 개선 #589

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/SecurityHandler.go
@@ -93,7 +93,7 @@ func (securityHandler *ClouditSecurityHandler) CreateSecurity(securityReqInfo ir
 			port = rule.FromPort + "-" + rule.ToPort
 		}
 		secRuleInfo := securitygroup.SecurityGroupRules{
-			Name:     fmt.Sprintf("%s-rules-%d", securityReqInfo.IId.NameId, i+1),
+			Name:     fmt.Sprintf("%s-rules-%d", rule.Direction, i+1),
 			Type:     rule.Direction,
 			Port:     port,
 			Target:   rule.CIDR,

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -675,7 +675,7 @@ func (vmHandler *ClouditVMHandler) AssociatePublicIP(vmName string, vmIp string)
 	// 2. PublicIP 생성 및 할당
 	reqInfo := adaptiveip.PublicIPReqInfo{
 		IP:        availableIP.IP,
-		Name:      vmName + "-PublicIP",
+		Name:      vmName,
 		PrivateIP: vmIp,
 	}
 


### PR DESCRIPTION
- VM : 최대 45자로 생성시  적응형 IP ID가 45글자가 넘어가 생성불가
  - 적응형 IP의 이름과 vm이름을 동일하게 생성
- SecurityGroup: 최대 45자로 생성시 Rule ID가 45글자가 넘어가 생성불가
  -  rule의 이름을  Direction과 인덱스 조합으로 생성