### PR TITLE
[Azure] SecurityGroup 생성시 rule이 2개일 경우 생성 안되는 현상 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/SecurityHandler.go
@@ -523,6 +523,7 @@ func addCBDefaultRule(azureSGRuleList *[]network.SecurityRule) (*[]network.Secur
 		FromPort:   fromPort,
 		ToPort:     toPort,
 	}
+	addAllowDefaultRule := false
 	for _, sgRule := range *azureSGRuleList {
 		if sgRule.Access == network.SecurityRuleAccessAllow {
 			protocols := convertRuleProtocolAZToCB(fmt.Sprint(sgRule.Protocol))
@@ -539,10 +540,13 @@ func addCBDefaultRule(azureSGRuleList *[]network.SecurityRule) (*[]network.Secur
 				FromPort:   fromPort,
 				ToPort:     toPort,
 			}
-			if !equalsRule(ruleInfo, cbDefaultAllowSGRuleInfo) {
-				addCBDefaultRuleList = append(addCBDefaultRuleList, cbDefaultAllowSGRule)
+			if equalsRule(ruleInfo, cbDefaultAllowSGRuleInfo) {
+				addAllowDefaultRule = true
 			}
 		}
+	}
+	if !addAllowDefaultRule {
+		addCBDefaultRuleList = append(addCBDefaultRuleList, cbDefaultAllowSGRule)
 	}
 
 	return &addCBDefaultRuleList, nil


### PR DESCRIPTION
- rule 생성시 default Rule 중복적으로 추가하는 부분 수정
