### PR TITLE
Add NCPVPC Cloud-init script file for MS Windows OS

### DIFF
--- a/cloud-driver-libs/.cloud-init-ncpvpc/cloud-init-windows
+++ b/cloud-driver-libs/.cloud-init-ncpvpc/cloud-init-windows
@@ -1,0 +1,3 @@
+'Visual Basic Code
+sCommandToRun = "net user Administrator {{PASSWORD}}"
+Call Shell("cmd.exe /S /C" & sCommandToRun, vbHide)


### PR DESCRIPTION
- Add NCPVPC Cloud-init script file for MS Windows OS
   - Note :  NCPVPC only supports Visual Basic as a Cloud-init script 