### PR TITLE
[Cloudit] DiskHandler, MyImageHandler 기능 구현

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/disk/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/disk/Request.go
@@ -1,0 +1,241 @@
+package disk
+
+import (
+	"errors"
+	cblog "github.com/cloud-barista/cb-log"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/sirupsen/logrus"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var cblogger *logrus.Logger
+
+func init() {
+	cblogger = cblog.GetLogger("CB-SPIDER")
+}
+
+type DiskReqInfo struct {
+	Name      string `json:"name,omitempty" required:"true"`
+	ID        string `json:"volumeId,omitempty"`
+	ClusterId string `json:"clusterId,omitempty" required:"true"`
+	Size      int    `json:"size,omitempty" required:"true"`
+	Mode      string `json:"mode,omitempty"`
+}
+
+type DiskInfo struct {
+	ID           string
+	Name         string `updateAble:"Name"`
+	State        string
+	Size         int `updateAble:"Size"`
+	CreatedTime  time.Time
+	VolumeVmList []string
+
+	// miscellaneous properties
+	TemplateId  string `responseType:"KeyValue"`
+	ClusterId   string `responseType:"KeyValue"`
+	PoolId      string `responseType:"KeyValue"`
+	Bootable    string `responseType:"KeyValue"`
+	Iops        int    `responseType:"KeyValue"`
+	Throughput  int    `responseType:"KeyValue"`
+	Creator     string `responseType:"KeyValue"`
+	Description string `responseType:"KeyValue" updateAble:"Description"`
+}
+
+func (diskInfo *DiskInfo) GetKeyValues() []irs.KeyValue {
+	var keyValues []irs.KeyValue
+
+	valueOfThis := reflect.ValueOf(*diskInfo)
+	typeOfThis := reflect.TypeOf(*diskInfo)
+
+	for idx := 0; idx < valueOfThis.NumField(); idx++ {
+		field := typeOfThis.Field(idx)
+		if field.Tag.Get("responseType") == "KeyValue" {
+			strValue, strOk := valueOfThis.Field(idx).Interface().(string)
+			if strOk {
+				keyValues = append(keyValues, irs.KeyValue{Key: field.Name, Value: strValue})
+			}
+			intValue, intOk := valueOfThis.Field(idx).Interface().(int)
+			if intOk {
+				keyValues = append(keyValues, irs.KeyValue{Key: field.Name, Value: strconv.Itoa(intValue)})
+			}
+		}
+	}
+
+	return keyValues
+}
+
+func (diskInfo *DiskInfo) ToIRSDisk(restClient *client.RestClient) irs.DiskInfo {
+	// 볼륨이 장착된 VM 이름 획득
+	ownerVm, _ := GetOwnerVm(restClient, diskInfo.ID, &client.RequestOpts{
+		MoreHeaders: restClient.AuthenticatedHeaders(),
+	})
+
+	return irs.DiskInfo{
+		IId:          irs.IID{NameId: diskInfo.Name, SystemId: diskInfo.ID},
+		DiskType:     "",
+		DiskSize:     strconv.Itoa(diskInfo.Size),
+		Status:       getDiskStatus(diskInfo.State),
+		CreatedTime:  diskInfo.CreatedTime,
+		KeyValueList: diskInfo.GetKeyValues(),
+		OwnerVM:      ownerVm.IId,
+	}
+}
+
+func (diskInfo *DiskInfo) ToUpdateDiskReqInfo() *DiskReqInfo {
+	diskReqInfo := DiskReqInfo{}
+
+	valueOfThis := reflect.ValueOf(*diskInfo)
+	typeOfThis := reflect.TypeOf(*diskInfo)
+	valueOfReqInfo := reflect.ValueOf(&diskReqInfo).Elem()
+	typeOfReqInfo := reflect.TypeOf(diskReqInfo)
+
+	for idxThisField := 0; idxThisField < valueOfThis.NumField(); idxThisField++ {
+		mappedFieldName := typeOfThis.Field(idxThisField).Tag.Get("updateAble")
+		_, exist := typeOfReqInfo.FieldByName(mappedFieldName)
+		if exist {
+			reqInfoFieldValue := valueOfReqInfo.FieldByName(mappedFieldName)
+			if reqInfoFieldValue.CanSet() {
+				strValue, strOk := valueOfThis.Field(idxThisField).Interface().(string)
+				if strOk {
+					reqInfoFieldValue.SetString(strValue)
+				}
+				intValue, intOk := valueOfThis.Field(idxThisField).Interface().(int)
+				if intOk {
+					reqInfoFieldValue.SetInt(int64(intValue))
+				}
+			}
+		}
+	}
+
+	if diskReqInfo == (DiskReqInfo{}) {
+		return nil
+	}
+
+	return &diskReqInfo
+}
+
+func getDiskStatus(diskStatus string) irs.DiskStatus {
+	var resultStatus string
+	switch strings.ToLower(diskStatus) {
+	case "creating":
+		resultStatus = "Creating"
+	case "deleting":
+		resultStatus = "Deleting"
+	case "available":
+		resultStatus = "Available"
+	case "attaching", "detaching", "in_use", "converting", "extending":
+		resultStatus = "Attached"
+	case "failed":
+		resultStatus = "Failed"
+	default:
+		resultStatus = "Failed"
+	}
+
+	return irs.DiskStatus(resultStatus)
+}
+
+func List(restClient *client.RestClient, requestOpts *client.RequestOpts) (*[]DiskInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
+		return nil, result.Err
+	}
+
+	var diskList []DiskInfo
+	if err := result.ExtractInto(&diskList); err != nil {
+		return nil, err
+	}
+
+	return &diskList, nil
+}
+
+func Get(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) (*DiskInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
+		return nil, result.Err
+	}
+
+	var diskList []DiskInfo
+	if err := result.ExtractInto(&diskList); err != nil {
+		return nil, err
+	}
+	for _, disk := range diskList {
+		if disk.ID == id {
+			return &disk, nil
+		}
+	}
+
+	return nil, errors.New("cannot find disk")
+}
+
+func Create(restClient *client.RestClient, requestOpts *client.RequestOpts) (*DiskInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Post(requestURL, nil, &result.Body, requestOpts); result.Err != nil {
+		return nil, result.Err
+	}
+
+	var disk DiskInfo
+	if err := result.ExtractInto(&disk); err != nil {
+		return nil, err
+	}
+
+	return &disk, nil
+}
+
+func Update(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) (*DiskInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes", id, "update")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Post(requestURL, nil, &result.Body, requestOpts); result.Err != nil {
+		return nil, result.Err
+	}
+
+	var disk DiskInfo
+	if err := result.ExtractInto(&disk); err != nil {
+		return nil, err
+	}
+
+	return &disk, nil
+}
+
+func Delete(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) error {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes", id)
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Delete(requestURL, requestOpts); result.Err != nil {
+		return result.Err
+	}
+
+	return nil
+}
+
+func GetOwnerVm(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) (irs.VMInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "volumes", id, "servers")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
+		return irs.VMInfo{}, result.Err
+	}
+
+	var ownerVmList []irs.VMInfo
+	if err := result.ExtractInto(&ownerVmList); err != nil || len(ownerVmList) == 0 {
+		return irs.VMInfo{}, err
+	}
+
+	return ownerVmList[0], nil
+}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
@@ -26,7 +26,7 @@ type VMReqInfo struct {
 	RootPassword string         `json:"rootPassword" required:"true"`
 	SubnetAddr   string         `json:"subnetAddr" required:"true"`
 	Secgroups    []SecGroupInfo `json:"secgroups" required:"true"`
-	Description  string            `json:"description" required:"false"`
+	Description  string         `json:"description" required:"false"`
 	Protection   int            `json:"protection" required:"false"`
 }
 
