### PR TITLE
Update NCP GoSDK version in NCP Classic and NCP VPC driver build script

### DIFF
--- a/utils/driver-build-docker/2.build/ncp-build.sh
+++ b/utils/driver-build-docker/2.build/ncp-build.sh
@@ -18,8 +18,8 @@ echo "\$CBSPIDER_ROOT" path is $CBSPIDER_ROOT
 echo "# cd" $CBSPIDER_ROOT
 cd $CBSPIDER_ROOT
 
-echo "# go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.4"
-go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.4
+echo "# go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.6"
+go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.6
 
 cd $HOME
 

--- a/utils/driver-build-docker/2.build/ncpvpc-build.sh
+++ b/utils/driver-build-docker/2.build/ncpvpc-build.sh
@@ -18,8 +18,8 @@ echo "\$CBSPIDER_ROOT" path is $CBSPIDER_ROOT
 echo "# cd" $CBSPIDER_ROOT
 cd $CBSPIDER_ROOT
 
-echo "# go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.4"
-go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.4
+echo "# go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.6"
+go get -v github.com/NaverCloudPlatform/ncloud-sdk-go-v2@v1.6.6
 
 cd $HOME
 


### PR DESCRIPTION
- Update NCP GoSDK version in NCP Classic and NCP VPC driver build script
  - version v1.6.4 -> v1.6.6