### PR TITLE
AWS 보안 그룹  기능 개선(룰 추가 / 룰 삭제)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -33,7 +33,8 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("AWS Resource Test")
-	cblog.SetLevel("info")
+	//cblog.SetLevel("info")
+	cblog.SetLevel("debug")
 }
 
 func handleSecurity() {
@@ -48,9 +49,9 @@ func handleSecurity() {
 	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	securityName := "CB-SecurityTest1"
+	securityName := "CB-SecurityAddTest1"
 	securityId := "sg-0d6a2bb960481ce68"
-	vpcId := "vpc-0c4d36a3ac3924419"
+	vpcId := "vpc-c0479cab"
 
 	for {
 		fmt.Println("Security Management")
@@ -59,6 +60,8 @@ func handleSecurity() {
 		fmt.Println("2. Security Create")
 		fmt.Println("3. Security Get")
 		fmt.Println("4. Security Delete")
+		fmt.Println("5. Security Add Rules")
+		fmt.Println("6. Security Delete Rules")
 
 		var commandNum int
 		inputCnt, err := fmt.Scan(&commandNum)
@@ -190,6 +193,82 @@ func handleSecurity() {
 					cblogger.Infof(securityId, " Security 삭제 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 삭제 결과 : [%s]", securityId, result)
+				}
+
+			case 5:
+				cblogger.Infof("[%s] Security 그룹 룰 추가 테스트", securityId)
+				result, err := handler.AddRules(irs.IID{SystemId: securityId}, &[]irs.SecurityRuleInfo{
+					{
+						FromPort:   "80",
+						ToPort:     "80",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "8080",
+						ToPort:     "8080",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "81",
+						ToPort:     "81",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "82",
+						ToPort:     "82",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "10.13.1.10/32",
+					},
+				})
+				if err != nil {
+					cblogger.Infof(securityId, " Security 그룹 룰 추가 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Security 그룹 룰 추가 결과 : [%s]", securityId, result)
+				}
+
+			case 6:
+				cblogger.Infof("[%s] Security 그룹 룰 제거 테스트", securityId)
+				result, err := handler.RemoveRules(irs.IID{SystemId: securityId}, &[]irs.SecurityRuleInfo{
+					{
+						FromPort:   "80",
+						ToPort:     "80",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "8080",
+						ToPort:     "8080",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "81",
+						ToPort:     "81",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "10.13.1.10/32",
+					},
+					{
+						FromPort:   "82",
+						ToPort:     "82",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "10.13.1.10/32",
+					},
+				})
+				if err != nil {
+					cblogger.Infof(securityId, " Security 그룹 룰 제거 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Security 그룹 룰 제거 결과 : [%s]", securityId, result)
 				}
 			}
 		}
@@ -1136,8 +1215,8 @@ func main() {
 	//handleVPC()
 	//handleKeyPair()
 	//handlePublicIP() // PublicIP 생성 후 conf
-	//handleSecurity()
-	handleVM()
+	handleSecurity()
+	//handleVM()
 
 	//handleImage() //AMI
 	//handleVNic() //Lancard


### PR DESCRIPTION
AWS 보안 그룹 핸들러에 룰 추가 / 룰 삭제 기능 반영
- 기본 룰 생성 확인 완료
- Inboud / Outbound에 각가 1개 및 2개의 룰 추가 기능 확인 완료
- Inboud / Outbound에 각가 1개 및 2개의 룰 제거 기능 확인 완료

**[고려 및 개선 사항]**
- 룰 추가 시 보안 그룹이 존재하는지는 체크하지만 보안 그룹 안에 존재하는 룰의 검증은 체크하지 않음.
  즉, AAA룰의 인바운드에 80 / 8080 포트를 추가하려 할 때 AAA룰이 존재하는지는 체크하지만...
  AAA 룰 안에 이미 80이나 8080 포트가 존재하는지는 사전 검증하지 않음(제거도 동일)
  --> [참고] AWS API의 경우 보안 그룹에 삭제할 룰이 존재하든 존재하지 않는 룰 제거 API 호출은 무조건 성공임.
  만약, 에러를 리턴하고 싶으면 사전 검증 로직이 추가되어야 함.