### PR TITLE
[Openstack]VMHandler - VolumeClient 안전 처리

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
@@ -37,6 +37,7 @@ func (OpenStackDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.PublicIPHandler = false
 	drvCapabilityInfo.VMHandler = true
 	drvCapabilityInfo.VMSpecHandler = true
+	drvCapabilityInfo.NLBHandler = true
 
 	return drvCapabilityInfo
 }
@@ -63,10 +64,7 @@ func (driver *OpenStackDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) 
 	if err != nil {
 		return nil, err
 	}
-	VolumeClient, err := getVolumeClient(connectionInfo)
-	if err != nil {
-		return nil, err
-	}
+	VolumeClient, _ := getVolumeClient(connectionInfo)
 
 	iConn := oscon.OpenStackCloudConnection{Region: connectionInfo.RegionInfo, Client: Client, ImageClient: ImageClient, NetworkClient: NetworkClient, VolumeClient: VolumeClient}
 
@@ -164,7 +162,12 @@ func getVolumeClient(connInfo idrv.ConnectionInfo) (*gophercloud.ServiceClient, 
 		Region: connInfo.RegionInfo.Region,
 	})
 	if err != nil {
-		return nil, err
+		client, err = openstack.NewBlockStorageV3(provider, gophercloud.EndpointOpts{
+			Region: connInfo.RegionInfo.Region,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 	return client, err
 }


### PR DESCRIPTION
[Openstack]VMHandler - VolumeClient 안전 처리
- NLB 기능 개발을 위해, openstack loadBalancer(octavia)가 설치된 새로운 팜을 이용하던 중, 발견한 버그 수정사항입니다.
- Volume을 제공하지 않는 경우와, Volume을 제공하지만, VolumeClient의 버전차이로 인해, 패닉에 빠지는 경우 수정사항입니다.
- NLB 기능과 직접적인 연관은 없으나, 버그픽스, 또 현재 테스트중인 팜, 이전 테스트팜에서 호환되도록 수정된 사항이라, NLB기능 PR전 해당 PR요청드립니다.

[적용사항]
- VolumeClient 버전 호환 및 VolumeClient 미제공 Openstack의 경우 패닉 방지
  - VolumeClientV2 제공하던 것을 VolumeClientV2가 없을시 VolumeClientV3로 연결
  - VolumeClientV2, VolumeClientV3 모두 없을 시, VolumeClient이 쓰이는 내부 코드에서 안전 처리 및 RootDiskSize 지정시 Error리턴(Volume을 이용한 방식)