### PR TITLE
[Azure] WindowOS 지원

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
@@ -56,6 +56,7 @@ type AzureCloudConnection struct {
 	AgentPoolsClient                *containerservice.AgentPoolsClient
 	VirtualMachineScaleSetsClient   *compute.VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient
+	VirtualMachineRunCommandsClient *compute.VirtualMachineRunCommandsClient
 }
 
 func (cloudConn *AzureCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
@@ -103,16 +104,17 @@ func (cloudConn *AzureCloudConnection) CreateKeyPairHandler() (irs.KeyPairHandle
 func (cloudConn *AzureCloudConnection) CreateVMHandler() (irs.VMHandler, error) {
 	cblogger.Info("Azure Cloud Driver: called CreateVMHandler()!")
 	vmHandler := azrs.AzureVMHandler{
-		CredentialInfo: cloudConn.CredentialInfo,
-		Region:         cloudConn.Region,
-		Ctx:            cloudConn.Ctx,
-		Client:         cloudConn.VMClient,
-		SubnetClient:   cloudConn.SubnetClient,
-		NicClient:      cloudConn.VNicClient,
-		PublicIPClient: cloudConn.PublicIPClient,
-		DiskClient:     cloudConn.DiskClient,
-		SshKeyClient:   cloudConn.SshKeyClient,
-		ImageClient:    cloudConn.ImageClient,
+		CredentialInfo:                  cloudConn.CredentialInfo,
+		Region:                          cloudConn.Region,
+		Ctx:                             cloudConn.Ctx,
+		Client:                          cloudConn.VMClient,
+		SubnetClient:                    cloudConn.SubnetClient,
+		NicClient:                       cloudConn.VNicClient,
+		PublicIPClient:                  cloudConn.PublicIPClient,
+		DiskClient:                      cloudConn.DiskClient,
+		SshKeyClient:                    cloudConn.SshKeyClient,
+		ImageClient:                     cloudConn.ImageClient,
+		VirtualMachineRunCommandsClient: cloudConn.VirtualMachineRunCommandsClient,
 	}
 	return &vmHandler, nil
 }
@@ -157,11 +159,12 @@ func (cloudConn *AzureCloudConnection) CreateDiskHandler() (irs.DiskHandler, err
 func (cloudConn *AzureCloudConnection) CreateMyImageHandler() (irs.MyImageHandler, error) {
 	cblogger.Info("Azure Cloud Driver: called CreateMyImageHandler()!")
 	myImageHandler := azrs.AzureMyImageHandler{
-		CredentialInfo: cloudConn.CredentialInfo,
-		Region:         cloudConn.Region,
-		Ctx:            cloudConn.Ctx,
-		ImageClient:    cloudConn.ImageClient,
-		VMClient:       cloudConn.VMClient,
+		CredentialInfo:                  cloudConn.CredentialInfo,
+		Region:                          cloudConn.Region,
+		Ctx:                             cloudConn.Ctx,
+		ImageClient:                     cloudConn.ImageClient,
+		VMClient:                        cloudConn.VMClient,
+		VirtualMachineRunCommandsClient: cloudConn.VirtualMachineRunCommandsClient,
 	}
 	return &myImageHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
@@ -96,6 +96,8 @@ type Config struct {
 				} `yaml:"SecurityGroupIIDs"`
 				RootDiskSize string `yaml:"RootDiskSize"`
 				RootDiskType string `yaml:"RootDiskType"`
+				VMUserId     string `yaml:"VMUserId"`
+				VMUserPasswd string `yaml:"VMUserPasswd"`
 			} `yaml:"vm"`
 			MyImage struct {
 				IID struct {
@@ -752,6 +754,8 @@ func testVMHandler(config Config) {
 		RootDiskSize:      config.Azure.Resources.Vm.RootDiskSize,
 		RootDiskType:      config.Azure.Resources.Vm.RootDiskType,
 		SecurityGroupIIDs: SecurityGroupIIDs,
+		VMUserId:          config.Azure.Resources.Vm.VMUserId,
+		VMUserPasswd:      config.Azure.Resources.Vm.VMUserPasswd,
 	}
 
 Loop:

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -29,25 +30,34 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
+type AzureOSTYPE string
+
 const (
-	ProvisioningStateCode string = "ProvisioningState/succeeded"
-	VM                           = "VM"
-	PremiumSSD                   = "PremiumSSD"
-	StandardSSD                  = "StandardSSD"
-	StandardHDD                  = "StandardHDD"
+	ProvisioningStateCode string      = "ProvisioningState/succeeded"
+	VM                                = "VM"
+	PremiumSSD                        = "PremiumSSD"
+	StandardSSD                       = "StandardSSD"
+	StandardHDD                       = "StandardHDD"
+	WindowBaseUser                    = "Administrator"
+	WindowBaseGroup                   = "Administrators"
+	WindowTempUser                    = CBVMUser
+	UnknownOS             AzureOSTYPE = "UnknownOS"
+	WindowOS              AzureOSTYPE = "WindowOS"
+	LinuxOS               AzureOSTYPE = "LinuxOS"
 )
 
 type AzureVMHandler struct {
-	CredentialInfo idrv.CredentialInfo
-	Region         idrv.RegionInfo
-	Ctx            context.Context
-	Client         *compute.VirtualMachinesClient
-	SubnetClient   *network.SubnetsClient
-	NicClient      *network.InterfacesClient
-	PublicIPClient *network.PublicIPAddressesClient
-	DiskClient     *compute.DisksClient
-	SshKeyClient   *compute.SSHPublicKeysClient
-	ImageClient    *compute.ImagesClient
+	CredentialInfo                  idrv.CredentialInfo
+	Region                          idrv.RegionInfo
+	Ctx                             context.Context
+	Client                          *compute.VirtualMachinesClient
+	SubnetClient                    *network.SubnetsClient
+	NicClient                       *network.InterfacesClient
+	PublicIPClient                  *network.PublicIPAddressesClient
+	DiskClient                      *compute.DisksClient
+	SshKeyClient                    *compute.SSHPublicKeysClient
+	ImageClient                     *compute.ImagesClient
+	VirtualMachineRunCommandsClient *compute.VirtualMachineRunCommandsClient
 }
 
 func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, error) {
@@ -75,7 +85,22 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 		LoggingError(hiscallInfo, createErr)
 		return irs.VMInfo{}, createErr
 	}
-	// 1-2. Check VMImageIID Image format, Exist Image
+	// 1-2. Check VMImageIID Image format, Exist Image, AuthInfo (Linux : SSHKey, Window: Password)
+	imageOsType, err := CheckVMReqInfoOSType(vmReqInfo, vmHandler.ImageClient, vmHandler.CredentialInfo, vmHandler.Region, vmHandler.Ctx)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.VMInfo{}, createErr
+	}
+
+	err = checkAuthInfoOSType(vmReqInfo, imageOsType)
+	if err != nil {
+		createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
+		cblogger.Error(createErr.Error())
+		LoggingError(hiscallInfo, createErr)
+		return irs.VMInfo{}, createErr
+	}
 	vmImage := vmReqInfo.ImageIID.SystemId
 	if vmImage == "" {
 		vmImage = vmReqInfo.ImageIID.NameId
@@ -265,55 +290,65 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			ID: to.StringPtr(convertMyImageIId.SystemId),
 		}
 	}
-	// snapshotPoint Start
-	// 3-2. Set VmReqInfo - KeyPair & tagging
-	if vmReqInfo.KeyPairIID.NameId != "" {
-		key, keyErr := GetRawKey(vmReqInfo.KeyPairIID, vmHandler.Region.ResourceGroup, vmHandler.SshKeyClient, vmHandler.Ctx)
-		if keyErr != nil {
-			createErr := errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Finished to rollback deleting", err.Error()))
-			cleanResource := CleanVMClientRequestResource{
-				publicIPIId.NameId, vNicIId.NameId, "",
-			}
-			clean, deperr := vmHandler.cleanVMRelatedResource(VMCleanRelatedResource{
-				RequiredSet:         cleanVMClientSet,
-				CleanTargetResource: cleanResource,
-			})
-			if deperr != nil {
-				createErr = errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Failed to rollback err = %s", err.Error(), deperr.Error()))
+
+	if imageOsType == LinuxOS {
+		// 3-2. Set VmReqInfo - KeyPair & tagging
+		if vmReqInfo.KeyPairIID.NameId != "" {
+			key, keyErr := GetRawKey(vmReqInfo.KeyPairIID, vmHandler.Region.ResourceGroup, vmHandler.SshKeyClient, vmHandler.Ctx)
+			if keyErr != nil {
+				createErr := errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Finished to rollback deleting", err.Error()))
+				cleanResource := CleanVMClientRequestResource{
+					publicIPIId.NameId, vNicIId.NameId, "",
+				}
+				clean, deperr := vmHandler.cleanVMRelatedResource(VMCleanRelatedResource{
+					RequiredSet:         cleanVMClientSet,
+					CleanTargetResource: cleanResource,
+				})
+				if deperr != nil {
+					createErr = errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Failed to rollback err = %s", err.Error(), deperr.Error()))
+					cblogger.Error(createErr.Error())
+					LoggingError(hiscallInfo, createErr)
+					return irs.VMInfo{}, createErr
+				}
+				if !clean {
+					createErr = errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Failed to rollback deleting", err.Error()))
+				}
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
 			}
-			if !clean {
-				createErr = errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Failed to rollback deleting", err.Error()))
-			}
-			cblogger.Error(createErr.Error())
-			LoggingError(hiscallInfo, createErr)
-			return irs.VMInfo{}, createErr
-		}
-		publicKey := *key.PublicKey
-		vmOpts.OsProfile.LinuxConfiguration = &compute.LinuxConfiguration{
-			SSH: &compute.SSHConfiguration{
-				PublicKeys: &[]compute.SSHPublicKey{
-					{
-						Path:    to.StringPtr(fmt.Sprintf("/home/%s/.ssh/authorized_keys", CBVMUser)),
-						KeyData: to.StringPtr(publicKey),
+			publicKey := *key.PublicKey
+			vmOpts.OsProfile.LinuxConfiguration = &compute.LinuxConfiguration{
+				SSH: &compute.SSHConfiguration{
+					PublicKeys: &[]compute.SSHPublicKey{
+						{
+							Path:    to.StringPtr(fmt.Sprintf("/home/%s/.ssh/authorized_keys", CBVMUser)),
+							KeyData: to.StringPtr(publicKey),
+						},
 					},
 				},
-			},
-		}
-		vmOpts.Tags = map[string]*string{
-			"keypair":   to.StringPtr(vmReqInfo.KeyPairIID.NameId),
-			"publicip":  to.StringPtr(publicIPIId.NameId),
-			"createdBy": to.StringPtr(vmReqInfo.IId.NameId),
+			}
+			vmOpts.Tags = map[string]*string{
+				"keypair":   to.StringPtr(vmReqInfo.KeyPairIID.NameId),
+				"publicip":  to.StringPtr(publicIPIId.NameId),
+				"createdBy": to.StringPtr(vmReqInfo.IId.NameId),
+			}
+		} else {
+			vmOpts.OsProfile.AdminPassword = to.StringPtr(vmReqInfo.VMUserPasswd)
+			vmOpts.Tags = map[string]*string{
+				"publicip":  to.StringPtr(publicIPIId.NameId),
+				"createdBy": to.StringPtr(vmReqInfo.IId.NameId),
+			}
 		}
 	} else {
 		vmOpts.OsProfile.AdminPassword = to.StringPtr(vmReqInfo.VMUserPasswd)
+		vmOpts.OsProfile.AdminUsername = to.StringPtr(WindowTempUser)
 		vmOpts.Tags = map[string]*string{
 			"publicip":  to.StringPtr(publicIPIId.NameId),
 			"createdBy": to.StringPtr(vmReqInfo.IId.NameId),
 		}
 	}
+
 	// 4. CreateVM
 	start := call.Start()
 	future, err := vmHandler.Client.CreateOrUpdate(vmHandler.Ctx, vmHandler.Region.ResourceGroup, vmReqInfo.IId.NameId, vmOpts)
@@ -403,7 +438,21 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			return irs.VMInfo{}, createErr
 		}
 	}
-	// 6. If DataDisk Exist
+	// 6. Window user Change
+	if imageOsType == WindowOS {
+		err = changeAdministratorUser(vmReqInfo.IId, WindowBaseUser, vmReqInfo.VMUserPasswd, CBVMUser, vmHandler.Client, vmHandler.VirtualMachineRunCommandsClient, vmHandler.Ctx, vmHandler.Region)
+		if err != nil {
+			createErr := errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Finished to rollback deleting", err.Error()))
+			cleanErr := vmHandler.cleanDeleteVm(vmReqInfo.IId)
+			if cleanErr != nil {
+				createErr = errors.New(fmt.Sprintf("Failed to Start VM. err = %s, and Failed to rollback err = %s", err.Error(), cleanErr.Error()))
+			}
+			cblogger.Error(createErr.Error())
+			LoggingError(hiscallInfo, createErr)
+			return irs.VMInfo{}, createErr
+		}
+	}
+	// 7. If DataDisk Exist
 	if len(vmReqInfo.DataDiskIIDs) > 0 {
 		vm, err := AttachList(vmReqInfo.DataDiskIIDs, vmReqInfo.IId, vmHandler.CredentialInfo, vmHandler.Region, vmHandler.Ctx, vmHandler.Client, vmHandler.DiskClient)
 		if err != nil {
@@ -432,6 +481,9 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			return irs.VMInfo{}, createErr
 		}
 		vmInfo := vmHandler.mappingServerInfo(vm)
+		if imageOsType == WindowOS {
+			vmInfo.VMUserPasswd = vmReqInfo.VMUserPasswd
+		}
 		LoggingInfo(hiscallInfo, start)
 		return vmInfo, nil
 	}
@@ -771,6 +823,8 @@ func (vmHandler *AzureVMHandler) GetVM(vmIID irs.IID) (irs.VMInfo, error) {
 		LoggingError(hiscallInfo, getErr)
 		return irs.VMInfo{}, getErr
 	}
+	// addAdministratorUser(convertedIID, vmHandler.Client, vmHandler.VirtualMachineRunCommandsClient, vmHandler.Ctx, vmHandler.Region)
+
 	LoggingInfo(hiscallInfo, start)
 
 	vmInfo := vmHandler.mappingServerInfo(vm)
@@ -961,11 +1015,19 @@ func (vmHandler *AzureVMHandler) mappingServerInfo(server compute.VirtualMachine
 			vmInfo.VpcIID = irs.IID{NameId: vpcName, SystemId: strings.Join(vpcIdArr, "/")}
 		}
 	}
-
-	// Set GuestUser Id/Pwd
-	if server.VirtualMachineProperties.OsProfile.AdminUsername != nil {
-		vmInfo.VMUserId = *server.VirtualMachineProperties.OsProfile.AdminUsername
+	osType, err := getOSTypeByVM(server)
+	if err == nil {
+		if osType == WindowOS {
+			vmInfo.VMUserId = WindowBaseUser
+		}
+		if osType == LinuxOS {
+			vmInfo.VMUserId = CBVMUser
+		}
 	}
+	// Set GuestUser Id/Pwd
+	//if server.VirtualMachineProperties.OsProfile.AdminUsername != nil {
+	//	vmInfo.VMUserId = *server.VirtualMachineProperties.OsProfile.AdminUsername
+	//}
 	if server.VirtualMachineProperties.OsProfile.AdminPassword != nil {
 		vmInfo.VMUserPasswd = *server.VirtualMachineProperties.OsProfile.AdminPassword
 	}
@@ -1401,6 +1463,44 @@ func ConvertVMIID(vmIID irs.IID, credentialInfo idrv.CredentialInfo, regionInfo 
 	}
 }
 
+func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType AzureOSTYPE) error {
+	if OSType == WindowOS {
+		_, idErr := windowUserIdCheck(vmReqInfo.VMUserId)
+		if idErr != nil {
+			return idErr
+		}
+		_, pwErr := windowPasswordCheck(vmReqInfo.VMUserPasswd)
+		if pwErr != nil {
+			return pwErr
+		}
+		if vmReqInfo.KeyPairIID.NameId != "" || vmReqInfo.KeyPairIID.SystemId != "" {
+			return errors.New("for Windows, SSH key login method is not supported")
+		}
+		computeErr := checkComputerNameWindow(vmReqInfo)
+		if computeErr != nil {
+			return computeErr
+		}
+	}
+	if OSType == LinuxOS {
+		if vmReqInfo.KeyPairIID.NameId == "" && vmReqInfo.KeyPairIID.SystemId == "" {
+			return errors.New("for Linux, KeyPairIID is required")
+		}
+	}
+	return nil
+}
+
+func checkComputerNameWindow(vmReqInfo irs.VMReqInfo) error {
+	if len(vmReqInfo.IId.NameId) > 15 {
+		return errors.New("for Windows, VM's computeName cannot exceed 15 characters")
+	}
+	// https://learn.microsoft.com/ko-KR/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
+	matchCase, _ := regexp.MatchString(`[\/?:|*<>\\\"]+`, vmReqInfo.IId.NameId)
+	if matchCase {
+		return errors.New("for Windows, VM's computeName contains unacceptable special characters")
+	}
+	return nil
+}
+
 func checkVMReqInfo(vmReqInfo irs.VMReqInfo) error {
 	if vmReqInfo.IId.NameId == "" {
 		return errors.New("invalid VM IID")
@@ -1414,11 +1514,127 @@ func checkVMReqInfo(vmReqInfo irs.VMReqInfo) error {
 	if vmReqInfo.SubnetIID.NameId == "" && vmReqInfo.SubnetIID.SystemId == "" {
 		return errors.New("invalid VM SubnetIID")
 	}
-	if vmReqInfo.KeyPairIID.NameId == "" && vmReqInfo.KeyPairIID.SystemId == "" && vmReqInfo.VMUserPasswd == "" {
-		return errors.New("specify one login method, Password or Keypair")
-	}
+	//if vmReqInfo.KeyPairIID.NameId == "" && vmReqInfo.KeyPairIID.SystemId == "" && vmReqInfo.VMUserPasswd == "" {
+	//	return errors.New("specify one login method, Password or Keypair")
+	//}
 	if vmReqInfo.VMSpecName == "" {
 		return errors.New("invalid VM VMSpecName")
 	}
+
 	return nil
+}
+
+func changeAdministratorUser(vmIID irs.IID, newusername string, newpassword string, oldusername string, virtualMachinesClient *compute.VirtualMachinesClient, virtualMachineRunCommandsClient *compute.VirtualMachineRunCommandsClient, ctx context.Context, region idrv.RegionInfo) error {
+	rawVm, err := GetRawVM(vmIID, region.ResourceGroup, virtualMachinesClient, ctx)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed window User Add %s", err.Error()))
+	}
+	runOpt := compute.VirtualMachineRunCommand{
+		VirtualMachineRunCommandProperties: &compute.VirtualMachineRunCommandProperties{
+			Source: &compute.VirtualMachineRunCommandScriptSource{
+				// Script: to.StringPtr(fmt.Sprintf("net user /add administrator qwe1212!Q; net localgroup administrators cb-user /add; net user /delete administrator;")),
+				Script: to.StringPtr(fmt.Sprintf("net user /add %s %s; net localgroup %s %s /add; net user /delete %s;", newusername, newpassword, WindowBaseGroup, newusername, oldusername)),
+			},
+		},
+		Location: to.StringPtr(region.Region),
+	}
+	runCommandResult, err := virtualMachineRunCommandsClient.CreateOrUpdate(ctx, region.ResourceGroup, *rawVm.Name, "RunPowerShellScript", runOpt)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed window User Add %s", err.Error()))
+	}
+	err = runCommandResult.WaitForCompletionRef(ctx, virtualMachineRunCommandsClient.Client)
+	if err != nil {
+		return errors.New(fmt.Sprintf("failed window User Add %s", err.Error()))
+	}
+	return nil
+}
+
+func CheckVMReqInfoOSType(vmReqInfo irs.VMReqInfo, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (AzureOSTYPE, error) {
+	if vmReqInfo.ImageType == "" || vmReqInfo.ImageType == irs.PublicImage {
+		return getOSTypeByPublicImage(vmReqInfo.ImageIID)
+	} else {
+		return getOSTypeByMyImage(vmReqInfo.ImageIID, imageClient, credentialInfo, region, ctx)
+	}
+}
+
+func getOSTypeByVM(server compute.VirtualMachine) (AzureOSTYPE, error) {
+	if server.OsProfile.LinuxConfiguration != nil {
+		return LinuxOS, nil
+	}
+	return WindowOS, nil
+}
+
+func getOSTypeByPublicImage(imageIID irs.IID) (AzureOSTYPE, error) {
+	if imageIID.NameId == "" && imageIID.SystemId == "" {
+		return UnknownOS, errors.New("failed get OSType By ImageIID err = empty ImageIID")
+	}
+	imageName := imageIID.NameId
+	if imageIID.NameId == "" {
+		imageName = imageIID.SystemId
+	}
+	imageNameSplits := strings.Split(imageName, ":")
+	if len(imageNameSplits) != 4 {
+		return UnknownOS, errors.New("failed get OSType By ImageIID err = invalid ImageIID, Image Name must be in the form of 'Publisher:Offer:Sku:Version'. ")
+	}
+	offer := imageNameSplits[1]
+	if strings.Contains(strings.ToLower(offer), "window") {
+		return WindowOS, nil
+	}
+	return LinuxOS, nil
+}
+
+func getOSTypeByMyImage(myImageIID irs.IID, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (AzureOSTYPE, error) {
+	convertedMyImageIID, err := ConvertMyImageIID(myImageIID, credentialInfo, region)
+	if err != nil {
+		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = %s", err.Error()))
+	}
+	myImage, err := imageClient.Get(ctx, region.ResourceGroup, convertedMyImageIID.NameId, "")
+	if err != nil {
+		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = failed get MyImage err = %s", err.Error()))
+	}
+	if reflect.ValueOf(myImage.StorageProfile.OsDisk).IsNil() {
+		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
+	}
+	if myImage.StorageProfile.OsDisk.OsType == compute.OperatingSystemTypesLinux {
+		return LinuxOS, nil
+	}
+	if myImage.StorageProfile.OsDisk.OsType == compute.OperatingSystemTypesWindows {
+		return WindowOS, nil
+	}
+	return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
+}
+func windowUserIdCheck(userId string) (bool, error) {
+	if userId == "Administrator" {
+		return true, nil
+	}
+	return false, errors.New("for Windows, the userId only provides Administrator")
+}
+
+func windowPasswordCheck(pw string) (bool, error) {
+	if len(pw) < 12 || len(pw) > 123 {
+		return false, errors.New("password must be between 12 and 123 characters long and must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character")
+	}
+	checkNum := 0
+	matchCase, err := regexp.MatchString(".*[a-z]+", pw)
+	if matchCase && err == nil {
+		checkNum++
+	}
+	matchCase, _ = regexp.MatchString(".*[A-Z]+", pw)
+	if matchCase && err == nil {
+		checkNum++
+	}
+	matchCase, _ = regexp.MatchString(".*[0-9]+", pw)
+	if matchCase && err == nil {
+		checkNum++
+	}
+	matchCase, _ = regexp.MatchString(`[\{\}\[\]\/?.,;:|\)*~!^\-_+<>@\#$%&\\\=\(\'\"\n\r]+`, pw)
+	if matchCase && err == nil {
+		checkNum++
+	}
+	if checkNum >= 3 {
+		return true, nil
+	} else {
+		return false, errors.New("Password must be between 12 and 123 characters long and must have 3 of the following: 1 lower case character, 1 upper case character, 1 number, and 1 special character.")
+
+	}
 }


### PR DESCRIPTION
- VMHandler: 
   - VMUserId, VMUserPasswd 지원 - Azure의 user 생성 정책상, cb-user라는 유저생성하여, VM 생성후 Administrator 유저 생성 후  cb-user 제거
   - Image OS 구분 로직 추가

- MyImageHandler: 
   - Window SnapShot을 위한 VM 내부 작업에 대한 PowerShell 추가 참고 [https://learn.microsoft.com/ko-kr/azure/virtual-machines/windows/upload-generalized-managed] - 해당 작업을 위해, Suspend인 VM은 Running으로 바꾼후 위 작업 후, 다시 Suspend후 일반화 수행
   - 버그 수정: 리소스 그룹단위가 아닌 모든 MyImage가져오는 버그 수정