### PR TITLE
[Tencent] Debian OS cb-user permission denied 이슈 보완

### DIFF
--- a/cloud-driver-libs/.cloud-init-tencent/cloud-init
+++ b/cloud-driver-libs/.cloud-init-tencent/cloud-init
@@ -2,6 +2,7 @@
 #### add Cloud-Barista user
 useradd -s /bin/bash cb-user -rm -G sudo;
 mkdir /home/cb-user/.ssh; 
-curl -s http://169.254.0.23/latest/meta-data/public-keys/0/openssh-key > /home/cb-user/.ssh/authorized_keys;
+cp -r /root/.ssh/ /home/cb-user/;
+cp -r /home/ubuntu/.ssh/ /home/cb-user/;
 chown -R cb-user:cb-user /home/cb-user;
 echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;


### PR DESCRIPTION
[Tencent] Debian OS cb-user permission denied 이슈 보완

기존 cloud-init의 경우 cb-user의 ssh key 파일 정보 조회를 curl을 이용해서 인스턴스의 메타 정보를 조회하는 방식입니다.

curl -s http://169.254.0.23/latest/meta-data/public-keys/0/openssh-key

하지만, Debian OS의 경우 curl이 없기 때문에 ssh key 파일을 조회할 수 없어서 임시 방편으로 OS 계정에 있는 .ssh파일을 복제하는 방식으로 수정했습니다.

텐센트의 경우 대부분의 Linux 계정은 root 이지만 Ubuntu의 경우 ubuntu를 사용하기 때문에 아래처럼 반영했습니다.

cp -r /root/.ssh/ /home/cb-user/;
cp -r /home/ubuntu/.ssh/ /home/cb-user/;

os에 따라서는 해당 계정 폴더가 없어서 cloud-init 로그에 에러는 발생하겠지만 Debian과 Ubuntu 모두 정상 동작하는 것을 확인했습니다.