### PR TITLE
[Openstack] Window OS 지원

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
@@ -540,11 +540,15 @@ func testVMHandler(config Config) {
 		NameId:   config.Openstack.Resources.Vm.IID.NameId,
 		SystemId: config.Openstack.Resources.Vm.IID.SystemId,
 	}
+	imageType := irs.PublicImage
+	if config.Openstack.Resources.Vm.ImageType == "MyImage" {
+		imageType = irs.MyImage
+	}
 	vmReqInfo := irs.VMReqInfo{
 		IId: irs.IID{
 			NameId: config.Openstack.Resources.Vm.IID.NameId,
 		},
-		ImageType: irs.MyImage,
+		ImageType: imageType,
 		ImageIID: irs.IID{
 			NameId:   config.Openstack.Resources.Vm.ImageIID.NameId,
 			SystemId: config.Openstack.Resources.Vm.ImageIID.SystemId,
@@ -564,6 +568,8 @@ func testVMHandler(config Config) {
 		RootDiskSize:      config.Openstack.Resources.Vm.RootDiskSize,
 		RootDiskType:      config.Openstack.Resources.Vm.RootDiskType,
 		SecurityGroupIIDs: SecurityGroupIIDs,
+		VMUserId:          config.Openstack.Resources.Vm.VMUserId,
+		VMUserPasswd:      config.Openstack.Resources.Vm.VMUserPasswd,
 	}
 
 Loop:
@@ -1026,10 +1032,10 @@ func testMyImageHandler(config Config) {
 	}
 	imageInfo := irs.MyImageInfo{
 		IId: irs.IID{
-			NameId: "vm-tester-snap",
+			NameId: "winfire1back",
 		},
 		SourceVM: irs.IID{
-			NameId: "vm-tester",
+			NameId: "winfire1winfire1winfire1",
 		},
 	}
 	delimageIId := irs.IID{
@@ -1226,6 +1232,7 @@ type Config struct {
 					NameId   string `yaml:"nameId"`
 					SystemId string `yaml:"systemId"`
 				} `yaml:"ImageIID"`
+				ImageType  string `yaml:"ImageType"`
 				VmSpecName string `yaml:"VmSpecName"`
 				KeyPairIID struct {
 					NameId string `yaml:"nameId"`
@@ -1244,6 +1251,8 @@ type Config struct {
 				} `yaml:"SecurityGroupIIDs"`
 				RootDiskSize string `yaml:"RootDiskSize"`
 				RootDiskType string `yaml:"RootDiskType"`
+				VMUserId     string `yaml:"VMUserId"`
+				VMUserPasswd string `yaml:"VMUserPasswd"`
 			} `yaml:"vm"`
 		} `yaml:"resources"`
 	} `yaml:"openstack"`

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -14,15 +14,16 @@ import (
 	"errors"
 	"fmt"
 	volumes3 "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
@@ -37,9 +38,15 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
+type OpenstackOSTYPE string
+
 const (
-	VM             = "VM"
-	SSHDefaultUser = "cb-user"
+	WindowBaseUser                 = "Administrator"
+	VM                             = "VM"
+	SSHDefaultUser                 = "cb-user"
+	WindowOS       OpenstackOSTYPE = "windows"
+	LinuxOS        OpenstackOSTYPE = "linux"
+	UnknownOS      OpenstackOSTYPE = "unknown"
 )
 
 type OpenStackVMHandler struct {
@@ -169,144 +176,70 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm i
 		}
 		sgIdArr[i] = SecurityGroup.ID
 	}
-	// serverCreateOpts.SecurityGroups = sgIdArr
-	// Add KeyPair
-	keyPair, err := GetRawKey(vmHandler.ComputeClient, vmReqInfo.KeyPairIID)
-	if err != nil {
-		createErr := errors.New(fmt.Sprintf("Failed to startVM err %s", err))
-		cblogger.Error(createErr.Error())
-		LoggingError(hiscallInfo, createErr)
-		return irs.VMInfo{}, createErr
-	}
-
-	// cloud-init 스크립트 설정
-	rootPath := os.Getenv("CBSPIDER_ROOT")
-	fileData, err := ioutil.ReadFile(rootPath + "/cloud-driver-libs/.cloud-init-openstack/cloud-init")
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-		return irs.VMInfo{}, err
-	}
-	fileStr := string(fileData)
-	fileStr = strings.ReplaceAll(fileStr, "{{username}}", SSHDefaultUser)
-	fileStr = strings.ReplaceAll(fileStr, "{{public_key}}", keyPair.PublicKey)
-
-	var image images.Image
-	// SnapShot
-	if vmReqInfo.ImageType == irs.MyImage {
-		image, err = getRawSnapshot(vmReqInfo.ImageIID, vmHandler.ComputeClient)
-		if err != nil {
-			createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to get image, err : %s", err))
-			cblogger.Error(createErr.Error())
-			LoggingError(hiscallInfo, createErr)
-			return irs.VMInfo{}, createErr
-		}
-	} else {
-		// PublicImage
-		image, err = getRawImage(vmReqInfo.ImageIID, vmHandler.ComputeClient)
-		if err != nil {
-			createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to get image, err : %s", err))
-			cblogger.Error(createErr.Error())
-			LoggingError(hiscallInfo, createErr)
-			return irs.VMInfo{}, createErr
-		}
-	}
 	serverCreateOpts := servers.CreateOpts{
 		Name:      vmReqInfo.IId.NameId,
 		FlavorRef: vmSpec.ID,
-		//Metadata: map[string]string{
-		//	"snapshot": snapshotImage.Name,
-		//},
 		Networks: []servers.Network{
 			{UUID: rawVpc.ID, FixedIP: fixedIp},
 		},
-		ImageRef:       image.ID,
 		SecurityGroups: sgIdArr,
-		UserData:       []byte(fileStr), // cloud-init 스크립트 적용
 	}
