### PR TITLE
Update deprecated GCP image id for test

### DIFF
--- a/test/sg-rules-validation-cli/common/gcp/setup.env
+++ b/test/sg-rules-validation-cli/common/gcp/setup.env
@@ -1,4 +1,5 @@
 CONN_CONFIG=gcp-iowa-config
 #IMAGE_NAME=https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024
-IMAGE_NAME=https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317
+#IMAGE_NAME=https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317 (deprecated image)
+IMAGE_NAME=https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20220505
 SPEC_NAME=f1-micro


### PR DESCRIPTION
GCP에 
projects/gce-uefi-images/global/images/ubuntu-1804-bionic-v20200317 (deprecated)
이미지가 사용 중단되어 있습니다.

projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20220505
로 변경하여,

테스트하면 좋을 것 같습니다.

CB-TB 차원에서는, 25개 리전에 대해 VM 생성 및 SSH 접속까지는 확인 하였습니다.

https://github.com/cloud-barista/cb-tumblebug/pull/1113

(참고: ssh 관련 오류가 발생하는 경우가 있어서 CB-TB 이슈 공유 드립니다.: https://github.com/cloud-barista/cb-tumblebug/issues/1112)

