### PR TITLE
Apply Region Info to KT Cloud VPC, and Add KT Cloud VPC RegionZoneHandler Test Code

### DIFF
--- a/api-runtime/rest-runtime/test/connect-config/15.ktcloudvpc-conn-config.sh
+++ b/api-runtime/rest-runtime/test/connect-config/15.ktcloudvpc-conn-config.sh
@@ -17,7 +17,7 @@ curl -X POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: applica
 ]}'
 
  # for Cloud Region Info
-curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"ktcloudvpc-DX-M1-zone","ProviderName":"KTCLOUDVPC","KeyValueInfoList": [{"Key":"Zone", "Value":"DX-M1"}]}'
+curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"ktcloudvpc-DX-M1-zone","ProviderName":"KTCLOUDVPC","KeyValueInfoList": [{"Key":"Region", "Value":"KR1"}, {"Key":"Zone", "Value":"DX-M1"}]}'
 
  # for Cloud Connection Config Info
-curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloudvpc-config01","ProviderName":"KTCLOUDVPC", "DriverName":"ktcloudvpc-driver01", "CredentialName":"ktcloudvpc-credential01", "RegionName":"ktcloudvpc-DX-M1-zone"}'
+curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloudvpc-mokdong1-config","ProviderName":"KTCLOUDVPC", "DriverName":"ktcloudvpc-driver01", "CredentialName":"ktcloudvpc-credential01", "RegionName":"ktcloudvpc-DX-M1-zone"}'

--- a/api-runtime/rest-runtime/test/region-zone-test/15.ktcloudvpc-region-zone-test.sh
+++ b/api-runtime/rest-runtime/test/region-zone-test/15.ktcloudvpc-region-zone-test.sh
@@ -1,0 +1,4 @@
+export CONN_CONFIG=ktcloudvpc-mokdong1-config
+export REGION_NAME=KR1
+
+./region-zone_test.sh

--- a/api-runtime/rest-runtime/test/region-zone-test/region-zone_test.sh
+++ b/api-runtime/rest-runtime/test/region-zone-test/region-zone_test.sh
@@ -1,8 +1,15 @@
+#!/bin/bash
 echo "#### Region-Zone Test Process - Start ###"
 
 sleep 1 
 echo -e "\n### Region/Zone : List"
+start=`date +%s.%N`
 curl -sX GET http://localhost:1024/spider/regionzone -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp
+finish=`date +%s.%N`
+diff=$( echo "$finish - $start" | bc -l )
+echo '# start:' $start
+echo '# finish:' $finish
+echo '# diff(sec):' $diff
 
 sleep 2 
 echo -e "\n### Region/Zone : Get"
@@ -10,10 +17,10 @@ curl -sX GET http://localhost:1024/spider/regionzone/${REGION_NAME} -H 'Content-
 
 sleep 2 
 echo -e "\n### ORG Region : List"
-curl -sX GET http://localhost:1024/spider/orgregion -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp 
+curl -sX GET http://localhost:1024/spider/orgregion -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp
 
 sleep 2
 echo -e "\n### ORG Zone : List"
-curl -sX GET http://localhost:1024/spider/orgzone -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp 
+curl -sX GET http://localhost:1024/spider/orgzone -H 'Content-Type: application/json' -d '{"ConnectionName": "'${CONN_CONFIG}'"}' | json_pp
 
 echo "#### Region-Zone Test Process- Finished ###"

--- a/cloud-control-manager/CloudDriverHandler_common.go
+++ b/cloud-control-manager/CloudDriverHandler_common.go
@@ -147,13 +147,11 @@ func getRegionNameByRegionInfo(rgnInfo *rim.RegionInfo) (string, string, error) 
 	switch strings.ToUpper(rgnInfo.ProviderName) {
 	case "AZURE":
 		regionName = getValue(rgnInfo.KeyValueInfoList, "location")
-	case "AWS", "ALIBABA", "GCP", "TENCENT", "IBM", "NCP", "NCPVPC", "KTCLOUD", "NHNCLOUD":
+	case "AWS", "ALIBABA", "GCP", "TENCENT", "IBM", "NCP", "NCPVPC", "KTCLOUD", "NHNCLOUD", "KTCLOUDVPC":
 		regionName = getValue(rgnInfo.KeyValueInfoList, "Region")
 		zoneName = getValue(rgnInfo.KeyValueInfoList, "Zone")
 	case "OPENSTACK", "CLOUDIT", "DOCKER", "CLOUDTWIN", "MOCK":
 		regionName = getValue(rgnInfo.KeyValueInfoList, "Region")
-	case "KTCLOUDVPC":
-		zoneName = getValue(rgnInfo.KeyValueInfoList, "Zone")
 	default:
 		errmsg := rgnInfo.ProviderName + " is not a valid ProviderName!!"
 		return "", "", fmt.Errorf(errmsg)


### PR DESCRIPTION
- Apply Region Info to KT Cloud VPC
  : There was only Zone info before.
  - Update CloudDriverHandler_common.go
  - Update 15.ktcloudvpc-conn-config.sh

- Add KT Cloud VPC RegionZoneHandler Test Code
  - Add 15.ktcloudvpc-region-zone-test.sh
  - Udate region-zone_test.sh