### PR TITLE
GCP, Tencent NLBHandler 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/connect/GCP_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/connect/GCP_CloudConnection.go
@@ -19,8 +19,6 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/sirupsen/logrus"
 	compute "google.golang.org/api/compute/v1"
-
-	"errors"
 )
 
 var cblogger *logrus.Logger
@@ -100,7 +98,7 @@ func (cloudConn *GCPCloudConnection) CreateVMSpecHandler() (irs.VMSpecHandler, e
 	return &vmSpecHandler, nil
 }
 
-func (cloudConn *GCPCloudConnection) CreateLoadBalancerHandler() (irs.NLBHandler, error) {
+func (cloudConn *GCPCloudConnection) CreateNLBHandler() (irs.NLBHandler, error) {
 	cblogger.Info("GCP Cloud Driver: called CreateLoadBalancerHandler()!")
 	nlbHandler := gcprs.GCPNLBHandler{Region: cloudConn.Region, Ctx: cloudConn.Ctx, Client: cloudConn.VMClient, Credential: cloudConn.Credential}
 	return &nlbHandler, nil
@@ -111,8 +109,4 @@ func (GCPCloudConnection) IsConnected() (bool, error) {
 }
 func (GCPCloudConnection) Close() error {
 	return nil
-}
-
-func (cloudConn *GCPCloudConnection) CreateNLBHandler() (irs.NLBHandler, error) {
-	return nil, errors.New("GCP Cloud Driver NLB: WIP")
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/Test_Resources.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
@@ -303,124 +302,120 @@ func handleSecurity() {
 			case 5:
 				cblogger.Infof("[%s] Rule 추가 테스트", securityId)
 				securityRules := &[]irs.SecurityRuleInfo{
-				
-						/*{
-							//20-22 Prot로 등록
-							FromPort:   "20",
-							ToPort:     "21",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							//20-22 Prot로 등록
-							FromPort:   "20",
-							ToPort:     "21",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							//20-22 Prot로 등록
-							FromPort:   "-1",
-							ToPort:     "-1",
-							IPProtocol: "icmp",
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							// 8080 Port로 등록
-							FromPort:   "8080",
-							ToPort:     "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{ // 1323 Prot로 등록
-							FromPort:   "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
-							ToPort:     "1323",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							// All Port로 등록
-							FromPort:   "",
-							ToPort:     "",
-							IPProtocol: "icmp", //icmp는 포트 정보가 없음
-							Direction:  "inbound",
-						},*/
-						/*{
-							//20-22 Prot로 등록
-							FromPort:   "20",
-							ToPort:     "22",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-						},*/
-						/*{
-							// 80 Port로 등록
-							FromPort:   "80",
-							ToPort:     "80",
-							IPProtocol: "tcp",
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{ // 모든 프로토콜 모든 포트로 등록
-							//FromPort:   "",
-							//ToPort:     "",
-							IPProtocol: "all", // 모두 허용 (포트 정보 없음)
-							Direction:  "inbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							FromPort:   "443",
-							ToPort:     "443",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},*/
-						/*{
-							FromPort:   "8443",
-							ToPort:     "9999",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-						},*/
-						{
-							//20-22 Prot로 등록
-							FromPort:   "22",
-							ToPort:     "22",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},
-						{
-							//20-22 Prot로 등록
-							FromPort:   "1000",
-							ToPort:     "1000",
-							IPProtocol: "tcp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},
-						{
-							//20-22 Prot로 등록
-							FromPort:   "1",
-							ToPort:     "65535",
-							IPProtocol: "udp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},
-						{
-							//20-22 Prot로 등록
-							FromPort:   "-1",
-							ToPort:     "-1",
-							IPProtocol: "icmp",
-							Direction:  "outbound",
-							CIDR:       "0.0.0.0/0",
-						},
-						
-						
-				
-					
+
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "21",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "21",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// 8080 Port로 등록
+						FromPort:   "8080",
+						ToPort:     "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 1323 Prot로 등록
+						FromPort:   "", //FromPort나 ToPort중 하나에 -1이 입력될 경우 -1이 입력된 경우 -1을 공백으로 처리
+						ToPort:     "1323",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						// All Port로 등록
+						FromPort:   "",
+						ToPort:     "",
+						IPProtocol: "icmp", //icmp는 포트 정보가 없음
+						Direction:  "inbound",
+					},*/
+					/*{
+						//20-22 Prot로 등록
+						FromPort:   "20",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+					},*/
+					/*{
+						// 80 Port로 등록
+						FromPort:   "80",
+						ToPort:     "80",
+						IPProtocol: "tcp",
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{ // 모든 프로토콜 모든 포트로 등록
+						//FromPort:   "",
+						//ToPort:     "",
+						IPProtocol: "all", // 모두 허용 (포트 정보 없음)
+						Direction:  "inbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						FromPort:   "443",
+						ToPort:     "443",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},*/
+					/*{
+						FromPort:   "8443",
+						ToPort:     "9999",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+					},*/
+					{
+						//20-22 Prot로 등록
+						FromPort:   "22",
+						ToPort:     "22",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1000",
+						ToPort:     "1000",
+						IPProtocol: "tcp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "1",
+						ToPort:     "65535",
+						IPProtocol: "udp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
+					{
+						//20-22 Prot로 등록
+						FromPort:   "-1",
+						ToPort:     "-1",
+						IPProtocol: "icmp",
+						Direction:  "outbound",
+						CIDR:       "0.0.0.0/0",
+					},
 				}
 
 				result, err := handler.AddRules(irs.IID{SystemId: securityId}, securityRules)
@@ -1237,6 +1232,362 @@ func handleVM() {
 	}
 }
 
+func handleLoadBalancer() {
+	cblogger.Debug("Start LoadBalancer Test")
+
+	ResourceHandler, err := testconf.GetResourceHandler("LB")
+	if err != nil {
+		panic(err)
+	}
+	nlbHandler := ResourceHandler.(irs.NLBHandler)
+
+	//config := readConfigFile()
+	//VmID := irs.IID{NameId: config.Aws.BaseName, SystemId: config.Aws.VmID}
+	//VmID := irs.IID{SystemId: "mcloud-barista-vm-test"}
+
+	for {
+		fmt.Println("LoadBalancer Management")
+		fmt.Println("0. Quit")
+		fmt.Println("1. CreateNLB TCP")
+		fmt.Println("2. ListNLB")
+		fmt.Println("3. GetNLB")
+		fmt.Println("4. DeleteNLB")
+		fmt.Println("5. ChangeListener")
+		fmt.Println("6. ChangeVMGroupInfo")
+
+		fmt.Println("7. AddVMs")
+		fmt.Println("8. RemoveVMs")
+		fmt.Println("9. GetVMGroupHealthInfo")
+		fmt.Println("10. ChangeHealthCheckerInfo")
+
+		fmt.Println("11. CreateNLB UDP")
+		fmt.Println("12. ListNLB")
+		fmt.Println("13. GetNLB")
+		fmt.Println("14. DeleteNLB")
+		fmt.Println("15. ChangeListener")
+		fmt.Println("16. ChangeVMGroupInfo")
+
+		fmt.Println("17. AddVMs")
+		fmt.Println("18. RemoveVMs")
+		fmt.Println("19. GetVMGroupHealthInfo")
+		fmt.Println("20. ChangeHealthCheckerInfo")
+
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			panic(err)
+		}
+		////------ NLB Management
+		//CreateNLB(nlbReqInfo NLBReqInfo) (NLBInfo, error)
+		//ListNLB() ([]*NLBInfo, error)
+		//GetNLB(nlbIID IID) (NLBInfo, error)
+		//DeleteNLB(nlbIID IID) (bool, error)
+		//
+		////------ Frontend Control
+		//AddListeners(nlbIID IID, listeners *[]ListenerInfo) (NLBInfo, error)
+		//RemoveListeners(nlbIID IID, listeners *[]ListenerInfo) (bool, error)
+		//
+		////------ Backend Control
+		//ChangeServiceGroupInfo(nlbIID IID, serviceGroup ServiceGroupInfo) (error)
+		//AddServiceVMs(nlbIID IID, vmIIDs *[]IID) (NLBInfo, error)
+		//RemoveServiceVMs(nlbIID IID, vmIIDs *[]IID) (bool, error)
+		//GetServiceVMStatus(nlbIID IID) (HealthyInfo, error)
+		//ChangeHealthCheckerInfo(nlbIID IID, healthChecker HealthCheckerInfo) (error)
+
+		nlbName := "lb-tcptest-be-03"
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 0: // quit
+				return
+
+			case 1: // lb create
+				nlbReqInfo := irs.NLBInfo{}
+				nlbReqInfo.IId.NameId = nlbName // targetpool = forwordingrule
+				nlbReqInfo.Listener.Protocol = "TCP"
+				nlbReqInfo.Listener.IP = "" //?
+				nlbReqInfo.Listener.Port = "80"
+
+				// 등록시 새로운 healthcker 추가. health checker = nlb name
+				healthCheckerInfo := irs.HealthCheckerInfo{}
+				healthCheckerInfo.Protocol = "HTTP"
+				healthCheckerInfo.Port = "80"
+				healthCheckerInfo.Interval = 30
+				healthCheckerInfo.Timeout = 20
+				healthCheckerInfo.Threshold = 5
+				nlbReqInfo.HealthChecker = healthCheckerInfo
+
+				instanceIIDs := []irs.IID{}
+				instanceIIDs = append(instanceIIDs, irs.IID{NameId: "lb-tcptest-instance-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/lb-tcptest-instance-01"})
+				instanceIIDs = append(instanceIIDs, irs.IID{NameId: "lb-tcptest-instance-02", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-c/instances/lb-tcptest-instance-02"})
+				nlbReqInfo.VMGroup.VMs = &instanceIIDs
+
+				result, err := nlbHandler.CreateNLB(nlbReqInfo)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 등록 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 등록 결과 : ", result)
+
+				}
+			case 2: // lb list
+				result, err := nlbHandler.ListNLB()
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 목록 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 목록 조회 결과 : ")
+					cblogger.Infof("전체 목록 수 : [%d]", len(result))
+				}
+
+			case 3: // lb info
+				nlbName = "lb-test-instances"
+				//nlbIID := irs.IID{NameId: "lb-test-seoul-03", SystemId: "lb-test-seoul-fe03"}
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.GetNLB(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 조회 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 4: // delete
+				//nlbReqInfo := irs.NLBInfo{}
+				//nlbReqInfo.IId.NameId = "lb-tcptest-be-01"     // targetpool
+				//nlbReqInfo.Listener.CspID = "lb-tcptest-fe-01" // forwordingrule
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.DeleteNLB(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 삭제 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 5: // change listener
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				// IP : 34.64.120.4 -> 34.64.52.190
+				// Port : 80 -> 90
+				//listener := irs.ListenerInfo{IP: "34.64.52.190", Port: "90"}
+				listener := irs.ListenerInfo{Port: "90"}
+				result, err := nlbHandler.ChangeListener(nlbIID, listener)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 수정 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 수정 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 6: // ChangeVMGroupInfo
+				// protocol, port변경이나, GCP는 없음.
+
+			case 7: // AddVMs
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				addVmID := "lb-tcptest-instance-03"
+				vmIID := irs.IID{NameId: addVmID, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/" + addVmID}
+				vmIIDs := []irs.IID{vmIID}
+				result, err := nlbHandler.AddVMs(nlbIID, &vmIIDs)
+				//AddVMs(nlbIID IID, vmIIDs *[]IID) (VMGroupInfo, error)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer instance 추가 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer instance 추가 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			//
+			case 8: // RemoveVMs
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				//vmIID := irs.IID{NameId: "lb-tcptest-instance-03", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/lb-tcptest-instance-03"}
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				addVmID := "lb-tcptest-instance-03"
+				vmIID := irs.IID{NameId: addVmID, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/" + addVmID}
+				vmIIDs := []irs.IID{vmIID}
+				result, err := nlbHandler.RemoveVMs(nlbIID, &vmIIDs)
+				//AddVMs(nlbIID IID, vmIIDs *[]IID) (VMGroupInfo, error)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer instance 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer instance 삭제 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 9: // GetVMGroupHealthInfo
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.GetVMGroupHealthInfo(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer health 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer health 조회 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 10: // ChangeHealthCheckerInfo
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				healthCheckerInfo := irs.HealthCheckerInfo{}
+				//,"HealthChecker":{"Protocol":"HTTP","Port":"80","Interval":5,"Timeout":5,"Threshold":2
+				//,"CspID":"https://www.googleapis.com/compute/v1/projects/[projectID]/global/httpHealthChecks/test-lb-seoul-healthchecker2"
+				healthCheckerInfo.CspID = "https://www.googleapis.com/compute/v1/projects/[projectID]/global/httpHealthChecks/lb-tcptest-be-01"
+				healthCheckerInfo.Protocol = "HTTP"
+				healthCheckerInfo.Port = "82"
+				healthCheckerInfo.Interval = 31
+				healthCheckerInfo.Timeout = 29
+				healthCheckerInfo.Threshold = 7
+
+				result, err := nlbHandler.ChangeHealthCheckerInfo(nlbIID, healthCheckerInfo)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer health 변경 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer health 변경 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+				/////////// ------ 11 부터는 UDP Test ///////////////
+			case 11: // udp lb create
+				nlbName = "lb-udptest-01"
+
+				nlbReqInfo := irs.NLBInfo{}
+				nlbReqInfo.IId.NameId = nlbName // targetpool = forwordingrule
+				nlbReqInfo.Listener.Protocol = "UDP"
+				nlbReqInfo.Listener.IP = "" //?
+				nlbReqInfo.Listener.Port = "80"
+
+				// 등록시 새로운 healthcker 추가. health checker = nlb name
+				healthCheckerInfo := irs.HealthCheckerInfo{}
+				healthCheckerInfo.Protocol = "HTTP"
+				healthCheckerInfo.Port = "80"
+				healthCheckerInfo.Interval = 30
+				healthCheckerInfo.Timeout = 20
+				healthCheckerInfo.Threshold = 5
+				nlbReqInfo.HealthChecker = healthCheckerInfo
+
+				instanceIIDs := []irs.IID{}
+				instanceIIDs = append(instanceIIDs, irs.IID{NameId: "lb-tcptest-instance-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/lb-tcptest-instance-01"})
+				instanceIIDs = append(instanceIIDs, irs.IID{NameId: "lb-tcptest-instance-02", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-c/instances/lb-tcptest-instance-02"})
+				nlbReqInfo.VMGroup.VMs = &instanceIIDs
+
+				result, err := nlbHandler.CreateNLB(nlbReqInfo)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 등록 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 등록 결과 : ", result)
+
+				}
+			case 12: // lb list
+				nlbName = "lb-udptest-01"
+
+				result, err := nlbHandler.ListNLB()
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 목록 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 목록 조회 결과 : ")
+					cblogger.Infof("전체 목록 수 : [%d]", len(result))
+				}
+
+			case 13: // lb info
+				nlbName = "lb-udptest-01"
+				//nlbIID := irs.IID{NameId: "lb-test-seoul-03", SystemId: "lb-test-seoul-fe03"}
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.GetNLB(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 조회 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 14: // delete
+				nlbName = "lb-udptest-01"
+				//nlbReqInfo := irs.NLBInfo{}
+				//nlbReqInfo.IId.NameId = "lb-tcptest-be-01"     // targetpool
+				//nlbReqInfo.Listener.CspID = "lb-tcptest-fe-01" // forwordingrule
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.DeleteNLB(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 삭제 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 15: // change listener
+				nlbName = "lb-udptest-01"
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				// IP : 34.64.120.4 -> 34.64.52.190
+				// Port : 80 -> 90
+				//listener := irs.ListenerInfo{IP: "34.64.52.190", Port: "90"}
+				listener := irs.ListenerInfo{Port: "90"}
+				result, err := nlbHandler.ChangeListener(nlbIID, listener)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer 수정 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer 수정 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 16: // ChangeVMGroupInfo
+				// protocol, port변경이나, GCP는 없음.
+
+			case 17: // AddVMs
+				nlbName = "lb-udptest-01"
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				addVmID := "lb-tcptest-instance-03"
+				vmIID := irs.IID{NameId: addVmID, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/" + addVmID}
+				vmIIDs := []irs.IID{vmIID}
+				result, err := nlbHandler.AddVMs(nlbIID, &vmIIDs)
+				//AddVMs(nlbIID IID, vmIIDs *[]IID) (VMGroupInfo, error)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer instance 추가 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer instance 추가 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			//
+			case 18: // RemoveVMs
+				nlbName = "lb-udptest-01"
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				//vmIID := irs.IID{NameId: "lb-tcptest-instance-03", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/lb-tcptest-instance-03"}
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				addVmID := "lb-tcptest-instance-03"
+				vmIID := irs.IID{NameId: addVmID, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/zones/[regionID]-b/instances/" + addVmID}
+				vmIIDs := []irs.IID{vmIID}
+				result, err := nlbHandler.RemoveVMs(nlbIID, &vmIIDs)
+				//AddVMs(nlbIID IID, vmIIDs *[]IID) (VMGroupInfo, error)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer instance 삭제 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer instance 삭제 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 19: // GetVMGroupHealthInfo
+				nlbName = "lb-udptest-01"
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				result, err := nlbHandler.GetVMGroupHealthInfo(nlbIID)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer health 조회 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer health 조회 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+			case 20: // ChangeHealthCheckerInfo
+				nlbName = "lb-udptest-01"
+				//nlbIID := irs.IID{NameId: "lb-tcptest-be-01", SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/lb-tcptest-be-01"} //lb-tcptest-be-01
+				nlbIID := irs.IID{NameId: nlbName, SystemId: "https://www.googleapis.com/compute/v1/projects/[projectID]/regions/[regionID]/targetPools/" + nlbName}
+				healthCheckerInfo := irs.HealthCheckerInfo{}
+				//,"HealthChecker":{"Protocol":"HTTP","Port":"80","Interval":5,"Timeout":5,"Threshold":2
+				//,"CspID":"https://www.googleapis.com/compute/v1/projects/[projectID]/global/httpHealthChecks/test-lb-seoul-healthchecker2"
+				healthCheckerInfo.CspID = "https://www.googleapis.com/compute/v1/projects/[projectID]/global/httpHealthChecks/lb-tcptest-be-01"
+				healthCheckerInfo.Protocol = "HTTP"
+				healthCheckerInfo.Port = "82"
+				healthCheckerInfo.Interval = 31
+				healthCheckerInfo.Timeout = 29
+				healthCheckerInfo.Threshold = 7
+
+				result, err := nlbHandler.ChangeHealthCheckerInfo(nlbIID, healthCheckerInfo)
+				if err != nil {
+					cblogger.Infof(" Loadbalancer health 변경 실패 : ", err)
+				} else {
+					cblogger.Infof(" Loadbalancer health 변경 결과 : ")
+					cblogger.Infof("result ", result)
+				}
+
+			}
+		}
+	}
+}
+
 //import "path/filepath"
 
 func main() {
@@ -1245,8 +1596,9 @@ func main() {
 	//handleVMSpec()
 	//handleImage() //AMI
 	//handleKeyPair()
-	handleSecurity()
+	//handleSecurity()
 	//handleVM()
+	handleLoadBalancer()
 	//cblogger.Info(filepath.Join("a/b", "\\cloud-driver-libs\\.ssh-gcp\\"))
 	//cblogger.Info(filepath.Join("\\cloud-driver-libs\\.ssh-gcp\\", "/b/c/d"))
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
@@ -474,6 +474,9 @@ func (nlbHandler *GCPNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	cblogger.Info("Targetpool end: ")
 	printToJson(nlbMap)
 
+	for _, nlbInfo := range nlbMap {
+		nlbInfoList = append(nlbInfoList, &nlbInfo)
+	}
 	return nlbInfoList, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
@@ -1489,7 +1489,7 @@ func (nlbHandler *GCPNLBHandler) deleteRegionForwardingRule(regionID string, for
 func (nlbHandler *GCPNLBHandler) deleteRegionForwardingRules(regionID string, nlbIID irs.IID) (string, error) {
 	// path param
 	targetPoolUrl := nlbIID.SystemId
-	targetPoolUrl = "https://www.googleapis.com/compute/v1/projects/yhnoh-335705/regions/asia-northeast3/targetPools/fe8080"
+
 	forwardingRuleList, err := nlbHandler.listRegionForwardingRules(regionID, "", targetPoolUrl)
 	if err != nil {
 		cblogger.Info("DeleteNLB forwardingRule  err: ", err)


### PR DESCRIPTION
Tencent
- VMHandler.go, NLBHandler.go: 맥락 상 에러가 아닌데 에러로 출력하는 부분 수정(cblogger.Errorf -> cblogger.Infof)
    - https://github.com/cloud-barista/cb-spider/issues/649#issue-1236555422
- IID에 NameId 값 Set(VPC, VM)
- HealthCheckerInfo 값을 입력하지 않아도 생성되도록 수정
   - 기존: HealthCheckInfo 값이 없을 때 다음과 같은 에러 생성 -> HealthCheck.TimeOut should be 2~60 등
   - 현재: HealthCheckInfo 값이 없어도 HealthChecker 생성
       - default: Protocl: TCP / Port: Real server port(null) / Timeout: 2sec / Interval: 5sec / Threshold: 3sec
- CreateNLB :
  . 생성 전 존재하는 리소스인지 체크
  . 생성 중 오류 시 리소스 회수
- DeleteNLB :
  . 호출하는 function이 1개로 별도 회수로직 필요없음.

GCP
- CreateNLB :
  . 생성 전 존재하는 리소스인지 체크
  . 생성 중 오류 시 리소스 회수

- DeleteNLB :
  . 삭제 전 존재하는 리소스인지 체크
  . 3개의 리소스 중 일부만 있는 경우 일부만 삭제