@@ -197,6 +197,28 @@ func Reboot(restClient *client.RestClient, id string, requestOpts *client.Reques
 //delete
 func Terminate(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) error {
 	requestURL := restClient.CreateRequestBaseURL(client.ACE, "servers", id)
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Delete(requestURL, requestOpts); result.Err != nil {
+		return result.Err
+	}
+	return nil
+}
+
+func AttachVolume(restClient *client.RestClient, serverId string, requestOpts *client.RequestOpts) error {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "servers", serverId, "volumes")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Post(requestURL, nil, nil, requestOpts); result.Err != nil {
+		return result.Err
+	}
+	return nil
+}
+
+func DetachVolume(restClient *client.RestClient, serverId string, volumeId string, requestOpts *client.RequestOpts) error {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "servers", serverId, "volumes", volumeId)
 	cblogger.Info(requestURL)
 
 	var result client.Result

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
@@ -20,7 +20,8 @@ type SecGroupInfo struct {
 }
 
 type VMReqInfo struct {
-	TemplateId   string         `json:"templateId" required:"true"`
+	TemplateId   string         `json:"templateId,omitempty"`
+	SnapshotId   string         `json:"snapshotId,omitempty"`
 	SpecId       string         `json:"specId" required:"true"`
 	Name         string         `json:"name" required:"true"`
 	HostName     string         `json:"hostName" required:"true"`

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server/Request.go
@@ -3,6 +3,7 @@ package server
 import (
 	cblog "github.com/cloud-barista/cb-log"
 	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/disk"
 	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/iam/securitygroup"
 	"github.com/sirupsen/logrus"
 )
@@ -226,4 +227,36 @@ func DetachVolume(restClient *client.RestClient, serverId string, volumeId strin
 		return result.Err
 	}
 	return nil
+}
+
+// get VM attached Volumes
+func GetRawVmVolumes(restClient *client.RestClient, id string, requestOpts *client.RequestOpts) (*[]disk.DiskInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "servers", id, "volumes")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	_, result.Err = restClient.Get(requestURL, &result.Body, requestOpts)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	var responseList []struct {
+		VolumeId    string
+		Dev         string
+		Description string
+	}
+	if err := result.ExtractInto(&responseList); err != nil {
+		return nil, err
+	}
+
+	var volumeList []disk.DiskInfo
+	for _, response := range responseList {
+		volumeList = append(volumeList, disk.DiskInfo{
+			ID:          response.VolumeId,
+			Dev:         response.Dev,
+			Description: response.Description,
+		})
+	}
+
+	return &volumeList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot/Request.go
@@ -45,7 +45,7 @@ func ToIRSMyImage(restClient *client.RestClient, associatedSnapshots *[]Snapshot
 	result.SourceVM.SystemId = ""
 	for _, snapshot := range *associatedSnapshots {
 		if snapshot.Bootable == "yes" {
-			result.IId.NameId = strings.Split(snapshot.Name, "/dev:")[0]
+			result.IId.NameId = strings.Split(snapshot.Name, "-dev-")[0]
 			result.IId.SystemId = snapshot.Id
 			result.SourceVM.NameId = snapshot.ServerName
 			if snapshot.CreatedAt != "" {

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot/Request.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot/Request.go
@@ -1,0 +1,142 @@
+package snapshot
+
+import (
+	"fmt"
+	cblog "github.com/cloud-barista/cb-log"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/sirupsen/logrus"
+	"strings"
+	"time"
+)
+
+var cblogger *logrus.Logger
+
+func init() {
+	// cblog is a global variable.
+	cblogger = cblog.GetLogger("CB-SPIDER")
+}
+
+type SnapshotReqInfo struct {
+	Name     string `json:"name,omitempty"`
+	VolumeId string `json:"volumeId,omitempty"`
+}
+
+type SnapshotInfo struct {
+	Name       string
+	Id         string
+	ServerName string
+	State      string
+	CreatedAt  string
+
+	// miscellaneous properties
+	Bootable string
+	Creator  string
+}
+
+func ToIRSMyImage(restClient *client.RestClient, associatedSnapshots *[]SnapshotInfo) (irs.MyImageInfo, error) {
+	var result irs.MyImageInfo
+
+	isAvailable := true
+	result.Status = irs.MyImageAvailable
+	result.SourceVM.SystemId = ""
+	for _, snapshot := range *associatedSnapshots {
+		if snapshot.Bootable == "yes" {
+			result.IId.NameId = strings.Split(snapshot.Name, "/dev:")[0]
+			result.IId.SystemId = snapshot.Id
+			result.SourceVM.NameId = snapshot.ServerName
+			if snapshot.CreatedAt != "" {
+				timeArr := strings.Split(snapshot.CreatedAt, " ")
+				timeFormatStr := fmt.Sprintf("%sT%sZ", timeArr[0], timeArr[1])
+				if createTime, err := time.Parse(time.RFC3339, timeFormatStr); err == nil {
+					result.CreatedTime = createTime
+				}
+			}
+		}
+		if isAvailable && getSnapshotStatus(snapshot.State) == irs.MyImageUnavailable {
+			isAvailable = false
+			result.Status = irs.MyImageUnavailable
+		}
+	}
+
+	requestOpts := client.RequestOpts{
+		MoreHeaders: restClient.AuthenticatedHeaders(),
+	}
+	serverList, err := server.List(restClient, &requestOpts)
+	if err != nil {
+		return irs.MyImageInfo{}, err
+	}
+	for _, server := range *serverList {
+		if server.Name == result.SourceVM.NameId {
+			result.SourceVM.SystemId = server.ID
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func List(restClient *client.RestClient, requestOpts *client.RequestOpts) (*[]SnapshotInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "snapshots")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Get(requestURL, &result.Body, requestOpts); result.Err != nil {
+		return nil, result.Err
+	}
+
+	var snapshotList []SnapshotInfo
+	if err := result.ExtractInto(&snapshotList); err != nil {
+		return nil, err
+	}
+
+	return &snapshotList, nil
+}
+
+//func GetSnapshotsByMyImage(restClient *client.RestClient, myImageNameId string, requestOpts *client.RequestOpts) (SnapshotInfo, error) {
+//
+//}
+
+func CreateSnapshot(restClient *client.RestClient, requestOpts *client.RequestOpts) (SnapshotInfo, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "snapshots")
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Post(requestURL, nil, &result.Body, requestOpts); result.Err != nil {
+		return SnapshotInfo{}, result.Err
+	}
+
+	var snapshot SnapshotInfo
+	if err := result.ExtractInto(&snapshot); err != nil {
+		return SnapshotInfo{}, err
+	}
+
+	return snapshot, nil
+}
+
+func DeleteSnapshot(restClient *client.RestClient, snapshotId string, requestOpts *client.RequestOpts) (bool, error) {
+	requestURL := restClient.CreateRequestBaseURL(client.ACE, "snapshots", snapshotId)
+	cblogger.Info(requestURL)
+
+	var result client.Result
+	if _, result.Err = restClient.Delete(requestURL, requestOpts); result.Err != nil {
+		return false, result.Err
+	}
+
+	return true, nil
+}
+
+func getSnapshotStatus(snapshotStatus string) irs.MyImageStatus {
+	var resultStatus string
+	switch strings.ToLower(snapshotStatus) {
+	case "completed":
+		resultStatus = "Available"
+	case "creating", "deleting", "converting", "failed":
+		resultStatus = "Unavailable"
+	default:
+		resultStatus = "Unavailable"
+	}
+
+	return irs.MyImageStatus(resultStatus)
+}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
@@ -86,6 +86,12 @@ func (cloudConn *ClouditCloudConnection) CreateNLBHandler() (irs.NLBHandler, err
 	return &nlbHandler, nil
 }
 
+func (cloudConn *ClouditCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {
+	cblogger.Info("Cloudit Cloud Driver: called CreateDiskHandler()!")
+	diskHandler := cirs.ClouditDiskHandler{CredentialInfo: cloudConn.CredentialInfo, Client: &cloudConn.Client}
+	return &diskHandler, nil
+}
+
 func (ClouditCloudConnection) IsConnected() (bool, error) {
 	return true, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
@@ -108,6 +108,8 @@ func (cloudConn *ClouditCloudConnection) CreateClusterHandler() (irs.ClusterHand
 }
 
 func (cloudConn *ClouditCloudConnection) CreateMyImageHandler() (irs.MyImageHandler, error) {
-        return nil, errors.New("Cloudit Driver: not implemented")
+	cblogger.Info("Cloudit Cloud Driver: called CreateMyImageHandler()!")
+	myImageHandler := cirs.ClouditMyImageHandler{CredentialInfo: cloudConn.CredentialInfo, Client: &cloudConn.Client}
+	return &myImageHandler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/connect/Cloudit_CloudConnection.go
@@ -11,13 +11,13 @@
 package connect
 
 import (
+	"errors"
 	cblog "github.com/cloud-barista/cb-log"
 	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
 	cirs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/resources"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/sirupsen/logrus"
-	"errors"
 )
 
 var cblogger *logrus.Logger
@@ -86,12 +86,6 @@ func (cloudConn *ClouditCloudConnection) CreateNLBHandler() (irs.NLBHandler, err
 	return &nlbHandler, nil
 }
 
-func (cloudConn *ClouditCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {
-	cblogger.Info("Cloudit Cloud Driver: called CreateDiskHandler()!")
-	diskHandler := cirs.ClouditDiskHandler{CredentialInfo: cloudConn.CredentialInfo, Client: &cloudConn.Client}
-	return &diskHandler, nil
-}
-
 func (ClouditCloudConnection) IsConnected() (bool, error) {
 	return true, nil
 }
@@ -100,11 +94,13 @@ func (ClouditCloudConnection) Close() error {
 }
 
 func (cloudConn *ClouditCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {
-        return nil, errors.New("Cloudit Driver: not implemented")
+	cblogger.Info("Cloudit Cloud Driver: called CreateDiskHandler()!")
+	diskHandler := cirs.ClouditDiskHandler{CredentialInfo: cloudConn.CredentialInfo, Client: &cloudConn.Client}
+	return &diskHandler, nil
 }
 
 func (cloudConn *ClouditCloudConnection) CreateClusterHandler() (irs.ClusterHandler, error) {
-        return nil, errors.New("Cloudit Driver: not implemented")
+	return nil, errors.New("Cloudit Driver: not implemented")
 }
 
 func (cloudConn *ClouditCloudConnection) CreateMyImageHandler() (irs.MyImageHandler, error) {
@@ -112,4 +108,3 @@ func (cloudConn *ClouditCloudConnection) CreateMyImageHandler() (irs.MyImageHand
 	myImageHandler := cirs.ClouditMyImageHandler{CredentialInfo: cloudConn.CredentialInfo, Client: &cloudConn.Client}
 	return &myImageHandler, nil
 }
-

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
@@ -561,6 +561,7 @@ func testVmHandler(config ResourceConfig) {
 		IId: irs.IID{
 			NameId: config.Cloudit.VM.IID.NameId,
 		},
+		ImageType: irs.PublicImage,
 		ImageIID: irs.IID{
 			NameId:   config.Cloudit.VM.ImageIID.NameId,
 			SystemId: config.Cloudit.VM.ImageIID.SystemId,
@@ -583,6 +584,7 @@ func testVmHandler(config ResourceConfig) {
 		IId: irs.IID{
 			NameId: config.Cloudit.VMFromMyImage.IID.NameId,
 		},
+		ImageType: irs.MyImage,
 		ImageIID: irs.IID{
 			NameId:   config.Cloudit.VMFromMyImage.ImageIID.NameId,
 			SystemId: config.Cloudit.VMFromMyImage.ImageIID.SystemId,
@@ -1041,7 +1043,8 @@ func testMyImageHandler(config ResourceConfig) {
 		},
 	}
 	myImageIId := irs.IID{
-		NameId: configmyimage.IID.NameId,
+		NameId:   configmyimage.IID.NameId,
+		SystemId: configmyimage.IID.SystemId,
 	}
 Loop:
 	for {
@@ -1349,7 +1352,8 @@ type ResourceConfig struct {
 		} `yaml:"disk"`
 		MYIMAGE struct {
 			IID struct {
-				NameId string `yaml:"nameId"`
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
 			} `yaml:"IID"`
 			SourceVMIID struct {
 				NameId string `yaml:"nameId"`

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
@@ -957,6 +957,8 @@ Loop:
 				res_cblogger.Info("Finish GetDisk()")
 			case 3:
 				res_cblogger.Info("Start CreateDisk() ...")
+				diskCreateReqInfo.KeyValueList = append(diskCreateReqInfo.KeyValueList,
+					irs.KeyValue{Key: "clusterId", Value: "8e01e169-8318-4676-b30a-fb339de4b44b"})
 				if createInfo, err := diskHandler.CreateDisk(diskCreateReqInfo); err != nil {
 					res_cblogger.Error(err)
 				} else {

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/main/Test_Resources.go
@@ -538,7 +538,8 @@ func testVMHandlerListPrint() {
 	res_cblogger.Info("7. SuspendVM()")
 	res_cblogger.Info("8. ResumeVM()")
 	res_cblogger.Info("9. TerminateVM()")
-	res_cblogger.Info("10. Exit")
+	res_cblogger.Info("10. StartVM() - from MyImage")
+	res_cblogger.Info("11. Exit")
 }
 
 func testVmHandler(config ResourceConfig) {
@@ -573,6 +574,28 @@ func testVmHandler(config ResourceConfig) {
 		VMSpecName: config.Cloudit.VM.VmSpecName,
 		KeyPairIID: irs.IID{
 			NameId: config.Cloudit.VM.KeyPairIID.NameId,
+		},
+		SecurityGroupIIDs: SecurityGroupIIDs,
+		RootDiskSize:      "",
+		RootDiskType:      "",
+	}
+	vmFromSnapshotReqInfo := irs.VMReqInfo{
+		IId: irs.IID{
+			NameId: config.Cloudit.VMFromMyImage.IID.NameId,
+		},
+		ImageIID: irs.IID{
+			NameId:   config.Cloudit.VMFromMyImage.ImageIID.NameId,
+			SystemId: config.Cloudit.VMFromMyImage.ImageIID.SystemId,
+		},
+		VpcIID: irs.IID{
+			NameId: config.Cloudit.VMFromMyImage.VpcIID.NameId,
+		},
+		SubnetIID: irs.IID{
+			NameId: config.Cloudit.VMFromMyImage.SubnetIID.NameId,
+		},
+		VMSpecName: config.Cloudit.VMFromMyImage.VmSpecName,
+		KeyPairIID: irs.IID{
+			NameId: config.Cloudit.VMFromMyImage.KeyPairIID.NameId,
 		},
 		SecurityGroupIIDs: SecurityGroupIIDs,
 		RootDiskSize:      "",
@@ -665,6 +688,14 @@ Loop:
 				}
 				res_cblogger.Info("Finish TerminateVM()")
 			case 10:
+				res_cblogger.Info("Start StartVM() - from MyImage ...")
+				if vmStatus, err := vmHandler.StartVM(vmFromSnapshotReqInfo); err != nil {
+					res_cblogger.Error(err)
+				} else {
+					spew.Dump(vmStatus)
+				}
+				res_cblogger.Info("Finish StartVM() - from MyImage ...")
+			case 11:
 				res_cblogger.Info("Exit")
 				break Loop
 			}
@@ -1167,6 +1198,34 @@ type ResourceConfig struct {
 			} `yaml:"SecurityGroupIIDs"`
 			VMUserPasswd string `yaml:"VMUserPasswd"`
 		} `yaml:"vm"`
+		VMFromMyImage struct {
+			IID struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"IID"`
+			ImageIID struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"ImageIID"`
+			VmSpecName string `yaml:"VmSpecName"`
+			KeyPairIID struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"KeyPairIID"`
+			VpcIID struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"VpcIID"`
+			SubnetIID struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"SubnetIID"`
+			SecurityGroupIIDs []struct {
+				NameId   string `yaml:"nameId"`
+				SystemId string `yaml:"systemId"`
+			} `yaml:"SecurityGroupIIDs"`
+			VMUserPasswd string `yaml:"VMUserPasswd"`
+		} `yaml:"vmFromMyImage"`
 		Resources struct {
 			ImageIID struct {
 				NameId   string `yaml:"nameId"`

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
@@ -1,0 +1,431 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/disk"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"strconv"
+	"strings"
+)
+
+type ClouditDiskHandler struct {
+	CredentialInfo idrv.CredentialInfo
+	Client         *client.RestClient
+}
+
+func (diskHandler *ClouditDiskHandler) CreateDisk(DiskReqInfo irs.DiskInfo) (irs.DiskInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", DiskReqInfo.IId.NameId, "CreateDisk()")
+
+	//가상디스크 이름 중복 체크
+	exist, err := diskHandler.getExistsDiskName(DiskReqInfo.IId.NameId)
+	if exist {
+		createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s already exist", DiskReqInfo.IId.NameId))
+		if err != nil {
+			createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s", err.Error()))
+			cblogger.Error(createErr.Error())
+			LoggingError(hiscallInfo, createErr)
+			return irs.DiskInfo{}, createErr
+		}
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.DiskInfo{}, createErr
+	}
+
+	// API Call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	intSize, _ := strconv.Atoi(DiskReqInfo.DiskSize)
+	reqInfo := disk.DiskReqInfo{
+		Name: DiskReqInfo.IId.NameId,
+		// ToDo: to static value?
+		ClusterId: "8e01e169-8318-4676-b30a-fb339de4b44b",
+		Size:      intSize,
+	}
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+		JSONBody:    reqInfo,
+	}
+
+	// 디스크 생성
+	start := call.Start()
+	createdDisk, err := disk.Create(diskHandler.Client, &requestOpts)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create Disk. err = %s", err.Error()))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.DiskInfo{}, createErr
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return createdDisk.ToIRSDisk(diskHandler.Client), nil
+}
+
+func (diskHandler *ClouditDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", "DISK", "ListDisk()")
+
+	// API call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	start := call.Start()
+	diskList, err := disk.List(diskHandler.Client, &requestOpts)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to Get DiskList. err = %s", err.Error()))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return nil, getErr
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	diskInfoList := make([]*irs.DiskInfo, len(*diskList))
+	for i, disk := range *diskList {
+		irsDisk := disk.ToIRSDisk(diskHandler.Client)
+		diskInfoList[i] = &irsDisk
+	}
+
+	return diskInfoList, nil
+}
+
+func (diskHandler *ClouditDiskHandler) GetDisk(diskIID irs.IID) (irs.DiskInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", diskIID.NameId, "GetDisk()")
+
+	start := call.Start()
+	disk, err := diskHandler.getRawDisk(diskIID)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to Get Disk. err = %s", err.Error()))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return irs.DiskInfo{}, getErr
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return disk.ToIRSDisk(diskHandler.Client), nil
+}
+
+func (diskHandler *ClouditDiskHandler) ChangeDiskSize(diskIID irs.IID, size string) (bool, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", diskIID.NameId, "ChangeDiskSize()")
+
+	// get target Disk
+	targetDiskSystemId := ""
+	if diskIID.SystemId == "" {
+		diskInfo, err := diskHandler.getRawDisk(diskIID)
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("Failed to Update Disk. err = %s", err))
+		}
+		diskStatus := diskInfo.ToIRSDisk(diskHandler.Client).Status
+		if diskStatus != irs.DiskAvailable {
+			return false, errors.New(fmt.Sprintf("Failed to Update Disk. err = cannot change disk size in %s state", diskStatus))
+		}
+		targetDiskSystemId = diskInfo.ID
+	} else {
+		targetDiskSystemId = diskIID.SystemId
+	}
+
+	// set update info
+	intSize, _ := strconv.Atoi(size)
+	diskUpdateInfo := disk.DiskInfo{
+		ID:   targetDiskSystemId,
+		Size: intSize,
+	}
+
+	start := call.Start()
+	result, err := diskHandler.updateDisk(diskUpdateInfo)
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to Update Disk. err = %s", err.Error()))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return false, getErr
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return result, nil
+}
+
+func (diskHandler *ClouditDiskHandler) DeleteDisk(diskIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", diskIID.NameId, "DeleteDisk()")
+
+	// get target Disk
+	targetDiskSystemId := ""
+	if diskIID.SystemId == "" {
+		diskInfo, _ := diskHandler.getRawDisk(diskIID)
+		diskStatus := diskInfo.ToIRSDisk(diskHandler.Client).Status
+		if !(diskStatus == irs.DiskAvailable || diskStatus == irs.DiskError) {
+			return false, errors.New(fmt.Sprintf("Failed to Delete Disk. err = cannot delete disk in %s state", diskStatus))
+		}
+		targetDiskSystemId = diskInfo.ID
+	} else {
+		targetDiskSystemId = diskIID.SystemId
+	}
+
+	start := call.Start()
+	result, err := diskHandler.deleteDisk(irs.IID{SystemId: targetDiskSystemId})
+	if err != nil {
+		getErr := errors.New(fmt.Sprintf("Failed to Delete Disk. err = %s", err.Error()))
+		cblogger.Error(getErr.Error())
+		LoggingError(hiscallInfo, getErr)
+		return false, getErr
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return result, nil
+}
+
+func (diskHandler *ClouditDiskHandler) AttachDisk(diskIID irs.IID, ownerVM irs.IID) (irs.DiskInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", diskIID.NameId, "AttachDisk()")
+
+	// get target Disk
+	targetDiskSystemId := ""
+	if diskIID.SystemId == "" {
+		diskInfo, err := diskHandler.getRawDisk(diskIID)
+		if err != nil {
+			return irs.DiskInfo{}, errors.New(fmt.Sprintf("Cannot Attach Disk. err = %s", err))
+		}
+		diskStatus := diskInfo.ToIRSDisk(diskHandler.Client).Status
+		if diskStatus != irs.DiskAvailable {
+			return irs.DiskInfo{}, errors.New(fmt.Sprintf("Cannot Attach Disk. err = cannot attach disk in %s state", diskStatus))
+		}
+		targetDiskSystemId = diskInfo.ID
+	} else {
+		targetDiskSystemId = diskIID.SystemId
+	}
+
+	// get target VM
+	targetVMSystemId := ""
+	if ownerVM.SystemId == "" {
+		diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+		authHeader := diskHandler.Client.AuthenticatedHeaders()
+		requestOpts := client.RequestOpts{
+			MoreHeaders: authHeader,
+		}
+		vmList, err := server.List(diskHandler.Client, &requestOpts)
+		if err != nil {
+			return irs.DiskInfo{}, errors.New(fmt.Sprintf("Failed to Attach Disk. err = %s", err))
+		}
+		for _, vm := range *vmList {
+			if strings.EqualFold(vm.Name, ownerVM.NameId) {
+				targetVMSystemId = vm.ID
+			}
+		}
+	} else {
+		targetVMSystemId = ownerVM.SystemId
+	}
+
+	start := call.Start()
+	err := diskHandler.attachDisk(irs.IID{SystemId: targetDiskSystemId}, irs.IID{SystemId: targetVMSystemId})
+	if err != nil {
+		return irs.DiskInfo{}, errors.New(fmt.Sprintf("Failed to attach disk. err = %s", err))
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	diskInfo, err := diskHandler.GetDisk(irs.IID{SystemId: targetDiskSystemId})
+	if err != nil {
+		return irs.DiskInfo{}, errors.New(fmt.Sprintf("Failed to get attached disk information. err = %s", err))
+	}
+
+	return diskInfo, nil
+}
+
+func (diskHandler *ClouditDiskHandler) DetachDisk(diskIID irs.IID, ownerVM irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "DISK", diskIID.NameId, "DetachDisk()")
+
+	// get target Disk
+	targetDiskSystemId := ""
+	if diskIID.SystemId == "" {
+		diskInfo, err := diskHandler.getRawDisk(diskIID)
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("Failed to Detach Disk. err = %s", err))
+		}
+		diskStatus := diskInfo.ToIRSDisk(diskHandler.Client).Status
+		if diskStatus != irs.DiskAttached {
+			return false, errors.New(fmt.Sprintf("Cannot Detach Disk. err = cannot detach disk in %s state", diskStatus))
+		}
+		targetDiskSystemId = diskInfo.ID
+	} else {
+		targetDiskSystemId = diskIID.SystemId
+	}
+
+	// get target VM
+	targetVMSystemId := ""
+	if ownerVM.SystemId == "" {
+		diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+		authHeader := diskHandler.Client.AuthenticatedHeaders()
+		requestOpts := client.RequestOpts{
+			MoreHeaders: authHeader,
+		}
+		vmList, err := server.List(diskHandler.Client, &requestOpts)
+		if err != nil {
+			return false, errors.New(fmt.Sprintf("Failed to Detach Disk. err = %s", err))
+		}
+		for _, vm := range *vmList {
+			if strings.EqualFold(vm.Name, ownerVM.NameId) {
+				targetVMSystemId = vm.ID
+			}
+		}
+	} else {
+		targetVMSystemId = ownerVM.SystemId
+	}
+
+	start := call.Start()
+	err := diskHandler.detachDisk(irs.IID{SystemId: targetDiskSystemId}, irs.IID{SystemId: targetVMSystemId})
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("Failed to Detach Disk. err = %s", err))
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return true, nil
+}
+
+func (diskHandler *ClouditDiskHandler) getExistsDiskName(name string) (bool, error) {
+	if name == "" {
+		return true, errors.New("invalid disk name")
+	}
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+	diskList, err := disk.List(diskHandler.Client, &requestOpts)
+	if err != nil {
+		return true, err
+	}
+	for _, rawDisk := range *diskList {
+		if strings.EqualFold(name, rawDisk.Name) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (diskHandler *ClouditDiskHandler) getRawDisk(diskIId irs.IID) (*disk.DiskInfo, error) {
+	if diskIId.SystemId == "" && diskIId.NameId == "" {
+		return nil, errors.New("invalid IID")
+	}
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+	if diskIId.SystemId == "" {
+		diskList, err := disk.List(diskHandler.Client, &requestOpts)
+		if err != nil {
+			return nil, err
+		}
+		for _, rawDisk := range *diskList {
+			if strings.EqualFold(diskIId.NameId, rawDisk.Name) {
+				return &rawDisk, nil
+			}
+		}
+	} else {
+		return disk.Get(diskHandler.Client, diskIId.SystemId, &requestOpts)
+	}
+
+	return nil, errors.New("cannot find disk")
+}
+
+func (diskHandler *ClouditDiskHandler) updateDisk(diskInfo disk.DiskInfo) (bool, error) {
+	if diskInfo.ID == "" {
+		return false, errors.New("target disk is not specified")
+	}
+
+	diskReqInfo := diskInfo.ToUpdateDiskReqInfo()
+	if diskReqInfo == nil {
+		return false, errors.New("nothings to update")
+	}
+
+	// API call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+		JSONBody:    diskReqInfo,
+	}
+
+	_, err := disk.Update(diskHandler.Client, diskInfo.ID, &requestOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (diskHandler *ClouditDiskHandler) deleteDisk(diskIId irs.IID) (bool, error) {
+	if diskIId.SystemId == "" {
+		return false, errors.New("target disk is not specified")
+	}
+
+	// API call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	err := disk.Delete(diskHandler.Client, diskIId.SystemId, &requestOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (diskHandler *ClouditDiskHandler) attachDisk(diskIID irs.IID, ownerVmIID irs.IID) error {
+	if diskIID.SystemId == "" {
+		return errors.New("cannot specify disk")
+	}
+
+	if ownerVmIID.SystemId == "" {
+		return errors.New("cannot specify owner VM")
+	}
+
+	// API call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	attachDiskReqInfo := disk.DiskReqInfo{
+		ID:   diskIID.SystemId,
+		Mode: "w",
+	}
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+		JSONBody:    attachDiskReqInfo,
+	}
+
+	err := server.AttachVolume(diskHandler.Client, ownerVmIID.SystemId, &requestOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (diskHandler *ClouditDiskHandler) detachDisk(diskIID irs.IID, ownerVmIID irs.IID) error {
+	if diskIID.SystemId == "" {
+		return errors.New("cannot specify disk")
+	}
+
+	if ownerVmIID.SystemId == "" {
+		return errors.New("cannot specify owner VM")
+	}
+
+	// API call prepare
+	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
+	authHeader := diskHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	err := server.DetachVolume(diskHandler.Client, ownerVmIID.SystemId, diskIID.SystemId, &requestOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
@@ -39,7 +39,10 @@ func (diskHandler *ClouditDiskHandler) CreateDisk(DiskReqInfo irs.DiskInfo) (irs
 	// API Call prepare
 	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
 	authHeader := diskHandler.Client.AuthenticatedHeaders()
-	intSize, _ := strconv.Atoi(DiskReqInfo.DiskSize)
+	var intSize = 50
+	if convResult, atoiErr := strconv.Atoi(DiskReqInfo.DiskSize); atoiErr == nil {
+		intSize = convResult
+	}
 	clusterId := ""
 	for _, keyValue := range DiskReqInfo.KeyValueList {
 		if keyValue.Key == "clusterId" {

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/DiskHandler.go
@@ -40,10 +40,19 @@ func (diskHandler *ClouditDiskHandler) CreateDisk(DiskReqInfo irs.DiskInfo) (irs
 	diskHandler.Client.TokenID = diskHandler.CredentialInfo.AuthToken
 	authHeader := diskHandler.Client.AuthenticatedHeaders()
 	intSize, _ := strconv.Atoi(DiskReqInfo.DiskSize)
+	clusterId := ""
+	for _, keyValue := range DiskReqInfo.KeyValueList {
+		if keyValue.Key == "clusterId" {
+			clusterId = keyValue.Value
+		}
+	}
+	if clusterId == "" {
+		return irs.DiskInfo{}, errors.New("Failed to Create Disk. err = clusterId is required.")
+	}
 	reqInfo := disk.DiskReqInfo{
 		Name: DiskReqInfo.IId.NameId,
 		// ToDo: to static value?
-		ClusterId: "8e01e169-8318-4676-b30a-fb339de4b44b",
+		ClusterId: clusterId,
 		Size:      intSize,
 	}
 	requestOpts := client.RequestOpts{

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
@@ -1,0 +1,296 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/server"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"strings"
+)
+
+type ClouditMyImageHandler struct {
+	CredentialInfo idrv.CredentialInfo
+	Client         *client.RestClient
+}
+
+const DEV = "/dev:"
+
+func (myImageHandler *ClouditMyImageHandler) SnapshotVM(snapshotReqInfo irs.MyImageInfo) (irs.MyImageInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "MYIMAGE", "MYIMAGE", "SnapshotVM()")
+
+	var createErr error
+
+	// MyImage 이름 중복 체크
+	exist, err := myImageHandler.getExistMyImageName(snapshotReqInfo.IId.NameId)
+	if exist {
+		createErr = errors.New(fmt.Sprintf("Failed to Create MyImage. err = %s already exist", snapshotReqInfo.IId.NameId))
+		if err != nil {
+			createErr = errors.New(fmt.Sprintf("Failed to Create MyImage. err = %s", err.Error()))
+			cblogger.Error(createErr.Error())
+			LoggingError(hiscallInfo, createErr)
+			return irs.MyImageInfo{}, createErr
+		}
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.MyImageInfo{}, createErr
+	}
+
+	// VM, Volume Snapshot 생성 (실패 시 롤백)
+	start := call.Start()
+	_, createVmSnapshotErr := myImageHandler.createMyImageSnapshots(snapshotReqInfo.IId.NameId, snapshotReqInfo.SourceVM)
+	if createVmSnapshotErr != nil {
+		createErr = createVmSnapshotErr
+		defer func(myImageNameId string) (irs.MyImageInfo, error) {
+			cleanErr := myImageHandler.cleanSnapshotsByMyImage(myImageNameId)
+			if cleanErr != nil {
+				createErr = errors.New(fmt.Sprintf("Failed to Create and Clean MyImage. err = %s", cleanErr.Error()))
+			}
+			if createErr != nil {
+				return irs.MyImageInfo{}, createErr
+			}
+			return irs.MyImageInfo{}, nil
+		}(snapshotReqInfo.IId.NameId)
+	}
+
+	// MyImageInfo 반환
+	myImageInfo, getMyImageInfoErr := myImageHandler.getMyImageInfo(snapshotReqInfo.IId.NameId)
+	if getMyImageInfoErr != nil {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Get MyImage Info. err = %s", getMyImageInfoErr.Error()))
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return myImageInfo, createErr
+}
+
+func (myImageHandler *ClouditMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "MYIMAGE", "MYIMAGE", "ListMyImage()")
+
+	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
+	authHeader := myImageHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	start := call.Start()
+	vmSnapshotList, err := snapshot.List(myImageHandler.Client, &requestOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	groupByMyImageResult := make(map[string][]snapshot.SnapshotInfo)
+	for _, vmSnapshot := range *vmSnapshotList {
+		groupByKey := strings.Split(vmSnapshot.Name, DEV)[0]
+		groupByMyImageResult[groupByKey] = append(groupByMyImageResult[groupByKey], vmSnapshot)
+	}
+
+	var myImageInfoList []*irs.MyImageInfo
+	for _, associcatedSnapshots := range groupByMyImageResult {
+		myImage, toMyImageErr := snapshot.ToIRSMyImage(myImageHandler.Client, &associcatedSnapshots)
+		if toMyImageErr != nil {
+			return nil, toMyImageErr
+		}
+		myImageInfoList = append(myImageInfoList, &myImage)
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return myImageInfoList, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) GetMyImage(myImageIID irs.IID) (irs.MyImageInfo, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "MYIMAGE", "MYIMAGE", "GetMyImage()")
+
+	if myImageIID.NameId == "" {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Get MyImage. err = MyImage Name ID is required"))
+	}
+
+	start := call.Start()
+	myImageList, err := myImageHandler.ListMyImage()
+	if err != nil {
+		return irs.MyImageInfo{}, err
+	}
+
+	for _, myImage := range myImageList {
+		if myImage.IId.NameId == myImageIID.NameId {
+			return *myImage, nil
+		}
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return irs.MyImageInfo{}, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) DeleteMyImage(myImageIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(ClouditRegion, "MYIMAGE", "MYIMAGE", "DeleteMyImage()")
+
+	if myImageIID.NameId == "" {
+		return false, errors.New(fmt.Sprintf("Failed to Delete MyImage. err = MyImage Name ID is required"))
+	}
+
+	start := call.Start()
+	if err := myImageHandler.cleanSnapshotsByMyImage(myImageIID.NameId); err != nil {
+		return false, errors.New(fmt.Sprintf("Failed to Delete MyImage. err = %s", err))
+	}
+	LoggingInfo(hiscallInfo, start)
+
+	return true, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) getRawVmSnapshotList() (*[]snapshot.SnapshotInfo, error) {
+	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
+	authHeader := myImageHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	vmSnapshotList, err := snapshot.List(myImageHandler.Client, &requestOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	var rawVmSnapshotList []snapshot.SnapshotInfo
+	for _, rawSnapshot := range *vmSnapshotList {
+		if strings.EqualFold("yes", rawSnapshot.Bootable) {
+			rawVmSnapshotList = append(rawVmSnapshotList, rawSnapshot)
+		}
+	}
+
+	return &rawVmSnapshotList, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) getExistMyImageName(myImageNameId string) (bool, error) {
+	if myImageNameId == "" {
+		return false, errors.New("MyImage Name ID is required")
+	}
+
+	rawVmSnapshotList, err := myImageHandler.getRawVmSnapshotList()
+	if err != nil {
+		return false, err
+	}
+
+	for _, rawVmSnapshot := range *rawVmSnapshotList {
+		if strings.EqualFold(myImageNameId, strings.Split(rawVmSnapshot.Name, DEV)[0]) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) createMyImageSnapshots(myImageNameId string, sourceVm irs.IID) (irs.MyImageInfo, error) {
+	// Find VM root volume
+	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
+	authHeader := myImageHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	if sourceVm.SystemId == "" {
+		if sourceVm.NameId == "" {
+			return irs.MyImageInfo{}, errors.New("SourceVM Name ID or System ID is required")
+		}
+		if strings.Contains(sourceVm.NameId, DEV) {
+			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("SourceVM Name ID cannot include reserved string: %s", DEV))
+		}
+		serverList, err := server.List(myImageHandler.Client, &requestOpts)
+		if err != nil {
+			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to get VM List. err = %s", err))
+		}
+		founded := false
+		for _, server := range *serverList {
+			if server.Name == sourceVm.NameId {
+				sourceVm.SystemId = server.ID
+				founded = true
+				break
+			}
+		}
+		if !founded {
+			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("SourceVM with Name ID: %s does not exists", sourceVm.NameId))
+		}
+	}
+
+	vmVolumeList, err := server.GetRawVmVolumes(myImageHandler.Client, sourceVm.SystemId, &requestOpts)
+	if err != nil {
+		return irs.MyImageInfo{}, errors.New("Failed to get VM attached volumes")
+	}
+
+	// Create snapshot of every volume associated with VM
+	for _, vmVolume := range *vmVolumeList {
+		myImageNameIdWithDev := fmt.Sprintf("%s%s%s", myImageNameId, DEV, vmVolume.Dev)
+		if len(myImageNameIdWithDev) > 45 {
+			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Snapshot name cannot be longer than 45. Generated name: %s", myImageNameIdWithDev))
+		}
+		snapshotCreateReqInfo := snapshot.SnapshotReqInfo{
+			Name:     myImageNameIdWithDev,
+			VolumeId: vmVolume.ID,
+		}
+		snapshotCreateRequestOpts := client.RequestOpts{
+			MoreHeaders: authHeader,
+			JSONBody:    snapshotCreateReqInfo,
+		}
+		_, createSnapshotErr := snapshot.CreateSnapshot(myImageHandler.Client, &snapshotCreateRequestOpts)
+		if createSnapshotErr != nil {
+			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Create MyImage. err = %s", createSnapshotErr.Error()))
+		}
+	}
+
+	// Get MyImageInfo
+	result, getResultErr := myImageHandler.getMyImageInfo(myImageNameId)
+	if getResultErr != nil {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Get Create MyImage Result. err = %s", getResultErr.Error()))
+	}
+
+	return result, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) getMyImageInfo(myImageNameId string) (irs.MyImageInfo, error) {
+	// Get status of all associated snapshot and gather into MyImageInfo
+	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
+	authHeader := myImageHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+	snapshotList, err := snapshot.List(myImageHandler.Client, &requestOpts)
+	if err != nil {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Get MyImage. err = %s", err.Error()))
+	}
+
+	var associatedSnapshots []snapshot.SnapshotInfo
+	for _, snapshot := range *snapshotList {
+		if strings.Split(snapshot.Name, DEV)[0] == myImageNameId {
+			associatedSnapshots = append(associatedSnapshots, snapshot)
+		}
+	}
+
+	myImageInfo, err := snapshot.ToIRSMyImage(myImageHandler.Client, &associatedSnapshots)
+	if err != nil {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Failed to Get MyImage. err = %s", err.Error()))
+	}
+
+	return myImageInfo, nil
+}
+
+func (myImageHandler *ClouditMyImageHandler) cleanSnapshotsByMyImage(myImageNameId string) error {
+	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
+	authHeader := myImageHandler.Client.AuthenticatedHeaders()
+	requestOpts := client.RequestOpts{
+		MoreHeaders: authHeader,
+	}
+
+	rawVmSnapshotList, err := snapshot.List(myImageHandler.Client, &requestOpts)
+	if err != nil {
+		return err
+	}
+
+	for _, rawVmSnapshot := range *rawVmSnapshotList {
+		parsed := strings.Split(rawVmSnapshot.Name, DEV)[0]
+		if parsed == myImageNameId {
+			snapshot.DeleteSnapshot(myImageHandler.Client, rawVmSnapshot.Id, &requestOpts)
+		}
+	}
+
+	return nil
+}

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
@@ -190,6 +190,10 @@ func (myImageHandler *ClouditMyImageHandler) getExistMyImageName(myImageNameId s
 }
 
 func (myImageHandler *ClouditMyImageHandler) createMyImageSnapshots(myImageNameId string, sourceVm irs.IID) (irs.MyImageInfo, error) {
+	if len(myImageNameId) > 35 {
+		return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Snapshot name cannot be longer than 35"))
+	}
+
 	// Find VM root volume
 	myImageHandler.Client.TokenID = myImageHandler.CredentialInfo.AuthToken
 	authHeader := myImageHandler.Client.AuthenticatedHeaders()
@@ -229,9 +233,6 @@ func (myImageHandler *ClouditMyImageHandler) createMyImageSnapshots(myImageNameI
 	// Create snapshot of every volume associated with VM
 	for _, vmVolume := range *vmVolumeList {
 		myImageNameIdWithDev := fmt.Sprintf("%s%s%s", myImageNameId, DEV, vmVolume.Dev)
-		if len(myImageNameIdWithDev) > 45 {
-			return irs.MyImageInfo{}, errors.New(fmt.Sprintf("Snapshot name cannot be longer than 45. Generated name: %s", myImageNameIdWithDev))
-		}
 		snapshotCreateReqInfo := snapshot.SnapshotReqInfo{
 			Name:     myImageNameIdWithDev,
 			VolumeId: vmVolume.ID,

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -13,6 +13,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/cloudit/client/ace/snapshot"
 	"strconv"
 	"strings"
 	"time"
@@ -66,17 +67,33 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 		return irs.VMInfo{}, createErr
 	}
 
-	// 이미지 정보 조회 (Name)
+	// 이미지, MyImage 정보 조회 (Name)
 	imageHandler := ClouditImageHandler{
 		Client:         vmHandler.Client,
 		CredentialInfo: vmHandler.CredentialInfo,
 	}
-	image, err := imageHandler.GetImage(vmReqInfo.ImageIID)
-	if err != nil {
-		createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = Failed to get image, %s", err.Error()))
+	myImageHandler := ClouditMyImageHandler{
+		Client:         vmHandler.Client,
+		CredentialInfo: vmHandler.CredentialInfo,
+	}
+	image, getImageErr := imageHandler.GetImage(vmReqInfo.ImageIID)
+	myImage, getMyImageErr := myImageHandler.GetMyImage(vmReqInfo.ImageIID)
+	if getImageErr != nil && getMyImageErr != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = Failed to get image, %s", getImageErr.Error()+getMyImageErr.Error()))
 		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
 		return irs.VMInfo{}, createErr
+	} else if getImageErr == nil && getMyImageErr == nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = Ambigous image ID, %s", vmReqInfo.ImageIID))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.VMInfo{}, createErr
+	}
+	if getImageErr == nil && myImage.Status != irs.MyImageAvailable {
+		getImageErr = errors.New("Failed to Create VM. err = Given MyImage is not Available")
+		cblogger.Error(getImageErr.Error())
+		LoggingError(hiscallInfo, getImageErr)
+		return irs.VMInfo{}, getImageErr
 	}
 
 	//  네트워크 정보 조회 (Name)
@@ -139,15 +156,38 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 	vmHandler.Client.TokenID = vmHandler.CredentialInfo.AuthToken
 	authHeader := vmHandler.Client.AuthenticatedHeaders()
 	KeyPairDes := fmt.Sprintf("keypair:%s", vmReqInfo.KeyPairIID.NameId)
-	reqInfo := server.VMReqInfo{
-		TemplateId:   image.IId.SystemId,
-		SpecId:       *vmSpecId,
-		Name:         vmReqInfo.IId.NameId,
-		HostName:     vmReqInfo.IId.NameId,
-		RootPassword: VMDefaultPassword,
-		SubnetAddr:   subnet.Addr,
-		Secgroups:    addUserSSHSG,
-		Description:  KeyPairDes,
+	var reqInfo server.VMReqInfo
+	if getImageErr == nil {
+		reqInfo = server.VMReqInfo{
+			TemplateId:   image.IId.SystemId,
+			SpecId:       *vmSpecId,
+			Name:         vmReqInfo.IId.NameId,
+			HostName:     vmReqInfo.IId.NameId,
+			RootPassword: VMDefaultPassword,
+			SubnetAddr:   subnet.Addr,
+			Secgroups:    addUserSSHSG,
+			Description:  KeyPairDes,
+		}
+	} else if getMyImageErr == nil {
+		snapshotReqOpts := client.RequestOpts{
+			MoreHeaders: authHeader,
+		}
+		snapshot, getSnapshotErr := snapshot.Get(myImageHandler.Client, myImage.IId.SystemId, &snapshotReqOpts)
+		if getSnapshotErr != nil {
+			return irs.VMInfo{}, errors.New(fmt.Sprintf("Failed to Create VM. err = %s", getSnapshotErr.Error()))
+		}
+
+		reqInfo = server.VMReqInfo{
+			TemplateId:   snapshot.TemplateId,
+			SnapshotId:   myImage.IId.SystemId,
+			SpecId:       *vmSpecId,
+			Name:         vmReqInfo.IId.NameId,
+			HostName:     vmReqInfo.IId.NameId,
+			RootPassword: VMDefaultPassword,
+			SubnetAddr:   subnet.Addr,
+			Secgroups:    addUserSSHSG,
+			Description:  KeyPairDes,
+		}
 	}
 
 	requestOpts := client.RequestOpts{
@@ -254,7 +294,7 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 
 	// 사용자 등록 및 sudoer 권한 추가
 	_, err = RunCommand(vm.AdaptiveIp, SSHDefaultPort, VMDefaultUser, VMDefaultPassword, fmt.Sprintf("useradd -s /bin/bash %s -rm", loginUserId))
-	if err != nil {
+	if err != nil && getImageErr == nil {
 		createErr = errors.New(fmt.Sprintf("Failed to Create VM. err = %s = %s", createUserErr.Error(), err.Error()))
 		cblogger.Error(createErr.Error())
 		LoggingError(hiscallInfo, createErr)
@@ -348,6 +388,26 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 		LoggingError(hiscallInfo, createErr)
 		return irs.VMInfo{}, createErr
 	}
+
+	// MyImage로 VM 생성 시, 볼륨 스냅샷으로 볼륨을 생성하고 attach
+	if getMyImageErr == nil {
+		isFailed := false
+		if createVolumeErr := myImageHandler.CreateAssociatedVolumeSnapshots(myImage.IId.NameId, vm.Name); createVolumeErr != nil {
+			isFailed = true
+		}
+		if volumeAttachError := myImageHandler.AttachAssociatedVolumesToVM(myImage.IId.NameId, vm.ID); volumeAttachError != nil {
+			isFailed = true
+		}
+		if isFailed {
+			defer func() {
+				cleanerErr := vmHandler.vmCleaner(cleanVMIID)
+				if cleanerErr != nil {
+					createError = errors.New(fmt.Sprintf("%s and Failed to rollback err = %s", createError.Error(), cleanerErr.Error()))
+				}
+			}()
+		}
+	}
+
 	vmInfo, err := vmHandler.mappingServerInfo(*vm)
 	if err != nil {
 		createErr = errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))


### PR DESCRIPTION
[Cloudit] DiskHandler, MyImageHandler 기능 구현

- Cloudit DiskHandler 기능 구현
    -  Cloudit은 Disk Size가 지정되지 않을 경우 오류를 반환하므로, Disk Size가 지정되지 않은 경우 50Gb로 설정하도록 하였습니다.
    - Cloudit은 Disk를 생성할 Cluster ID를 지정하지 않을 경우 오류를 반환하므로, DiskHandler::CreateDisk의 DiskReqInfo 파라메터에 Key-Value 형태로 Cluster ID를 전달받도록 하였습니다.
    
- Cloudit MyImageHandler 기능 구현
    - Cloudit은 VM + Data Disk를 조합한 단일 이미지를 생성하는 기능을 제공하지 않으므로, VM과 Data Disk들의 스냅샷을 생성하고, 생성된 스냅샷들을 MyImage와 연결할 수 있는 메타데이터를 스냅샷 이름에 저장하도록 하였습니다.
    - 상기 과정에서 스냅샷의 이름이 자동으로 생성되며, 메타데이터를 저장할 공간을 확보하기 위하여 MyImage의 이름의 길이를 최대 35자로 제한하였습니다.

- Cloudit MyImage to VM 기능 구현