### PR TITLE
[Alibaba] 버그 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/pmks_test/ClusterHandler_test.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/pmks_test/ClusterHandler_test.go
@@ -245,9 +245,9 @@ func TestAddNodeGroupTokyo(t *testing.T) {
 		RootDiskSize:    "70",
 		KeyPairIID:      irs.IID{NameId: "kp1", SystemId: ""},
 		OnAutoScaling:   true,
-		DesiredNodeSize: 0, // not supported.
-		MinNodeSize:     2,
-		MaxNodeSize:     2,
+		DesiredNodeSize: 2,
+		MinNodeSize:     1,
+		MaxNodeSize:     3,
 	}
 
 	clusters, _ := clusterHandler.ListCluster()
@@ -303,7 +303,7 @@ func TestAddNodeGroupTokyo(t *testing.T) {
 // 	println(node_group.IId.NameId)
 // }
 
-func TestSetNodeGroupAutoScaling(t *testing.T) {
+func TestSetNodeGroupAutoScalingOn(t *testing.T) {
 	clusterHandler, err := getClusterHandler()
 	if err != nil {
 		t.Error(err)
@@ -323,6 +323,26 @@ func TestSetNodeGroupAutoScaling(t *testing.T) {
 	}
 }
 
+func TestSetNodeGroupAutoScalingOff(t *testing.T) {
+	clusterHandler, err := getClusterHandler()
+	if err != nil {
+		t.Error(err)
+	}
+
+	clusters, _ := clusterHandler.ListCluster()
+	for _, cluster := range clusters {
+		// node_groups, _ := clusterHandler.ListNodeGroup(cluster.IId)
+		// for _, node_group := range node_groups {
+		for _, node_group_info := range cluster.NodeGroupList {
+			res, err := clusterHandler.SetNodeGroupAutoScaling(cluster.IId, node_group_info.IId, false)
+			if err != nil {
+				t.Error(err)
+			}
+			println(res)
+		}
+	}
+}
+
 func TestChangeNodeGroupScaling(t *testing.T) {
 	clusterHandler, err := getClusterHandler()
 	if err != nil {
@@ -332,7 +352,7 @@ func TestChangeNodeGroupScaling(t *testing.T) {
 	clusters, _ := clusterHandler.ListCluster()
 	for _, cluster := range clusters {
 		for _, node_group_info := range cluster.NodeGroupList {
-			res, err := clusterHandler.ChangeNodeGroupScaling(cluster.IId, node_group_info.IId, 1, 0, 5)
+			res, err := clusterHandler.ChangeNodeGroupScaling(cluster.IId, node_group_info.IId, 0, 1, 2)
 			if err != nil {
 				t.Error(err)
 			}

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/main/pmks_test/ClusterHandler_test.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/main/pmks_test/ClusterHandler_test.go
@@ -91,7 +91,7 @@ func TestCreateClusterOnlyAtTokyo(t *testing.T) {
 
 	clusterInfo := irs.ClusterInfo{
 		IId: irs.IID{
-			NameId:   "cluster-tokyo",
+			NameId:   "cluster-tokyo2",
 			SystemId: "",
 		},
 		Version: "1.22.15-aliyun.1",

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -562,7 +562,9 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 	nodes := nodes_json_obj["nodes"].([]interface{})
 	for _, node := range nodes {
 		node_id := node.(map[string]interface{})["instance_id"].(string)
-		nodeGroupInfo.Nodes = append(nodeGroupInfo.Nodes, irs.IID{NameId: "", SystemId: node_id})
+		if node_id != "" {
+			nodeGroupInfo.Nodes = append(nodeGroupInfo.Nodes, irs.IID{NameId: "", SystemId: node_id})
+		}
 	}
 
 	return nodeGroupInfo, err

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -533,9 +533,10 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 		OnAutoScaling:   node_group_json_obj["auto_scaling"].(map[string]interface{})["enable"].(bool),
 		MinNodeSize:     int(node_group_json_obj["auto_scaling"].(map[string]interface{})["min_instances"].(float64)),
 		MaxNodeSize:     int(node_group_json_obj["auto_scaling"].(map[string]interface{})["max_instances"].(float64)),
-		DesiredNodeSize: 0, // not supported in alibaba
-		Nodes:           []irs.IID{},
-		KeyValueList:    []irs.KeyValue{},
+		DesiredNodeSize: -1, // Parameter desired_size/count setting or modification is not supported for autoscaling-enabled nodepool
+
+		Nodes:        []irs.IID{},
+		KeyValueList: []irs.KeyValue{},
 	}
 
 	// k,v 추출 & 추가
@@ -649,7 +650,7 @@ func getNodeGroupJSONString(clusterHandler *AlibabaClusterHandler, clusterIID ir
 	enable := nodeGroupReqInfo.OnAutoScaling
 	max_instances := nodeGroupReqInfo.MaxNodeSize
 	min_instances := nodeGroupReqInfo.MinNodeSize
-	// desired_instances := nodeGroupReqInfo.DesiredNodeSize // not supported in alibaba
+	//desired_instances := nodeGroupReqInfo.DesiredNodeSize
 	instance_type := nodeGroupReqInfo.VMSpecName
 	key_pair := nodeGroupReqInfo.KeyPairIID.NameId
 	system_disk_category := nodeGroupReqInfo.RootDiskType
@@ -682,7 +683,7 @@ func getNodeGroupJSONString(clusterHandler *AlibabaClusterHandler, clusterIID ir
 			"enable": %t,
 			"max_instances": %d,
 			"min_instances": %d
-		},
+		},		
 		"scaling_group": {
 			"instance_types": ["%s"],
 			"key_pair": "%s",

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/utils/alibaba/alibaba_api.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/utils/alibaba/alibaba_api.go
@@ -11,6 +11,8 @@
 package alibaba
 
 import (
+	"strings"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -254,10 +256,18 @@ func DeleteNodeGroup(access_key string, access_secret string, region_id string, 
 	request.Headers["Content-Type"] = "application/json"
 	request.QueryParams["force"] = "true"
 
-	_, _ = client.ProcessCommonRequest(request) // force option은 두번 실행해야 삭제됨
+	// 노드그룹을 삭제 또는 오토스케일러 변경을 최초 호출하면 에러가 발생한다.
+	// 어떻게 하면 좋은가?
+	// 첫번째 호출에서 에러가 없으면 리턴! // 최초 호출이 아닌 경우
+	// 첫번째 호출에서 에러 발생하면 한번 더 호출! // 최초 호출인 경우
 	response, err := client.ProcessCommonRequest(request)
 	if err != nil {
-		return "", err
+		if strings.EqualFold(err.Error(), "cluster-autoscaler") {
+			response, err = client.ProcessCommonRequest(request)
+			if err != nil {
+				return "", err
+			}
+		}
 	}
 
 	return response.GetHttpContentString(), nil
@@ -280,15 +290,20 @@ func ModifyNodeGroup(access_key string, access_secret string, region_id string, 
 	request.Version = "2015-12-15"
 	request.PathPattern = "/clusters/" + cluster_id + "/nodepools/" + nodepool_id
 	request.Headers["Content-Type"] = "application/json"
-
-	// body := `{"auto_scaling":{"enable":false}}`
-	// body := `{"auto_scaling":{"enable":true}}`
-	// body := `{"auto_scaling":{"max_instances":5,"min_instances":0},"scaling_group":{"desired_size":2}}`
 	request.Content = []byte(body)
 
+	// 노드그룹을 삭제 또는 오토스케일러 변경을 최초 호출하면 에러가 발생한다.
+	// 어떻게 하면 좋은가?
+	// 첫번째 호출에서 에러가 없으면 리턴! // 최초 호출이 아닌 경우
+	// 첫번째 호출에서 에러 발생하면 한번 더 호출! // 최초 호출인 경우
 	response, err := client.ProcessCommonRequest(request)
 	if err != nil {
-		return "", err
+		if strings.EqualFold(err.Error(), "cluster-autoscaler") {
+			response, err = client.ProcessCommonRequest(request)
+			if err != nil {
+				return "", err
+			}
+		}
 	}
 
 	return response.GetHttpContentString(), nil

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -550,7 +550,9 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 	}
 	for _, node := range nodes.Response.InstanceSet {
 		if node_group_id == *node.NodePoolId {
-			nodeGroupInfo.Nodes = append(nodeGroupInfo.Nodes, irs.IID{NameId: "", SystemId: *node.InstanceId})
+			if *node.InstanceId != "" {
+				nodeGroupInfo.Nodes = append(nodeGroupInfo.Nodes, irs.IID{NameId: "", SystemId: *node.InstanceId})
+			}
 		}
 	}
 


### PR DESCRIPTION
- 노드그룹 최초 삭제, 변경시 발생하는 에러 핸들링 코드 추가
- 노드가 추가/삭제 중인경우에 노드 ID가 빈 문자열로 조회되는 경우, 노드정보에 추가하지 않도록 변경