### PR TITLE
Upgrade the actions runner OS

### DIFF
--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -19,8 +19,9 @@ jobs:
     # Job name is "Building"
     name: Building
 
-    # This job runs on Ubuntu-latest
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:

--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -12,7 +12,9 @@ jobs:
   execute:
     # Execute when author_association of the comment is OWNER or MEMBER
     if: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' }}
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     # Execute action according to commands
     steps:
       # Check author_association

--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -28,7 +28,9 @@ jobs:
     name: Publishing
 
     # This job runs on Ubuntu-latest
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
**GitHub actions runner의 OS 중 하나인 Ubuntu 18.04가 Deprecated 예정 입니다. (2022년 12월 1일 까지)**

관련하여 workflow의 구동 환경을 ubuntu-latest(현재 20.04)로 업데이트 하는 것이 좋을 것 같습니다 ^^ 

NOTE - Cloud-Barista의 개발/테스트를 위한 공식 OS(Ubuntu 22.04)와는 관련이 없습니다. CB-Spider는 container image build를 통해 코드 필드 성공 여부를 테스트하고 있기 때문입니다.

Ref: [GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)