### PR TITLE
[OpenStack] Image 조회 방식 변경

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
@@ -7,8 +7,8 @@ openstack:
   region: RegionOne
   resources:
     image:
-      nameId: ubuntu 18.04 LTS
-      systemId:
+      nameId: 37d7ad6c-e3e0-4a46-a288-963d182f05c7
+      systemId: 37d7ad6c-e3e0-4a46-a288-963d182f05c7
     security:
       nameId: mcb-test-security
       systemId:

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
@@ -28,7 +28,7 @@ type OpenStackImageHandler struct {
 func setterImage(image images.Image) *irs.ImageInfo {
 	imageInfo := &irs.ImageInfo{
 		IId: irs.IID{
-			NameId:   image.Name,
+			NameId:   image.ID,
 			SystemId: image.ID,
 		},
 		Status: image.Status,
@@ -188,24 +188,6 @@ func (imageHandler *OpenStackImageHandler) getRawImage(imageIId irs.IID) (*image
 	if !CheckIIDValidation(imageIId) {
 		return nil, errors.New("invalid IID")
 	}
-	if imageIId.SystemId == "" {
-		pager, err := images.ListDetail(imageHandler.Client, images.ListOpts{Name: imageIId.NameId}).AllPages()
-		if err != nil {
-			return nil, err
-		}
-		imageList, err := images.ExtractImages(pager)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(imageList) > 1 {
-			return nil, errors.New(fmt.Sprintf("found multiple images with name %s", imageIId.NameId))
-		} else if len(imageList) == 0 {
-			return nil, errors.New(fmt.Sprintf("could not found image with name %s", imageIId.NameId))
-		}
-		return &imageList[0], nil
-	} else {
-		return images.Get(imageHandler.Client, imageIId.SystemId).Extract()
-	}
+	return images.Get(imageHandler.Client, imageIId.SystemId).Extract()
 }
 

--- a/test/sg-rules-validation-cli/common/openstack-inno/setup.env
+++ b/test/sg-rules-validation-cli/common/openstack-inno/setup.env
@@ -1,3 +1,3 @@
 CONN_CONFIG=openstack-config01
-IMAGE_NAME=Ubuntu18.04_app
+IMAGE_NAME=37d7ad6c-e3e0-4a46-a288-963d182f05c7
 SPEC_NAME=m1


### PR DESCRIPTION
- OpenStack - Image 정보 관련
  - OpenStack은 User NameId(ubuntu 18.04 LTS)의 identity가 보장되지 않기에 SystemId 기준으로 사용
   - Image조회 방식 변경 및 Image Get/List 반환 값 변경
   - 테스트 변수 변경