### PR TITLE
[Azure] AddRule, RemoveRule 기능 추가 및 핸들러 기능 개선

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
@@ -39,6 +39,20 @@ type Config struct {
 					CIDR       string `yaml:"CIDR"`
 					Direction  string `yaml:"Direction"`
 				} `yaml:"rules"`
+				AddRules []struct {
+					FromPort   string `yaml:"FromPort"`
+					ToPort     string `yaml:"ToPort"`
+					IPProtocol string `yaml:"IPProtocol"`
+					CIDR       string `yaml:"CIDR"`
+					Direction  string `yaml:"Direction"`
+				} `yaml:"addRules"`
+				RemoveRules []struct {
+					FromPort   string `yaml:"FromPort"`
+					ToPort     string `yaml:"ToPort"`
+					IPProtocol string `yaml:"IPProtocol"`
+					CIDR       string `yaml:"CIDR"`
+					Direction  string `yaml:"Direction"`
+				} `yaml:"removeRules"`
 			} `yaml:"security"`
 			KeyPair struct {
 				NameId string `yaml:"nameId"`
@@ -234,7 +248,9 @@ func testSecurityHandlerListPrint() {
 	cblogger.Info("2. GetSecurity()")
 	cblogger.Info("3. CreateSecurity()")
 	cblogger.Info("4. DeleteSecurity()")
-	cblogger.Info("5. Exit")
+	cblogger.Info("5. AddRules()")
+	cblogger.Info("6. RemoveRules()")
+	cblogger.Info("7. Exit")
 }
 
 //SecurityGroup
@@ -264,6 +280,30 @@ func testSecurityHandler(config Config) {
 	}
 	targetVPCIId := irs.IID{
 		NameId: config.Azure.Resources.Security.VpcIID.NameId,
+	}
+	securityAddRules := config.Azure.Resources.Security.AddRules
+	var securityAddRulesInfos []irs.SecurityRuleInfo
+	for _, securityRule := range securityAddRules {
+		infos := irs.SecurityRuleInfo{
+			FromPort:   securityRule.FromPort,
+			ToPort:     securityRule.ToPort,
+			IPProtocol: securityRule.IPProtocol,
+			Direction:  securityRule.Direction,
+			CIDR:       securityRule.CIDR,
+		}
+		securityAddRulesInfos = append(securityAddRulesInfos, infos)
+	}
+	securityRemoveRules := config.Azure.Resources.Security.RemoveRules
+	var securityRemoveRulesInfos []irs.SecurityRuleInfo
+	for _, securityRule := range securityRemoveRules {
+		infos := irs.SecurityRuleInfo{
+			FromPort:   securityRule.FromPort,
+			ToPort:     securityRule.ToPort,
+			IPProtocol: securityRule.IPProtocol,
+			Direction:  securityRule.Direction,
+			CIDR:       securityRule.CIDR,
+		}
+		securityRemoveRulesInfos = append(securityRemoveRulesInfos, infos)
 	}
 Loop:
 	for {
@@ -315,6 +355,21 @@ Loop:
 				}
 				fmt.Println("Finish DeleteSecurity()")
 			case 5:
+				fmt.Println("Start AddRules() ...")
+				security, err := securityHandler.AddRules(securityIId, &securityAddRulesInfos)
+				if err != nil {
+					fmt.Println(err)
+				} else {
+					spew.Dump(security)
+				}
+				fmt.Println("Finish AddRules()")
+			case 6:
+				fmt.Println("Start RemoveRules() ...")
+				if ok, err := securityHandler.RemoveRules(securityIId, &securityRemoveRulesInfos); !ok {
+					fmt.Println(err)
+				}
+				fmt.Println("Finish RemoveRules()")
+			case 7:
 				fmt.Println("Exit")
 				break Loop
 			}

--- a/cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml.sample
@@ -18,6 +18,18 @@ azure:
           IPProtocol: "tcp"
           CIDR: "0.0.0.0/0"
           Direction: "inbound"
+      addRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
+      removeRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
     keyPair:
       nameId: mcb-test-key
     vmSpec:


### PR DESCRIPTION
- AddRule, RemoveRule 기능 추가
   - 시험 항목에 대한 테스트 완료.
   - portRange, protocol등 CB <-> Azure 포매팅 수정
      - portRange의 all CB => -1 or 1-65535 => Azure "*"
      - ptotocol의 all CB => all => Azure "*"
- 핸들러 기능 개선 
	- 핸들러 별로 SystemId, NameId 기준이 다른 경우 개선
		- 테스트 용이성 및 기능 통일
		- 적용 핸들러 VPC, SecurityGroup
- TestResource 수정