### PR TITLE
[+Region/Zone]  Remove a useless variable in RegionZoneHandler

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
@@ -63,7 +63,6 @@ func (regionZoneHandler *AzureRegionZoneHandler) ListRegionZone() ([]*irs.Region
 	var mutex = &sync.Mutex{}
 	var lenLocations = len(*resultListLocations.Value)
 	var zoneErrorOccurred bool
-	k := 0
 
 	for i := 0; i < lenLocations; {
 		if lenLocations-i < routineMax {
@@ -119,9 +118,7 @@ func (regionZoneHandler *AzureRegionZoneHandler) ListRegionZone() ([]*irs.Region
 				mutex.Unlock()
 
 				wait.Done()
-			}(&wait, (*resultListLocations.Value)[k])
-
-			k++
+			}(&wait, (*resultListLocations.Value)[i])
 
 			i++
 			if i == lenLocations {

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/RegionZoneHandler.go
@@ -38,7 +38,6 @@ func (regionZoneHandler *IbmRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 	var mutex = &sync.Mutex{}
 	var lenRegions = len(regions.Regions)
 	var zoneErrorOccurred bool
-	k := 0
 
 	for i := 0; i < lenRegions; {
 		if lenRegions-i < routineMax {
@@ -84,9 +83,7 @@ func (regionZoneHandler *IbmRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 				mutex.Unlock()
 
 				wait.Done()
-			}(&wait, regions.Regions[k])
-
-			k++
+			}(&wait, regions.Regions[i])
 
 			i++
 			if i == lenRegions {

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/RegionZoneHandler.go
@@ -86,7 +86,6 @@ func (regionZoneHandler *OpenStackRegionZoneHandler) ListRegionZone() ([]*irs.Re
 	var mutex = &sync.Mutex{}
 	var lenRegions = len(regionList)
 	var zoneErrorOccurred bool
-	k := 0
 
 	for i := 0; i < lenRegions; {
 		if lenRegions-i < routineMax {
@@ -121,9 +120,7 @@ func (regionZoneHandler *OpenStackRegionZoneHandler) ListRegionZone() ([]*irs.Re
 				mutex.Unlock()
 
 				wait.Done()
-			}(&wait, regionList[k])
-
-			k++
+			}(&wait, regionList[i])
 
 			i++
 			if i == lenRegions {


### PR DESCRIPTION
- Fixed by this discussion.
https://github.com/cloud-barista/cb-spider/pull/984#discussion_r1430764360

- Remove a useless variable in RegionZoneHandler of Azure, IBM and OpenStack.