### PR TITLE
[Cloudit] AddRule, RemoveRule 기능 추가 및 핸들러 기능 개선

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
@@ -328,7 +328,9 @@ func testSecurityHandlerListPrint() {
 	res_cblogger.Info("2. GetSecurity()")
 	res_cblogger.Info("3. CreateSecurity()")
 	res_cblogger.Info("4. DeleteSecurity()")
-	res_cblogger.Info("5. Exit")
+	res_cblogger.Info("5. AddRules()")
+	res_cblogger.Info("6. RemoveRules()")
+	res_cblogger.Info("7. Exit")
 }
 
 func testsecurityGroupHandler(config ResourceConfig) {
@@ -347,6 +349,30 @@ func testsecurityGroupHandler(config ResourceConfig) {
 			CIDR:       securityRule.CIDR,
 		}
 		securityRulesInfos = append(securityRulesInfos, infos)
+	}
+	securityAddRules := config.Cloudit.Resources.SecurityGroup.AddRules
+	var securityAddRulesInfos []irs.SecurityRuleInfo
+	for _, securityRule := range securityAddRules {
+		infos := irs.SecurityRuleInfo{
+			FromPort:   securityRule.FromPort,
+			ToPort:     securityRule.ToPort,
+			IPProtocol: securityRule.IPProtocol,
+			Direction:  securityRule.Direction,
+			CIDR:       securityRule.CIDR,
+		}
+		securityAddRulesInfos = append(securityAddRulesInfos, infos)
+	}
+	securityRemoveRules := config.Cloudit.Resources.SecurityGroup.RemoveRules
+	var securityRemoveRulesInfos []irs.SecurityRuleInfo
+	for _, securityRule := range securityRemoveRules {
+		infos := irs.SecurityRuleInfo{
+			FromPort:   securityRule.FromPort,
+			ToPort:     securityRule.ToPort,
+			IPProtocol: securityRule.IPProtocol,
+			Direction:  securityRule.Direction,
+			CIDR:       securityRule.CIDR,
+		}
+		securityRemoveRulesInfos = append(securityRemoveRulesInfos, infos)
 	}
 Loop:
 	for {
@@ -397,6 +423,21 @@ Loop:
 				}
 				fmt.Println("Finish DeleteSecurity()")
 			case 5:
+				fmt.Println("Start AddRules() ...")
+				security, err := securityHandler.AddRules(securityIId, &securityAddRulesInfos)
+				if err != nil {
+					fmt.Println(err)
+				} else {
+					spew.Dump(security)
+				}
+				fmt.Println("Finish AddRules()")
+			case 6:
+				fmt.Println("Start RemoveRules() ...")
+				if ok, err := securityHandler.RemoveRules(securityIId, &securityRemoveRulesInfos); !ok {
+					fmt.Println(err)
+				}
+				fmt.Println("Finish RemoveRules()")
+			case 7:
 				fmt.Println("Exit")
 				break Loop
 			}
@@ -758,6 +799,20 @@ type ResourceConfig struct {
 					CIDR       string `yaml:"CIDR"`
 					Direction  string `yaml:"Direction"`
 				} `yaml:"rules"`
+				AddRules []struct {
+					FromPort   string `yaml:"FromPort"`
+					ToPort     string `yaml:"ToPort"`
+					IPProtocol string `yaml:"IPProtocol"`
+					CIDR       string `yaml:"CIDR"`
+					Direction  string `yaml:"Direction"`
+				} `yaml:"addRules"`
+				RemoveRules []struct {
+					FromPort   string `yaml:"FromPort"`
+					ToPort     string `yaml:"ToPort"`
+					IPProtocol string `yaml:"IPProtocol"`
+					CIDR       string `yaml:"CIDR"`
+					Direction  string `yaml:"Direction"`
+				} `yaml:"removeRules"`
 			} `yaml:"SecurityGroup"`
 		} `yaml:"resources"`
 	} `yaml:"cloudit"`

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml.sample
@@ -43,6 +43,18 @@ cloudit:
           IPProtocol: "tcp"
           CIDR: "0.0.0.0/0"
           Direction: "inbound"
+      addRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
+      removeRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
     KeyPairIID:
       nameId: CB-Keypair
       systemId: CB-Keypair


### PR DESCRIPTION
- AddRule, RemoveRule 기능 추가
   - 시험 항목에 대한 테스트
	   - Cloudit은 TCP/UDP 2가지만을 제공(ICMP 미제공)
	   - ICMP 외 테스트 완료
   - portRange CB <-> Cloudit 포매팅 수정
      -  portRange의 all CB => -1 or 1-65535 => Cloudit 1-65535
	- Rule 이름 변경 
       - 기존 index 방식 시 추가 삭제시 중복 가능성 존재 => 랜덤 값으로 변경
       - Rule 이름 중복이여도 Error는 발생하지 않음
 - 핸들러 기능 개선 
	- 핸들러 별로 SystemId, NameId 기준이 다른 경우 개선
		- 테스트 용이성 및 기능 통일 
		-  적용 핸들러 VM, VPC, SecurityGroup