-	serverCreateOpts.Metadata = map[string]string{
-		"imagekey": image.ID,
-	}
-	createOpts := keypairs.CreateOptsExt{
-		KeyName: keyPair.Name,
-	}
-	var server *servers.Server
+
+	var server servers.Server
+	// Public
 	if vmReqInfo.ImageType != irs.MyImage {
-		// PublicImage
-		// DiskSize 변경
-		if !(vmReqInfo.RootDiskSize == "" || vmReqInfo.RootDiskSize == "default") {
-			if vmHandler.VolumeClient == nil {
-				// Disk Size 변경 && vmHandler.VolumeClient == nil
-				createErr := errors.New(fmt.Sprintf("Failed to startVM err = this Openstack cannot provide VolumeClient. RootDiskSize cannot be changed"))
-				cblogger.Error(createErr.Error())
-				LoggingError(hiscallInfo, createErr)
-				return irs.VMInfo{}, createErr
-			}
-			vmSize, err := strconv.Atoi(vmReqInfo.RootDiskSize)
-			if err != nil {
-				createErr := errors.New(fmt.Sprintf("Failed to startVM err = Invalid RootDiskSize"))
-				cblogger.Error(createErr.Error())
-				LoggingError(hiscallInfo, createErr)
-				return irs.VMInfo{}, createErr
-			}
-			blockDeviceSet := []bootfromvolume.BlockDevice{
-				bootfromvolume.BlockDevice{
-					UUID:                image.ID,
-					SourceType:          bootfromvolume.SourceImage,
-					VolumeSize:          vmSize,
-					DestinationType:     bootfromvolume.DestinationVolume,
-					DeleteOnTermination: true,
-				},
-			}
-			createOpts.CreateOptsBuilder = serverCreateOpts
-			bootOpt := bootfromvolume.CreateOptsExt{
-				CreateOptsBuilder: createOpts,
-				BlockDevice:       blockDeviceSet,
-			}
-			server, err = bootfromvolume.Create(vmHandler.ComputeClient, bootOpt).Extract()
-		} else {
-			// Disk Size 변경 X
-			if vmHandler.VolumeClient == nil { // Disk Size 변경 X && VolumeClient == nil
-				createOpts.CreateOptsBuilder = serverCreateOpts
-				server, err = servers.Create(vmHandler.ComputeClient, createOpts).Extract()
-			} else { // Disk Size 변경 X && VolumeClient != nil
-				vmSize := vmSpec.Disk
-				blockDeviceSet := []bootfromvolume.BlockDevice{
-					bootfromvolume.BlockDevice{
-						UUID:                image.ID,
-						SourceType:          bootfromvolume.SourceImage,
-						VolumeSize:          vmSize,
-						DestinationType:     bootfromvolume.DestinationVolume,
-						DeleteOnTermination: true,
-					},
-				}
-				createOpts.CreateOptsBuilder = serverCreateOpts
-				bootOpt := bootfromvolume.CreateOptsExt{
-					CreateOptsBuilder: createOpts,
-					BlockDevice:       blockDeviceSet,
-				}
-				server, err = bootfromvolume.Create(vmHandler.ComputeClient, bootOpt).Extract()
-			}
-		}
-	} else {
-		// snapshot block_device_mapping Check (volumeClient)
-		_, exist := image.Metadata["block_device_mapping"]
-		if exist && vmHandler.VolumeClient == nil {
-			createErr := errors.New(fmt.Sprintf("Failed to startVM err = this Openstack cannot provide VolumeClient. BlockDevice information is located within the snapshot."))
+		imageOSType, err := getOSTypeByImage(vmReqInfo.ImageIID, vmHandler.ComputeClient)
+		if err != nil {
+			createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to get image os type, err : %s", err))
 			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)
 			return irs.VMInfo{}, createErr
 		}
-		// MyImage
-		createOpts.CreateOptsBuilder = serverCreateOpts
-		server, err = servers.Create(vmHandler.ComputeClient, createOpts).Extract()
+		if imageOSType == WindowOS {
+			server, err = severCreatePublicImageWindowOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
+			if err != nil {
+				createErr := errors.New(fmt.Sprintf("Failed to startVM err =  %s", err))
+				cblogger.Error(createErr.Error())
+				LoggingError(hiscallInfo, createErr)
+				return irs.VMInfo{}, createErr
+			}
+		} else {
+			server, err = severCreatePublicImageLinuxOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
+			if err != nil {
+				createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
+				cblogger.Error(createErr.Error())
+				LoggingError(hiscallInfo, createErr)
+				return irs.VMInfo{}, createErr
+			}
+		}
+	} else {
+		//MyImage
+		imageOSType, err := getOSTypeByMyImage(vmReqInfo.ImageIID, vmHandler.ComputeClient)
+		if err != nil {
+			createErr := errors.New(fmt.Sprintf("Failed to startVM err = failed to get image os type, err : %s", err))
+			cblogger.Error(createErr.Error())
+			LoggingError(hiscallInfo, createErr)
+			return irs.VMInfo{}, createErr
+		}
+		if imageOSType == WindowOS {
+			server, err = severCreateMyImageWindowOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
+			if err != nil {
+				createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
+				cblogger.Error(createErr.Error())
+				LoggingError(hiscallInfo, createErr)
+				return irs.VMInfo{}, createErr
+			}
+		} else {
+			server, err = severCreateMyImageLinuxOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
+			if err != nil {
+				createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
+				cblogger.Error(createErr.Error())
+				LoggingError(hiscallInfo, createErr)
+				return irs.VMInfo{}, createErr
+			}
+		}
 	}
