### PR TITLE
[Azure] Window 생성시 14글자 이상 Password 지정시, 확인 문구 스킵 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -1551,7 +1551,7 @@ func createAdministratorUser(vmIID irs.IID, newusername string, newpassword stri
 		VirtualMachineRunCommandProperties: &compute.VirtualMachineRunCommandProperties{
 			Source: &compute.VirtualMachineRunCommandScriptSource{
 				// Script: to.StringPtr(fmt.Sprintf("net user /add administrator qwe1212!Q; net localgroup administrators cb-user /add; net user /delete administrator;")),
-				Script: to.StringPtr(fmt.Sprintf("net user /add %s %s; net localgroup %s %s /add", newusername, newpassword, WindowBaseGroup, newusername)),
+				Script: to.StringPtr(fmt.Sprintf("net user /add %s %s /Y; net localgroup %s %s /add;", newusername, newpassword, WindowBaseGroup, newusername)),
 			},
 		},
 		Location: to.StringPtr(region.Region),


### PR DESCRIPTION
타기능 부착을 위해 VM 생성시, 버그사항을 발견하여 수정합니다.

윈도우 생성시, Password가 14글자 이상시 아래와 같은 확인 문구 출력.
```
The password entered is longer than 14 charactors. Computers
with Winodows prior to windows 2000 will not be able to use
this account. Do you want to continue this operation? (Y/N) [Y]:
```

해당 응답에 답을 하지 않아, 대기되어 Y로 지정 하기 위해 /Y 추가.

MyImage에서 사용하는 패스워드 변경은 해당 문제가 없음을 확인하였습니다.