### PR TITLE
Add NCP Classic / NCP VPC driver RegionZoneHandler Test Scripts using CB-Spider API

### DIFF
--- a/api-runtime/rest-runtime/test/region-zone-test/14.ncpvpc-region-zone-test.sh
+++ b/api-runtime/rest-runtime/test/region-zone-test/14.ncpvpc-region-zone-test.sh
@@ -1,0 +1,3 @@
+export CONN_CONFIG=ncpvpc-korea1-config
+
+./region-zone_test.sh

--- a/api-runtime/rest-runtime/test/region-zone-test/8.ncp-region-zone-test.sh
+++ b/api-runtime/rest-runtime/test/region-zone-test/8.ncp-region-zone-test.sh
@@ -1,0 +1,4 @@
+export CONN_CONFIG=ncp-korea1-config
+#export CONN_CONFIG=ncp-germany-config
+
+./region-zone_test.sh

--- a/api-runtime/rest-runtime/test/region-zone-test/region-zone_test.sh
+++ b/api-runtime/rest-runtime/test/region-zone-test/region-zone_test.sh
@@ -1,0 +1,19 @@
+echo "#### Region-Zone Test Process - Start ###"
+
+sleep 1 
+echo -e "\n### Region/Zone : List"
+curl -sX GET http://localhost:1024/spider/regionzone -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp
+
+sleep 2 
+echo -e "\n### Region/Zone : Get"
+curl -sX GET http://localhost:1024/spider/regionzone/KR -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}'
+
+sleep 2 
+echo -e "\n### ORG Region : List"
+curl -sX GET http://localhost:1024/spider/orgregion -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp 
+
+sleep 2
+echo -e "\n### ORG Zone : List"
+curl -sX GET http://localhost:1024/spider/orgzone -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp 
+
+echo "#### Region-Zone Test Process- Finished ###"


### PR DESCRIPTION
- Add NCP Classic and NCP VPC RegionZoneHandler Test Scripts using CB-Spider API
  - Add NCP Classic driver RegionZoneHandler Test Scripts
  - Add NCP VPC driver RegionZoneHandler Test Script

