### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -55,14 +55,14 @@ jobs:
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}.*$ ]]; then
             DOCKER_TAGS="$DOCKER_TAGS,${DOCKER_IMAGE}:latest"
           fi
-          echo ::set-output name=docker-tags::${DOCKER_TAGS}
+          echo "docker-tags=${DOCKER_TAGS}" >> $GITHUB_OUTPUT
           echo ${DOCKER_TAGS}
           GHCR_IMAGE=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           GHCR_TAGS="${GHCR_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}.*$ ]]; then
             GHCR_TAGS="$GHCR_TAGS,${GHCR_IMAGE}:latest"
           fi
-          echo ::set-output name=ghcr-tags::${GHCR_TAGS}
+          echo "ghcr-tags=${GHCR_TAGS}" >> $GITHUB_OUTPUT
           echo ${GHCR_TAGS}
 
       - name: Set up QEMU


### PR DESCRIPTION
## Description

Closes #903 

Update `.github/workflows/publish-multi-arch-container-images.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=docker-tags::${DOCKER_TAGS}
```

**TO-BE**

```yaml
echo "docker-tags=${DOCKER_TAGS}" >> $GITHUB_OUTPUT
```