### PR TITLE
[Cloudit] VM 생성 실패시 자원 반환 및 VM VPC-subnet 체크, API Client 함수 제거 #589

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/dna/subnet/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/dna/subnet/Request.go
@@ -54,38 +54,6 @@ func List(restClient *client.RestClient, requestOpts *client.RequestOpts) (*[]Su
 	return &subnet, nil
 }
 
-func ListCreatableSubnet(restClient *client.RestClient, requestOpts *client.RequestOpts) (*[]SubnetInfo, error) {
-	requestURL := restClient.CreateRequestBaseURL(client.DNA, "subnets", "creatable")
-	cblogger.Info(requestURL)
-
-	var result client.Result
-	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
-		return nil, result.Err
-	}
-
-	var subnet []SubnetInfo
-	if err := result.ExtractInto(&subnet); err != nil {
-		return nil, err
-	}
-	return &subnet, nil
-}
-
-func Get(restClient *client.RestClient, subnetId string, requestOpts *client.RequestOpts) (*SubnetInfo, error) {
-	requestURL := restClient.CreateRequestBaseURL(client.DNA, subnetId, "detail")
-	cblogger.Info(requestURL)
-
-	var result client.Result
-	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
-		return nil, result.Err
-	}
-
-	var subnet SubnetInfo
-	if err := result.ExtractInto(&subnet); err != nil {
-		return nil, err
-	}
-	return &subnet, nil
-}
-
 func Create(restClient *client.RestClient, requestOpts *client.RequestOpts) (*SubnetInfo, error) {
 	requestURL := restClient.CreateRequestBaseURL(client.DNA, "subnets")
 	cblogger.Info(requestURL)


### PR DESCRIPTION
 - VM 생성 실패시 Resource 반환 #589 이슈3
   - Resource 반환 함수 정의 TerminateVM에 적용
 - VM 생성시 subnet 확인 중 VPC 관계 확인 추가
   - 기존 Cloudit의 네트워크는 subnet을 기준으로 하여 VM 생성시 VPC 확인을 하지 않았으나, Cloudit VPC 적용에 따른 VPC, subnet 확인 로직 변경
 - Cloudit API 변경에 따른 API Client 함수 제거
   - Cloudit V5 미제공 API 제거