-	if err != nil {
-		createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
-		cblogger.Error(createErr.Error())
-		LoggingError(hiscallInfo, createErr)
-		return irs.VMInfo{}, createErr
-	}
+
 	defer func() {
 		if createErr != nil {
 			cleanVMIId := irs.IID{
@@ -373,6 +306,10 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm i
 		}
 	}
 	serverInfo = vmHandler.mappingServerInfo(*serverResult)
+	password, err := getPassword(*serverResult)
+	if err == nil {
+		serverInfo.VMUserPasswd = password
+	}
 	LoggingInfo(hiscallInfo, start)
 	return serverInfo, nil
 }
@@ -640,15 +577,23 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 			Zone:   vmHandler.Region.Zone,
 			Region: vmHandler.Region.Region,
 		},
-		KeyPairIId: irs.IID{
-			NameId:   server.KeyName,
-			SystemId: server.KeyName,
-		},
+
 		//VMUserId:          server.UserID,
 		//VMUserPasswd:      server.AdminPass,
 		NetworkInterface:  server.HostID,
 		KeyValueList:      nil,
 		SecurityGroupIIds: nil,
+	}
+	OSType, err := getOSTypeByServer(server)
+	if err == nil {
+		if OSType == WindowOS {
+			vmInfo.VMUserId = WindowBaseUser
+		} else {
+			vmInfo.KeyPairIId = irs.IID{
+				NameId:   server.KeyName,
+				SystemId: server.KeyName,
+			}
+		}
 	}
 	if creatTime, err := time.Parse(time.RFC3339, server.Created.String()); err == nil {
 		vmInfo.StartTime = creatTime
@@ -951,4 +896,334 @@ func getAllVolumeByServerAttachedVolume(attachedVolumes []servers.AttachedVolume
 		volumeList[i] = vol
 	}
 	return volumeList, nil
+}
+
+func getOSTypeByImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (OpenstackOSTYPE, error) {
+	image, err := getRawImage(imageIID, computeClient)
+	if err != nil {
+		return UnknownOS, err
+	}
+	value, exist := image.Metadata["os_type"]
+	if !exist {
+		return LinuxOS, nil
+	}
+	if value == "windows" {
+		return WindowOS, nil
+	}
+	return LinuxOS, nil
+}
+
+func getOSTypeByMyImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (OpenstackOSTYPE, error) {
+	image, err := getRawSnapshot(imageIID, computeClient)
+	if err != nil {
+		return UnknownOS, err
+	}
+	value, exist := image.Metadata["os_type"]
+	if !exist {
+		return LinuxOS, nil
+	}
+	if value == "windows" {
+		return WindowOS, nil
+	}
+	return LinuxOS, nil
+}
+
+func getOSTypeByServer(server servers.Server) (OpenstackOSTYPE, error) {
+	value, exist := server.Metadata["os_type"]
+	if !exist {
+		return LinuxOS, nil
+	}
+	if value == "windows" {
+		return WindowOS, nil
+	}
+	return LinuxOS, nil
+}
+
+func getPassword(server servers.Server) (string, error) {
+	pw, exist := server.Metadata["admin_pass"]
+	if exist {
+		return pw, nil
+	}
+	return "", errors.New("failed get password err = password information not found")
+}
+
+func checkWindowVMReqInfo(vmReqInfo irs.VMReqInfo) error {
+	//if len(vmReqInfo.IId.NameId) > 15 {
+	//	return errors.New("for Windows, VM's computeName cannot exceed 15 characters")
+	//}
+	// https://learn.microsoft.com/ko-KR/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
+	matchCase, _ := regexp.MatchString(`[\/?:|*<>\\\"]+`, vmReqInfo.IId.NameId)
+	if matchCase {
+		return errors.New("for Windows, VM's computeName contains unacceptable special characters")
+	}
+	if vmReqInfo.VMUserId != WindowBaseUser {
+		return errors.New("for Windows, the userId only provides Administrator")
+	}
+	// password
+	if len(vmReqInfo.VMUserPasswd) < 8 {
+		return errors.New("password length of Windows cannot be less than 8")
+	}
+
+	passwordComplexityScore := 0
+	var regexMatchers []*regexp.Regexp
+	regexMatcherHasDigit := regexp.MustCompile(`\d`)
+	regexMatchers = append(regexMatchers, regexMatcherHasDigit)
+	regexMatcherHasUpperCase := regexp.MustCompile("[A-Z]")
+	regexMatchers = append(regexMatchers, regexMatcherHasUpperCase)
+	regexMatcherHasLowerCase := regexp.MustCompile("[a-z]")
+	regexMatchers = append(regexMatchers, regexMatcherHasLowerCase)
+	regexMatcherHasNonAlphanumeric := regexp.MustCompile(`[^a-zA-Z0-9]`)
+	regexMatchers = append(regexMatchers, regexMatcherHasNonAlphanumeric)
+
+	for _, matcher := range regexMatchers {
+		if matcher.MatchString(vmReqInfo.VMUserPasswd) {
+			passwordComplexityScore++
+		}
+	}
+
+	for _, c := range vmReqInfo.VMUserPasswd {
+		if unicode.IsLetter(c) && !unicode.IsUpper(c) && !unicode.IsLower(c) {
+			passwordComplexityScore++
+			break
+		}
+	}
+	if passwordComplexityScore < 3 {
+		return errors.New("password must meet Windows password complexity requirements")
+	}
+	if vmReqInfo.KeyPairIID.NameId != "" || vmReqInfo.KeyPairIID.SystemId != "" {
+		return errors.New("for Windows, SSH key login method is not supported")
+	}
+	return nil
+}
+
+func linuxServerCreatOptConvertKeyPairWrapping(baseServerCreateOpt servers.CreateOpts, keyPairIID irs.IID, computeClient *gophercloud.ServiceClient) (keypairs.CreateOptsExt, error) {
+	keyPair, err := GetRawKey(computeClient, keyPairIID)
+	if err != nil {
+		return keypairs.CreateOptsExt{}, err
+	}
+	rootPath := os.Getenv("CBSPIDER_ROOT")
+	fileData, err := ioutil.ReadFile(rootPath + "/cloud-driver-libs/.cloud-init-openstack/cloud-init")
+	if err != nil {
+		return keypairs.CreateOptsExt{}, err
+	}
+	fileStr := string(fileData)
+	fileStr = strings.ReplaceAll(fileStr, "{{username}}", SSHDefaultUser)
+	fileStr = strings.ReplaceAll(fileStr, "{{public_key}}", keyPair.PublicKey)
+
+	baseServerCreateOpt.UserData = []byte(fileStr)
+	createOptsExt := keypairs.CreateOptsExt{
+		KeyName: keyPair.Name,
+	}
+	createOptsExt.CreateOptsBuilder = baseServerCreateOpt
+	return createOptsExt, nil
+}
+
+func createBlockDeviceSet(imageUUID string, diskSize string) (bootfromvolume.BlockDevice, error) {
+	volumeSize, err := strconv.Atoi(diskSize)
+	if err != nil {
+		return bootfromvolume.BlockDevice{}, errors.New(fmt.Sprintf("Invalid RootDiskSize"))
+	}
+	return bootfromvolume.BlockDevice{
+		UUID:                imageUUID,
+		SourceType:          bootfromvolume.SourceImage,
+		VolumeSize:          volumeSize,
+		DestinationType:     bootfromvolume.DestinationVolume,
+		DeleteOnTermination: true,
+	}, nil
+}
+
+func severCreatePublicImageLinuxOS(baseServerCreateOpt servers.CreateOpts, vmReqInfo irs.VMReqInfo, VolumeClient *gophercloud.ServiceClient, computeClient *gophercloud.ServiceClient) (servers.Server, error) {
+	image, err := getRawImage(vmReqInfo.ImageIID, computeClient)
+	if err != nil {
+		return servers.Server{}, err
+	}
+	baseServerCreateOpt.ImageRef = image.ID
+	baseServerCreateOpt.Metadata = map[string]string{
+		"imagekey": image.ID,
+		"os_type":  string(LinuxOS),
+	}
+
+	if !(vmReqInfo.RootDiskSize == "" || vmReqInfo.RootDiskSize == "default") {
+		if VolumeClient == nil {
+			// Disk Size 변경 && vmHandler.VolumeClient == nil
+			return servers.Server{}, errors.New(fmt.Sprintf("this Openstack cannot provide VolumeClient. RootDiskSize cannot be changed"))
+		}
+		rootBlockDeviceSet, err := createBlockDeviceSet(image.ID, vmReqInfo.RootDiskSize)
+		if err != nil {
+			return servers.Server{}, err
+		}
+		blockDeviceSet := []bootfromvolume.BlockDevice{
+			rootBlockDeviceSet,
+		}
+		// Linux
+		createOptsExt, err := linuxServerCreatOptConvertKeyPairWrapping(baseServerCreateOpt, vmReqInfo.KeyPairIID, computeClient)
+		if err != nil {
+			return servers.Server{}, err
+		}
+		bootOpt := bootfromvolume.CreateOptsExt{
+			CreateOptsBuilder: createOptsExt,
+			BlockDevice:       blockDeviceSet,
+		}
+		server, err := bootfromvolume.Create(computeClient, bootOpt).Extract()
+		if err != nil {
+			return servers.Server{}, err
+		}
+		return *server, nil
+	} else {
+		// Disk Size 변경 X
+		if VolumeClient == nil { // Disk Size 변경 X && VolumeClient == nil
+			server, err := servers.Create(computeClient, baseServerCreateOpt).Extract()
+			if err != nil {
+				return servers.Server{}, err
+			}
+			return *server, nil
+		} else { // Disk Size 변경 X && VolumeClient != nil
+			vmSpec, err := GetFlavorByName(computeClient, vmReqInfo.VMSpecName)
+			if err != nil {
+				return servers.Server{}, errors.New(fmt.Sprintf("failed to get vmspec, err : %s", err))
+			}
+			rootBlockDeviceSet, err := createBlockDeviceSet(image.ID, strconv.Itoa(vmSpec.Disk))
+			if err != nil {
+				return servers.Server{}, err
+			}
+			blockDeviceSet := []bootfromvolume.BlockDevice{
+				rootBlockDeviceSet,
+			}
+			createOptsExt, err := linuxServerCreatOptConvertKeyPairWrapping(baseServerCreateOpt, vmReqInfo.KeyPairIID, computeClient)
+			if err != nil {
+				return servers.Server{}, err
+			}
+			bootOpt := bootfromvolume.CreateOptsExt{
+				CreateOptsBuilder: createOptsExt,
+				BlockDevice:       blockDeviceSet,
+			}
+			server, err := bootfromvolume.Create(computeClient, bootOpt).Extract()
+			if err != nil {
+				return servers.Server{}, err
+			}
+			return *server, nil
+		}
+	}
+
+}
+
+func severCreatePublicImageWindowOS(baseServerCreateOpt servers.CreateOpts, vmReqInfo irs.VMReqInfo, VolumeClient *gophercloud.ServiceClient, computeClient *gophercloud.ServiceClient) (servers.Server, error) {
+	err := checkWindowVMReqInfo(vmReqInfo)
+	if err != nil {
+		return servers.Server{}, err
+	}
+	image, err := getRawImage(vmReqInfo.ImageIID, computeClient)
+	if err != nil {
+		return servers.Server{}, err
+	}
+	baseServerCreateOpt.ImageRef = image.ID
+	baseServerCreateOpt.Metadata = map[string]string{
+		"imagekey":   image.ID,
+		"admin_pass": vmReqInfo.VMUserPasswd,
+		"os_type":    string(WindowOS),
+	}
+	// Disk Size 변경
+	if !(vmReqInfo.RootDiskSize == "" || vmReqInfo.RootDiskSize == "default") {
+		if VolumeClient == nil {
+			// Disk Size 변경 && vmHandler.VolumeClient == nil
+			return servers.Server{}, errors.New(fmt.Sprintf("this Openstack cannot provide VolumeClient. RootDiskSize cannot be changed"))
+		}
+		rootBlockDeviceSet, err := createBlockDeviceSet(image.ID, vmReqInfo.RootDiskSize)
+		if err != nil {
+			return servers.Server{}, err
+		}
+		blockDeviceSet := []bootfromvolume.BlockDevice{
+			rootBlockDeviceSet,
+		}
+		// Window
+		bootOpt := bootfromvolume.CreateOptsExt{
+			CreateOptsBuilder: baseServerCreateOpt,
+			BlockDevice:       blockDeviceSet,
+		}
+		server, err := bootfromvolume.Create(computeClient, bootOpt).Extract()
+		if err != nil {
+			return servers.Server{}, err
+		}
+		return *server, nil
+	} else {
+		// Disk Size 변경 X
+		if VolumeClient == nil { // Disk Size 변경 X && VolumeClient == nil
+			server, err := servers.Create(computeClient, baseServerCreateOpt).Extract()
+			if err != nil {
+				return servers.Server{}, err
+			}
+			return *server, nil
+		} else { // Disk Size 변경 X && VolumeClient != nil
+			vmSpec, err := GetFlavorByName(computeClient, vmReqInfo.VMSpecName)
+			if err != nil {
+				return servers.Server{}, errors.New(fmt.Sprintf("failed to get vmspec, err : %s", err))
+			}
+			rootBlockDeviceSet, err := createBlockDeviceSet(image.ID, strconv.Itoa(vmSpec.Disk))
+			if err != nil {
+				return servers.Server{}, err
+			}
+			blockDeviceSet := []bootfromvolume.BlockDevice{
+				rootBlockDeviceSet,
+			}
+			bootOpt := bootfromvolume.CreateOptsExt{
+				CreateOptsBuilder: baseServerCreateOpt,
+				BlockDevice:       blockDeviceSet,
+			}
+			server, err := bootfromvolume.Create(computeClient, bootOpt).Extract()
+			if err != nil {
+				return servers.Server{}, err
+			}
+			return *server, nil
+		}
+	}
+}
+
+func severCreateMyImageWindowOS(baseServerCreateOpt servers.CreateOpts, vmReqInfo irs.VMReqInfo, VolumeClient *gophercloud.ServiceClient, ComputeClient *gophercloud.ServiceClient) (servers.Server, error) {
+	err := checkWindowVMReqInfo(vmReqInfo)
+	if err != nil {
+		return servers.Server{}, err
+	}
+	image, err := getRawSnapshot(vmReqInfo.ImageIID, ComputeClient)
+	if err != nil {
+		return servers.Server{}, err
+	}
+	baseServerCreateOpt.ImageRef = image.ID
+	baseServerCreateOpt.Metadata = map[string]string{
+		"imagekey":   image.ID,
+		"os_type":    string(WindowOS),
+		"admin_pass": vmReqInfo.VMUserPasswd,
+	}
+	_, exist := image.Metadata["block_device_mapping"]
+	if exist && VolumeClient == nil {
+		return servers.Server{}, errors.New(fmt.Sprintf("Failed to startVM err = this Openstack cannot provide VolumeClient. BlockDevice information is located within the snapshot."))
+	}
+	server, err := servers.Create(ComputeClient, baseServerCreateOpt).Extract()
+	if err != nil {
+		return servers.Server{}, err
+	}
+	return *server, err
+}
+
+func severCreateMyImageLinuxOS(baseServerCreateOpt servers.CreateOpts, vmReqInfo irs.VMReqInfo, volumeClient *gophercloud.ServiceClient, computeClient *gophercloud.ServiceClient) (servers.Server, error) {
+	image, err := getRawSnapshot(vmReqInfo.ImageIID, computeClient)
+	if err != nil {
+		return servers.Server{}, errors.New(fmt.Sprintf("failed to get image, err : %s", err))
+	}
+	baseServerCreateOpt.ImageRef = image.ID
+	baseServerCreateOpt.Metadata = map[string]string{
+		"imagekey": image.ID,
+		"os_type":  string(LinuxOS),
+	}
+	// snapshot block_device_mapping Check (volumeClient)
+	_, exist := image.Metadata["block_device_mapping"]
+	if exist && volumeClient == nil {
+		return servers.Server{}, errors.New(fmt.Sprintf("Failed to startVM err = this Openstack cannot provide VolumeClient. BlockDevice information is located within the snapshot."))
+	}
+
+	createOptsExt, err := linuxServerCreatOptConvertKeyPairWrapping(baseServerCreateOpt, vmReqInfo.KeyPairIID, computeClient)
+	server, err := servers.Create(computeClient, createOptsExt).Extract()
+	if err != nil {
+		return servers.Server{}, err
+	}
+	return *server, err
 }


### PR DESCRIPTION
- VMHandler:
  - VMUserId, VMUserPasswd 지원
  - Image OS 구분 로직 추가
  - Openstack의 특성상 VM 생성시, 고려사항이 많아 복잡도가 증가하여, 구조의 변경이 있습니다.
    - Disk 유무, Cinder 유무, MyImage, PublicImage 별로 if 처리 되던 것을 보기 편하도록 함수로 변경한 부분이 있어 변경점이 많습니다.   
  - MyImage 기반 생성 테스트 완료
    - MyImage에서 변경사항은 없습니다.

Openstack은 Window 이미지를 제공하지 않아, 사용자가 Window 이미지를 만들어야합니다. 해당 가이드라인은 [이슈에 등록](https://github.com/cloud-barista/cb-spider/issues/805#issuecomment-1303036845)해놓겠습니다.(markdown 원본이 필요하실 경우 슬랙으로 전달드리겠습니다.) 