### PR TITLE
[Openstack] ImageInfo 내 GuestOS 정보 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/ImageHandler.go
@@ -31,6 +31,7 @@ func setterImage(image images.Image) *irs.ImageInfo {
 			NameId:   image.ID,
 			SystemId: image.ID,
 		},
+		GuestOS: image.Name,
 		Status: image.Status,
 	}
 


### PR DESCRIPTION
이슈 (#641 )
- Openstack의 경우 Image에 OS와 관련된 정보가 없기에, Image의 이름을 GuestOS로 정보를 제공