### PR TITLE
[Azure] DiskHandler Type/Size, VMHandler VM내 DataDisk 정보 추가 (#717)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
@@ -190,16 +190,18 @@ func GetVMDiskInfoType(diskType compute.StorageAccountTypes) string {
 }
 
 // DiskType
-func GetDiskTypeInitType(diskType string) compute.DiskStorageAccountTypes {
+func GetDiskTypeInitType(diskType string) (compute.DiskStorageAccountTypes, error) {
 	switch diskType {
+	case "":
+		return compute.DiskStorageAccountTypesPremiumLRS, nil
 	case PremiumSSD:
-		return compute.DiskStorageAccountTypesPremiumLRS
+		return compute.DiskStorageAccountTypesPremiumLRS, nil
 	case StandardSSD:
-		return compute.DiskStorageAccountTypesStandardSSDLRS
+		return compute.DiskStorageAccountTypesStandardSSDLRS, nil
 	case StandardHHD:
-		return compute.DiskStorageAccountTypesStandardLRS
+		return compute.DiskStorageAccountTypesStandardLRS, nil
 	default:
-		return compute.DiskStorageAccountTypesPremiumLRS
+		return "", errors.New(fmt.Sprintf("invalid DiskType, Please select one of %s, %s, %s", PremiumSSD, StandardSSD, StandardHHD))
 	}
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -890,6 +890,19 @@ func (vmHandler *AzureVMHandler) mappingServerInfo(server compute.VirtualMachine
 		}
 	}
 
+	if server.StorageProfile != nil && server.StorageProfile.DataDisks != nil && len(*server.StorageProfile.DataDisks) > 0 {
+		dataDisks := *server.StorageProfile.DataDisks
+		dataDiskIIDList := make([]irs.IID, len(dataDisks))
+		for i, dataDisk := range dataDisks {
+			diskId := *dataDisk.ManagedDisk.ID
+			dataDiskIIDList[i] = irs.IID{
+				NameId:   GetResourceNameById(diskId),
+				SystemId: diskId,
+			}
+		}
+		vmInfo.DataDiskIIDs = dataDiskIIDList
+	}
+
 	return vmInfo
 }
 


### PR DESCRIPTION
- 1. CreateDisk 시 type/Size 기본 값 설정 (https://github.com/cloud-barista/cb-spider/issues/717#issuecomment-1228418584)
   - Size의 경우 콘솔의 기본값인 1024로 설정하였습니다. 
- 2. VM 내 DataDiskIIDs 정보 추가 (https://github.com/cloud-barista/cb-spider/issues/717#issuecomment-1228407758)