### PR TITLE
Add NHN Cloud RootDiskType and RootDiskSize specifying test scripts

### DIFF
--- a/api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-1.sh
+++ b/api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-1.sh
@@ -1,0 +1,14 @@
+export CONN_CONFIG=nhncloud-korea-pangyo-config
+#export CONN_CONFIG=nhncloud-korea-pyeongchon-config
+
+export IMAGE_NAME=5396655e-166a-4875-80d2-ed8613aa054f
+# Image Guest OS : Ubuntu Linux 18.04 기준
+
+export SPEC_NAME=u2.c2m4
+# VM Spec : vCPU: 2, Mem: 4GB, Local Disk : 50GB
+
+#export SPEC_NAME=c2.c2m2
+#export SPEC_NAME=m2.c4m8
+# VM Spec : vCPU: 4, Mem: 8GB, Need to Attach Block Disk
+
+./nhn-vm-rootdisk-test-1.sh

--- a/api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-2.sh
+++ b/api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-2.sh
@@ -1,0 +1,14 @@
+export CONN_CONFIG=nhncloud-korea-pangyo-config
+#export CONN_CONFIG=nhncloud-korea-pyeongchon-config
+
+export IMAGE_NAME=5396655e-166a-4875-80d2-ed8613aa054f
+# Image Guest OS : Ubuntu Linux 18.04 기준
+
+# export SPEC_NAME=u2.c2m4
+# VM Spec : vCPU: 2, Mem: 4GB, Local Disk : 50GB
+
+#export SPEC_NAME=c2.c2m2
+export SPEC_NAME=m2.c4m8
+# VM Spec : vCPU: 4, Mem: 8GB, Need to Attach Block Disk
+
+./nhn-vm-rootdisk-test-2.sh

--- a/api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-1.sh
+++ b/api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-1.sh
@@ -1,0 +1,148 @@
+echo "#########################################################################"
+echo "## VM RootDisk Type and Resize Test Scripts for CB-Spider - 2022.04.12."
+echo "#########################################################################"
+
+# $$$ In case of SPEC_NAME=u2.c2m4 $$$
+
+#### RootDiskType / RootDiskSize
+#### "" / ""
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'", 
+		"ReqInfo": { 
+			"Name": "nhn-vm-10", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01"
+		} 
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### default / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+    '{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-11", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "default",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_HDD / 50
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": { 
+			"Name": "nhn-vm-12", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_HDD",
+			"RootDiskSize": "50"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_HDD / 20  ==> Must Fail
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-13", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_HDD",
+			"RootDiskSize": "20"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / 50  ==> Must Fail
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-14", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "50"
+		}
+	}' |json_pp
+
+
+#### RootDiskType / RootDiskSize
+#### TYPE1 / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-15", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "TYPE1",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / 25  ==> Must Fail
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-16", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "25"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / 25  ==> Must Fail
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-17", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "HDD",
+			"RootDiskSize": "50"
+		}
+	}' |json_pp

--- a/api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-2.sh
+++ b/api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-2.sh
@@ -1,0 +1,187 @@
+echo "#########################################################################"
+echo "## VM RootDisk Type and Resize Test Scripts for CB-Spider - 2022.04.12."
+echo "#########################################################################"
+
+# $$$ In case of SPEC_NAME=m2.c4m8 $$$
+
+#### RootDiskType / RootDiskSize
+#### "" / ""
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'", 
+		"ReqInfo": { 
+			"Name": "nhn-vm-20", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01"
+		} 
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### default / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+    '{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-21", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "default",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### standard / ""
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": { 
+			"Name": "nhn-vm-22", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_HDD",
+			"RootDiskSize": "50"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_HDD / 20
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-23", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_HDD",
+			"RootDiskSize": "550"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / 50
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-24", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "77"
+		}
+	}' |json_pp
+
+
+#### RootDiskType / RootDiskSize
+#### TYPE1 / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-25", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "TYPE1",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / 5000
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-26", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "5000"
+		}
+	}' |json_pp
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-27", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-28", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "SSD",
+			"RootDiskSize": "default"
+		}
+	}' |json_pp
+
+
+#### RootDiskType / RootDiskSize
+#### General_SSD / default
+curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+	'{
+		"ConnectionName": "'${CONN_CONFIG}'",
+		"ReqInfo": {
+			"Name": "nhn-vm-29", 
+			"ImageName": "'${IMAGE_NAME}'", 
+			"VPCName": "nhn-vpc-1", 
+			"SubnetName": "nhn-subnet-1", 
+			"SecurityGroupNames": [ "nhn-sg-02" ], 
+			"VMSpecName": "'${SPEC_NAME}'", 
+			"KeyPairName": "nhn-key-01",
+			"RootDiskType": "General_SSD",
+			"RootDiskSize": "1100"
+		}
+	}' |json_pp
+


### PR DESCRIPTION
- Add NHN Cloud RootDiskType and RootDiskSize specifying test scripts
  - Test scripts : In case of u2 type of VMSpec
    - api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-1.sh
    - api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-1.sh
 
  - Test scripts : In case of not u2 type of VMSpec
    - api-runtime/rest-runtime/test/each-test/13.nhn-4.vm-rootdisk-2.sh
    - api-runtime/rest-runtime/test/each-test/nhn-vm-rootdisk-test-2.sh
