### PR TITLE
[Cloudit/Azure/Ibm] Max-Length Issue Fix #594 #596

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ utils/clone-mc-meta-info/vm-image/az-data/*
 cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml
 
 cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml
+cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/conf/config.yaml
+

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -88,7 +88,7 @@ func (securityHandler *AzureSecurityHandler) CreateSecurity(securityReqInfo irs.
 	for idx, rule := range *securityReqInfo.SecurityRules {
 		priorityNum = int32(300 + idx*100)
 		sgRuleInfo := network.SecurityRule{
-			Name: to.StringPtr(fmt.Sprintf("%s-rules-%d", securityReqInfo.IId.NameId, idx+1)),
+			Name: to.StringPtr(fmt.Sprintf("%s-rules-%d", rule.Direction, idx+1)),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				SourceAddressPrefix:      &rule.CIDR,
 				DestinationAddressPrefix: to.StringPtr("*"),

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
@@ -120,7 +121,7 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 				VMSize: compute.VirtualMachineSizeTypes(vmReqInfo.VMSpecName),
 			},
 			OsProfile: &compute.OSProfile{
-				ComputerName:  &vmReqInfo.IId.NameId,
+				ComputerName: to.StringPtr(CBVMUser),
 				AdminUsername: to.StringPtr(CBVMUser),
 			},
 			NetworkProfile: &compute.NetworkProfile{
@@ -1160,13 +1161,13 @@ func GetRawVM(vmIID irs.IID, resourceGroup string, client *compute.VirtualMachin
 }
 
 func generatePublicIPName(vmName string) string {
-	nanos := time.Now().UnixNano()
-	return fmt.Sprintf("%s-%s-PublicIP", vmName, strconv.FormatInt(nanos, 10))
+	rand.Seed(time.Now().UnixNano())
+	return fmt.Sprintf("%s-%s-PublicIP", vmName, strconv.FormatInt(rand.Int63n(100000), 10))
 }
 
 func generateVNicName(vmName string) string {
-	nanos := time.Now().UnixNano()
-	return fmt.Sprintf("%s-%s-VNic", vmName, strconv.FormatInt(nanos, 10))
+	rand.Seed(time.Now().UnixNano())
+	return fmt.Sprintf("%s-%s-VNic", vmName, strconv.FormatInt(rand.Int63n(100000), 10))
 }
 
 func resizeVMOsDisk(RootDiskSize string, vmReqIId irs.IID, resourceGroup string, client *compute.VirtualMachinesClient, diskClient *compute.DisksClient, ctx context.Context) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
@@ -101,7 +101,7 @@ func readConfigFile() Config {
 	// Set Environment Value of Project Root Path
 	rootPath := os.Getenv("CBSPIDER_ROOT")
 	fmt.Println(rootPath)
-	data, err := ioutil.ReadFile(rootPath + "/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/conf/config.yaml.sample")
+	data, err := ioutil.ReadFile(rootPath + "/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/conf/config.yaml")
 	if err != nil {
 		cblogger.Error(err)
 	}


### PR DESCRIPTION
Cloudit/Azure/Ibm 에 대한 Max-Length에 따른 생성 불가 오류, 버그 픽스하였습니다.(#594)(#596)
 - OpenStack도 금주내에 확인 후 적용 예정입니다.
 
[Cloudit]
- cloudos_meta.yaml 기준 

|VPC|Subnet|SecurityGroup|KeyPair|VM|
|---|---|---|---|---|
|0|45|45|0|45|

- 위에 명시되지 않은 VPC, KeyPair도 45로 동일하게 테스트하였습니다.
- max-Length 관련 문제는 발견되지 않았습니다.
- 위와 별개로 VM, SecurityGroup에서 VPCInfo 누락했던 부분이 있어 수정했습니다.

[Azure]
- cloudos_meta.yaml 기준 

|VPC|Subnet|SecurityGroup|KeyPair|VM|
|---|---|---|---|---|
|64|80|64|80|64|

- SecurityGroup Rule, PublicIP, VNIC,OS ComputerName 의 Name 생성 방식이 변경되었습니다.

[IBM]
- cloudos_meta.yaml 기준 

|VPC|Subnet|SecurityGroup|KeyPair|VM|
|---|---|---|---|---|
|63|63|63|63|63|

- FloatingIP Name 생성 방식이 변경되었습니다.

OpenStack은 금주내에 테스트 후 반영하도록 하겠습니다.
