### PR TITLE
Apply Separated Availability Zone to NHN Cloud Connection config and Test Code

### DIFF
--- a/api-runtime/rest-runtime/test/connect-config/13.nhncloud-conn-config.sh
+++ b/api-runtime/rest-runtime/test/connect-config/13.nhncloud-conn-config.sh
@@ -14,17 +14,31 @@ curl -X POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: applica
         {"Key":"DomainName", "Value":"default"},
         {"Key":"TenantId", "Value":"XXXXXXXXXXXXXXXXX"}
 ]}'
+    # TenantId : NHN Cloud Console > Instance > 관리 > API 엔드포인트 설정 > TenantID를 입력해야함.
 
  # Cloud Region Info
-curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pangyo","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR1"}]}'
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pangyo1","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR1"}, {"Key":"Zone", "Value":"kr-pub-a"}]}'
 
-curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pyeongchon","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR2"}]}'
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pangyo2","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR1"}, {"Key":"Zone", "Value":"kr-pub-b"}]}'
 
-curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-japan-tokyo","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"JP1"}]}'
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pyeongchon1","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR2"}, {"Key":"Zone", "Value":"kr2-pub-a"}]}'
+
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-korea-pyeongchon2","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"KR2"}, {"Key":"Zone", "Value":"kr2-pub-b"}]}'
+
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-japan-tokyo1","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"JP1"}, {"Key":"Zone", "Value":"jp-pub-a"}]}'
+
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"nhncloud-japan-tokyo2","ProviderName":"NHNCLOUD","KeyValueInfoList": [{"Key":"Region", "Value":"JP1"}, {"Key":"Zone", "Value":"jp-pub-b"}]}'
 
  # Cloud Connection Config Info
-curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pangyo-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pangyo"}'
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pangyo1-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pangyo1"}'
 
-curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pyeongchon-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pyeongchon"}'
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pangyo2-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pangyo2"}'
 
-curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-japan-tokyo-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-japan-tokyo"}'
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pyeongchon1-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pyeongchon1"}'
+
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-korea-pyeongchon2-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-korea-pyeongchon2"}'
+
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-japan-tokyo1-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-japan-tokyo1"}'
+
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"nhncloud-japan-tokyo2-config","ProviderName":"NHNCLOUD", "DriverName":"nhncloud-driver01", "CredentialName":"nhncloud-credential01", "RegionName":"nhncloud-japan-tokyo2"}'
+

--- a/api-runtime/rest-runtime/test/full-test/13.nhncloud-test.sh
+++ b/api-runtime/rest-runtime/test/full-test/13.nhncloud-test.sh
@@ -1,15 +1,15 @@
-export CONN_CONFIG=nhncloud-korea-pangyo-config
-#export CONN_CONFIG=nhncloud-korea-pyeongchon-config
+export CONN_CONFIG=nhncloud-korea-pangyo1-config
+#export CONN_CONFIG=nhncloud-korea-pyeongchon1-config
 
 export IMAGE_NAME=5396655e-166a-4875-80d2-ed8613aa054f
 # Image Guest OS : Ubuntu Linux 18.04 기준
 
-#export SPEC_NAME=u2.c2m4
+export SPEC_NAME=u2.c2m4
 # VM Spec : vCPU: 2, Mem: 4GB
 # Not need to specify Disk Size incase of u2.~~~ type of VMSpec
 
 #export SPEC_NAME=c2.c2m2
-export SPEC_NAME=m2.c4m8
+#export SPEC_NAME=m2.c4m8
 # VM Spec : vCPU: 4, Mem: 8GB
 # Need to specify Disk Type and Disk Size
 


### PR DESCRIPTION
- Apply Separated Availability Zone to NHN Cloud Connection config and Test Code
  - Before
     - region: KR1
     - region: KR2
     - region: JP1
  - After
     - region: KR1
        - zone: kr-pub-a
        - zone: kr-pub-b
     - region: KR2
        - zone: kr2-pub-a
        - zone: kr2-pub-b
     - region: JP1
        - zone: jp-pub-a
        - zone: jp-pub-b

Related Issue) https://github.com/cloud-barista/nhncloud/issues/85