### PR TITLE
[Inno] Window ComputerName 제한

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -341,6 +341,9 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			}
 		}
 	} else {
+		if len(vmReqInfo.IId.NameId) > 15 {
+			vmOpts.OsProfile.ComputerName = to.StringPtr(vmReqInfo.IId.NameId[:15])
+		}
 		vmOpts.OsProfile.AdminPassword = to.StringPtr(vmReqInfo.VMUserPasswd)
 		vmOpts.OsProfile.AdminUsername = to.StringPtr(WindowTempUser)
 		vmOpts.Tags = map[string]*string{
@@ -1490,9 +1493,9 @@ func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType AzureOSTYPE) error {
 }
 
 func checkComputerNameWindow(vmReqInfo irs.VMReqInfo) error {
-	if len(vmReqInfo.IId.NameId) > 15 {
-		return errors.New("for Windows, VM's computeName cannot exceed 15 characters")
-	}
+	//if len(vmReqInfo.IId.NameId) > 15 {
+	//	return errors.New("for Windows, VM's computeName cannot exceed 15 characters")
+	//}
 	// https://learn.microsoft.com/ko-KR/troubleshoot/windows-server/identity/naming-conventions-for-computer-domain-site-ou
 	matchCase, _ := regexp.MatchString(`[\/?:|*<>\\\"]+`, vmReqInfo.IId.NameId)
 	if matchCase {

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -207,7 +207,7 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 	}
 
 	var reqInfo server.VMReqInfo
-	rawRootImage, getRawRootImageErr := imageHandler.GetRawRootImage(irs.IID{NameId: vmReqInfo.ImageIID.NameId}, vmReqInfo.ImageType == irs.MyImage)
+	rawRootImage, getRawRootImageErr := imageHandler.GetRawRootImage(irs.IID{SystemId: vmReqInfo.ImageIID.SystemId, NameId: vmReqInfo.ImageIID.NameId}, vmReqInfo.ImageType == irs.MyImage)
 	if getRawRootImageErr != nil {
 		return irs.VMInfo{}, errors.New(fmt.Sprintf("Failed to Create VM. err = %s", getRawRootImageErr.Error()))
 	}
@@ -226,7 +226,7 @@ func (vmHandler *ClouditVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startVM irs
 
 	if isWindows {
 		if len(vmReqInfo.IId.NameId) > 15 {
-			return irs.VMInfo{}, errors.New("Failed to Create VM. err = Hostname length of Windows cannot exceed 15")
+			reqInfo.HostName = vmReqInfo.IId.NameId[:15]
 		}
 		if len(vmReqInfo.VMUserPasswd) < 8 {
 			return irs.VMInfo{}, errors.New("Failed to Create VM. err = Password length of Windows cannot be less than 8")


### PR DESCRIPTION
Window HostName 관련 변경사항 아래와 같습니다. Azure와 Cloudit만 변경되었습니다.
[Azure] : 15글자이상일 경우 뒤에서 자르기
[IBM-VPC] : 15글자 이상시, IBM내부에서 15글자로 잘려서 지정됨(변경사항X)
[Cloudit] : 15글자이상일 경우 뒤에서 자르기
[Openstack] : 15글자 이상시, Cloudbase-init에 의해 15글자로 잘려서 지정됨(변경사항X)
