### PR TITLE
[Azure]SG-Rule 버그 픽스 (#482)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -38,7 +38,7 @@ func (securityHandler *AzureSecurityHandler) setterSec(securityGroup network.Sec
 	var securityRuleArr []irs.SecurityRuleInfo
 	for _, sgRule := range *securityGroup.SecurityRules {
 		protocols := convertRuleProtocolAZToCB(fmt.Sprint(sgRule.Protocol))
-		fromPort, toPort := convertRulePortRangeAZToCB(*sgRule.SourcePortRange, protocols)
+		fromPort, toPort := convertRulePortRangeAZToCB(*sgRule.DestinationPortRange, protocols)
 		ruleInfo := irs.SecurityRuleInfo{
 			IPProtocol: protocols,
 			Direction:  strings.ToLower(fmt.Sprint(sgRule.Direction)),
@@ -416,9 +416,9 @@ func convertRuleInfoCBToAZ(rules []irs.SecurityRuleInfo) (*[]network.SecurityRul
 			Name: to.StringPtr(fmt.Sprintf("%s-rules-%d", rule.Direction, idx+1)),
 			SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
 				SourceAddressPrefix:      &rule.CIDR,
-				SourcePortRange:          to.StringPtr(portRange),
+				SourcePortRange:          to.StringPtr("*"),
 				DestinationAddressPrefix: to.StringPtr("*"),
-				DestinationPortRange:     to.StringPtr("*"),
+				DestinationPortRange:     to.StringPtr(portRange),
 				Protocol:                 network.SecurityRuleProtocol(protocol),
 				Access:                   network.SecurityRuleAccess("Allow"),
 				Priority:                 to.Int32Ptr(priorityNum),


### PR DESCRIPTION
https://github.com/cloud-barista/cb-spider/issues/482#issuecomment-1111430312

- AddRules/RemoveRules return 후 CSP가 반영위한 소요 시간 필요
    - (안1)에 관련해서 조사해보겠습니다.

[azure-03.inbound-case-03.sh-Test:2022.04.27-19:32:25]
- SecurityGroup Rule의 포트가 뒤집혀 있던 버그 개선하였습니다.

테스트 결과는 issue 하단에 코멘트로 추가하겠습니다.


