### PR TITLE
[Azure]NLB HealthCheck Test 버그 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
@@ -1548,8 +1548,8 @@ func checkValidationNLB(nlbReqInfo irs.NLBInfo) error {
 }
 
 func checkValidationNLBHealthCheck(healthCheckerInfo irs.HealthCheckerInfo) error {
-	// default 0, Not -1
-	if !(healthCheckerInfo.Timeout == 0 || healthCheckerInfo.Timeout == -1) {
+	// Not -1
+	if healthCheckerInfo.Timeout != -1 {
 		return errors.New(fmt.Sprintf("Azure NLB does not support timeout."))
 	}
 	if healthCheckerInfo.Interval < 5 {

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
@@ -53,7 +53,13 @@ const (
 func (nlbHandler *AzureNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB irs.NLBInfo, createError error) {
 	hiscallInfo := GetCallLogScheme(nlbHandler.Region, "NETWORKLOADBALANCE", nlbReqInfo.IId.NameId, "CreateNLB()")
 	start := call.Start()
-
+	err := checkValidationNLB(nlbReqInfo)
+	if err != nil {
+		createError = errors.New(fmt.Sprintf("Failed to Create NLB. err = %s", err.Error()))
+		cblogger.Error(createError)
+		LoggingError(hiscallInfo, createError)
+		return irs.NLBInfo{}, createError
+	}
 	exist, err := nlbHandler.existNLB(nlbReqInfo.IId)
 	if err != nil {
 		createError = errors.New(fmt.Sprintf("Failed to Create NLB. err = %s", err.Error()))
@@ -770,6 +776,13 @@ func (nlbHandler *AzureNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs.Hea
 func (nlbHandler *AzureNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, healthChecker irs.HealthCheckerInfo) (irs.HealthCheckerInfo, error) {
 	hiscallInfo := GetCallLogScheme(nlbHandler.Region, "NETWORKLOADBALANCE", nlbIID.NameId, "ChangeHealthCheckerInfo()")
 	start := call.Start()
+	err := checkValidationNLBHealthCheck(healthChecker)
+	if err != nil {
+		changeErr := errors.New(fmt.Sprintf("Failed to ChangeHealthCheckerInfo NLB. err = %s", err.Error()))
+		cblogger.Error(changeErr.Error())
+		LoggingError(hiscallInfo, changeErr)
+		return irs.HealthCheckerInfo{}, changeErr
+	}
 	nlb, err := nlbHandler.getRawNLB(nlbIID)
 	if err != nil {
 		changeErr := errors.New(fmt.Sprintf("Failed to ChangeHealthCheckerInfo NLB. err = %s", err.Error()))
@@ -1255,7 +1268,7 @@ func (nlbHandler *AzureNLBHandler) getLoadBalancingRuleInfoByNLB(nlb network.Loa
 	for _, probe := range Probes {
 		if *probe.ID == probeId {
 			// Azure not support
-			healthCheckerInfo.Timeout = 0
+			healthCheckerInfo.Timeout = -1
 			healthCheckerInfo.Threshold = int(*probe.NumberOfProbes)
 			healthCheckerInfo.Interval = int(*probe.IntervalInSeconds)
 			healthCheckerInfo.Port = strconv.Itoa(int(*probe.Port))
@@ -1527,4 +1540,26 @@ func convertListenerInfoProtocolsToInboundRuleProtocol(protocol string) (network
 		return network.TransportProtocolUDP, nil
 	}
 	return "", errors.New("invalid Protocols")
+}
+
+func checkValidationNLB(nlbReqInfo irs.NLBInfo) error {
+	err := checkValidationNLBHealthCheck(nlbReqInfo.HealthChecker)
+	return err
+}
+
+func checkValidationNLBHealthCheck(healthCheckerInfo irs.HealthCheckerInfo) error {
+	// default 0, Not -1
+	if !(healthCheckerInfo.Timeout == 0 || healthCheckerInfo.Timeout == -1) {
+		return errors.New(fmt.Sprintf("Azure NLB does not support timeout."))
+	}
+	if healthCheckerInfo.Interval < 5 {
+		return errors.New("invalid HealthCheckerInfo Interval, interval must be greater than 5")
+	}
+	if healthCheckerInfo.Threshold < 1 {
+		return errors.New("invalid HealthCheckerInfo Threshold, Threshold  must be greater than 1")
+	}
+	if healthCheckerInfo.Interval*healthCheckerInfo.Threshold > 2147483647 {
+		return errors.New("invalid HealthCheckerInfo Interval * Threshold must be between 5 and 2147483647 ")
+	}
+	return nil
 }


### PR DESCRIPTION
CB-Spider-API-CSP적용-가능여부-및-이슈-2차분석-2022.07.11 버그 수정(#791)
Azure HealthCheck TimeOut 값 유효성 체크 추가/ CreateNLB, ChangeHealthCheckerInfo

Timeout 0, -1 일 경우만 생성되도록 변경 => 값 -1로 리턴
Timeout 0, -1 이 아닌 경우 (예제의 '10'같은 경우) => 에러 리턴 {"message":"Failed to Create NLB. err = Azure NLB does not support timeout."}

=>

[오후 2:11:31]    ==> {"message":"Failed to Create NLB. err = Azure NLB does not support timeout."}

CB-Spider-API-CSP적용-가능여부-및-이슈-2차분석-2022.07.11 버그 수정

Azure HealthCheck TimeOut 값 유효성 체크 추가/ CreateNLB, ChangeHealthCheckerInfo

Timeout -1 일 경우만 생성되도록 변경 => 값 -1로 리턴
Timeout -1 이 아닌 경우 (예제의 '10'같은 경우) => 에러 리턴 {"message":"Failed to Create NLB. err = Azure NLB does not support timeout."}
