### PR TITLE
[Openstack] AddRule, RemoveRule 기능 추가 및 핸들러 기능 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml
 
 cloud-control-manager/cloud-driver/drivers/cloudit/main/conf/config.yaml
 cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/conf/config.yaml
+cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml
 

--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -44,7 +44,7 @@ func (cloudConn *OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandle
 
 func (cloudConn *OpenStackCloudConnection) CreateVPCHandler() (irs.VPCHandler, error) {
 	cblogger.Info("OpenStack Cloud Driver: called CreateVPCHandler()!")
-	vpcHandler := osrs.OpenStackVPCHandler{Client: cloudConn.NetworkClient}
+	vpcHandler := osrs.OpenStackVPCHandler{Client: cloudConn.NetworkClient, VMClient: cloudConn.Client}
 	return &vpcHandler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
@@ -1,0 +1,73 @@
+openstack:
+  identity_endpoint: TBD
+  project_id: TBD
+  domain_name: TBD
+  username: TBD
+  password: TBD
+  region: RegionOne
+  resources:
+    image:
+      nameId: ubuntu 18.04 LTS
+      systemId:
+    security:
+      nameId: mcb-test-security
+      systemId:
+      VpcIID:
+        nameId: mcb-test-vpc
+        systemId:
+      rules:
+        - FromPort: "22"
+          ToPort: "22"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
+      addRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
+      removeRules:
+        - FromPort: "66"
+          ToPort: "88"
+          IPProtocol: "tcp"
+          CIDR: "0.0.0.0/0"
+          Direction: "inbound"
+    keyPair:
+      nameId: mcb-test-key
+      systemId:
+    vmSpec:
+      nameId: m1.small
+      systemId:
+    vpc:
+      nameId:  mcb-test-vpc
+      systemId:
+      ipv4CIDR: 180.0.0.0/16
+      subnets:
+        - nameId: mcb-test-vpc-subnet1
+          ipv4CIDR: 180.0.40.0/24
+        - nameId: mcb-test-vpc-subnet2
+          ipv4CIDR: 180.0.30.0/24
+      addSubnet:
+        nameId: mcb-test-vpc-subnet3
+        ipv4CIDR: 180.0.50.0/24
+    vm:
+      IID:
+        nameId: mcb-test-vm
+        systemId:
+      ImageIID:
+        nameId: ubuntu-16.04.7-server-amd64
+        systemId:
+      VmSpecName: m1.small
+      KeyPairIID:
+        nameId: mcb-test-key
+        systemId:
+      VpcIID:
+        nameId: mcb-test-vpc
+        systemId:
+      SubnetIID:
+        nameId: mcb-test-vpc-subnet1
+        systemId:
+      SecurityGroupIIDs:
+        - nameId: mcb-test-security
+          systemId:

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/CommonOpenStackFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/CommonOpenStackFunc.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DNSNameservers       = "8.8.8.8"
+	DNSNameservers   = "8.8.8.8"
 	ResourceNotFound = "Resource not found"
 )
 
@@ -168,8 +168,8 @@ func GetPortByDeviceID(networkClient *gophercloud.ServiceClient, deviceID string
 	return nil, errors.New(fmt.Sprintf("could not found SecurityGroups with name %s ", deviceID))
 }
 
-func CheckIIDValidation(IId irs.IID, )bool{
-	if IId.NameId == "" && IId.SystemId == ""{
+func CheckIIDValidation(IId irs.IID) bool {
+	if IId.NameId == "" && IId.SystemId == "" {
 		return false
 	}
 	return true

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/SecurityHandler.go
@@ -47,37 +47,19 @@ func (securityHandler *OpenStackSecurityHandler) setterSeg(secGroup secgroups.Se
 	}
 
 	// 보안그룹 룰 정보 등록
-	secRuleList := make([]irs.SecurityRuleInfo, len(secList))
-	for i, rule := range secList {
-		var direction string
-		if strings.EqualFold(rule.Direction, string(rules.DirIngress)) {
-			direction = Inbound
-		} else {
-			direction = Outbound
+	var secRuleList []irs.SecurityRuleInfo
+	for _, rule := range secList {
+		if rule.EtherType == string(rules.EtherType4) {
+			ruleInfo := convertOpenStackRuleToCBRuleInfo(&rule)
+			secRuleList = append(secRuleList, ruleInfo)
 		}
-
-		ruleInfo := irs.SecurityRuleInfo{
-			Direction:  direction,
-			IPProtocol: strings.ToLower(rule.Protocol),
-			CIDR:       rule.RemoteIPPrefix,
-		}
-
-		if strings.ToLower(rule.Protocol) == ICMP {
-			ruleInfo.FromPort = "-1"
-			ruleInfo.ToPort = "-1"
-		} else {
-			ruleInfo.FromPort = strconv.Itoa(rule.PortRangeMin)
-			ruleInfo.ToPort = strconv.Itoa(rule.PortRangeMax)
-		}
-
-		secRuleList[i] = ruleInfo
 	}
 	secInfo.SecurityRules = &secRuleList
 
 	return secInfo
 }
 
-func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo irs.SecurityReqInfo) (irs.SecurityInfo, error) {
+func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo irs.SecurityReqInfo) (createdSG irs.SecurityInfo, creteErr error) {
 	// log HisCall
 	hiscallInfo := GetCallLogScheme(securityHandler.Client.IdentityEndpoint, call.SECURITYGROUP, securityReqInfo.IId.NameId, "CreateSecurity()")
 
@@ -110,58 +92,58 @@ func (securityHandler *OpenStackSecurityHandler) CreateSecurity(securityReqInfo 
 		LoggingError(hiscallInfo, err)
 		return irs.SecurityInfo{}, err
 	}
-	LoggingInfo(hiscallInfo, start)
 
+	defer func() {
+		if creteErr != nil {
+			secgroups.Delete(securityHandler.Client, group.ID)
+		}
+	}()
+
+	securityDefaultInfo := securityHandler.setterSeg(*group)
+
+	var updateRules []irs.SecurityRuleInfo
+
+	for _, newRule := range *securityReqInfo.SecurityRules {
+		chk := true
+		for _, baseRule := range *securityDefaultInfo.SecurityRules {
+			if equalsRule(newRule, baseRule) {
+				chk = false
+				break
+			}
+		}
+		if chk {
+			updateRules = append(updateRules, newRule)
+		}
+	}
+
+	createRuleOpts, err := convertCBRuleInfosToOpenStackRules(group.ID, &updateRules)
+	if err != nil {
+		creteErr = err
+		cblogger.Error(err.Error())
+		LoggingError(hiscallInfo, err)
+		return irs.SecurityInfo{}, creteErr
+	}
 	// Create SecurityGroup Rules
-	for _, rule := range *securityReqInfo.SecurityRules {
-
-		var direction string
-		if strings.EqualFold(strings.ToLower(rule.Direction), Inbound) {
-			direction = string(rules.DirIngress)
-		} else {
-			direction = string(rules.DirEgress)
-		}
-
-		var createRuleOpts rules.CreateOpts
-
-		if strings.ToLower(rule.IPProtocol) == ICMP {
-			createRuleOpts = rules.CreateOpts{
-				Direction:      rules.RuleDirection(direction),
-				EtherType:      rules.EtherType4,
-				SecGroupID:     group.ID,
-				Protocol:       rules.RuleProtocol(strings.ToLower(rule.IPProtocol)),
-				RemoteIPPrefix: rule.CIDR,
-			}
-		} else {
-			fromPort, _ := strconv.Atoi(rule.FromPort)
-			toPort, _ := strconv.Atoi(rule.ToPort)
-			createRuleOpts = rules.CreateOpts{
-				Direction:      rules.RuleDirection(direction),
-				EtherType:      rules.EtherType4,
-				SecGroupID:     group.ID,
-				PortRangeMin:   fromPort,
-				PortRangeMax:   toPort,
-				Protocol:       rules.RuleProtocol(strings.ToLower(rule.IPProtocol)),
-				RemoteIPPrefix: rule.CIDR,
-			}
-		}
-
-		_, err := rules.Create(securityHandler.NetworkClient, createRuleOpts).Extract()
+	for _, createRuleOpt := range *createRuleOpts {
+		_, err := rules.Create(securityHandler.NetworkClient, createRuleOpt).Extract()
 		if err != nil {
+			creteErr = err
 			cblogger.Error(err.Error())
 			LoggingError(hiscallInfo, err)
-			return irs.SecurityInfo{}, err
+			return irs.SecurityInfo{}, creteErr
 		}
 	}
 
 	// 생성된 SecurityGroup 정보 리턴
 	securityInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: group.ID})
 	if err != nil {
+		creteErr = err
 		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
-		return irs.SecurityInfo{}, err
+		return irs.SecurityInfo{}, creteErr
 	}
-	return securityInfo, nil
+	LoggingInfo(hiscallInfo, start)
+	return securityInfo, creteErr
 }
 
 func (securityHandler *OpenStackSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, error) {
@@ -199,7 +181,7 @@ func (securityHandler *OpenStackSecurityHandler) GetSecurity(securityIID irs.IID
 	hiscallInfo := GetCallLogScheme(securityHandler.Client.IdentityEndpoint, call.SECURITYGROUP, securityIID.NameId, "GetSecurity()")
 
 	start := call.Start()
-	securityGroup, err := secgroups.Get(securityHandler.Client, securityIID.SystemId).Extract()
+	securityGroup, err := securityHandler.getRawSecurity(securityIID)
 	if err != nil {
 		cblogger.Error(err.Error())
 		LoggingError(hiscallInfo, err)
@@ -227,9 +209,275 @@ func (securityHandler *OpenStackSecurityHandler) DeleteSecurity(securityIID irs.
 }
 
 func (securityHandler *OpenStackSecurityHandler) AddRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (irs.SecurityInfo, error) {
-        return irs.SecurityInfo{}, fmt.Errorf("Coming Soon!")
+	hiscallInfo := GetCallLogScheme(securityHandler.Client.IdentityEndpoint, call.SECURITYGROUP, sgIID.NameId, "AddRules()")
+
+	start := call.Start()
+	securityGroup, err := securityHandler.getRawSecurity(sgIID)
+	if err != nil {
+		cblogger.Error(err.Error())
+		LoggingError(hiscallInfo, err)
+		return irs.SecurityInfo{}, err
+	}
+
+	securityInfo := securityHandler.setterSeg(*securityGroup)
+
+	var updateRules []irs.SecurityRuleInfo
+	for _, newRule := range *securityRules {
+		chk := true
+		for _, baseRule := range *securityInfo.SecurityRules {
+			if equalsRule(newRule, baseRule) {
+				chk = false
+				break
+			}
+		}
+		if chk {
+			updateRules = append(updateRules, newRule)
+		}
+	}
+	createRuleOpts, err := convertCBRuleInfosToOpenStackRules(securityGroup.ID, &updateRules)
+	if err != nil {
+		cblogger.Error(err.Error())
+		LoggingError(hiscallInfo, err)
+		return irs.SecurityInfo{}, err
+	}
+	for _, createRuleOpt := range *createRuleOpts {
+		_, err := rules.Create(securityHandler.NetworkClient, createRuleOpt).Extract()
+		if err != nil {
+			cblogger.Error(err.Error())
+			LoggingError(hiscallInfo, err)
+			return irs.SecurityInfo{}, err
+		}
+	}
+
+	//  SecurityGroup 정보 리턴
+	updatedSecurity, err := securityHandler.getRawSecurity(sgIID)
+	if err != nil {
+		cblogger.Error(err.Error())
+		LoggingError(hiscallInfo, err)
+		return irs.SecurityInfo{}, err
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	updatedSecurityInfo := securityHandler.setterSeg(*updatedSecurity)
+
+	return *updatedSecurityInfo, nil
 }
 
 func (securityHandler *OpenStackSecurityHandler) RemoveRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (bool, error) {
-        return false, fmt.Errorf("Coming Soon!")
+	hiscallInfo := GetCallLogScheme(securityHandler.Client.IdentityEndpoint, call.SECURITYGROUP, sgIID.NameId, "AddRules()")
+
+	start := call.Start()
+
+	listOpts := rules.ListOpts{
+		SecGroupID: sgIID.SystemId,
+	}
+	pager, err := rules.List(securityHandler.NetworkClient, listOpts).AllPages()
+	if err != nil {
+		return false, err
+	}
+	secList, err := rules.ExtractRules(pager)
+	if err != nil {
+		return false, err
+	}
+	var deleteRuleIds []string
+	ruleWithIds, err := getRuleInfoWithIds(&secList)
+	if err != nil {
+		return false, err
+	}
+	for _, newRule := range *securityRules {
+		for _, baseRuleWithId := range *ruleWithIds {
+			if equalsRule(newRule, baseRuleWithId.RuleInfo) {
+				deleteRuleIds = append(deleteRuleIds, baseRuleWithId.Id)
+				break
+			}
+		}
+	}
+	for _, deleteRuleId := range deleteRuleIds {
+		err := rules.Delete(securityHandler.NetworkClient, deleteRuleId).ExtractErr()
+		if err != nil {
+			return false, err
+		}
+	}
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
 }
+func convertRuleProtocolOPToCB(protocol string) string {
+	switch strings.ToUpper(protocol) {
+	case "":
+		return "all"
+	default:
+		return strings.ToLower(protocol)
+	}
+}
+
+func convertRuleProtocolCBToOP(protocol string) (string, error) {
+	switch strings.ToUpper(protocol) {
+	case "ALL":
+		return "", nil
+	case "ICMP", "TCP", "UDP":
+		return strings.ToLower(protocol), nil
+	}
+	return "", errors.New("invalid Rule Protocol. The rule protocol of OpenStack must be specified accurately tcp, udp, icmp")
+}
+
+func convertRulePortRangeOPToCB(min int, max int, protocol string) (from string, to string) {
+	if strings.ToLower(protocol) == ICMP {
+		return "-1", "-1"
+	} else {
+		if min == 0 && max == 0 {
+			return "1", "65535"
+		}
+		return strconv.Itoa(min), strconv.Itoa(max)
+	}
+}
+
+func convertRulePortRangeCBToOP(from string, to string) (min int, max int, err error) {
+	if from == "" || to == "" {
+		return 0, 0, errors.New("invalid Rule PortRange")
+	}
+	fromInt, err := strconv.Atoi(from)
+	if err != nil {
+		return 0, 0, errors.New("invalid Rule PortRange")
+	}
+	toInt, err := strconv.Atoi(to)
+	if err != nil {
+		return 0, 0, errors.New("invalid Rule PortRange")
+	}
+	if fromInt == -1 || toInt == -1 {
+		return 1, 65535, nil
+	}
+	if fromInt > 65535 || fromInt < -1 || toInt > 65535 || toInt < -1 {
+		return 0, 0, errors.New("invalid Rule PortRange")
+	}
+	if fromInt == toInt {
+		return fromInt, fromInt, nil
+	} else {
+		return fromInt, toInt, nil
+	}
+}
+
+func equalsRule(pre irs.SecurityRuleInfo, post irs.SecurityRuleInfo) bool {
+	if pre.ToPort == "-1" || pre.FromPort == "-1" {
+		pre.FromPort = "1"
+		pre.ToPort = "65535"
+	}
+	if post.ToPort == "-1" || post.FromPort == "-1" {
+		post.FromPort = "1"
+		post.ToPort = "65535"
+	}
+	return strings.ToLower(fmt.Sprintf("%#v", pre)) == strings.ToLower(fmt.Sprintf("%#v", post))
+}
+
+func convertCBRuleInfosToOpenStackRules(sgId string, sgRules *[]irs.SecurityRuleInfo) (*[]rules.CreateOpts, error) {
+	openStackRuleCreateOpts := make([]rules.CreateOpts, len(*sgRules))
+	for i, rule := range *sgRules {
+		var direction string
+		if strings.EqualFold(strings.ToLower(rule.Direction), Inbound) {
+			direction = string(rules.DirIngress)
+		} else {
+			direction = string(rules.DirEgress)
+		}
+
+		var createRuleOpts rules.CreateOpts
+		protocol, err := convertRuleProtocolCBToOP(rule.IPProtocol)
+		if err != nil {
+			return nil, err
+		}
+		if strings.ToLower(rule.IPProtocol) == ICMP {
+			createRuleOpts = rules.CreateOpts{
+				Direction:      rules.RuleDirection(direction),
+				EtherType:      rules.EtherType4,
+				SecGroupID:     sgId,
+				Protocol:       rules.RuleProtocol(protocol),
+				RemoteIPPrefix: rule.CIDR,
+			}
+		} else {
+			min, max, err := convertRulePortRangeCBToOP(rule.FromPort, rule.ToPort)
+			if err != nil {
+				return nil, err
+			}
+			createRuleOpts = rules.CreateOpts{
+				Direction:      rules.RuleDirection(direction),
+				EtherType:      rules.EtherType4,
+				SecGroupID:     sgId,
+				PortRangeMin:   min,
+				PortRangeMax:   max,
+				Protocol:       rules.RuleProtocol(protocol),
+				RemoteIPPrefix: rule.CIDR,
+			}
+		}
+		openStackRuleCreateOpts[i] = createRuleOpts
+	}
+	return &openStackRuleCreateOpts, nil
+}
+
+type securityRuleInfoWithId struct {
+	Id       string
+	RuleInfo irs.SecurityRuleInfo
+}
+
+func convertOpenStackRuleToCBRuleInfo(rawRules *rules.SecGroupRule) irs.SecurityRuleInfo {
+	var direction string
+	if strings.EqualFold(rawRules.Direction, string(rules.DirIngress)) {
+		direction = Inbound
+	} else {
+		direction = Outbound
+	}
+	cidr := rawRules.RemoteIPPrefix
+	if cidr == "" {
+		cidr = "0.0.0.0/0"
+	}
+	ruleInfo := irs.SecurityRuleInfo{
+		Direction:  direction,
+		IPProtocol: convertRuleProtocolOPToCB(rawRules.Protocol),
+		CIDR:       cidr,
+	}
+
+	if strings.ToLower(rawRules.Protocol) == ICMP {
+		ruleInfo.FromPort = "-1"
+		ruleInfo.ToPort = "-1"
+	} else {
+		min, max := convertRulePortRangeOPToCB(rawRules.PortRangeMin, rawRules.PortRangeMax, rawRules.Protocol)
+		ruleInfo.FromPort = min
+		ruleInfo.ToPort = max
+	}
+
+	return ruleInfo
+}
+
+func getRuleInfoWithIds(rawRules *[]rules.SecGroupRule) (*[]securityRuleInfoWithId, error) {
+	var secRuleArrIds []securityRuleInfoWithId
+	for _, rawRule := range *rawRules {
+		if rawRule.EtherType == string(rules.EtherType4) {
+			ruleInfo := convertOpenStackRuleToCBRuleInfo(&rawRule)
+			secRuleArrIds = append(secRuleArrIds, securityRuleInfoWithId{
+				Id:       rawRule.ID,
+				RuleInfo: ruleInfo,
+			})
+		}
+	}
+	return &secRuleArrIds, nil
+}
+
+
+func (securityHandler *OpenStackSecurityHandler) getRawSecurity(securityIID irs.IID) (*secgroups.SecurityGroup, error) {
+	if securityIID.SystemId == "" && securityIID.NameId == "" {
+		return nil, errors.New("invalid IID")
+	}
+	if securityIID.SystemId != ""{
+		return secgroups.Get(securityHandler.Client, securityIID.SystemId).Extract()
+	} else {
+		pager, err := secgroups.List(securityHandler.Client).AllPages()
+		if err != nil {
+			return nil, err
+		}
+		rawSecurityGroups, err := secgroups.ExtractSecurityGroups(pager)
+		for _, rawSeg := range rawSecurityGroups {
+			if  securityIID.NameId == rawSeg.Name {
+				return &rawSeg, nil
+			}
+		}
+		return nil, errors.New("not found SecurityGroup")
+	}
+}
+

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -13,7 +13,10 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"io/ioutil"
+	"math/rand"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -45,10 +48,9 @@ type OpenStackVMHandler struct {
 	VolumeClient  *gophercloud.ServiceClient
 }
 
-func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
+func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm irs.VMInfo, createErr error) {
 	// log HisCall
 	hiscallInfo := GetCallLogScheme(vmHandler.Client.IdentityEndpoint, call.VM, vmReqInfo.IId.NameId, "StartVM()")
-
 	// 가상서버 이름 중복 체크
 	pager, err := servers.List(vmHandler.Client, servers.ListOpts{Name: vmReqInfo.IId.NameId}).AllPages()
 	if err != nil {
@@ -71,58 +73,6 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		return irs.VMInfo{}, createErr
 	}
 
-	/*vNetId, err := GetCBVNetId(vmHandler.NetworkClient)
-	if err != nil {
-		return irs.VMInfo{}, err
-	}
-	if vNetId == "" {
-		cblogger.Error(fmt.Sprintf("failed to get vnetwork"))
-		return irs.VMInfo{}, err
-	}*/
-
-	//  이미지 정보 조회 (Name)
-	/*imageHandler := OpenStackImageHandler{
-		Client: vmHandler.Client,
-	}
-	image, err := imageHandler.GetImage(vmReqInfo.IId)
-	if err != nil {
-		cblogger.Error(fmt.Sprintf("failed to get image, err : %s", err))
-		return irs.VMInfo{}, err
-	}*/
-
-	//  네트워크 정보 조회 (Name)
-	/*vNetworkHandler := OpenStackVPCHandler{
-		Client: vmHandler.Client,
-	}
-	vNetwork, err := vNetworkHandler.GetVNetwork(vmReqInfo.VirtualNetworkId)
-	if err != nil {
-		cblogger.Error(fmt.Sprintf("failed to get virtual network, err : %s", err))
-		return irs.VMInfo{}, err
-	}*/
-
-	// 보안그룹 정보 조회 (Name)
-	/*securityHandler := OpenStackSecurityHandler{
-		Client:        vmHandler.Client,
-		NetworkClient: vmHandler.NetworkClient,
-	}
-	secGroups := make([]string, len(vmReqInfo.SecurityGroupIIDs))
-	for i, s := range vmReqInfo.SecurityGroupIIDs {
-		security, err := securityHandler.GetSecurity(s)
-		if err != nil {
-			cblogger.Error(fmt.Sprintf("failed to get security group, err : %s", err))
-			return irs.VMInfo{}, err
-			//continue
-		}
-		secGroups[i] = security.IId.SystemId
-	}*/
-
-	// Flavor 정보 조회 (Name)
-	/*flavorId, err := GetFlavor(vmHandler.Client, vmReqInfo.VMSpecName)
-	if err != nil {
-		cblogger.Error(fmt.Sprintf("failed to get vm spec, err : %s", err))
-		return irs.VMInfo{}, err
-	}*/
-
 	//  이미지 정보 조회 (Name)
 	imageHandler := OpenStackImageHandler{
 		Client: vmHandler.Client,
@@ -143,7 +93,14 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		LoggingError(hiscallInfo, createErr)
 		return irs.VMInfo{}, createErr
 	}
-
+	// Private IP 할당 서브넷 매핑
+	fixedIp, err := vmHandler.availableFixedIP(vmReqInfo.SubnetIID)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to startVM err %s", err))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.VMInfo{}, createErr
+	}
 	// VM 생성
 	createVolumeFlag := true
 	serverCreateOpts := servers.CreateOpts{
@@ -153,7 +110,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 			"imagekey": image.IId.NameId,
 		},
 		Networks: []servers.Network{
-			{UUID: vmReqInfo.VpcIID.SystemId},
+			{UUID: vmReqInfo.VpcIID.SystemId, FixedIP: fixedIp},
 		},
 	}
 
@@ -226,13 +183,23 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		}
 		server, err = bootfromvolume.Create(vmHandler.Client, bootopt).Extract()
 	}
-
 	if err != nil {
 		createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
 		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.VMInfo{}, createErr
 	}
+	defer func() {
+		if createErr != nil {
+			cleanVMIId := irs.IID{
+				SystemId: server.ID,
+			}
+			cleanErr := vmHandler.vmCleaner(cleanVMIId)
+			if cleanErr != nil {
+				createErr = errors.New(fmt.Sprintf("%s Failed to rollback deleting err = %s", createErr, cleanErr))
+			}
+		}
+	}()
 	LoggingInfo(hiscallInfo, start)
 
 	var serverResult *servers.Server
@@ -248,7 +215,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		// Check VM Deploy Status
 		serverResult, err = servers.Get(vmHandler.Client, server.ID).Extract()
 		if err != nil {
-			createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to get vmInfo, err : %s", err))
+			createErr = errors.New(fmt.Sprintf("Failed to startVM err = failed to get vmInfo, err : %s", err))
 			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)
 			return irs.VMInfo{}, createErr
@@ -257,7 +224,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		if strings.ToLower(serverResult.Status) == "active" {
 			// Associate Public IP
 			if ok, err := vmHandler.AssociatePublicIP(serverResult.ID); !ok {
-				createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to Associate PublicIP, err : %s", err))
+				createErr = errors.New(fmt.Sprintf("Failed to startVM err = failed to Associate PublicIP, err : %s", err))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
@@ -265,7 +232,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 			// Get server info
 			serverResult, err = servers.Get(vmHandler.Client, server.ID).Extract()
 			if err != nil {
-				createErr := errors.New(fmt.Sprintf("Failed to startVM err =  %s", err))
+				createErr = errors.New(fmt.Sprintf("Failed to startVM err =  %s", err))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
@@ -276,7 +243,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInf
 		curRetryCnt++
 		time.Sleep(1 * time.Second)
 		if curRetryCnt > maxRetryCnt {
-			createErr := errors.New(fmt.Sprintf("failed to start vm, exceeded maximum retry count %d", maxRetryCnt))
+			createErr = errors.New(fmt.Sprintf("failed to start vm, exceeded maximum retry count %d", maxRetryCnt))
 			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)
 			return irs.VMInfo{}, createErr
@@ -359,59 +326,15 @@ func (vmHandler *OpenStackVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, erro
 func (vmHandler *OpenStackVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, error) {
 	// log HisCall
 	hiscallInfo := GetCallLogScheme(vmHandler.Client.IdentityEndpoint, call.VM, vmIID.NameId, "TerminateVM()")
-
-	// VM 정보 조회
-	server, err := vmHandler.GetVM(vmIID)
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-		return irs.Failed, err
-	}
-
-	// VM에 연결된 PublicIP 삭제
-	pager, err := floatingips.List(vmHandler.Client).AllPages()
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-		return irs.Failed, err
-	}
-	publicIPList, err := floatingips.ExtractFloatingIPs(pager)
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-		return irs.Failed, err
-	}
-
-	// IP 기준 PublicIP 검색
-	var publicIPId string
-	for _, p := range publicIPList {
-		if strings.EqualFold(server.PublicIP, p.IP) {
-			publicIPId = p.ID
-			break
-		}
-	}
-	// Public IP 삭제
-	if publicIPId != "" {
-		err := floatingips.Delete(vmHandler.Client, publicIPId).ExtractErr()
-		if err != nil {
-			cblogger.Error(err.Error())
-			LoggingError(hiscallInfo, err)
-			return irs.Failed, err
-		}
-	}
-
-	// VM 삭제
 	start := call.Start()
-	err = servers.Delete(vmHandler.Client, server.IId.SystemId).ExtractErr()
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-		return irs.Failed, err
+	cleanErr := vmHandler.vmCleaner(vmIID)
+	if cleanErr != nil {
+		return irs.Failed, cleanErr
 	}
 	LoggingInfo(hiscallInfo, start)
 
 	// 자체생성상태 반환 (OpenStack은 진행 중인 상태에 대한 정보 미제공)
-	return irs.Terminating, nil
+	return irs.Terminated, nil
 }
 
 func (vmHandler *OpenStackVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
@@ -707,4 +630,139 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 	}
 
 	return vmInfo
+}
+
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+func Hosts(cidr string) ([]string, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+	var ips []string
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		ips = append(ips, ip.String())
+	}
+	// remove network address and broadcast address and gateway, dhcp
+	if ips != nil && len(ips) > 3 {
+		return ips[3 : len(ips)-1], nil
+	}
+	return nil, errors.New("Not Exist Available IPs")
+}
+
+func difference(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}
+
+func (vmHandler *OpenStackVMHandler) availableFixedIP(subnetIId irs.IID) (string, error) {
+	if subnetIId.SystemId == "" {
+		return "", errors.New(fmt.Sprintf("Failed to Create SubnetIP err = invalid subnetIId"))
+	}
+	subnet, err := subnets.Get(vmHandler.NetworkClient, subnetIId.SystemId).Extract()
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to Create SubnetIP err = %s", err))
+	}
+	vms, err := vmHandler.ListVM()
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to Create SubnetIP err = %s", err))
+	}
+	subnetIps, err := Hosts(subnet.CIDR)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Failed to Create SubnetIP err = %s", err))
+	}
+	var vmIps []string
+	for _, vm := range vms {
+		vmIps = append(vmIps, vm.PrivateIP)
+	}
+	filteredIps := difference(subnetIps, vmIps)
+	if len(filteredIps) > 0 {
+		rand.Seed(time.Now().UnixNano())
+		index := rand.Intn(len(filteredIps))
+		return filteredIps[index], nil
+	}
+	return "", errors.New(fmt.Sprintf("Failed to Create SubnetIP err = Not Exist Available IPs"))
+}
+
+func (vmHandler *OpenStackVMHandler) vmCleaner(vmIId irs.IID) error {
+	// VM 정보 조회
+	server, err := vmHandler.GetVM(vmIId)
+	if err != nil {
+		return err
+	}
+	if server.PublicIP != "" {
+		// VM에 연결된 PublicIP 삭제
+		pager, err := floatingips.List(vmHandler.Client).AllPages()
+		if err != nil {
+			return err
+		}
+		publicIPList, err := floatingips.ExtractFloatingIPs(pager)
+		if err != nil {
+			return err
+		}
+
+		// IP 기준 PublicIP 검색
+		var publicIPId string
+		for _, p := range publicIPList {
+			if strings.EqualFold(server.PublicIP, p.IP) {
+				publicIPId = p.ID
+				break
+			}
+		}
+		// Public IP 삭제
+		if publicIPId != "" {
+			err := floatingips.Delete(vmHandler.Client, publicIPId).ExtractErr()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	err = servers.Delete(vmHandler.Client, server.IId.SystemId).ExtractErr()
+	if err != nil {
+		return err
+	}
+	curRetryCnt := 0
+	maxRetryCnt := 120
+	for {
+		listopts := servers.ListOpts{
+			Name: server.IId.NameId,
+		}
+		pager, err := servers.List(vmHandler.Client, listopts).AllPages()
+		if err != nil {
+			curRetryCnt++
+			time.Sleep(1 * time.Second)
+			continue
+		}
+
+		servers, err := servers.ExtractServers(pager)
+		if err != nil {
+			curRetryCnt++
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if len(servers) == 0 {
+			return nil
+		}
+		curRetryCnt++
+		time.Sleep(1 * time.Second)
+		if curRetryCnt > maxRetryCnt {
+			return errors.New(fmt.Sprintf("Success to Terminate. but Failed to confirm Terminate VM err = exceeded maximum retry count %d", maxRetryCnt))
+		}
+	}
 }


### PR DESCRIPTION
OpenStack은 장기간 테스트 및 기능 점검이 되지 않아, 기능추가 하며 버그 수정 등의 내용도 있습니다.. 
 - 테스트 코드 개선
	 - 테스트 코드 수정
	 -  AddRule, RemoveRule 테스트 추가

- VPC 핸들러 개선
   - VPC 생성 실패시 리소스 반환 로직 추가 
	- 삭제 플로우 개선
	   - vm 존재 확인 추가 - vm이 존재 할 경우 서브넷 삭제시 도중 실패 방지
	- VPC maxlen 이슈 수정
	   - router 생성시 VPC 이름과 동일하게 생성

- VM 핸들러 개선 및 버그 픽스
	- VM-서브넷 IP 할당 로직 추가
	   - OpenStack에는 서브넷 지정이 아닌 서브넷 내의 IP 입력방식(fixedip)
	      - 현재 vm이 지정된 서브넷에 생성되지 않아, API 단에서 IP주소 생성하여 할당으로 변경
	- VM 생성 실패시 clean 로직 추가

- 핸들러별 SystemId, NameId 기준이 다른 경우 개선
	- SystemId, NameId 둘중 하나만 있어도 조회가능하도록 수정(기능 통일)
	- 적용 핸들러 : Image, VM, VPC
	   - SecurityGroup : AddRule, RemoveRule 적용 후 추가
	
- AddRule, RemoveRule 기능 추가 및 버그 픽스
	- portRange, ptotocol input에 맞도록 Ibm 포매팅 수정
	   - portRange의 all CB => -1 or 1-65535 => Openstack 1-65535
	- 생성 시 Default Rule로 인해 생성 실패 버그 수정
		- 1. SG 생성 후 Default Rule과 Req의 Rule 비교 후 다른 룰만 추가
		- 2. SG 생성 시 SG 생성 후 룰생성 과정 중 실패시 SG 삭제
	- SystemId, NameId 둘중 하나만 있어도 조회가능하도록 수정