### PR TITLE
[IBM-VPC] Disk 기능시험 결과 오류 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
@@ -100,6 +100,10 @@ type Config struct {
 					NameId   string `yaml:"nameId"`
 					SystemId string `yaml:"systemId"`
 				} `yaml:"SecurityGroupIIDs"`
+				DataDiskIIDs []struct {
+					NameId   string `yaml:"nameId"`
+					SystemId string `yaml:"systemId"`
+				} `yaml:"DataDiskIIDs"`
 			} `yaml:"vm"`
 			VmFromMyImage struct {
 				IID struct {
@@ -750,6 +754,10 @@ func testVMHandler(config Config) {
 	for _, sg := range configsgIIDs {
 		SecurityGroupIIDs = append(SecurityGroupIIDs, irs.IID{NameId: sg.NameId})
 	}
+	var vmDataDiskIIDs []irs.IID
+	for _, dataDisk := range config.IbmVPC.Resources.Vm.DataDiskIIDs {
+		vmDataDiskIIDs = append(vmDataDiskIIDs, irs.IID{NameId: dataDisk.NameId})
+	}
 	vmIID := irs.IID{
 		NameId: config.IbmVPC.Resources.Vm.IID.NameId,
 	}
@@ -773,6 +781,7 @@ func testVMHandler(config Config) {
 		SecurityGroupIIDs: SecurityGroupIIDs,
 		RootDiskSize:      "",
 		RootDiskType:      "",
+		DataDiskIIDs:      vmDataDiskIIDs,
 	}
 	vmFromSnapshotReqInfo := irs.VMReqInfo{
 		IId: irs.IID{

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/DiskHandler.go
@@ -33,7 +33,7 @@ func (diskHandler *IbmDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.Dis
 		// set default capacity as minimum
 		ptrCapacity = core.Int64Ptr(50)
 	}
-	if &diskReqInfo.DiskType == nil || diskReqInfo.DiskType == "" {
+	if &diskReqInfo.DiskType == nil || diskReqInfo.DiskType == "" || diskReqInfo.DiskType == "default" {
 		// set default type as least performance
 		diskReqInfo.DiskType = "general-purpose"
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMHandler.go
@@ -1206,6 +1206,15 @@ func (vmHandler *IbmVMHandler) getNetworkInfo(instance vpcv1.Instance) vmNetwork
 }
 
 func (vmHandler *IbmVMHandler) setVmInfo(instance vpcv1.Instance) (irs.VMInfo, error) {
+	var dataDiskIIDs []irs.IID
+	for _, rawDataDisk := range instance.VolumeAttachments {
+		if *rawDataDisk.Volume.ID != *instance.BootVolumeAttachment.Volume.ID {
+			dataDiskIIDs = append(dataDiskIIDs, irs.IID{
+				NameId:   *rawDataDisk.Volume.Name,
+				SystemId: *rawDataDisk.Volume.ID,
+			})
+		}
+	}
 	vmInfo := irs.VMInfo{
 		IId: irs.IID{
 			NameId:   *instance.Name,
@@ -1229,6 +1238,7 @@ func (vmHandler *IbmVMHandler) setVmInfo(instance vpcv1.Instance) (irs.VMInfo, e
 		VMUserId:       CBDefaultVmUserName,
 		RootDeviceName: "Not visible in IBMCloud-VPC",
 		VMBlockDisk:    "Not visible in IBMCloud-VPC",
+		DataDiskIIDs:   dataDiskIIDs,
 	}
 	chanCount := 0
 	// KeyGet


### PR DESCRIPTION
- Disk Type이 default일 경우, 기본값이 적용되지 않는 오류 수정
- VM 생성 시, 지정한 데이터 디스크를 장착하는 기능 추가
- VM 조회 시, 장착된 데이터 디스크의 정보를 반환하도록 수정