### PR TITLE
Tencent, Alibaba Rootdisk type, size 로직 보완 - 이슈#660 반영

### DIFF
--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -34,10 +34,10 @@ GCP:
 ALIBABA:
   region: Region / Zone
   credential: ClientId / ClientSecret
-  #rootdisktype: cloud_efficiency / cloud / cloud_ssd / cloud_essd
-  rootdisktype: cloud_efficiency / cloud / cloud_ssd
-  #rootdisksize: cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB / cloud_essd|20|32768|GB
-  rootdisksize: cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
+  rootdisktype: cloud_essd / cloud_efficiency / cloud / cloud_ssd
+  #rootdisktype: cloud_efficiency / cloud / cloud_ssd
+  rootdisksize: cloud_essd|20|32768|GB / cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
+  #rootdisksize: cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
   # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM
   idmaxlength: 128 / 128 / 128 / 128 / 128 
 


### PR DESCRIPTION
- VM 생성 요청시 RootDiskType 및 RootDiskSize 기본값("", or "default") 처리 방법 변경
(https://github.com/cloud-barista/cb-spider/issues/660#issuecomment-1140721384 및 https://github.com/cloud-barista/cb-spider/issues/660#issuecomment-1140962549)
- 기본값 입력 시 아무것도 수행하지 않고 CSP에게 RootDiskType 및 size를 자동 생성으로 맡기는 방법으로 변경
- 테스트 결과
<html>
<body>
<!--StartFragment--><h3>Tencent</h3>

Spec: SA2.MEDIUM2
Image: img-pi0ii46r


Type | Size | Result
-- | -- | --
“” | “” | CLOUD_PREMIUM / 50 으로 생성
“” | 60 | CLOUD_PREMIUM / 60 으로 생성
“” | 10 | ERROR: Root Disk Size must be larger then the image size (50 GB).
default | default | CLOUD_PREMIUM / 50 으로 생성
default | 60 | CLOUD_PREMIUM / 60 으로 생성
default | 7 | ERROR: Root Disk Size must be larger then the image size (50 GB).
CLOUD_PREMIUM | “” | CLOUD_PREMIUM / 50 으로 생성
CLOUD_SSD | “” | CLOUD_SSD / 50 으로 생성
CLOUD_SSD | 54 | CLOUD_SSD / 54 으로 생성

<!--EndFragment-->
</body>
</html>

<html>
<body>
<!--StartFragment--><h3>Alibaba</h3>

Spec: ecs.t5-lc1m2.small
Image: ubuntu_18_04_x64_20G_alibase_20210420.vhd



Type | Size | Result
-- | -- | --
“” | “” | cloud_efficiency / 40 으로 생성 
“” | 40 | cloud_efficiency / 40 으로 생성 
“” | 10 | ERROR: Root Disk Size must be larger then the image size (20 GB).
default | default | cloud_efficiency / 40 으로 생성 
default | 42 | cloud_efficiency / 42 으로 생성 
default | 7 | ERROR: Root Disk Size must be larger then the image size (20 GB).
cloud_efficiency | “” | cloud_efficiency / 40 으로 생성 
cloud_ssd | “” | cloud_ssd / 40 으로 생성 
cloud_ssd | 54 | cloud_ssd / 54 으로 생성 


<!--EndFragment-->
</body>
</html>

