### PR TITLE
[Openstack] 디스크 핸들러 구현

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -11,7 +11,6 @@
 package connect
 
 import (
-	"errors"
 	cblog "github.com/cloud-barista/cb-log"
 	"github.com/gophercloud/gophercloud"
 	"github.com/sirupsen/logrus"
@@ -84,7 +83,13 @@ func (cloudConn *OpenStackCloudConnection) CreateNLBHandler() (irs.NLBHandler, e
 }
 
 func (cloudConn *OpenStackCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {
-	return nil, errors.New("OpenStack Driver: not implemented")
+	cblogger.Info("OpenStack Driver: called CreateDiskHandler()!")
+	diskHandler := osrs.OpenstackDiskHandler{
+		CredentialInfo: cloudConn.CredentialInfo, Region: cloudConn.Region,
+		ComputeClient: cloudConn.ComputeClient,
+		Volume2Client: cloudConn.Volume2Client, Volume3Client: cloudConn.Volume3Client,
+	}
+	return &diskHandler, nil
 }
 
 func (cloudConn *OpenStackCloudConnection) IsConnected() (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -66,7 +66,10 @@ func (cloudConn *OpenStackCloudConnection) CreateKeyPairHandler() (irs.KeyPairHa
 
 func (cloudConn *OpenStackCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
 	cblogger.Info("OpenStack Cloud Driver: called CreateVMHandler()!")
-	vmHandler := osrs.OpenStackVMHandler{Region: cloudConn.Region, ComputeClient: cloudConn.ComputeClient, NetworkClient: cloudConn.NetworkClient, Volume2Client: cloudConn.Volume2Client, Volume3Client: cloudConn.Volume3Client}
+	vmHandler := osrs.OpenStackVMHandler{Region: cloudConn.Region, ComputeClient: cloudConn.ComputeClient, NetworkClient: cloudConn.NetworkClient, VolumeClient: cloudConn.Volume3Client}
+	if vmHandler.VolumeClient == nil {
+		vmHandler.VolumeClient = cloudConn.Volume2Client
+	}
 	return &vmHandler, nil
 }
 
@@ -87,7 +90,10 @@ func (cloudConn *OpenStackCloudConnection) CreateDiskHandler() (irs.DiskHandler,
 	diskHandler := osrs.OpenstackDiskHandler{
 		CredentialInfo: cloudConn.CredentialInfo, Region: cloudConn.Region,
 		ComputeClient: cloudConn.ComputeClient,
-		Volume2Client: cloudConn.Volume2Client, Volume3Client: cloudConn.Volume3Client,
+		VolumeClient:  cloudConn.Volume3Client,
+	}
+	if diskHandler.VolumeClient == nil {
+		diskHandler.VolumeClient = cloudConn.Volume2Client
 	}
 	return &diskHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
@@ -907,9 +907,19 @@ func testDiskHandler(config Config) {
 
 	testDiskHandlerListPrint()
 	diskIId := irs.IID{}
-	createDiskReqInfo := irs.DiskInfo{}
+	createDiskReqInfo := irs.DiskInfo{
+		IId: irs.IID{
+			NameId: "test-0818-2",
+		},
+		DiskSize: "3",
+	}
 	delDiskIId := irs.IID{}
-	attachVMIId := irs.IID{}
+	attachedDisk := irs.IID{
+		NameId: "test-0818-2",
+	}
+	attachVMIId := irs.IID{
+		NameId: "vmclient",
+	}
 
 Loop:
 	for {
@@ -957,7 +967,7 @@ Loop:
 				cblogger.Info("Finish DeleteDisk()")
 			case 5:
 				cblogger.Info("Start ChangeDiskSize() ...")
-				if nlbInfo, err := diskHandler.ChangeDiskSize(diskIId, ""); err != nil {
+				if nlbInfo, err := diskHandler.ChangeDiskSize(attachedDisk, "4"); err != nil {
 					cblogger.Error(err)
 				} else {
 					spew.Dump(nlbInfo)
@@ -965,7 +975,7 @@ Loop:
 				cblogger.Info("Finish ChangeDiskSize()")
 			case 6:
 				cblogger.Info("Start AttachDisk() ...")
-				if info, err := diskHandler.AttachDisk(delDiskIId, attachVMIId); err != nil {
+				if info, err := diskHandler.AttachDisk(attachedDisk, attachVMIId); err != nil {
 					cblogger.Error(err)
 				} else {
 					spew.Dump(info)
@@ -973,7 +983,7 @@ Loop:
 				cblogger.Info("Finish AttachDisk()")
 			case 7:
 				cblogger.Info("Start DetachDisk() ...")
-				if info, err := diskHandler.DetachDisk(delDiskIId, attachVMIId); err != nil {
+				if info, err := diskHandler.DetachDisk(attachedDisk, attachVMIId); err != nil {
 					cblogger.Error(err)
 				} else {
 					spew.Dump(info)

--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
@@ -696,6 +696,8 @@ func getResourceHandler(resourceType string, config Config) (interface{}, error)
 		resourceHandler, err = cloudConnection.CreateVMHandler()
 	case "nlb":
 		resourceHandler, _ = cloudConnection.CreateNLBHandler()
+	case "disk":
+		resourceHandler, err = cloudConnection.CreateDiskHandler()
 	}
 
 	if err != nil {
@@ -882,6 +884,109 @@ Loop:
 	}
 }
 
+func testDiskHandlerListPrint() {
+	cblogger.Info("Test DiskHandler")
+	cblogger.Info("0. Print Menu")
+	cblogger.Info("1. ListDisk()")
+	cblogger.Info("2. GetDisk()")
+	cblogger.Info("3. CreateDisk()")
+	cblogger.Info("4. DeleteDisk()")
+	cblogger.Info("5. ChangeDiskSize()")
+	cblogger.Info("6. AttachDisk()")
+	cblogger.Info("7. DetachDisk()")
+	cblogger.Info("8. Exit")
+}
+
+func testDiskHandler(config Config) {
+	resourceHandler, err := getResourceHandler("disk", config)
+	if err != nil {
+		cblogger.Error(err)
+		return
+	}
+	diskHandler := resourceHandler.(irs.DiskHandler)
+
+	testDiskHandlerListPrint()
+	diskIId := irs.IID{}
+	createDiskReqInfo := irs.DiskInfo{}
+	delDiskIId := irs.IID{}
+	attachVMIId := irs.IID{}
+
+Loop:
+	for {
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			cblogger.Error(err)
+		}
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 0:
+				testDiskHandlerListPrint()
+			case 1:
+				cblogger.Info("Start ListDisk() ...")
+				if list, err := diskHandler.ListDisk(); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(list)
+				}
+				cblogger.Info("Finish ListDisk()")
+			case 2:
+				cblogger.Info("Start GetDisk() ...")
+				if vm, err := diskHandler.GetDisk(diskIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(vm)
+				}
+				cblogger.Info("Finish GetDisk()")
+			case 3:
+				cblogger.Info("Start CreateDisk() ...")
+				if createInfo, err := diskHandler.CreateDisk(createDiskReqInfo); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(createInfo)
+				}
+				cblogger.Info("Finish CreateDisk()")
+			case 4:
+				cblogger.Info("Start DeleteDisk() ...")
+				if vmStatus, err := diskHandler.DeleteDisk(delDiskIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(vmStatus)
+				}
+				cblogger.Info("Finish DeleteDisk()")
+			case 5:
+				cblogger.Info("Start ChangeDiskSize() ...")
+				if nlbInfo, err := diskHandler.ChangeDiskSize(diskIId, ""); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(nlbInfo)
+				}
+				cblogger.Info("Finish ChangeDiskSize()")
+			case 6:
+				cblogger.Info("Start AttachDisk() ...")
+				if info, err := diskHandler.AttachDisk(delDiskIId, attachVMIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish AttachDisk()")
+			case 7:
+				cblogger.Info("Start DetachDisk() ...")
+				if info, err := diskHandler.DetachDisk(delDiskIId, attachVMIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish DetachDisk()")
+			case 8:
+				cblogger.Info("Exit")
+				break Loop
+			}
+		}
+	}
+}
+
 func main() {
 
 	showTestHandlerInfo()      // ResourceHandler 테스트 정보 출력
@@ -920,6 +1025,9 @@ Loop:
 				testNLBHandler(config)
 				showTestHandlerInfo()
 			case 8:
+				testDiskHandler(config)
+				showTestHandlerInfo()
+			case 9:
 				cblogger.Info("Exit Test ResourceHandler Program")
 				break Loop
 			}
@@ -937,7 +1045,8 @@ func showTestHandlerInfo() {
 	cblogger.Info("5. VmSpecHandler")
 	cblogger.Info("6. VmHandler")
 	cblogger.Info("7. NLBHandler")
-	cblogger.Info("8. Exit")
+	cblogger.Info("8. DiskHandler")
+	cblogger.Info("9. Exit")
 	cblogger.Info("==========================================================")
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
@@ -1,0 +1,105 @@
+package resources
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/gophercloud/gophercloud"
+	volumes2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+	volumes3 "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+)
+
+type OpenstackDiskHandler struct {
+	CredentialInfo idrv.CredentialInfo
+	Region         idrv.RegionInfo
+	ComputeClient  *gophercloud.ServiceClient
+	Volume2Client  *gophercloud.ServiceClient
+	Volume3Client  *gophercloud.ServiceClient
+}
+
+//------ Disk Management
+func (diskHandler *OpenstackDiskHandler) CreateDisk(DiskReqInfo irs.DiskInfo) (irs.DiskInfo, error) {
+	return irs.DiskInfo{}, nil
+}
+func (diskHandler *OpenstackDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
+	list2, err := diskHandler.getRawDiskList()
+	list3, err := GetRawDiskListV3(diskHandler.Volume3Client)
+
+	fmt.Println(list2, list3, err)
+	fmt.Println("dd")
+	return nil, nil
+}
+func (diskHandler *OpenstackDiskHandler) GetDisk(diskIID irs.IID) (irs.DiskInfo, error) {
+	return irs.DiskInfo{}, nil
+}
+func (diskHandler *OpenstackDiskHandler) ChangeDiskSize(diskIID irs.IID, size string) (bool, error) {
+	return false, nil
+}
+func (diskHandler *OpenstackDiskHandler) DeleteDisk(diskIID irs.IID) (bool, error) {
+	return false, nil
+}
+
+//------ Disk Attachment
+func (diskHandler *OpenstackDiskHandler) AttachDisk(diskIID irs.IID, ownerVM irs.IID) (irs.DiskInfo, error) {
+	return irs.DiskInfo{}, nil
+}
+func (diskHandler *OpenstackDiskHandler) DetachDisk(diskIID irs.IID, ownerVM irs.IID) (bool, error) {
+	return false, nil
+}
+
+func volumes2Tovolumes3(vol2 volumes2.Volume) (volumes3.Volume, error) {
+	bytes, err := json.Marshal(vol2)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	var vol3 volumes3.Volume
+	err = json.Unmarshal(bytes, &vol3)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	return vol3, err
+}
+
+func GetRawDiskListV2(volume2Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
+	pager2, err := volumes2.List(volume2Client, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	list2, err := volumes2.ExtractVolumes(pager2)
+	if err != nil {
+		return nil, err
+	}
+	newList := make([]volumes3.Volume, len(list2))
+	for i, vol := range list2 {
+		vol3, err := volumes2Tovolumes3(vol)
+		if err != nil {
+			return nil, err
+		}
+		newList[i] = vol3
+	}
+	return newList, nil
+}
+
+func GetRawDiskListV3(volume3Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
+	pager3, err := volumes3.List(volume3Client, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	list3, err := volumes3.ExtractVolumes(pager3)
+	if err != nil {
+		return nil, err
+	}
+	return list3, nil
+}
+
+func (diskHandler *OpenstackDiskHandler) getRawDiskList() ([]volumes3.Volume, error) {
+	if diskHandler.Volume3Client != nil {
+		return GetRawDiskListV3(diskHandler.Volume3Client)
+	}
+	if diskHandler.Volume2Client != nil {
+		return GetRawDiskListV2(diskHandler.Volume2Client)
+	}
+	return nil, errors.New("VolumeClient not found")
+}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
@@ -4,52 +4,169 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
 	volumes2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	volumes3 "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"strconv"
+	"strings"
 )
 
 type OpenstackDiskHandler struct {
 	CredentialInfo idrv.CredentialInfo
 	Region         idrv.RegionInfo
 	ComputeClient  *gophercloud.ServiceClient
-	Volume2Client  *gophercloud.ServiceClient
-	Volume3Client  *gophercloud.ServiceClient
+	VolumeClient   *gophercloud.ServiceClient
 }
+
+const (
+	VolumeV2 string = "volumev2"
+	VolumeV3 string = "volumev3"
+)
 
 //------ Disk Management
 func (diskHandler *OpenstackDiskHandler) CreateDisk(DiskReqInfo irs.DiskInfo) (irs.DiskInfo, error) {
-	return irs.DiskInfo{}, nil
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", "DISK", "CreateDisk()")
+	start := call.Start()
+
+	err := validationDiskReq(DiskReqInfo, diskHandler.VolumeClient)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s", err))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.DiskInfo{}, createErr
+	}
+	vol, err := createDisk(DiskReqInfo, diskHandler.VolumeClient)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s", err))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.DiskInfo{}, createErr
+	}
+	info, err := diskHandler.setterDisk(vol)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s", err))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.DiskInfo{}, createErr
+	}
+	LoggingInfo(hiscallInfo, start)
+	return info, nil
 }
 func (diskHandler *OpenstackDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
-	list2, err := diskHandler.getRawDiskList()
-	list3, err := GetRawDiskListV3(diskHandler.Volume3Client)
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", "DISK", "ListDisk()")
+	start := call.Start()
 
-	fmt.Println(list2, list3, err)
-	fmt.Println("dd")
-	return nil, nil
+	list, err := getRawDiskList(diskHandler.VolumeClient)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return []*irs.DiskInfo{}, getErr
+	}
+	infoList := make([]*irs.DiskInfo, len(list))
+	for i, vol := range list {
+		info, err := diskHandler.setterDisk(vol)
+		if err != nil {
+			getErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+			cblogger.Error(getErr.Error())
+			LoggingError(hiscallInfo, getErr)
+			return []*irs.DiskInfo{}, getErr
+		}
+		infoList[i] = &info
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return infoList, nil
 }
 func (diskHandler *OpenstackDiskHandler) GetDisk(diskIID irs.IID) (irs.DiskInfo, error) {
-	return irs.DiskInfo{}, nil
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", diskIID.NameId, "GetDisk()")
+	start := call.Start()
+	disk, err := getRawDisk(diskIID, diskHandler.VolumeClient)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return irs.DiskInfo{}, getErr
+	}
+	info, err := diskHandler.setterDisk(disk)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return irs.DiskInfo{}, getErr
+	}
+	LoggingInfo(hiscallInfo, start)
+	return info, nil
 }
 func (diskHandler *OpenstackDiskHandler) ChangeDiskSize(diskIID irs.IID, size string) (bool, error) {
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", diskIID.NameId, "DeleteDisk()")
+	start := call.Start()
+	err := changeDiskSize(diskIID, size, diskHandler.VolumeClient)
+	if err != nil {
+		changeDiskSizeErr := errors.New(fmt.Sprintf("Failed to ChangeDiskSize. err = %s", err))
+		cblogger.Error(changeDiskSizeErr.Error())
+		LoggingError(hiscallInfo, changeDiskSizeErr)
+		return false, changeDiskSizeErr
+	}
+
+	LoggingInfo(hiscallInfo, start)
 	return false, nil
 }
 func (diskHandler *OpenstackDiskHandler) DeleteDisk(diskIID irs.IID) (bool, error) {
-	return false, nil
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", diskIID.NameId, "DeleteDisk()")
+	start := call.Start()
+	err := deleteDisk(diskIID, diskHandler.VolumeClient)
+	if err != nil {
+		delErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(delErr.Error())
+		LoggingError(hiscallInfo, delErr)
+		return false, delErr
+	}
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
 }
 
 //------ Disk Attachment
 func (diskHandler *OpenstackDiskHandler) AttachDisk(diskIID irs.IID, ownerVM irs.IID) (irs.DiskInfo, error) {
-	return irs.DiskInfo{}, nil
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", diskIID.NameId, "AttachDisk()")
+	start := call.Start()
+	disk, err := attachDisk(diskIID, ownerVM, diskHandler.ComputeClient, diskHandler.VolumeClient)
+	if err != nil {
+		attachErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(attachErr.Error())
+		LoggingError(hiscallInfo, attachErr)
+		return irs.DiskInfo{}, attachErr
+	}
+	info, err := diskHandler.setterDisk(disk)
+	if err != nil {
+		attachErr := errors.New(fmt.Sprintf("Failed to List Disk. err = %s", err))
+		cblogger.Error(attachErr.Error())
+		LoggingError(hiscallInfo, attachErr)
+		return irs.DiskInfo{}, attachErr
+	}
+	LoggingInfo(hiscallInfo, start)
+	return info, nil
 }
 func (diskHandler *OpenstackDiskHandler) DetachDisk(diskIID irs.IID, ownerVM irs.IID) (bool, error) {
-	return false, nil
+	hiscallInfo := GetCallLogScheme(diskHandler.CredentialInfo.IdentityEndpoint, "DISK", diskIID.NameId, "DetachDisk()")
+	start := call.Start()
+	err := detachDisk(diskIID, ownerVM, diskHandler.ComputeClient, diskHandler.VolumeClient)
+	if err != nil {
+		detachErr := errors.New(fmt.Sprintf("Failed to DetachDisk. err = %s", err))
+		cblogger.Error(detachErr.Error())
+		LoggingError(hiscallInfo, detachErr)
+		return false, detachErr
+	}
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
 }
 
-func volumes2Tovolumes3(vol2 volumes2.Volume) (volumes3.Volume, error) {
+func volumes2ToVolumes3(vol2 volumes2.Volume) (volumes3.Volume, error) {
 	bytes, err := json.Marshal(vol2)
 	if err != nil {
 		return volumes3.Volume{}, err
@@ -62,7 +179,7 @@ func volumes2Tovolumes3(vol2 volumes2.Volume) (volumes3.Volume, error) {
 	return vol3, err
 }
 
-func GetRawDiskListV2(volume2Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
+func getRawDiskListV2(volume2Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
 	pager2, err := volumes2.List(volume2Client, nil).AllPages()
 	if err != nil {
 		return nil, err
@@ -73,7 +190,7 @@ func GetRawDiskListV2(volume2Client *gophercloud.ServiceClient) ([]volumes3.Volu
 	}
 	newList := make([]volumes3.Volume, len(list2))
 	for i, vol := range list2 {
-		vol3, err := volumes2Tovolumes3(vol)
+		vol3, err := volumes2ToVolumes3(vol)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +199,7 @@ func GetRawDiskListV2(volume2Client *gophercloud.ServiceClient) ([]volumes3.Volu
 	return newList, nil
 }
 
-func GetRawDiskListV3(volume3Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
+func getRawDiskListV3(volume3Client *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
 	pager3, err := volumes3.List(volume3Client, nil).AllPages()
 	if err != nil {
 		return nil, err
@@ -94,12 +211,421 @@ func GetRawDiskListV3(volume3Client *gophercloud.ServiceClient) ([]volumes3.Volu
 	return list3, nil
 }
 
-func (diskHandler *OpenstackDiskHandler) getRawDiskList() ([]volumes3.Volume, error) {
-	if diskHandler.Volume3Client != nil {
-		return GetRawDiskListV3(diskHandler.Volume3Client)
+func getRawDiskV2(diskIID irs.IID, volume3Client *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return volumes3.Volume{}, errors.New("invalid disk IID")
 	}
-	if diskHandler.Volume2Client != nil {
-		return GetRawDiskListV2(diskHandler.Volume2Client)
+	if diskIID.SystemId != "" {
+		disk, err := volumes2.Get(volume3Client, diskIID.SystemId).Extract()
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		diskVol3, err := volumes2ToVolumes3(*disk)
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		return diskVol3, err
+	}
+	//volumes3.Get By NameId
+	nameOpts := volumes2.ListOpts{
+		Name: diskIID.NameId,
+	}
+	pager3, err := volumes2.List(volume3Client, nameOpts).AllPages()
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	list3, err := volumes2.ExtractVolumes(pager3)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	if len(list3) < 1 {
+		return volumes3.Volume{}, errors.New("not found Disk")
+	}
+	diskVol3, err := volumes2ToVolumes3(list3[0])
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	return diskVol3, nil
+}
+
+func getRawDiskV3(diskIID irs.IID, volume3Client *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return volumes3.Volume{}, errors.New("invalid disk IID")
+	}
+	if diskIID.SystemId != "" {
+		disk, err := volumes3.Get(volume3Client, diskIID.SystemId).Extract()
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		return *disk, err
+	}
+	//volumes3.Get By NameId
+	nameOpts := volumes3.ListOpts{
+		Name: diskIID.NameId,
+	}
+	pager3, err := volumes3.List(volume3Client, nameOpts).AllPages()
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	list3, err := volumes3.ExtractVolumes(pager3)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	if len(list3) < 1 {
+		return volumes3.Volume{}, errors.New("not found Disk")
+	}
+	return list3[0], nil
+}
+
+func getRawDisk(diskIId irs.IID, volumeClient *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	if volumeClient.Type == VolumeV3 {
+		return getRawDiskV3(diskIId, volumeClient)
+	}
+	if volumeClient.Type == VolumeV2 {
+		return getRawDiskV2(diskIId, volumeClient)
+	}
+	return volumes3.Volume{}, errors.New("VolumeClient not found")
+}
+
+func getRawDiskList(volumeClient *gophercloud.ServiceClient) ([]volumes3.Volume, error) {
+	if volumeClient.Type == VolumeV3 {
+		return getRawDiskListV3(volumeClient)
+	}
+	if volumeClient.Type == VolumeV2 {
+		return getRawDiskListV2(volumeClient)
 	}
 	return nil, errors.New("VolumeClient not found")
+}
+
+func deleteDiskV2(diskIID irs.IID, volume2Client *gophercloud.ServiceClient) error {
+	disk, err := getRawDiskV2(diskIID, volume2Client)
+	if err != nil {
+		return err
+	}
+	return volumes2.Delete(volume2Client, disk.ID, nil).ExtractErr()
+}
+
+func deleteDiskV3(diskIID irs.IID, volume3Client *gophercloud.ServiceClient) error {
+	disk, err := getRawDiskV3(diskIID, volume3Client)
+	if err != nil {
+		return err
+	}
+	return volumes3.Delete(volume3Client, disk.ID, nil).ExtractErr()
+}
+
+func deleteDisk(diskIID irs.IID, volumeClient *gophercloud.ServiceClient) error {
+	if volumeClient.Type == VolumeV3 {
+		return deleteDiskV3(diskIID, volumeClient)
+	}
+	if volumeClient.Type == VolumeV2 {
+		return deleteDiskV2(diskIID, volumeClient)
+	}
+	return errors.New("VolumeClient not found")
+}
+
+func (diskHandler *OpenstackDiskHandler) setterDisk(rawVolume volumes3.Volume) (irs.DiskInfo, error) {
+	info := irs.DiskInfo{
+		IId: irs.IID{
+			NameId:   rawVolume.Name,
+			SystemId: rawVolume.ID,
+		},
+		DiskType:    "default",
+		DiskSize:    strconv.Itoa(rawVolume.Size),
+		CreatedTime: rawVolume.CreatedAt,
+	}
+
+	if rawVolume.Attachments != nil && len(rawVolume.Attachments) > 0 {
+		vmId := rawVolume.Attachments[0].ServerID
+		vm, err := servers.Get(diskHandler.ComputeClient, vmId).Extract()
+		if err == nil {
+			info.OwnerVM = irs.IID{
+				NameId:   vm.Name,
+				SystemId: vm.ID,
+			}
+		}
+	}
+	//  status (“available”, “error”, “creating”, “deleting”, “in-use”, “attaching”, “detaching”, “error_deleting” or “maintenance”)
+	switch strings.ToLower(rawVolume.Status) {
+	case "creating":
+		info.Status = irs.DiskCreating
+	case "deleting":
+		info.Status = irs.DiskDeleting
+	case "error", "error_deleting":
+		info.Status = irs.DiskError
+	case "available":
+		info.Status = irs.DiskAvailable
+	default:
+		info.Status = irs.DiskAttached
+	}
+	return info, nil
+}
+
+func checkExistDiskV2(diskIID irs.IID, volume2Client *gophercloud.ServiceClient) (bool, error) {
+	pager, err := volumes2.List(volume2Client, volumes2.ListOpts{}).AllPages()
+	if err != nil {
+		return false, err
+	}
+	list2, err := volumes2.ExtractVolumes(pager)
+	if err != nil {
+		return false, err
+	}
+	for _, disk := range list2 {
+		if diskIID.SystemId != "" && diskIID.SystemId == disk.ID {
+			return true, nil
+		}
+		if diskIID.NameId != "" && diskIID.NameId == disk.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func checkExistDiskV3(diskIID irs.IID, volume3Client *gophercloud.ServiceClient) (bool, error) {
+	pager, err := volumes3.List(volume3Client, volumes3.ListOpts{}).AllPages()
+	if err != nil {
+		return false, err
+	}
+	list3, err := volumes3.ExtractVolumes(pager)
+	if err != nil {
+		return false, err
+	}
+	for _, disk := range list3 {
+		if diskIID.SystemId != "" && diskIID.SystemId == disk.ID {
+			return true, nil
+		}
+		if diskIID.NameId != "" && diskIID.NameId == disk.Name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func checkExistDisk(diskIID irs.IID, volumeClient *gophercloud.ServiceClient) (bool, error) {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return false, errors.New("invalid Disk IID")
+	}
+	if volumeClient.Type == VolumeV3 {
+		return checkExistDiskV3(diskIID, volumeClient)
+	}
+	if volumeClient.Type == VolumeV2 {
+		return checkExistDiskV2(diskIID, volumeClient)
+	}
+	return false, errors.New("VolumeClient not found")
+}
+
+func validationDiskReq(diskReq irs.DiskInfo, volumeClient *gophercloud.ServiceClient) error {
+	if diskReq.IId.NameId == "" {
+		return errors.New("invalid DiskReqInfo NameId")
+	}
+	exist, err := checkExistDisk(diskReq.IId, volumeClient)
+	if err != nil {
+		return errors.New("failed Check disk Name Exist")
+	}
+	if exist {
+		return errors.New("invalid DiskReqInfo NameId, Already exist")
+	}
+	//if diskReq.DiskType == "" {
+	//	return errors.New("invalid DiskReqInfo DiskType")
+	//}
+	//if diskReq.DiskSize == "" {
+	//	return errors.New("invalid DiskReqInfo DiskSize")
+	//}
+	// default?
+	//_, err = strconv.Atoi(diskReq.DiskSize)
+	//if err != nil {
+	//	return errors.New(fmt.Sprintf("invalid DiskReqInfo DiskSize, %s", err.Error()))
+	//}
+	return nil
+}
+func createDiskV2(diskReq irs.DiskInfo, volume2Client *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	size, err := strconv.Atoi(diskReq.DiskSize)
+	if diskReq.DiskSize == "" {
+		size = 1
+		err = nil
+	}
+	if err != nil {
+		return volumes3.Volume{}, errors.New("invalid Disk Size")
+	}
+	createOpt := volumes2.CreateOpts{
+		Name: diskReq.IId.NameId,
+		Size: size,
+	}
+	createVol, err := volumes2.Create(volume2Client, createOpt).Extract()
+	if err != nil {
+		return volumes3.Volume{}, errors.New("invalid Disk Size")
+	}
+	createVolV3, err := volumes2ToVolumes3(*createVol)
+	if err != nil {
+		return volumes3.Volume{}, errors.New("invalid Disk Size")
+	}
+	return createVolV3, nil
+}
+
+func createDiskV3(diskReq irs.DiskInfo, volume3Client *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	size, err := strconv.Atoi(diskReq.DiskSize)
+	if diskReq.DiskSize == "" {
+		size = 1
+		err = nil
+	}
+	if err != nil {
+		return volumes3.Volume{}, errors.New("invalid Disk Size")
+	}
+	createOpt := volumes3.CreateOpts{
+		Name: diskReq.IId.NameId,
+		Size: size,
+	}
+	createVol, err := volumes3.Create(volume3Client, createOpt).Extract()
+	if err != nil {
+		return volumes3.Volume{}, errors.New("invalid Disk Size")
+	}
+	return *createVol, nil
+}
+
+func createDisk(diskReq irs.DiskInfo, volumeClient *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	if volumeClient.Type == VolumeV3 {
+		return createDiskV3(diskReq, volumeClient)
+	}
+	if volumeClient.Type == VolumeV2 {
+		return createDiskV2(diskReq, volumeClient)
+	}
+	return volumes3.Volume{}, errors.New("VolumeClient not found")
+}
+
+func attachDisk(diskIID irs.IID, ownerVMIID irs.IID, computeClient *gophercloud.ServiceClient, volumeClient *gophercloud.ServiceClient) (volumes3.Volume, error) {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return volumes3.Volume{}, errors.New("invalid Disk IID")
+	}
+	if ownerVMIID.NameId == "" && ownerVMIID.SystemId == "" {
+		return volumes3.Volume{}, errors.New("invalid ownerVM IID")
+	}
+	disk, err := getRawDisk(diskIID, volumeClient)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	var ownerRawVM servers.Server
+	if ownerVMIID.SystemId == "" {
+		pager, err := servers.List(computeClient, nil).AllPages()
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		rawServers, err := servers.ExtractServers(pager)
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		vmCheck := false
+		for _, vm := range rawServers {
+			if vm.Name == ownerVMIID.NameId {
+				ownerRawVM = vm
+				vmCheck = true
+				break
+			}
+		}
+		if !vmCheck {
+			return volumes3.Volume{}, errors.New("not found vm")
+		}
+	} else {
+		server, err := servers.Get(computeClient, ownerVMIID.SystemId).Extract()
+		if err != nil {
+			return volumes3.Volume{}, err
+		}
+		ownerRawVM = *server
+	}
+
+	attachOpt := volumeactions.AttachOpts{InstanceUUID: ownerRawVM.ID, MountPoint: "/dev/vdc"}
+	err = volumeactions.Attach(volumeClient, disk.ID, attachOpt).ExtractErr()
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	newDisk, err := getRawDisk(irs.IID{NameId: disk.Name, SystemId: disk.ID}, volumeClient)
+	if err != nil {
+		return volumes3.Volume{}, err
+	}
+	return newDisk, nil
+}
+
+func detachDisk(diskIID irs.IID, ownerVMIID irs.IID, computeClient *gophercloud.ServiceClient, volumeClient *gophercloud.ServiceClient) error {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return errors.New("invalid Disk IID")
+	}
+	if ownerVMIID.NameId == "" && ownerVMIID.SystemId == "" {
+		return errors.New("invalid ownerVM IID")
+	}
+	disk, err := getRawDisk(diskIID, volumeClient)
+	if err != nil {
+		return err
+	}
+	if len(disk.Attachments) == 0 {
+		return errors.New("not exist Disk Attachment")
+	}
+	var ownerRawVM servers.Server
+	if ownerVMIID.SystemId == "" {
+		pager, err := servers.List(computeClient, nil).AllPages()
+		if err != nil {
+			return err
+		}
+		rawServers, err := servers.ExtractServers(pager)
+		if err != nil {
+			return err
+		}
+		vmCheck := false
+		for _, vm := range rawServers {
+			if vm.Name == ownerVMIID.NameId {
+				ownerRawVM = vm
+				vmCheck = true
+				break
+			}
+		}
+		if !vmCheck {
+			return errors.New("not found vm")
+		}
+	} else {
+		server, err := servers.Get(computeClient, ownerVMIID.SystemId).Extract()
+		if err != nil {
+			return err
+		}
+		ownerRawVM = *server
+	}
+	detachmentId := ""
+	for _, attachment := range disk.Attachments {
+		if attachment.ServerID == ownerRawVM.ID {
+			detachmentId = attachment.AttachmentID
+		}
+	}
+	if detachmentId == "" {
+		return errors.New("not exist Disk Attached VM")
+	}
+	detachOpt := volumeactions.DetachOpts{AttachmentID: detachmentId}
+	err = volumeactions.Detach(volumeClient, disk.ID, detachOpt).ExtractErr()
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+func changeDiskSize(diskIID irs.IID, diskSize string, volumeClient *gophercloud.ServiceClient) error {
+	if diskIID.NameId == "" && diskIID.SystemId == "" {
+		return errors.New("invalid Disk IID")
+	}
+	newSizeNum, err := strconv.Atoi(diskSize)
+	if err != nil {
+		return errors.New("invalid Disk IID")
+	}
+	disk, err := getRawDisk(diskIID, volumeClient)
+	if err != nil {
+		return err
+	}
+	if disk.Status != "available" {
+		return errors.New(fmt.Sprintf("Resizing is only possible if it is mounted on a VM in the Available state"))
+	}
+	if disk.Size >= newSizeNum {
+		return errors.New(fmt.Sprintf("New size must be greater than current size"))
+	}
+	if volumeClient == nil {
+		return errors.New("VolumeClient not found")
+	}
+	changeSizeOpts := volumeactions.ExtendSizeOpts{
+		NewSize: newSizeNum,
+	}
+	return volumeactions.ExtendSize(volumeClient, disk.ID, changeSizeOpts).ExtractErr()
 }


### PR DESCRIPTION
- Disk핸들러 구현을 위한 Connect 및 CreateHandler 부분 수정
  - VolumeClient v2,v3 기능 제공을 위한 Connection, ConnectCloud 변경
    - Openstack의 Vloume(Cinder)의 버전에 따라 생성할 Client가 달라지고, 타 서비스도 버전에 따라 분기될 가능성이 있음
    - 타 Client 도 추후 버전이 나뉘어 제공될 경우, 기능 추가
    - OpenStackCloudConnection의 Client 이름 변경
- Disk핸들러 구현
  - DiskHandler 기능 구현
  - VMHandler VMInfo 반영
  - 핸들러 단의 VolumeClient v2, v3 통일식
    - 핸들러 생성시, V3 버전 혹은 V2 버전으로 1개만 넣어주는 방식