### PR TITLE
[Openstack] GetVMGroupHealthInfo 버그 픽스

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/NLBHandler.go
@@ -626,8 +626,7 @@ func (nlbHandler *OpenStackNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs
 		allVMs[i] = vmIID
 		if strings.EqualFold(strings.ToUpper(member.OperatingStatus), "ONLINE") {
 			healthVMs = append(healthVMs, vmIID)
-		}
-		if strings.EqualFold(strings.ToUpper(member.OperatingStatus), "DRAINING") {
+		} else if strings.EqualFold(strings.ToUpper(member.OperatingStatus), "DRAINING") {
 			unHealthVMs = append(unHealthVMs, vmIID)
 		} else {
 			// OFFLINE DEGRADED ERROR NO_MONITOR 일 경우, HealthCheck 결과가 멤버에 제대로 갱신되지 않는 octavia 이슈일 수 있음
@@ -642,7 +641,7 @@ func (nlbHandler *OpenStackNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs
 		AllVMs:       &allVMs,
 		HealthyVMs:   &healthVMs,
 		UnHealthyVMs: &unHealthVMs,
-	}, errors.New("OPENSTACK_CANNOT_GET_VMGroupHealthInfo")
+	}, nil
 }
 func (nlbHandler *OpenStackNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, healthChecker irs.HealthCheckerInfo) (irs.HealthCheckerInfo, error) {
 	hiscallInfo := GetCallLogScheme(nlbHandler.Region.Region, "NETWORKLOADBALANCE", nlbIID.NameId, "ChangeHealthCheckerInfo()")


### PR DESCRIPTION
Openstack 팜 구축으로 기존에 시행하지 못했던 NLB 테스트 진행중, GetVMGroupHealthInfo 이 제대로 동작하지 않아, 수정하였습니다.(테스트 결과에 메모로 남겨두었습니다.)
- vmGroup Member OperatingStatus 체크조건 식 변경
- 리턴 값에 Error가 포함된 부분 수정