### PR TITLE
[Alibaba] VM Snapshot 과정 중 Timeout 이슈 보완

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
@@ -3,15 +3,16 @@ package resources
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/davecgh/go-spew/spew"
-	"reflect"
-	"strings"
-	"time"
 )
 
 //// Alibaba API 1:1로 대응
@@ -435,7 +436,7 @@ func WaitForImageStatus(client *ecs.Client, regionInfo idrv.RegionInfo, imageIID
 	//cblogger.Info("======> MyImage 생성 직후에는 정보 조회가 안되기 때문에 원하는 상태(ex.Available) 될 때까지 대기함.")
 
 	curRetryCnt := 0
-	maxRetryCnt := 120
+	maxRetryCnt := 600
 
 	targetStatus := ""
 	failStatus := ALIBABA_IMAGE_STATE_ERROR

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
@@ -3,12 +3,13 @@ package resources
 // https://www.alibabacloud.com/help/en/elastic-compute-service/latest/deleteimage
 
 import (
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
-	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
 type AlibabaMyImageHandler struct {
@@ -68,6 +69,10 @@ func (myImageHandler AlibabaMyImageHandler) SnapshotVM(snapshotReqInfo irs.MyIma
 	curStatus, errStatus := WaitForImageStatus(myImageHandler.Client, myImageHandler.Region, imageIID, "")
 	if errStatus != nil {
 		cblogger.Error(errStatus)
+		_, deleteErr := myImageHandler.DeleteMyImage(imageIID)
+		if deleteErr != nil { // 중간 생성 자원 삭제 실패
+			return irs.MyImageInfo{}, deleteErr
+		}
 		return irs.MyImageInfo{}, errStatus
 	}
 	cblogger.Info("==>생성된 Image[%s]의 현재 상태[%s]", imageIID, curStatus)
@@ -116,13 +121,13 @@ func (myImageHandler AlibabaMyImageHandler) GetMyImage(myImageIID irs.IID) (irs.
 func (myImageHandler AlibabaMyImageHandler) DeleteMyImage(myImageIID irs.IID) (bool, error) {
 
 	// 상태체크해서 available일 때 삭제
-	imageStatus, err := DescribeImageStatus(myImageHandler.Client, myImageHandler.Region, myImageIID, ALIBABA_IMAGE_STATE_AVAILABLE)
-	if err != nil {
-		cblogger.Info("DeleteMyImage : status " + imageStatus)
-		return false, err
-	}
+	// imageStatus, err := DescribeImageStatus(myImageHandler.Client, myImageHandler.Region, myImageIID, ALIBABA_IMAGE_STATE_AVAILABLE)
+	// if err != nil {
+	// 	cblogger.Info("DeleteMyImage : status " + imageStatus)
+	// 	return false, err
+	// }
 
-	cblogger.Info("DeleteMyImage : status " + imageStatus)
+	// cblogger.Info("DeleteMyImage : status " + imageStatus)
 	request := ecs.CreateDeleteImageRequest()
 	request.Scheme = "https"
 	// 필수 Req Name


### PR DESCRIPTION
**[Alibaba] Check remained resources when vm snapshot timeout**(https://github.com/cloud-barista/cb-spider/issues/790) 

**[120s timeout의 적합성 확인]**

- 대기 시간을 600s로 재설정

**[오류 발생 시 중간 생성 자원 삭제]**

- Timeout 발생 시 생성 중인 MyImage 삭제 로직 추가