### PR TITLE
[Cloudit] Window VM 관련 오류 수정

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/MyImageHandler.go
@@ -221,6 +221,20 @@ func (myImageHandler *ClouditMyImageHandler) createMyImageSnapshots(myImageNameI
 		}
 	}
 
+	vmHandler := ClouditVMHandler{
+		CredentialInfo: myImageHandler.CredentialInfo,
+		Client:         myImageHandler.Client,
+	}
+
+	rawVm, getRawVmErr := vmHandler.getRawVm(irs.IID{SystemId: sourceVm.SystemId})
+	if getRawVmErr != nil {
+		return irs.MyImageInfo{}, errors.New("Failed to get Source VM Info")
+	}
+	if strings.Contains(strings.ToLower(rawVm.Template), "window") &&
+		rawVm.State != "STOPPED" {
+		return irs.MyImageInfo{}, errors.New("Cannot Create Windows VM Snapshot while Source VM is not Stopped")
+	}
+
 	vmVolumeList, err := server.GetRawVmVolumes(myImageHandler.Client, sourceVm.SystemId, &requestOpts)
 	if err != nil {
 		return irs.MyImageInfo{}, errors.New("Failed to get VM attached volumes")

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -745,24 +745,27 @@ func (vmHandler *ClouditVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, error)
 		LoggingError(hiscallInfo, createErr)
 		return irs.Failed, createErr
 	}
+	isWindows := strings.Contains(strings.ToLower(rawVm.Template), "windows")
 	curRetryCnt = 0
-	for {
-		_, commandError := RunCommand(serverIP, 22, "dumy", "", "")
-		errStr := commandError.Error()
-		if strings.Contains(errStr, "ssh") {
-			LoggingInfo(hiscallInfo, start)
-			return irs.Running, nil
-		}
-		time.Sleep(1 * time.Second)
-		curRetryCnt++
-		if curRetryCnt > maxRetryCnt {
-			createErr := errors.New(fmt.Sprintf("Failed to RebootVM. err = exceeded maximum retry count %d", maxRetryCnt))
-			cblogger.Error(createErr.Error())
-			LoggingError(hiscallInfo, createErr)
-			return irs.Failed, createErr
+	if !isWindows {
+		for {
+			_, commandError := RunCommand(serverIP, 22, "dumy", "", "")
+			errStr := commandError.Error()
+			if strings.Contains(errStr, "ssh") {
+				LoggingInfo(hiscallInfo, start)
+				return irs.Running, nil
+			}
+			time.Sleep(1 * time.Second)
+			curRetryCnt++
+			if curRetryCnt > maxRetryCnt {
+				createErr := errors.New(fmt.Sprintf("Failed to RebootVM. err = exceeded maximum retry count %d", maxRetryCnt))
+				cblogger.Error(createErr.Error())
+				LoggingError(hiscallInfo, createErr)
+				return irs.Failed, createErr
+			}
 		}
 	}
-	// return vmStatus, nil
+	return vmStatus, nil
 }
 
 func (vmHandler *ClouditVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, error) {


### PR DESCRIPTION
- 정지된 Windows VM 시작 시, SSH 접근 가능 여부 체크 생략
- Windows VM Reboot 시, SSH 접근 가능 여부 체크 생략
- Windows MyImage 생성 시, 원본 VM이 종료되어야만 MyImage를 생성할 수 있도록 수정    
  - Windows VM을 정지하지 않고 MyImage를 생성한 뒤, 해당 MyImage로 VM을 생성할 경우, VM 생성에 실패하는 오류를 발견하였습니다.
  - 해당 오류는 NTFS 파티션이 unsafe 상태이나, Hostname을 변경하기 위해 해당 파티션을 마운트하는 과정에서 발생하였습니다.
    - https://libguestfs.org/guestfs.3.html (WINDOWS HIBERNATION AND WINDOWS 8 FAST STARTUP 항목)
  - 따라서 Windows VM의 MyImage를 생성하는 과정에서 원본 VM이 정지되었는지 확인하는 과정을 추가하였습니다.