### PR TITLE
Update NHN Cloud conn. driver build script - Remove go get nhncloud repo.

### DIFF
--- a/utils/driver-build-docker/2.build/nhncloud-build.sh
+++ b/utils/driver-build-docker/2.build/nhncloud-build.sh
@@ -20,7 +20,6 @@ cd $CBSPIDER_ROOT
 
 echo "# env GIT_TERMINAL_PROMPT=1 GOPRIVATE=github.com/cloud-barista go get -v github.com/cloud-barista/nhncloud-sdk-for-drv@latest"
 env GIT_TERMINAL_PROMPT=1 GOPRIVATE=github.com/cloud-barista go get -v github.com/cloud-barista/nhncloud-sdk-for-drv@latest
-env GIT_TERMINAL_PROMPT=1 GOPRIVATE=github.com/cloud-barista go get -v github.com/cloud-barista/nhncloud@latest
 
 cd $HOME
 


### PR DESCRIPTION
- Update NHN Cloud connection driver build script - Remove go get nhncloud repo.
  - Related Issue) https://github.com/cloud-barista/nhncloud/issues/101
  - Related PR) https://github.com/cloud-barista/nhncloud/pull/107