### PR TITLE
[Azure]Window시 KeyPair 존재 시 에러 제거

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -1476,9 +1476,9 @@ func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType AzureOSTYPE) error {
 		if pwErr != nil {
 			return pwErr
 		}
-		if vmReqInfo.KeyPairIID.NameId != "" || vmReqInfo.KeyPairIID.SystemId != "" {
-			return errors.New("for Windows, SSH key login method is not supported")
-		}
+		//if vmReqInfo.KeyPairIID.NameId != "" || vmReqInfo.KeyPairIID.SystemId != "" {
+		//	return errors.New("for Windows, SSH key login method is not supported")
+		//}
 		computeErr := checkComputerNameWindow(vmReqInfo)
 		if computeErr != nil {
 			return computeErr


### PR DESCRIPTION
[Azure] Remove Req's SSH Key Info in the driver when WindowsOS #833
- Window VM 생성시, KeyPair의 값이 존재하는 경우 에러로 리턴 => 검사하지 않도록 변경
  - CSP 별로 KeyPair의 필요 여부가 다름 => Azure에서 에러를 리턴하기보단, 이용하지 않는 방향으로 수정 