### PR TITLE
[InnoCommon] VMInfo.Platform 추가

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/MyImageHandler.go
@@ -300,7 +300,7 @@ func preparationOperationForGeneralize(rawVm compute.VirtualMachine, vmClient *c
 		return err
 	}
 	vmStatus := getVmStatus(*rawVm.InstanceView)
-	if sourceVMOSType == WindowOS {
+	if sourceVMOSType == irs.WINDOWS {
 		if vmStatus == irs.Running {
 			err = windowShellPreparationOperationForGeneralize(*rawVm.Name, virtualMachineRunCommandsClient, ctx, region)
 			if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -1095,6 +1095,13 @@ func (vmHandler *AzureVMHandler) mappingServerInfo(server compute.VirtualMachine
 	if err == nil {
 		vmInfo.Platform = osPlatform
 	}
+	if vmInfo.PublicIP != "" {
+		if osPlatform == irs.WINDOWS {
+			vmInfo.AccessPoint = fmt.Sprintf("%s:%s", vmInfo.PublicIP, "3389")
+		} else {
+			vmInfo.AccessPoint = fmt.Sprintf("%s:%s", vmInfo.PublicIP, "22")
+		}
+	}
 	return vmInfo
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -30,20 +30,15 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
-type AzureOSTYPE string
-
 const (
-	ProvisioningStateCode string      = "ProvisioningState/succeeded"
-	VM                                = "VM"
-	PremiumSSD                        = "PremiumSSD"
-	StandardSSD                       = "StandardSSD"
-	StandardHDD                       = "StandardHDD"
-	WindowBaseUser                    = "Administrator"
-	WindowBaseGroup                   = "Administrators"
-	WindowBuitinUser                  = CBVMUser
-	UnknownOS             AzureOSTYPE = "UnknownOS"
-	WindowOS              AzureOSTYPE = "WindowOS"
-	LinuxOS               AzureOSTYPE = "LinuxOS"
+	ProvisioningStateCode string = "ProvisioningState/succeeded"
+	VM                           = "VM"
+	PremiumSSD                   = "PremiumSSD"
+	StandardSSD                  = "StandardSSD"
+	StandardHDD                  = "StandardHDD"
+	WindowBaseUser               = "Administrator"
+	WindowBaseGroup              = "Administrators"
+	WindowBuitinUser             = CBVMUser
 )
 
 type AzureVMHandler struct {
@@ -291,7 +286,7 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 		}
 	}
 
-	if imageOsType == LinuxOS {
+	if imageOsType == irs.LINUX {
 		// 3-2. Set VmReqInfo - KeyPair & tagging
 		if vmReqInfo.KeyPairIID.NameId != "" {
 			key, keyErr := GetRawKey(vmReqInfo.KeyPairIID, vmHandler.Region.ResourceGroup, vmHandler.SshKeyClient, vmHandler.Ctx)
@@ -442,7 +437,7 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 		}
 	}
 	// 6. Window user Change
-	if imageOsType == WindowOS {
+	if imageOsType == irs.WINDOWS {
 		if vmReqInfo.ImageType == "" || vmReqInfo.ImageType == irs.PublicImage {
 			err = createAdministratorUser(vmReqInfo.IId, WindowBaseUser, vmReqInfo.VMUserPasswd, vmHandler.Client, vmHandler.VirtualMachineRunCommandsClient, vmHandler.Ctx, vmHandler.Region)
 			if err != nil {
@@ -499,7 +494,7 @@ func (vmHandler *AzureVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			return irs.VMInfo{}, createErr
 		}
 		vmInfo := vmHandler.mappingServerInfo(vm)
-		if imageOsType == WindowOS {
+		if imageOsType == irs.WINDOWS {
 			vmInfo.VMUserPasswd = vmReqInfo.VMUserPasswd
 		}
 		LoggingInfo(hiscallInfo, start)
@@ -1035,10 +1030,10 @@ func (vmHandler *AzureVMHandler) mappingServerInfo(server compute.VirtualMachine
 	}
 	osType, err := getOSTypeByVM(server)
 	if err == nil {
-		if osType == WindowOS {
+		if osType == irs.WINDOWS {
 			vmInfo.VMUserId = WindowBaseUser
 		}
-		if osType == LinuxOS {
+		if osType == irs.LINUX {
 			vmInfo.VMUserId = CBVMUser
 		}
 	}
@@ -1096,7 +1091,10 @@ func (vmHandler *AzureVMHandler) mappingServerInfo(server compute.VirtualMachine
 		}
 		vmInfo.DataDiskIIDs = dataDiskIIDList
 	}
-
+	osPlatform, err := getOSTypeByVM(server)
+	if err == nil {
+		vmInfo.Platform = osPlatform
+	}
 	return vmInfo
 }
 
@@ -1481,8 +1479,8 @@ func ConvertVMIID(vmIID irs.IID, credentialInfo idrv.CredentialInfo, regionInfo 
 	}
 }
 
-func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType AzureOSTYPE) error {
-	if OSType == WindowOS {
+func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType irs.Platform) error {
+	if OSType == irs.WINDOWS {
 		_, idErr := windowUserIdCheck(vmReqInfo.VMUserId)
 		if idErr != nil {
 			return idErr
@@ -1499,7 +1497,7 @@ func checkAuthInfoOSType(vmReqInfo irs.VMReqInfo, OSType AzureOSTYPE) error {
 			return computeErr
 		}
 	}
-	if OSType == LinuxOS {
+	if OSType == irs.LINUX {
 		if vmReqInfo.KeyPairIID.NameId == "" && vmReqInfo.KeyPairIID.SystemId == "" {
 			return errors.New("for Linux, KeyPairIID is required")
 		}
@@ -1591,7 +1589,7 @@ func changeUserPassword(vmIID irs.IID, username string, newpassword string, virt
 	return nil
 }
 
-func CheckVMReqInfoOSType(vmReqInfo irs.VMReqInfo, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (AzureOSTYPE, error) {
+func CheckVMReqInfoOSType(vmReqInfo irs.VMReqInfo, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (irs.Platform, error) {
 	if vmReqInfo.ImageType == "" || vmReqInfo.ImageType == irs.PublicImage {
 		return getOSTypeByPublicImage(vmReqInfo.ImageIID)
 	} else {
@@ -1599,16 +1597,16 @@ func CheckVMReqInfoOSType(vmReqInfo irs.VMReqInfo, imageClient *compute.ImagesCl
 	}
 }
 
-func getOSTypeByVM(server compute.VirtualMachine) (AzureOSTYPE, error) {
+func getOSTypeByVM(server compute.VirtualMachine) (irs.Platform, error) {
 	if server.OsProfile.LinuxConfiguration != nil {
-		return LinuxOS, nil
+		return irs.LINUX, nil
 	}
-	return WindowOS, nil
+	return irs.WINDOWS, nil
 }
 
-func getOSTypeByPublicImage(imageIID irs.IID) (AzureOSTYPE, error) {
+func getOSTypeByPublicImage(imageIID irs.IID) (irs.Platform, error) {
 	if imageIID.NameId == "" && imageIID.SystemId == "" {
-		return UnknownOS, errors.New("failed get OSType By ImageIID err = empty ImageIID")
+		return "", errors.New("failed get OSType By ImageIID err = empty ImageIID")
 	}
 	imageName := imageIID.NameId
 	if imageIID.NameId == "" {
@@ -1616,34 +1614,34 @@ func getOSTypeByPublicImage(imageIID irs.IID) (AzureOSTYPE, error) {
 	}
 	imageNameSplits := strings.Split(imageName, ":")
 	if len(imageNameSplits) != 4 {
-		return UnknownOS, errors.New("failed get OSType By ImageIID err = invalid ImageIID, Image Name must be in the form of 'Publisher:Offer:Sku:Version'. ")
+		return "", errors.New("failed get OSType By ImageIID err = invalid ImageIID, Image Name must be in the form of 'Publisher:Offer:Sku:Version'. ")
 	}
 	offer := imageNameSplits[1]
 	if strings.Contains(strings.ToLower(offer), "window") {
-		return WindowOS, nil
+		return irs.WINDOWS, nil
 	}
-	return LinuxOS, nil
+	return irs.LINUX, nil
 }
 
-func getOSTypeByMyImage(myImageIID irs.IID, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (AzureOSTYPE, error) {
+func getOSTypeByMyImage(myImageIID irs.IID, imageClient *compute.ImagesClient, credentialInfo idrv.CredentialInfo, region idrv.RegionInfo, ctx context.Context) (irs.Platform, error) {
 	convertedMyImageIID, err := ConvertMyImageIID(myImageIID, credentialInfo, region)
 	if err != nil {
-		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = %s", err.Error()))
+		return "", errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = %s", err.Error()))
 	}
 	myImage, err := imageClient.Get(ctx, region.ResourceGroup, convertedMyImageIID.NameId, "")
 	if err != nil {
-		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = failed get MyImage err = %s", err.Error()))
+		return "", errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = failed get MyImage err = %s", err.Error()))
 	}
 	if reflect.ValueOf(myImage.StorageProfile.OsDisk).IsNil() {
-		return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
+		return "", errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
 	}
 	if myImage.StorageProfile.OsDisk.OsType == compute.OperatingSystemTypesLinux {
-		return LinuxOS, nil
+		return irs.LINUX, nil
 	}
 	if myImage.StorageProfile.OsDisk.OsType == compute.OperatingSystemTypesWindows {
-		return WindowOS, nil
+		return irs.LINUX, nil
 	}
-	return UnknownOS, errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
+	return "", errors.New(fmt.Sprintf("failed get OSType By MyImageIID err = empty MyImage OSType"))
 }
 func windowUserIdCheck(userId string) (bool, error) {
 	if userId == "Administrator" {

--- a/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/cloudit/resources/VMHandler.go
@@ -1034,10 +1034,16 @@ func (vmHandler *ClouditVMHandler) mappingServerInfo(serverInfo server.ServerInf
 	}
 
 	var vmUser string
+	var platform irs.Platform
+	var accessPoint string
 	if strings.Contains(strings.ToLower(serverInfo.Template), "window") {
 		vmUser = "Administrator"
+		platform = irs.WINDOWS
+		accessPoint = serverInfo.AdaptiveIp + ":3389"
 	} else {
 		vmUser = SSHDefaultUser
+		platform = irs.WINDOWS
+		accessPoint = serverInfo.AdaptiveIp + ":22"
 	}
 
 	vmInfo := irs.VMInfo{
@@ -1056,7 +1062,8 @@ func (vmHandler *ClouditVMHandler) mappingServerInfo(serverInfo server.ServerInf
 		VMUserId:       vmUser,
 		PublicIP:       serverInfo.AdaptiveIp,
 		PrivateIP:      serverInfo.PrivateIp,
-		SSHAccessPoint: fmt.Sprintf("%s:%d", serverInfo.AdaptiveIp, SSHDefaultPort),
+		Platform:       platform,
+		AccessPoint:    accessPoint,
 		RootDiskSize:   strconv.Itoa(serverInfo.VolumeSize),
 		RootDeviceName: "Not visible in Cloudit",
 		VMBlockDisk:    "Not visible in Cloudit",

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -583,6 +583,7 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 		if OSType == irs.WINDOWS {
 			vmInfo.VMUserId = WindowBaseUser
 		} else {
+			vmInfo.VMUserId = SSHDefaultUser
 			vmInfo.KeyPairIId = irs.IID{
 				NameId:   server.KeyName,
 				SystemId: server.KeyName,
@@ -689,6 +690,13 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 	osPlatform, err := getOSTypeByServer(server)
 	if err == nil {
 		vmInfo.Platform = osPlatform
+	}
+	if vmInfo.PublicIP != "" {
+		if osPlatform == irs.WINDOWS {
+			vmInfo.AccessPoint = fmt.Sprintf("%s:%s", vmInfo.PublicIP, "3389")
+		} else {
+			vmInfo.AccessPoint = fmt.Sprintf("%s:%s", vmInfo.PublicIP, "22")
+		}
 	}
 	return vmInfo
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -37,15 +37,10 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
-type OpenstackOSTYPE string
-
 const (
-	WindowBaseUser                 = "Administrator"
-	VM                             = "VM"
-	SSHDefaultUser                 = "cb-user"
-	WindowOS       OpenstackOSTYPE = "windows"
-	LinuxOS        OpenstackOSTYPE = "linux"
-	UnknownOS      OpenstackOSTYPE = "unknown"
+	WindowBaseUser = "Administrator"
+	VM             = "VM"
+	SSHDefaultUser = "cb-user"
 )
 
 type OpenStackVMHandler struct {
@@ -194,7 +189,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm i
 			LoggingError(hiscallInfo, createErr)
 			return irs.VMInfo{}, createErr
 		}
-		if imageOSType == WindowOS {
+		if imageOSType == irs.WINDOWS {
 			server, err = severCreatePublicImageWindowOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
 			if err != nil {
 				createErr := errors.New(fmt.Sprintf("Failed to startVM err =  %s", err))
@@ -220,7 +215,7 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm i
 			LoggingError(hiscallInfo, createErr)
 			return irs.VMInfo{}, createErr
 		}
-		if imageOSType == WindowOS {
+		if imageOSType == irs.WINDOWS {
 			server, err = severCreateMyImageWindowOS(serverCreateOpts, vmReqInfo, vmHandler.VolumeClient, vmHandler.ComputeClient)
 			if err != nil {
 				createErr := errors.New(fmt.Sprintf("Failed to startVM err = %s", err))
@@ -585,7 +580,7 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 	}
 	OSType, err := getOSTypeByServer(server)
 	if err == nil {
-		if OSType == WindowOS {
+		if OSType == irs.WINDOWS {
 			vmInfo.VMUserId = WindowBaseUser
 		} else {
 			vmInfo.KeyPairIId = irs.IID{
@@ -691,6 +686,10 @@ func (vmHandler *OpenStackVMHandler) mappingServerInfo(server servers.Server) ir
 		vmInfo.NetworkInterface = port.ID
 	}
 
+	osPlatform, err := getOSTypeByServer(server)
+	if err == nil {
+		vmInfo.Platform = osPlatform
+	}
 	return vmInfo
 }
 
@@ -897,45 +896,47 @@ func getAllVolumeByServerAttachedVolume(attachedVolumes []servers.AttachedVolume
 	return volumeList, nil
 }
 
-func getOSTypeByImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (OpenstackOSTYPE, error) {
+func getOSTypeByImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (irs.Platform, error) {
 	image, err := getRawImage(imageIID, computeClient)
 	if err != nil {
-		return UnknownOS, err
+		return "", err
 	}
 	value, exist := image.Metadata["os_type"]
 	if !exist {
-		return LinuxOS, nil
+		return irs.LINUX, nil
 	}
+	// os_type의 값 windows는 정해진 값, irs.Platform의 값이 바뀔 경우를 대비하여, static
 	if value == "windows" {
-		return WindowOS, nil
+		return irs.WINDOWS, nil
 	}
-	return LinuxOS, nil
+	return irs.LINUX, nil
 }
 
-func getOSTypeByMyImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (OpenstackOSTYPE, error) {
+func getOSTypeByMyImage(imageIID irs.IID, computeClient *gophercloud.ServiceClient) (irs.Platform, error) {
 	image, err := getRawSnapshot(imageIID, computeClient)
 	if err != nil {
-		return UnknownOS, err
+		return "", err
 	}
 	value, exist := image.Metadata["os_type"]
 	if !exist {
-		return LinuxOS, nil
+		return irs.LINUX, nil
 	}
+	// os_type의 값 windows는 정해진 값, irs.Platform의 값이 바뀔 경우를 대비하여, static
 	if value == "windows" {
-		return WindowOS, nil
+		return irs.WINDOWS, nil
 	}
-	return LinuxOS, nil
+	return irs.LINUX, nil
 }
 
-func getOSTypeByServer(server servers.Server) (OpenstackOSTYPE, error) {
+func getOSTypeByServer(server servers.Server) (irs.Platform, error) {
 	value, exist := server.Metadata["os_type"]
 	if !exist {
-		return LinuxOS, nil
+		return irs.LINUX, nil
 	}
 	if value == "windows" {
-		return WindowOS, nil
+		return irs.WINDOWS, nil
 	}
-	return LinuxOS, nil
+	return irs.LINUX, nil
 }
 
 func getPassword(server servers.Server) (string, error) {
@@ -1013,7 +1014,7 @@ func severCreatePublicImageLinuxOS(baseServerCreateOpt servers.CreateOpts, vmReq
 	baseServerCreateOpt.ImageRef = image.ID
 	baseServerCreateOpt.Metadata = map[string]string{
 		"imagekey": image.ID,
-		"os_type":  string(LinuxOS),
+		"os_type":  "linux",
 	}
 
 	if !(vmReqInfo.RootDiskSize == "" || vmReqInfo.RootDiskSize == "default") {
@@ -1093,7 +1094,8 @@ func severCreatePublicImageWindowOS(baseServerCreateOpt servers.CreateOpts, vmRe
 	baseServerCreateOpt.Metadata = map[string]string{
 		"imagekey":   image.ID,
 		"admin_pass": vmReqInfo.VMUserPasswd,
-		"os_type":    string(WindowOS),
+		// os_type의 값 windows는 정해진 값, irs.Platform의 값이 바뀔 경우를 대비하여, static
+		"os_type": "windows",
 	}
 	// Disk Size 변경
 	if !(vmReqInfo.RootDiskSize == "" || vmReqInfo.RootDiskSize == "default") {
@@ -1162,8 +1164,9 @@ func severCreateMyImageWindowOS(baseServerCreateOpt servers.CreateOpts, vmReqInf
 	}
 	baseServerCreateOpt.ImageRef = image.ID
 	baseServerCreateOpt.Metadata = map[string]string{
-		"imagekey":   image.ID,
-		"os_type":    string(WindowOS),
+		"imagekey": image.ID,
+		// os_type의 값 windows는 정해진 값, irs.Platform의 값이 바뀔 경우를 대비하여, static
+		"os_type":    "windows",
 		"admin_pass": vmReqInfo.VMUserPasswd,
 	}
 	_, exist := image.Metadata["block_device_mapping"]
@@ -1185,7 +1188,7 @@ func severCreateMyImageLinuxOS(baseServerCreateOpt servers.CreateOpts, vmReqInfo
 	baseServerCreateOpt.ImageRef = image.ID
 	baseServerCreateOpt.Metadata = map[string]string{
 		"imagekey": image.ID,
-		"os_type":  string(LinuxOS),
+		"os_type":  "linux",
 	}
 	// snapshot block_device_mapping Check (volumeClient)
 	_, exist := image.Metadata["block_device_mapping"]


### PR DESCRIPTION
- Azure: OS의 종류를 이미지와 독립적으로 획득하는 로직 추가 및 GetVM시 Platform 제공
- OpenStack: OS의 종류를  이미지와 독립적으로 획득하는 로직 추가 및 GetVM시 Platform 제공
- IBM-VPC: OS의 종류를 이미지와 독립적으로 획득하는 로직 추가 및 GetVM시 Platform 제공
- Cloudit: Cloudit 로직 확인 결과, 이미지를 기반으로 생성한 VM 또는 스냅샷이 존재할 시, 해당 이미지 삭제가 불가능하여 기존 로직을 유지하였으며, GetVM시 Platform을 제공하도록 수정하였습니다.