### PR TITLE
Alibaba, GCP, Tencent 보안 그룹 기능 개선(룰 추가 / 룰 삭제)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/Test_Resources.go
@@ -339,9 +339,10 @@ func handleSecurity() {
 	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	securityName := "CB-SecurityTestCidr"
-	securityId := "sg-6wedru4yb4m6qqfvd3sj"
-	vpcId := "vpc-6wed2mg4ox4xphl18461h"
+	//securityName := "CB-SecurityTestCidr"
+	securityName := "sg10"
+	securityId := "sg-6we0jr4qremmfu2wyd8q"
+	vpcId := "vpc-6weuepknbuvs90y6k1ss2"
 
 	for {
 		fmt.Println("Security Management")
@@ -350,6 +351,8 @@ func handleSecurity() {
 		fmt.Println("2. Security Create")
 		fmt.Println("3. Security Get")
 		fmt.Println("4. Security Delete")
+		fmt.Println("5. Rule Add")
+		fmt.Println("6. Rule Remove")
 
 		var commandNum int
 		inputCnt, err := fmt.Scan(&commandNum)
@@ -382,7 +385,7 @@ func handleSecurity() {
 					VpcIID: irs.IID{SystemId: vpcId},
 					SecurityRules: &[]irs.SecurityRuleInfo{ //보안 정책 설정
 						//CIDR 테스트
-						{
+						/*{
 							FromPort:   "20",
 							ToPort:     "22",
 							IPProtocol: "tcp",
@@ -395,7 +398,7 @@ func handleSecurity() {
 							IPProtocol: "tcp",
 							Direction:  "outbound",
 							CIDR:       "10.13.1.10/32",
-						},
+						},*/
 						/*
 							{
 								FromPort:   "20",
@@ -442,8 +445,15 @@ func handleSecurity() {
 								//ToPort:     "9999",
 								IPProtocol: "-1", // 모두 허용 (포트 정보 없음)
 								Direction:  "inbound",
+							},*/
+							{
+								FromPort:   "-1",
+								ToPort:     "-1",
+								IPProtocol: "all",
+								Direction:  "outbound",
+								CIDR:       "0.0.0.0/0",
 							},
-						*/
+						
 					},
 				}
 
@@ -473,6 +483,343 @@ func handleSecurity() {
 					cblogger.Infof(securityId, " Security 삭제 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 삭제 결과 : [%s]", securityId, result)
+				}
+			case 5:
+				cblogger.Infof("[%s] Rule 추가 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+				
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// 8080 Port로 등록
+							FromPort:   "8080",
+							ToPort:     "8080", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{ // 1323 Prot로 등록
+							FromPort:   "1323", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							ToPort:     "1323",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// All Port로 등록
+							FromPort:   "",
+							ToPort:     "",
+							IPProtocol: "icmp", //icmp는 포트 정보가 없음
+							Direction:  "inbound",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "22",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+						},*/
+						/*{
+							// 80 Port로 등록
+							FromPort:   "80",
+							ToPort:     "80",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{ // 모든 프로토콜 모든 포트로 등록
+							//FromPort:   "",
+							//ToPort:     "",
+							IPProtocol: "all", // 모두 허용 (포트 정보 없음)
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "443",
+							ToPort:     "443",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "8443",
+							ToPort:     "9999",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+						},*/
+						/*{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "all",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "4.5.6.7/32",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+						
+				
+					
+				}
+
+				result, err := handler.AddRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 추가 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 추가 결과 : [%v]", securityId, result)
+					spew.Dump(result)
+				}
+			case 6:
+				cblogger.Infof("[%s] Rule 삭제 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+					/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						FromPort:   "40",
+						ToPort:     "40",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "10.13.1.10/32",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "21",
+						IPProtocol: "udp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 8080 Port로 등록
+						FromPort:   "8080",
+						ToPort:     "8080", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 1323 Prot로 등록
+						FromPort:   "1323", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						ToPort:     "1323",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// All Port로 등록
+						FromPort:   "",
+						ToPort:     "",
+						IPProtocol: "icmp", //icmp는 포트 정보가 없음
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 모든 프로토콜 모든 포트로 등록
+						//FromPort:   "",
+						//ToPort:     "",
+						IPProtocol: "all", // 모두 허용 (포트 정보 없음)
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "all",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+				}
+
+				result, err := handler.RemoveRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 삭제 결과 : [%v]", securityId, result)
 				}
 			}
 		}
@@ -985,8 +1332,8 @@ func main() {
 	//handleVPC() //VPC
 	//handleVMSpec()
 	//handleImage() //AMI
-	//handleSecurity()
-	handleKeyPair()
+	handleSecurity()
+	//handleKeyPair()
 	//handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
@@ -73,43 +73,51 @@ func (securityHandler *AlibabaSecurityHandler) CreateSecurity(securityReqInfo ir
 	// 보안 정책 추가
 	//=======================================
 	cblogger.Infof("보안 그룹[%s]에 인바운드/아웃바운드 보안 정책 처리", createRes.SecurityGroupId)
-	createRuleRes, errRule := securityHandler.AuthorizeSecurityRules(createRes.SecurityGroupId, securityReqInfo.VpcIID.SystemId, securityReqInfo.SecurityRules)
-	if errRule != nil {
-		cblogger.Errorf("Unable to create security group rule %q, %v", securityReqInfo.IId.NameId, err)
-		return irs.SecurityInfo{}, errRule
-	} else {
-		cblogger.Info("Successfully set security group AuthorizeSecurityRules")
-	}
+	return securityHandler.AddRules(irs.IID{SystemId: createRes.SecurityGroupId}, securityReqInfo.SecurityRules)
 
-	cblogger.Debug("AuthorizeSecurityRules Result")
-	// spew.Dump(createRuleRes)
-	cblogger.Debug(createRuleRes)
-
-	securityInfo, _ := securityHandler.GetSecurity(irs.IID{SystemId: createRes.SecurityGroupId})
-	//securityInfo.IId.NameId = securityReqInfo.IId.NameId
-	return securityInfo, nil
+	//createRuleRes, errRule := securityHandler.AuthorizeSecurityRules(createRes.SecurityGroupId, securityReqInfo.VpcIID.SystemId, securityReqInfo.SecurityRules)
+	//createRuleRes, errRule := securityHandler.AuthorizeSecurityRules(createRes.SecurityGroupId, securityReqInfo.SecurityRules)
+	//if errRule != nil {
+	//	cblogger.Errorf("Unable to create security group rule %q, %v", securityReqInfo.IId.NameId, err)
+	//	return irs.SecurityInfo{}, errRule
+	//} else {
+	//	cblogger.Info("Successfully set security group AuthorizeSecurityRules")
+	//}
+	//
+	//cblogger.Debug("AuthorizeSecurityRules Result")
+	//// spew.Dump(createRuleRes)
+	//cblogger.Debug(createRuleRes)
+	//
+	//securityInfo, _ := securityHandler.GetSecurity(irs.IID{SystemId: createRes.SecurityGroupId})
+	////securityInfo.IId.NameId = securityReqInfo.IId.NameId
+	//return securityInfo, nil
 }
 
-func (securityHandler *AlibabaSecurityHandler) AuthorizeSecurityRules(securityGroupId string, vpcId string, securityRuleInfos *[]irs.SecurityRuleInfo) (*[]irs.SecurityRuleInfo, error) {
-	cblogger.Infof("securityGroupId : [%s] / vpcId : [%s] / securityRuleInfos : [%v]", securityGroupId, vpcId, securityRuleInfos)
+// SecurityGroup에 Rule 추가
+// 공통 함수명은 AddRules 이나 실제 Alibaba는 AuthorizeSecurityRules
+// SecurityGroup 생성시에도 호출
+// 저장 후 rule 목록 조회하여 return
+//  - vpcId deprecated
+//  - function name 변경 : AuthorizeSecurityRules to AddRules
+//func (securityHandler *AlibabaSecurityHandler) AuthorizeSecurityRules(securityGroupId string, vpcId string, securityRuleInfos *[]irs.SecurityRuleInfo) (*[]irs.SecurityRuleInfo, error) {
+//func (securityHandler *AlibabaSecurityHandler) AuthorizeSecurityRules(securityGroupId string, securityRuleInfos *[]irs.SecurityRuleInfo) (*[]irs.SecurityRuleInfo, error) {
+func (securityHandler *AlibabaSecurityHandler) AddRules(securityIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (irs.SecurityInfo, error) {
+	securityGroupId := securityIID.SystemId
+	cblogger.Infof("securityGroupId : [%s]  / securityRuleInfos : [%v]", securityGroupId, securityRules)
 	//cblogger.Info("AuthorizeSecurityRules ", securityRuleInfos)
-	spew.Dump(securityRuleInfos)
+	spew.Dump(securityRules)
 
-	/*
-		if strings.EqualFold(curRule.Direction, "inbound") {
-		} else if strings.EqualFold(curRule.Direction, "outbound") {
-		}
-	*/
+	if len(*securityRules) < 1 {
+		return irs.SecurityInfo{}, errors.New("invalid value - The SecurityRules to add is empty")
+	}
 
-	for _, curRule := range *securityRuleInfos {
-		//if curRule.Direction == "inbound" {
+	for _, curRule := range *securityRules {
 		if strings.EqualFold(curRule.Direction, "inbound") {
 			request := ecs.CreateAuthorizeSecurityGroupRequest()
 			request.Scheme = "https"
 			request.IpProtocol = curRule.IPProtocol
 			request.PortRange = curRule.FromPort + "/" + curRule.ToPort
 			request.SecurityGroupId = securityGroupId
-			//request.SourceCidrIp = "0.0.0.0/0"
 			request.SourceCidrIp = curRule.CIDR
 
 			cblogger.Infof("[%s] [%s] inbound rule Request", request.IpProtocol, request.PortRange)
@@ -118,17 +126,15 @@ func (securityHandler *AlibabaSecurityHandler) AuthorizeSecurityRules(securityGr
 			if err != nil {
 				cblogger.Errorf("Unable to create security group[%s] inbound rule - [%s] [%s] AuthorizeSecurityGroup Request", securityGroupId, request.IpProtocol, request.PortRange)
 				cblogger.Error(err)
-				return nil, err
+				return irs.SecurityInfo{}, err
 			}
 			cblogger.Infof("[%s] [%s] AuthorizeSecurityGroup Request success - RequestId:[%s]", request.IpProtocol, request.PortRange, response)
-			//} else if curRule.Direction == "outbound" {
 		} else if strings.EqualFold(curRule.Direction, "outbound") {
 			request := ecs.CreateAuthorizeSecurityGroupEgressRequest()
 			request.Scheme = "https"
 			request.IpProtocol = curRule.IPProtocol
 			request.PortRange = curRule.FromPort + "/" + curRule.ToPort
 			request.SecurityGroupId = securityGroupId
-			//request.DestCidrIp = "0.0.0.0/0"
 			request.DestCidrIp = curRule.CIDR
 
 			cblogger.Infof("[%s] [%s] outbound rule Request", request.IpProtocol, request.PortRange)
@@ -137,13 +143,93 @@ func (securityHandler *AlibabaSecurityHandler) AuthorizeSecurityRules(securityGr
 			if err != nil {
 				cblogger.Errorf("Unable to create security group[%s] outbound rule - [%s] [%s] AuthorizeSecurityGroup Request", securityGroupId, request.IpProtocol, request.PortRange)
 				cblogger.Error(err)
-				return nil, err
+				return irs.SecurityInfo{}, err
 			}
 			cblogger.Infof("[%s] [%s] AuthorizeSecurityGroup Request success - RequestId:[%s]", request.IpProtocol, request.PortRange, response)
 		}
 	}
 
-	return nil, nil
+	securityInfo, _ := securityHandler.GetSecurity(irs.IID{SystemId: securityGroupId})
+	//securityInfo.IId.NameId = securityReqInfo.IId.NameId
+	return securityInfo, nil
+}
+
+// SecurityGroup의 Rule 제거
+// 공통 함수명은 RemoveRules 이나 실제 Alibaba는 RevokeSecurityRules
+
+// If the security group rule to be deleted does not exist, the RevokeSecurityGroup operation succeeds but no rule is deleted.
+//func (securityHandler *AlibabaSecurityHandler) RevokeSecurityRules(securityGroupId string, securityRuleInfos *[]irs.SecurityRuleInfo) (*[]irs.SecurityRuleInfo, error) {
+func (securityHandler *AlibabaSecurityHandler) RemoveRules(securityIID irs.IID, securityRuleInfos *[]irs.SecurityRuleInfo) (bool, error) {
+	securityGroupId := securityIID.SystemId
+	cblogger.Infof("securityGroupId : [%s]  / securityRuleInfos : [%v]", securityGroupId, securityRuleInfos)
+	spew.Dump(securityRuleInfos)
+	// "cidr": "string",
+	// "fromPort": "string",
+	// "ipprotocol": "string",
+	// "toPort": "string"
+	for _, curRule := range *securityRuleInfos {
+		if strings.EqualFold(curRule.Direction, "inbound") {
+			// 3가지 case중 1번 사용.
+			// SourceGroupId : The ID of the source security group
+			// - At least one of SourceGroupId and SourceCidrIp must be specified.
+			//   .If SourceGroupId is specified but SourceCidrIp is not, the NicType parameter can be set only to intranet.
+			//     -> securityRuleInfo 에는 nicType, policy 가 들어있지 않음.
+			//   .If both SourceGroupId and SourceCidrIp are specified, SourceCidrIp takes precedence.
+			//nicType := "intranet"
+
+			request := ecs.CreateRevokeSecurityGroupRequest()
+			// case 1. 특정 CIDR block 의 인바운드 Rule 삭제 : IpProtocol, PortRange, SourcePortRange (optional), NicType, Policy, DestCidrIp (optional), and SourceCidrIp
+			request.IpProtocol = curRule.IPProtocol
+			request.PortRange = curRule.FromPort + "/" + curRule.ToPort
+			request.SecurityGroupId = securityGroupId
+			request.SourceCidrIp = curRule.CIDR
+
+			//// case 2. 특정 securityGroup의 인바운드 Rule 삭제 : IpProtocol, PortRange, SourcePortRange (optional), NicType, Policy, DestCidrIp (optional), and SourceCidrIp
+			//request.SecurityGroupId = securityGroupId
+			////request.SourceGroupId = SourceGroupId
+			//request.IpProtocol = curRule.IPProtocol
+			//request.PortRange = curRule.FromPort + "/" + curRule.ToPort
+			////request.NicType = nicType
+			////request.Policy =
+			//
+			//// case 3. 접두사(prefix)목록과 연결 된 인바운드 Rule 삭제 : IpProtocol, PortRange, SourcePortRange (optional), NicType, Policy, DestCidrIp (optional), and SourceCidrIp
+			//request.SecurityGroupId = securityGroupId
+			////request.SourcePrefixListId =
+			//request.IpProtocol = curRule.IPProtocol
+			//request.PortRange = curRule.FromPort + "/" + curRule.ToPort
+			////request.NicType = nicType
+			////request.Policy =
+
+			cblogger.Infof("[%s] [%s] inbound rule Request", request.IpProtocol, request.PortRange)
+			spew.Dump(request)
+			response, err := securityHandler.Client.RevokeSecurityGroup(request)
+			if err != nil {
+				cblogger.Errorf("Unable to revoke security group[%s] inbound rule - [%s] [%s] RevokeSecurityGroup Request", securityGroupId, request.IpProtocol, request.PortRange)
+				cblogger.Error(err)
+				return false, err
+			}
+			cblogger.Infof("[%s] [%s] RevokeSecurityGroup Request success - RequestId:[%s]", request.IpProtocol, request.PortRange, response)
+		} else if strings.EqualFold(curRule.Direction, "outbound") {
+			request := ecs.CreateRevokeSecurityGroupEgressRequest()
+			request.Scheme = "https"
+			request.IpProtocol = curRule.IPProtocol
+			request.PortRange = curRule.FromPort + "/" + curRule.ToPort
+			request.SecurityGroupId = securityGroupId
+			request.DestCidrIp = curRule.CIDR
+
+			cblogger.Infof("[%s] [%s] outbound rule Request", request.IpProtocol, request.PortRange)
+			spew.Dump(request)
+			response, err := securityHandler.Client.RevokeSecurityGroupEgress(request)
+			if err != nil {
+				cblogger.Errorf("Unable to revoke security group[%s] outbound rule - [%s] [%s] RevokeSecurityGroupEgress Request", securityGroupId, request.IpProtocol, request.PortRange)
+				cblogger.Error(err)
+				return false, err
+			}
+			cblogger.Infof("[%s] [%s] RevokeSecurityGroupEgress Request success - RequestId:[%s]", request.IpProtocol, request.PortRange, response)
+		}
+	}
+
+	return true, nil
 }
 
 func (securityHandler *AlibabaSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, error) {
@@ -236,7 +322,7 @@ func (securityHandler *AlibabaSecurityHandler) GetSecurity(securityIID irs.IID) 
 	//ecs.DescribeSecurityGroupsResponse.SecurityGroups
 	//ecs.SecurityGroups
 	//spew.Dump(result)
-	
+
 	//ecs.DescribeSecurityGroupsResponse
 	if result.TotalCount < 1 {
 		return irs.SecurityInfo{}, errors.New("Notfound: '" + securityIID.SystemId + "' SecurityGroup Not found")
@@ -357,12 +443,4 @@ func (securityHandler *AlibabaSecurityHandler) DeleteSecurity(securityIID irs.II
 	cblogger.Info(response)
 	cblogger.Infof("Successfully delete security group %q.", securityIID.SystemId)
 	return true, nil
-}
-
-func (securityHandler *AlibabaSecurityHandler) AddRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (irs.SecurityInfo, error) {
-        return irs.SecurityInfo{}, errors.New("Coming Soon!")
-}
-
-func (securityHandler *AlibabaSecurityHandler) RemoveRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (bool, error) {
-        return false, errors.New("Coming Soon!")
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -126,8 +126,10 @@ func handleSecurity() {
 	//config := readConfigFile()
 	//VmID := config.Aws.VmID
 
-	securityName := "cb-securitytest1"
-	securityId := "cb-securitytest1"
+	// securityName := "cb-securitytest1"
+	// securityId := "cb-securitytest1"
+	securityName := "sg10"
+	securityId := "sg10"
 	//securityId := "cb-secu-all"
 	//vpcId := "cb-vpc"
 	vpcId := "cb-vpc-load-test"
@@ -139,6 +141,8 @@ func handleSecurity() {
 		fmt.Println("2. Security Create")
 		fmt.Println("3. Security Get")
 		fmt.Println("4. Security Delete")
+		fmt.Println("5. Rule Add")
+		fmt.Println("6. Rule Remove")
 
 		var commandNum int
 		inputCnt, err := fmt.Scan(&commandNum)
@@ -189,10 +193,10 @@ func handleSecurity() {
 
 						{
 							//20-22 Prot로 등록
-							FromPort:   "20",
-							ToPort:     "22",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "all",
+							Direction:  "outbound",
 							CIDR:       "0.0.0.0/0",
 						},
 
@@ -295,6 +299,241 @@ func handleSecurity() {
 					cblogger.Infof(securityId, " Security 삭제 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 삭제 결과 : [%s]", securityId, result)
+				}
+			case 5:
+				cblogger.Infof("[%s] Rule 추가 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+				
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "icmp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// 8080 Port로 등록
+							FromPort:   "8080",
+							ToPort:     "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{ // 1323 Prot로 등록
+							FromPort:   "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							ToPort:     "1323",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// All Port로 등록
+							FromPort:   "",
+							ToPort:     "",
+							IPProtocol: "icmp", //icmp는 포트 정보가 없음
+							Direction:  "inbound",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "22",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+						},*/
+						/*{
+							// 80 Port로 등록
+							FromPort:   "80",
+							ToPort:     "80",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{ // 모든 프로토콜 모든 포트로 등록
+							//FromPort:   "",
+							//ToPort:     "",
+							IPProtocol: "all", // 모두 허용 (포트 정보 없음)
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "443",
+							ToPort:     "443",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "8443",
+							ToPort:     "9999",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+						},*/
+						{
+							//20-22 Prot로 등록
+							FromPort:   "22",
+							ToPort:     "22",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							//20-22 Prot로 등록
+							FromPort:   "1000",
+							ToPort:     "1000",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							//20-22 Prot로 등록
+							FromPort:   "1",
+							ToPort:     "65535",
+							IPProtocol: "udp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							//20-22 Prot로 등록
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "icmp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						
+						
+				
+					
+				}
+
+				result, err := handler.AddRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 추가 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 추가 결과 : [%v]", securityId, result)
+					spew.Dump(result)
+				}
+			case 6:
+				cblogger.Infof("[%s] Rule 삭제 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+					/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "21",
+						IPProtocol: "udp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 8080 Port로 등록
+						FromPort:   "8080",
+						ToPort:     "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 1323 Prot로 등록
+						FromPort:   "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						ToPort:     "1323",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// All Port로 등록
+						FromPort:   "",
+						ToPort:     "",
+						IPProtocol: "icmp", //icmp는 포트 정보가 없음
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 모든 프로토콜 모든 포트로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "all", // 모두 허용 (포트 정보 없음)
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 80 Port로 등록
+						FromPort:   "80",
+						ToPort:     "80",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "all",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+				}
+
+				result, err := handler.RemoveRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 삭제 결과 : [%v]", securityId, result)
 				}
 			}
 		}
@@ -1006,8 +1245,8 @@ func main() {
 	//handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
-	//handleSecurity()
-	handleVM()
+	handleSecurity()
+	//handleVM()
 	//cblogger.Info(filepath.Join("a/b", "\\cloud-driver-libs\\.ssh-gcp\\"))
 	//cblogger.Info(filepath.Join("\\cloud-driver-libs\\.ssh-gcp\\", "/b/c/d"))
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
@@ -128,9 +128,7 @@ func (securityHandler *GCPSecurityHandler) CreateSecurity(securityReqInfo irs.Se
 	} else if strings.EqualFold(commonDirection, "outbound") || strings.EqualFold(commonDirection, "EGRESS") {
 		commonDirection = "EGRESS"
 	} else {
-		// cblogger.Errorf("!!!!!!!!! SecurityReqInfo.Direction 정보[%s]가 없어서 INGRESS로 처리합니다.", securityReqInfo.Direction)
-		// Direction deprecated; return irs.SecurityInfo{}, errors.New("invalid value - The direction[" + securityReqInfo.Direction + "] information is unknown")
-		return irs.SecurityInfo{}, errors.New("invalid value - The direction[" + "securityReqInfo.Direction" + "] information is unknown")
+		return irs.SecurityInfo{}, errors.New("invalid value - The direction[" + commonDirection + "] information is unknown")
 	}
 
 	prefix := "https://www.googleapis.com/compute/v1/projects/" + projectID
@@ -346,9 +344,345 @@ func (securityHandler *GCPSecurityHandler) DeleteSecurity(securityIID irs.IID) (
 }
 
 func (securityHandler *GCPSecurityHandler) AddRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (irs.SecurityInfo, error) {
-        return irs.SecurityInfo{}, fmt.Errorf("Coming Soon!")
+	cblogger.Info(*securityRules)
+
+	projectID := securityHandler.Credential.ProjectID
+
+	security, err := securityHandler.Client.Firewalls.Get(projectID, sgIID.SystemId).Do()
+	vpcArr := strings.Split(security.Network, "/")
+	vpcName := vpcArr[len(vpcArr)-1]
+
+	if len(*securityRules) < 1 {
+		return irs.SecurityInfo{}, errors.New("invalid value - The SecurityRules policy to add is empty")
+	}
+
+	//GCP의 경우 1개의 보안그룹에 Inbound나 Outbound를 1개만 지정할 수 있으며 CIDR도 1개의 보안그룹에 1개만 공통으로 지정됨.
+	//즉, 1개의 보안 정책에 다중 포트를 선언하는 형태라서  irs.SecurityReqInfo의 정보를 사용할 것인지
+	// irs.SecurityReqInfo의 *[]SecurityRuleInfo 배열의 첫 번째 값을 사용할 것인지 미정이라 공통 변수를 만들어서 처리함.
+	commonPolicy := *securityRules
+	commonDirection := commonPolicy[0].Direction
+	commonCidr := strings.Split(commonPolicy[0].CIDR, ",")
+
+	if len(commonCidr[0]) < 2 {
+		return irs.SecurityInfo{}, errors.New("invalid value - The CIDR is empty")
+	}
+
+	
+	// @TODO: SecurityGroup 생성 요청 파라미터 정의 필요
+	ports := *securityRules
+	existedRules := security.Allowed
+	var firewallAllowed []*compute.FirewallAllowed
+
+	for _,rule := range existedRules {
+		firewallAllowed = append(firewallAllowed, rule)
+	}
+
+	//다른 드라이버와의 통일을 위해 All은 -1로 처리함.
+	//GCP는 포트 번호를 적지 않으면 All임.
+	//GCP 방화벽 정책
+	//https://cloud.google.com/vpc/docs/firewalls?hl=ko&_ga=2.238147008.-1577666838.1589162755#protocols_and_ports
+	for _, item := range ports {
+		var port string
+		fp := item.FromPort
+		tp := item.ToPort
+
+		//GCP는 1개의 정책에 1가지 Direction만 지정 가능하기 때문에 Inbound와 Outbound 모두 지정되었을 경우 에러 처리함.
+		if !strings.EqualFold(item.Direction, commonDirection) {
+			return irs.SecurityInfo{}, errors.New("invalid value - GCP can only use one Direction for one security policy")
+		}
+
+		// CB Rule에 의해 Port 번호에 -1이 기입된 경우 GCP Rule에 맞게 치환함.
+		if fp == "-1" || tp == "-1" {
+			if (fp == "-1" && tp == "-1") || (fp == "-1" && tp == "") || (fp == "" && tp == "-1") {
+				port = ""
+			} else if fp == "-1" {
+				port = tp
+			} else {
+				port = fp
+			}
+		} else {
+			//둘 다 있는 경우
+			if tp != "" && fp != "" {
+				port = fp + "-" + tp
+				//From Port가 없는 경우
+			} else if tp != "" && fp == "" {
+				port = tp
+				//To Port가 없는 경우
+			} else if tp == "" && fp != "" {
+				port = fp
+			} else {
+				port = ""
+			}
+		}
+
+		if port == "" {
+			firewallAllowed = append(firewallAllowed, &compute.FirewallAllowed{
+				IPProtocol: item.IPProtocol,
+			})
+		} else {
+			firewallAllowed = append(firewallAllowed, &compute.FirewallAllowed{
+				IPProtocol: item.IPProtocol,
+				Ports: []string{
+					port,
+				},
+			})
+		}
+	}
+
+	if strings.EqualFold(commonDirection, "inbound") || strings.EqualFold(commonDirection, "INGRESS") {
+		commonDirection = "INGRESS"
+	} else if strings.EqualFold(commonDirection, "outbound") || strings.EqualFold(commonDirection, "EGRESS") {
+		commonDirection = "EGRESS"
+	} else {
+		return irs.SecurityInfo{}, errors.New("invalid value - The direction[" + commonDirection + "] information is unknown")
+	}
+
+	if !strings.EqualFold(security.Direction, commonDirection) {
+		return irs.SecurityInfo{}, errors.New("invalid value - GCP can only use one Direction for one security policy")
+	}
+
+	prefix := "https://www.googleapis.com/compute/v1/projects/" + projectID
+	//networkURL := prefix + "/global/networks/" + securityReqInfo.VpcIID.NameId
+	networkURL := prefix + "/global/networks/" + vpcName
+
+	fireWall := &compute.Firewall{
+		Allowed:   firewallAllowed,
+		Direction: commonDirection, //INGRESS(inbound), EGRESS(outbound)
+		// SourceRanges: []string{
+		// 	// "0.0.0.0/0",
+		// 	commonCidr,
+		// },
+		//Name: security.Name,
+		//TargetTags: []string{
+			//security.Name,
+		//},
+		Network: networkURL,
+	}
+
+	//CIDR 처리
+	if strings.EqualFold(commonDirection, "INGRESS") {
+		//fireWall.SourceRanges = []string{commonCidr}
+		fireWall.SourceRanges = commonCidr
+	} else {
+		//fireWall.DestinationRanges = []string{commonCidr}
+		fireWall.DestinationRanges = commonCidr
+	}
+
+	cblogger.Info("생성할 방화벽 정책")
+	cblogger.Debug(fireWall)
+	//spew.Dump(fireWall)
+
+	// logger for HisCall
+	callogger := call.GetLogger("HISCALL")
+	callLogInfo := call.CLOUDLOGSCHEMA{
+		CloudOS:      call.GCP,
+		RegionZone:   securityHandler.Region.Zone,
+		ResourceType: call.SECURITYGROUP,
+		ResourceName: security.Name,
+		CloudOSAPI:   "Firewalls.Update()",
+		ElapsedTime:  "",
+		ErrorMSG:     "",
+	}
+	callLogStart := call.Start()
+
+	res, err := securityHandler.Client.Firewalls.Update(projectID, sgIID.SystemId, fireWall).Do()
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	if err != nil {
+		callLogInfo.ErrorMSG = err.Error()
+		callogger.Error(call.String(callLogInfo))
+		cblogger.Error(err)
+		return irs.SecurityInfo{}, err
+	}
+	callogger.Info(call.String(callLogInfo))
+	fmt.Println("create result : ", res)
+	time.Sleep(time.Second * 3)
+	//secInfo, _ := securityHandler.GetSecurity(securityReqInfo.IId)
+	secInfo, _ := securityHandler.GetSecurity(irs.IID{SystemId: sgIID.SystemId})
+	return secInfo, nil
+	//return irs.SecurityInfo{}, fmt.Errorf("Coming Soon!")
 }
 
 func (securityHandler *GCPSecurityHandler) RemoveRules(sgIID irs.IID, securityRules *[]irs.SecurityRuleInfo) (bool, error) {
-        return false, fmt.Errorf("Coming Soon!")
+	cblogger.Info(*securityRules)
+
+	projectID := securityHandler.Credential.ProjectID
+
+	security, err := securityHandler.Client.Firewalls.Get(projectID, sgIID.SystemId).Do()
+	vpcArr := strings.Split(security.Network, "/")
+	vpcName := vpcArr[len(vpcArr)-1]
+
+	if len(*securityRules) < 1 {
+		return false, errors.New("invalid value - The SecurityRules policy to delete is empty")
+	}
+
+	//GCP의 경우 1개의 보안그룹에 Inbound나 Outbound를 1개만 지정할 수 있으며 CIDR도 1개의 보안그룹에 1개만 공통으로 지정됨.
+	//즉, 1개의 보안 정책에 다중 포트를 선언하는 형태라서  irs.SecurityReqInfo의 정보를 사용할 것인지
+	// irs.SecurityReqInfo의 *[]SecurityRuleInfo 배열의 첫 번째 값을 사용할 것인지 미정이라 공통 변수를 만들어서 처리함.
+	commonPolicy := security
+	commonDirection := commonPolicy.Direction
+	commonCidr := commonPolicy.SourceRanges
+	if strings.EqualFold(commonPolicy.Direction, "EGRESS") {
+		commonCidr = security.DestinationRanges
+	}
+
+	if len(commonCidr[0]) < 2 {
+		return false, errors.New("invalid value - The CIDR is empty")
+	}
+
+	
+	// @TODO: SecurityGroup 생성 요청 파라미터 정의 필요
+	ports := *securityRules
+	existedAllowed := security.Allowed
+	var firewallAllowed []*compute.FirewallAllowed
+	var newFirewallAllowed []*compute.FirewallAllowed
+
+	//다른 드라이버와의 통일을 위해 All은 -1로 처리함.
+	//GCP는 포트 번호를 적지 않으면 All임.
+	//GCP 방화벽 정책
+	//https://cloud.google.com/vpc/docs/firewalls?hl=ko&_ga=2.238147008.-1577666838.1589162755#protocols_and_ports
+	for _, item := range ports {
+		var port string
+		fp := item.FromPort
+		tp := item.ToPort
+
+		// CB Rule에 의해 Port 번호에 -1이 기입된 경우 GCP Rule에 맞게 치환함.
+		if fp == "-1" || tp == "-1" {
+			if (fp == "-1" && tp == "-1") || (fp == "-1" && tp == "") || (fp == "" && tp == "-1") {
+				port = ""
+			} else if fp == "-1" {
+				port = tp
+			} else {
+				port = fp
+			}
+		} else {
+			//둘 다 있는 경우
+			if tp != "" && fp != "" {
+				port = fp + "-" + tp
+				if tp == fp {
+					port = tp
+				}
+				//From Port가 없는 경우
+			} else if tp != "" && fp == "" {
+				port = tp
+				//To Port가 없는 경우
+			} else if tp == "" && fp != "" {
+				port = fp
+			} else {
+				port = ""
+			}
+		}
+
+		if strings.EqualFold(item.Direction, "inbound") || strings.EqualFold(item.Direction, "INGRESS") {
+			item.Direction = "INGRESS"
+		} else if strings.EqualFold(item.Direction, "outbound") || strings.EqualFold(item.Direction, "EGRESS") {
+			item.Direction = "EGRESS"
+		} else {
+			return false, errors.New("invalid value - The direction[" + item.Direction + "] information is unknown")
+		}
+
+		if strings.EqualFold(commonDirection, item.Direction) && strings.EqualFold(commonCidr[0], item.CIDR) { 
+			if port == "" {
+				firewallAllowed = append(firewallAllowed, &compute.FirewallAllowed{
+					IPProtocol: item.IPProtocol,
+				})
+			} else {
+				firewallAllowed = append(firewallAllowed, &compute.FirewallAllowed{
+					IPProtocol: item.IPProtocol,
+					Ports: []string{
+						port,
+					},
+				})
+			}
+		}
+	}
+
+
+	// 삭제할 rule을 제외시킨 새로운 firewallAllowed 생성, firewallAllowed == 삭제하려는 rule의 모음
+	for _, rule := range existedAllowed {
+		count := 0
+		for _, deleteRule := range firewallAllowed {
+			if len(deleteRule.Ports) == 0 && strings.EqualFold(rule.IPProtocol, deleteRule.IPProtocol) { // port값이 없는 경우
+				break
+			} else if strings.EqualFold(rule.IPProtocol, deleteRule.IPProtocol) && strings.EqualFold(rule.Ports[0], deleteRule.Ports[0]) {
+				break
+			}
+			count++
+		}
+
+		if len(firewallAllowed)!= 0 && count < len(firewallAllowed) { // 삭제하려는 rule이 존재하는 경우
+			continue
+		}
+
+		newFirewallAllowed = append(newFirewallAllowed, &compute.FirewallAllowed{
+			IPProtocol: rule.IPProtocol,
+			Ports: rule.Ports,
+		})
+
+	}
+
+	if len(newFirewallAllowed) == 0 {
+		return false, errors.New("invalid value - Must specify at least one rule")
+	}
+
+	prefix := "https://www.googleapis.com/compute/v1/projects/" + projectID
+	//networkURL := prefix + "/global/networks/" + securityReqInfo.VpcIID.NameId
+	networkURL := prefix + "/global/networks/" + vpcName
+
+	fireWall := &compute.Firewall{
+		Allowed:   newFirewallAllowed,
+		Direction: commonDirection, //INGRESS(inbound), EGRESS(outbound)
+		// SourceRanges: []string{
+		// 	// "0.0.0.0/0",
+		// 	commonCidr,
+		// },
+		//Name: security.Name,
+		//TargetTags: []string{
+			//security.Name,
+		//},
+		Network: networkURL,
+	}
+
+	//CIDR 처리
+	if strings.EqualFold(commonDirection, "INGRESS") {
+		//fireWall.SourceRanges = []string{commonCidr}
+		fireWall.SourceRanges = commonCidr
+	} else {
+		//fireWall.DestinationRanges = []string{commonCidr}
+		fireWall.DestinationRanges = commonCidr
+	}
+
+	cblogger.Info("생성할 방화벽 정책")
+	cblogger.Debug(fireWall)
+	//spew.Dump(fireWall)
+
+	// logger for HisCall
+	callogger := call.GetLogger("HISCALL")
+	callLogInfo := call.CLOUDLOGSCHEMA{
+		CloudOS:      call.GCP,
+		RegionZone:   securityHandler.Region.Zone,
+		ResourceType: call.SECURITYGROUP,
+		ResourceName: security.Name,
+		CloudOSAPI:   "Firewalls.Update()",
+		ElapsedTime:  "",
+		ErrorMSG:     "",
+	}
+	callLogStart := call.Start()
+
+	res, err := securityHandler.Client.Firewalls.Update(projectID, sgIID.SystemId, fireWall).Do()
+	cblogger.Info(res)
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	if err != nil {
+		callLogInfo.ErrorMSG = err.Error()
+		callogger.Error(call.String(callLogInfo))
+		cblogger.Error(err)
+		return false, err
+	}
+	callogger.Info(call.String(callLogInfo))
+	//fmt.Println("create result : ", res)
+	time.Sleep(time.Second * 3)
+	//secInfo, _ := securityHandler.GetSecurity(securityReqInfo.IId)
+	secInfo, _ := securityHandler.GetSecurity(irs.IID{SystemId: sgIID.SystemId})
+	cblogger.Info(secInfo)
+	return true, nil
+	//return irs.SecurityInfo{}, fmt.Errorf("Coming Soon!")
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/main/Test_Resources.go
@@ -136,9 +136,9 @@ func handleSecurity() {
 	}
 	handler := ResourceHandler.(irs.SecurityHandler)
 
-	securityName := "CB-SecurityTestAll"
-	securityId := "sg-6wedru4yb4m6qqfvd3sj"
-	vpcId := "vpc-6wei16ufuimfcct41o0xh"
+	securityName := "sg10"
+	securityId := "sg-98w7lc11"
+	vpcId := "vpc-f3teez1l"
 
 	for {
 		fmt.Println("Security Management")
@@ -147,6 +147,8 @@ func handleSecurity() {
 		fmt.Println("2. Security Create")
 		fmt.Println("3. Security Get")
 		fmt.Println("4. Security Delete")
+		fmt.Println("5. Rule Add")
+		fmt.Println("6. Rule Remove")
 
 		var commandNum int
 		inputCnt, err := fmt.Scan(&commandNum)
@@ -187,20 +189,20 @@ func handleSecurity() {
 						// 	CIDR:       "0.0.0.0/0",
 						// },
 						{
-							FromPort:   "20",
-							ToPort:     "-",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "all",
+							Direction:  "outbound",
 							CIDR:       "0.0.0.0/0",
 						},
 
-						{
+						/*{
 							FromPort:   "8080",
 							ToPort:     "",
 							IPProtocol: "tcp",
 							Direction:  "inbound",
 							CIDR:       "0.0.0.0/0",
-						},
+						},*/
 
 						// {
 						// 	FromPort:   "40",
@@ -286,6 +288,244 @@ func handleSecurity() {
 					cblogger.Infof(securityId, " Security 삭제 실패 : ", err)
 				} else {
 					cblogger.Infof("[%s] Security 삭제 결과 : [%s]", securityId, result)
+				}
+			case 5:
+				cblogger.Infof("[%s] Rule 추가 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+				
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "20",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// 8080 Port로 등록
+							FromPort:   "8080",
+							ToPort:     "-1", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{ // 1323 Prot로 등록
+							FromPort:   "-1", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+							ToPort:     "1323",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							// All Port로 등록
+							FromPort:   "",
+							ToPort:     "",
+							IPProtocol: "icmp", //icmp는 포트 정보가 없음
+							Direction:  "inbound",
+						},*/
+						/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "22",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+						},*/
+						/*{
+							// 80 Port로 등록
+							FromPort:   "80",
+							ToPort:     "80",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "all",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "443",
+							ToPort:     "443",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "8443",
+							ToPort:     "9999",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+						},*/
+						/*{
+							FromPort:   "20",
+							ToPort:     "20",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "1000",
+							ToPort:     "1000",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "1",
+							ToPort:     "65535",
+							IPProtocol: "udp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						/*{
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "icmp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+						},*/
+						{
+							FromPort:   "20",
+							ToPort:     "20",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							FromPort:   "1000",
+							ToPort:     "1000",
+							IPProtocol: "tcp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							FromPort:   "1",
+							ToPort:     "65535",
+							IPProtocol: "udp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						{
+							FromPort:   "-1",
+							ToPort:     "-1",
+							IPProtocol: "icmp",
+							Direction:  "outbound",
+							CIDR:       "0.0.0.0/0",
+						},
+						
+				
+					
+				}
+
+				result, err := handler.AddRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 추가 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 추가 결과 : [%v]", securityId, result)
+					spew.Dump(result)
+				}
+			case 6:
+				cblogger.Infof("[%s] Rule 삭제 테스트", securityId)
+				securityRules := &[]irs.SecurityRuleInfo{
+					/*{
+							//20-22 Prot로 등록
+							FromPort:   "20",
+							ToPort:     "21",
+							IPProtocol: "tcp",
+							Direction:  "inbound",
+							CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "21",
+						IPProtocol: "udp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 8080 Port로 등록
+						FromPort:   "8080",
+						ToPort:     "-1", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 1323 Prot로 등록
+						FromPort:   "-1", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						ToPort:     "1323",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// All Port로 등록
+						FromPort:   "",
+						ToPort:     "",
+						IPProtocol: "icmp", //icmp는 포트 정보가 없음
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "all",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 80 Port로 등록
+						FromPort:   "80",
+						ToPort:     "80",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					{
+						FromPort:   "20",
+						ToPort:     "20",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+				}
+
+				result, err := handler.RemoveRules(irs.IID{SystemId: securityId}, securityRules)
+				if err != nil {
+					cblogger.Infof(securityId, " Rule 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof("[%s] Rule 삭제 결과 : [%v]", securityId, result)
 				}
 			}
 		}
@@ -765,10 +1005,10 @@ func main() {
 	cblogger.Info("Tencent Cloud Resource Test")
 	//handleVPC() //VPC
 	//handleVMSpec()
-	//handleSecurity()
+	handleSecurity()
 	//handleImage() //AMI
 	//handleKeyPair()
-	handleVM()
+	//handleVM()
 
 	//handlePublicIP() // PublicIP 생성 후 conf
 	//handleVNic() //Lancard


### PR DESCRIPTION
Alibaba, GCP, Tencent 보안 그룹 핸들러에 룰 추가 / 룰 삭제 기능 반영

1. 기본 룰 생성 확인 완료

- Inboud / Outbound에 각각 1개 및 2개 이상의 룰 추가 기능 확인 완료
- Inboud / Outbound에 각각 1개 및 2개 이상의 룰 제거 기능 확인 완료

2. Alibaba : 기존 Rule 추가 관련 function이 존재했음
- 기존 AuthorizeSecurityRules 를 AddRules로 이름 변경
- 기존 RevokeSecurityRules 를 RemoveRules로 이름 변경
[고려 및 개선 사항]

3. ADD Rules에서 INBOUND/OUTBOUND 가 같이 있는경우 (리스트 이므로)
- GCP : 불가. one direction만 가능.
- TENCENT : 불가. Cannot not add at the same time
   -> inbound 추가 후 outbound 추가를 따로했을 때는 가능
- ALI : 같이 있어도 가능.

4. RemoveRule에서 모든 rule을 지우려고 하면
 - ALI : 허용
 - GCP : 허용안함. 최소 1개의 Rule이 존재해야 함.
 - TENCENT : 허용
 
 5. TestResource 보완
  - AddRules, RemoveRules 추가(ALI, GCP, TENCENT)