### PR TITLE
Add KT Cloud Classic (G1/G2 platform) NLBHandler features

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/connect/KtCloud_Connection.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/connect/KtCloud_Connection.go
@@ -30,6 +30,7 @@ type KtCloudConnection struct {
 	CredentialInfo idrv.CredentialInfo
 	RegionInfo     idrv.RegionInfo
 	Client         *ktsdk.KtCloudClient
+	NLBClient      *ktsdk.KtCloudClient
 }
 
 var cblogger *logrus.Logger
@@ -88,7 +89,8 @@ func (cloudConn *KtCloudConnection) CreateVPCHandler() (irs.VPCHandler, error) {
 
 func (cloudConn *KtCloudConnection) CreateNLBHandler() (irs.NLBHandler, error) {
 	cblogger.Info("KT Cloud Driver: called CreateNLBHandler()!")
-	return nil, fmt.Errorf("KT Cloud Driver does not support CreateNLBHandler yet.")
+	nlbHandler := ktrs.KtCloudNLBHandler{RegionInfo: cloudConn.RegionInfo, Client: cloudConn.Client, NLBClient: cloudConn.NLBClient}
+	return &nlbHandler, nil
 }
 
 func (cloudConn *KtCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_NLBHandler.go
@@ -1,0 +1,340 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Tester Example.
+//
+// by ETRI, 2022.07.
+
+package main
+
+import (
+	"os"
+	"fmt"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+
+	cblog "github.com/cloud-barista/cb-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+
+	ktdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ktcloud"
+)
+
+var cblogger *logrus.Logger
+
+func init() {
+	// cblog is a global variable.
+	cblogger = cblog.GetLogger("KT Cloud Resource Test")
+	cblog.SetLevel("info")
+}
+
+// Test VMSpec
+func handleNLB() {
+	cblogger.Debug("Start NLBHandler Resource Test")
+
+	ResourceHandler, err := getResourceHandler("NLB")
+	if err != nil {
+		panic(err)
+	}
+
+	nlbHandler := ResourceHandler.(irs.NLBHandler)
+
+	for {
+		fmt.Println("\n============================================================================================")
+		fmt.Println("[ NLB Resource Test ]")
+		cblogger.Info("1. ListNLB()")
+		cblogger.Info("2. GetNLB()")
+		cblogger.Info("3. CreateNLB()")
+		cblogger.Info("4. DeleteNLB()")
+		cblogger.Info("5. ChangeListener()")
+		cblogger.Info("6. ChangeVMGroupInfo()")
+		cblogger.Info("7. AddVMs()")
+		cblogger.Info("8. RemoveVMs()")
+		cblogger.Info("9. GetVMGroupHealthInfo()")
+		cblogger.Info("10. ChangeHealthCheckerInfo()")
+		cblogger.Info("11. Exit")
+		fmt.Println("============================================================================================")
+
+		config := readConfigFile()
+		cblogger.Infof("\n # KT Cloud Region : [%s]", config.KtCloud.Region)
+		cblogger.Infof("\n # KT Cloud Zone : [%s]", config.KtCloud.Zone)
+		cblogger.Info("\n # Num : ")
+
+		nlbIId := irs.IID{
+			NameId: "new_lb-5",
+			SystemId: "38044",
+		}
+
+		nlbCreateReqInfo := irs.NLBInfo{
+			IId: irs.IID{
+				NameId: "new-nlb-2",
+			},
+			VpcIID: irs.IID{
+				NameId: "kt-vpc-01",
+			},
+			Listener: irs.ListenerInfo{
+				Protocol: "TCP",
+				Port:     "80",
+			},
+			VMGroup: irs.VMGroupInfo{
+				Protocol: "TCP",
+				Port:     "80",
+				VMs: &[]irs.IID{
+					{NameId: "kt-vm-1"},
+					{NameId: "kt-vm-2"},
+				},
+			},
+			HealthChecker: irs.HealthCheckerInfo{
+				Protocol:  "TCP",
+				Port:      "80",
+				Interval:  -1,
+				Timeout:   -1,
+				Threshold: -1,
+			},
+			// HealthChecker: irs.HealthCheckerInfo{
+			// 	Protocol:  "TCP",
+			// 	Port:      "8080",
+			// 	Interval:  30,
+			// 	Timeout:   5,
+			// 	Threshold: 3,
+			// },
+		}
+
+		updateListener := irs.ListenerInfo{
+			Protocol: "TCP",
+			Port:     "8087",
+		}
+
+		updateVMGroups := irs.VMGroupInfo{
+			Protocol: "TCP",
+			Port:     "8087",
+		}
+
+		addVMs := []irs.IID{
+			{NameId: "kt-vm-03"},
+			{NameId: "kt-vm-04"},
+		}
+
+		removeVMs := []irs.IID{
+			{NameId: "kt-vm-01"},
+			{NameId: "kt-vm-02"},
+			// {NameId: "kt-vm-3"},
+			// {NameId: "kt-vm-4"},
+		}
+	
+		updateHealthCheckerInfo := irs.HealthCheckerInfo{
+			Protocol:  "HTTP",
+			Port:      "8080",
+			Interval:  7,
+			Timeout:   5,
+			Threshold: 4,
+		}
+
+		var commandNum int
+		inputCnt, err := fmt.Scan(&commandNum)
+		if err != nil {
+			panic(err)
+		}
+
+		if inputCnt == 1 {
+			switch commandNum {
+			case 1:
+				cblogger.Info("Start ListNLB() ...")
+				if list, err := nlbHandler.ListNLB(); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(list)
+					cblogger.Info("출력 결과 수 : ", len(list))
+				}
+				cblogger.Info("Finish ListNLB()")
+			case 2:
+				cblogger.Info("Start GetNLB() ...")
+				if nlbInfo, err := nlbHandler.GetNLB(nlbIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(nlbInfo)
+				}
+				cblogger.Info("Finish GetNLB()")
+			case 3:
+				cblogger.Info("Start CreateNLB() ...")
+				if nlbInfo, err := nlbHandler.CreateNLB(nlbCreateReqInfo); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(nlbInfo)
+				}
+				cblogger.Info("Finish CreateNLB()")
+			case 4:
+				cblogger.Info("Start DeleteNLB() ...")
+				if nlbStatus, err := nlbHandler.DeleteNLB(nlbIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(nlbStatus)
+				}
+				cblogger.Info("Finish DeleteNLB()")
+			case 5:
+				cblogger.Info("Start ChangeListener() ...")
+				if nlbInfo, err := nlbHandler.ChangeListener(nlbIId, updateListener); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(nlbInfo)
+				}
+				cblogger.Info("Finish ChangeListener()")
+			case 6:
+				cblogger.Info("Start ChangeVMGroupInfo() ...")
+				if info, err := nlbHandler.ChangeVMGroupInfo(nlbIId, updateVMGroups); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish ChangeVMGroupInfo()")
+			case 7:
+				cblogger.Info("Start AddVMs() ...")
+				if info, err := nlbHandler.AddVMs(nlbIId, &addVMs); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish AddVMs()")
+			case 8:
+				cblogger.Info("Start RemoveVMs() ...")
+				if result, err := nlbHandler.RemoveVMs(nlbIId, &removeVMs); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(result)
+				}
+				cblogger.Info("Finish RemoveVMs()")
+			case 9:
+				cblogger.Info("Start GetVMGroupHealthInfo() ...")
+				if info, err := nlbHandler.GetVMGroupHealthInfo(nlbIId); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish GetVMGroupHealthInfo()")
+			case 10:
+				cblogger.Info("Start ChangeHealthCheckerInfo() ...")
+				if info, err := nlbHandler.ChangeHealthCheckerInfo(nlbIId, updateHealthCheckerInfo); err != nil {
+					cblogger.Error(err)
+				} else {
+					spew.Dump(info)
+				}
+				cblogger.Info("Finish ChangeHealthCheckerInfo()")
+			case 11:
+				cblogger.Info("Exit")
+			}
+		}
+	}
+}
+
+func main() {
+	cblogger.Info("KT Cloud Resource Test")
+
+	handleNLB()
+}
+
+//handlerType : resources폴더의 xxxHandler.go에서 Handler이전까지의 문자열
+//(예) ImageHandler.go -> "Image"
+func getResourceHandler(handlerType string) (interface{}, error) {
+	var cloudDriver idrv.CloudDriver
+	cloudDriver = new(ktdrv.KtCloudDriver)
+
+	config := readConfigFile()
+	connectionInfo := idrv.ConnectionInfo{
+		CredentialInfo: idrv.CredentialInfo{
+			ClientId:     config.KtCloud.KtCloudAccessKeyID,
+			ClientSecret: config.KtCloud.KtCloudSecretKey,
+		},
+		RegionInfo: idrv.RegionInfo{
+			Region: config.KtCloud.Region,
+			Zone:   config.KtCloud.Zone,
+		},
+	}
+
+	cloudConnection, errCon := cloudDriver.ConnectCloud(connectionInfo)
+	if errCon != nil {
+		return nil, errCon
+	}
+
+	var resourceHandler interface{}
+	var err error
+
+	switch handlerType {
+	case "Image":
+		resourceHandler, err = cloudConnection.CreateImageHandler()
+	case "Security":
+		resourceHandler, err = cloudConnection.CreateSecurityHandler()
+	case "VNetwork":
+		resourceHandler, err = cloudConnection.CreateVPCHandler()
+	case "VM":
+		resourceHandler, err = cloudConnection.CreateVMHandler()
+	case "VMSpec":
+		resourceHandler, err = cloudConnection.CreateVMSpecHandler()
+	case "VPC":
+		resourceHandler, err = cloudConnection.CreateVPCHandler()
+	case "NLB":
+		resourceHandler, err = cloudConnection.CreateNLBHandler()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return resourceHandler, nil
+}
+
+type Config struct {
+	KtCloud struct {
+		KtCloudAccessKeyID string `yaml:"ktcloud_access_key_id"`
+		KtCloudSecretKey   string `yaml:"ktcloud_secret_key"`
+		Region             string `yaml:"region"`
+		Zone               string `yaml:"zone"`
+
+		ImageID string `yaml:"image_id"`
+
+		VmID         string `yaml:"ktcloud_instance_id"`
+		BaseName     string `yaml:"base_name"`
+		InstanceType string `yaml:"instance_type"`
+		KeyName      string `yaml:"key_name"`
+		MinCount     int64  `yaml:"min_count"`
+		MaxCount     int64  `yaml:"max_count"`
+
+		SubnetID        string `yaml:"subnet_id"`
+		SecurityGroupID string `yaml:"security_group_id"`
+
+		PublicIP string `yaml:"public_ip"`
+	} `yaml:"ktcloud"`
+}
+
+// 환경변수 CBSPIDER_PATH 설정 후 해당 폴더 하위에 /config/config.yaml 파일 생성해야 함.
+func readConfigFile() Config {
+	rootPath := os.Getenv("CBSPIDER_ROOT")
+	configPath := rootPath + "/cloud-control-manager/cloud-driver/drivers/ktcloud/main/config/config.yaml"
+	cblogger.Debugf("Test Data 설정파일 : [%s]", configPath)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		panic(err)
+	}
+
+	var config Config
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		panic(err)
+	}
+
+	cblogger.Info("Loaded ConfigFile...")
+	//spew.Dump(config)
+	//cblogger.Info(config)
+
+	// NOTE Just for test
+	//cblogger.Info(config.KtCloud.KtCloudAccessKeyID)
+	//cblogger.Info(config.KtCloud.KtCloudSecretKey)
+
+	// NOTE Just for test
+	cblogger.Debug(config.KtCloud.KtCloudAccessKeyID, " ", config.KtCloud.Region)
+
+	return config
+}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/goget-ktsdk.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/goget-ktsdk.sh
@@ -2,4 +2,4 @@
 export GIT_TERMINAL_PROMPT=1
 export GOPRIVATE="github.com/cloud-barista"
 
-go get -u github.com/cloud-barista/ktcloud-sdk-go@latest
+go get -u github.com/cloud-barista/ktcloud-sdk-go@46f90aa8d02f80f3d5a5975c2e5503a120d2443c

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/test_nlb.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/test_nlb.sh
@@ -1,0 +1,3 @@
+source ../../../../../setup.env
+
+go run Test_NLBHandler.go

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/NLBHandler.go
@@ -1,0 +1,755 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// by ETRI Team, 2024.01.
+
+package resources
+
+import (
+	"fmt"
+	"strings"
+	"strconv"
+	"time"
+	// "github.com/davecgh/go-spew/spew"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	
+	ktsdk "github.com/cloud-barista/ktcloud-sdk-go"
+)
+
+type KtCloudNLBHandler struct {
+	RegionInfo     	idrv.RegionInfo
+	Client       	*ktsdk.KtCloudClient
+	NLBClient  		*ktsdk.KtCloudClient
+}
+
+const (
+	DefaultNLBOption 		string  = "roundrobin" // NLBOption : roundrobin / leastconnection / leastresponse / sourceiphash / 
+	DefaultHealthCheckURL	string  = "abc.kt.com"
+)
+
+func (nlbHandler *KtCloudNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLBInfo, error) {
+	cblogger.Info("KT Cloud Driver: called CreateNLB()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbReqInfo.IId.NameId, "CreateNLB()")
+
+	if strings.EqualFold(nlbReqInfo.IId.NameId, "") {
+		newErr := fmt.Errorf("Invalid NLB NameId!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+
+	if strings.EqualFold(nlbReqInfo.VpcIID.NameId, "") {
+		newErr := fmt.Errorf("Invalid VPC NameId!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+
+	if !strings.EqualFold(nlbReqInfo.Listener.Protocol, nlbReqInfo.VMGroup.Protocol) {
+		newErr := fmt.Errorf("Listener Protocol and VMGroup Protocol should be the Same for KT Cloud NLB!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+
+	if !strings.EqualFold(nlbReqInfo.Listener.Port, nlbReqInfo.VMGroup.Port) {
+		newErr := fmt.Errorf("Listener Port and VMGroup Prot should be the Same for this KT Cloud connection driver!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+
+	lbReq := ktsdk.CreateNLBReqInfo{
+		Name:           	nlbReqInfo.IId.NameId,  			// Required
+		ZoneId:         	nlbHandler.RegionInfo.Zone, 		// Required
+		NLBOption: 			DefaultNLBOption,					// Required
+		ServiceIP: 			"",									// Required. KT Cloud Virtual IP. $$$ In case of an empty value(""), it is newly created.
+		ServicePort: 		nlbReqInfo.Listener.Port,			// Required
+		ServiceType: 		nlbReqInfo.Listener.Protocol,		// Required
+		HealthCheckType: 	nlbReqInfo.HealthChecker.Protocol,  // Required
+		HealthCheckURL: 	DefaultHealthCheckURL,				// URL when the HealthCheckType (above) is 'http' or 'https'.
+	}
+	start := call.Start()
+	nlbResp, err := nlbHandler.NLBClient.CreateNLB(lbReq) // Not 'Client'
+	if (err != nil) ||(nlbResp.Createnlbresponse.ErrorText != "") { // Note!! : Apply 'ErrorText'
+		newErr := fmt.Errorf("Failed to Create New NLB. [%v]. [%v]", err, nlbResp.Createnlbresponse.ErrorText)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+	LoggingInfo(callLogInfo, start)
+	cblogger.Infof("# New NLBId : %s", nlbResp.Createnlbresponse.NLBId)
+
+	cblogger.Info("\n### New NLB is Creating Now!!")
+	time.Sleep(time.Second * 7)
+
+	newNlbIID := irs.IID{SystemId: nlbResp.Createnlbresponse.NLBId}
+	nlbInfo, err := nlbHandler.GetNLB(newNlbIID)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get the New NLB Info. [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)	
+		return irs.NLBInfo{}, newErr
+	}
+	return nlbInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
+	cblogger.Info("KT Cloud Driver: called ListNLB()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", "ListNLB()", "ListNLB()")
+
+	lbReq := ktsdk.ListNLBsReqInfo{
+		ZoneId: nlbHandler.RegionInfo.Zone,
+	}
+	start := call.Start()
+	nlbResp, err := nlbHandler.NLBClient.ListNLBs(lbReq) // Not 'Client'
+	if err != nil {
+		cblogger.Error("Failed to Get KT Cloud NLB list : [%v]", err)
+		return []*irs.NLBInfo{}, err
+	}
+	LoggingInfo(callLogInfo, start)
+	// spew.Dump(result)
+
+	time.Sleep(time.Second * 1) // Before the next if ...
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbResp.Listnlbsresponse.NLB) < 1 {
+		cblogger.Info("# KT Cloud NLB does Not Exist!!")
+		return []*irs.NLBInfo{}, nil // Not Return Error
+	}
+	// cblogger.Info("\n\n### nlbResp.Listnlbsresponse : ")
+	// spew.Dump(nlbResp.Listnlbsresponse)
+
+	var nlbInfoList []*irs.NLBInfo
+    for _, nlb := range nlbResp.Listnlbsresponse.NLB {
+		nlbInfo, err := nlbHandler.MappingNlbInfo(&nlb)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get NLB Info. : [%v]", err)
+			cblogger.Error(newErr.Error())
+			LoggingError(callLogInfo, newErr)
+			return nil, newErr
+		}
+		nlbInfoList = append(nlbInfoList, &nlbInfo)
+    }
+	return nlbInfoList, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error) {
+	cblogger.Info("KT Cloud Driver: called GetNLB()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "GetNLB()")
+
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return irs.NLBInfo{}, newErr
+	}
+	
+	ktNLB, err := nlbHandler.GetKTCloudNLB(nlbIID.SystemId)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get KT Cloud NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+
+	var nlbInfo irs.NLBInfo
+	nlbInfo, err = nlbHandler.MappingNlbInfo(ktNLB)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Map NLB Info with the NLB : [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+	return nlbInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) DeleteNLB(nlbIID irs.IID) (bool, error) {
+	cblogger.Info("KT Cloud Driver: called DeleteNLB()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "DeleteNLB()")
+
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	// Note!!) Should check 'EstablishedConn'(Client Connections) value before deletion?
+	start := call.Start()
+	nlbResp, err := nlbHandler.NLBClient.DeleteNLB(nlbIID.SystemId) // Not 'Client'
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Delete the NLB!! : [%v] ", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+	LoggingInfo(callLogInfo, start)
+	// cblogger.Info("\n\n### delResult : ")
+	// spew.Dump(nlbResp)
+
+	if !nlbResp.Deletenlbresponse.Success {
+		newErr := fmt.Errorf("Failed to Delete the NLB!! : [%s] ", nlbResp.Deletenlbresponse.Displaytext)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	} else {
+		cblogger.Infof("# Result : %s", nlbResp.Deletenlbresponse.Displaytext)		
+	}
+
+	return true, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) ChangeListener(nlbIID irs.IID, listener irs.ListenerInfo) (irs.ListenerInfo, error) {
+	cblogger.Info("KT Cloud Driver: called ChangeListener()")
+
+	return irs.ListenerInfo{}, fmt.Errorf("KT Cloud does not support ChangeListener() yet!!")
+}
+
+func (nlbHandler *KtCloudNLBHandler) ChangeVMGroupInfo(nlbIID irs.IID, vmGroup irs.VMGroupInfo) (irs.VMGroupInfo, error) {
+	cblogger.Info("KT Cloud Driver: called ChangeVMGroupInfo()")
+
+	return irs.VMGroupInfo{}, fmt.Errorf("KT Cloud does not support ChangeVMGroupInfo() yet!!")
+}
+
+func (nlbHandler *KtCloudNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (irs.VMGroupInfo, error) {
+	cblogger.Info("KT Cloud Driver: called AddVMs()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "AddVMs()")
+
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	if len(*vmIIDs) < 1 {
+		newErr := fmt.Errorf("Failded to Find any requested VM to Add to the NLB!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+
+	nlbInfo, err := nlbHandler.GetNLB(nlbIID)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	cblogger.Infof("# NLB Service Port : %s", nlbInfo.Listener.Port)
+
+	vmHandler := KtCloudVMHandler{
+		RegionInfo: nlbHandler.RegionInfo,
+		Client:   	nlbHandler.Client,
+	}
+	var vmIdList []string
+	if len(*vmIIDs) > 0 {
+		for _, vmIID := range *vmIIDs {
+			vmId, err := vmHandler.GetVmIdWithName(vmIID.NameId)
+			if err != nil {
+				newErr := fmt.Errorf("Failed to Get the VM ID with the VM Name : [%v]", err)
+				cblogger.Error(newErr.Error())
+				return irs.VMGroupInfo{}, newErr
+			}
+			vmIdList = append(vmIdList, vmId)
+
+			time.Sleep(time.Second * 1)
+			// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+		}
+	} else {
+		newErr := fmt.Errorf("Failded to Find any VM NameId to Add to the NLB!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+
+	for _, vmId := range vmIdList {
+		publicIP, err := vmHandler.GetIPFromPortForwardingRules(vmId)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get Public IP Info : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return irs.VMGroupInfo{}, newErr
+		}
+		cblogger.Infof("# VM Public IP : %s", publicIP)
+
+		time.Sleep(time.Second * 1)
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+		addVmReq := ktsdk.AddNLBVMReqInfo{
+			NLBId:         	nlbIID.SystemId,		// Required
+			VMId:			vmId,					// Required
+			IpAddress: 		publicIP,				// Required. 'Public IP' of the VM
+			PublicPort: 	nlbInfo.Listener.Port,	// Required. The same as the Listener Port (Service Port)
+		}
+		start := call.Start()
+		addVMResp, err := nlbHandler.NLBClient.AddNLBVM(addVmReq)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Attach the Disk Volume. [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			LoggingError(callLogInfo, newErr)
+			return irs.VMGroupInfo{}, newErr
+		}
+		LoggingInfo(callLogInfo, start)
+		// cblogger.Info("\n\n### AddVMResp : ")
+		// spew.Dump(addVMResp)
+		// cblogger.Info("\n")
+		cblogger.Infof("# ServiceId of the VM : %s : %d ", vmId, addVMResp.Addnlbvmresponse.ServiceId)
+
+		time.Sleep(time.Second * 1)
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+	}
+	
+	newVMGroupNlbInfo, err := nlbHandler.GetNLB(nlbIID)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	return newVMGroupNlbInfo.VMGroup, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) RemoveVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (bool, error) {
+	cblogger.Info("KT Cloud Driver: called RemoveVMs()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", "RemoveVMs()", "RemoveVMs()")
+
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+	if len(*vmIIDs) < 1 {
+		newErr := fmt.Errorf("Failed to Find any VM to Remove!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	vmHandler := KtCloudVMHandler{
+		RegionInfo: nlbHandler.RegionInfo,
+		Client:   	nlbHandler.Client,
+	}
+	var vmIdList []string
+	if len(*vmIIDs) > 0 {
+		for _, vmIID := range *vmIIDs {
+			vmId, err := vmHandler.GetVmIdWithName(vmIID.NameId)
+			if err != nil {
+				newErr := fmt.Errorf("Failed to Get the VM ID with the VM Name : [%v]", err)
+				cblogger.Error(newErr.Error())
+				return false, newErr
+			}
+			vmIdList = append(vmIdList, vmId)
+
+			time.Sleep(time.Second * 1)
+			// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+		}
+	} else {
+		newErr := fmt.Errorf("Failded to Find any VM NameId to Add to the NLB!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	for _, vmId := range vmIdList {
+		serviceId, err := nlbHandler.GetServiceIdWithVMId(nlbIID.SystemId, vmId)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get Service ID of the NLB VM!! [%v]", err)
+			cblogger.Error(newErr.Error())
+			LoggingError(callLogInfo, newErr)
+			return false, newErr
+		}
+		cblogger.Infof("# ServiceId : %d of VM : %s", serviceId, vmId)
+
+		start := call.Start()
+		removeResp, err := nlbHandler.NLBClient.RemoveNLBVM(strconv.Itoa(serviceId))
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Attach the Disk Volume. [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			LoggingError(callLogInfo, newErr)
+			return false, newErr
+		}
+		LoggingInfo(callLogInfo, start)
+		// cblogger.Info("\n\n### RemoveResp : ")
+		// spew.Dump(removeResp)
+		// cblogger.Info("\n")		
+
+		time.Sleep(time.Second * 1) // Before the next if ...
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+		if !removeResp.Removenlbvmresponse.Success {
+			newErr := fmt.Errorf("Failed to Remove the NLB VM!! : [%s] ", removeResp.Removenlbvmresponse.Displaytext)
+			cblogger.Error(newErr.Error())
+			LoggingError(callLogInfo, newErr)
+			return false, newErr
+		} else {
+			cblogger.Infof("# Result : %s", removeResp.Removenlbvmresponse.Displaytext)		
+		}
+	}
+
+	return true, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs.HealthInfo, error) {
+	cblogger.Info("KT Cloud Driver: called GetVMGroupHealthInfo()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "GetVMGroupHealthInfo()")
+
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.HealthInfo{}, newErr
+	}
+
+	// Get KT Cloud NLB VM list
+	nlbResp, err := nlbHandler.NLBClient.ListNLBVMs(nlbIID.SystemId) // Not 'Client'
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB VM list : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.HealthInfo{}, newErr
+	}
+	
+	time.Sleep(time.Second * 1) // Before the next if ...
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbResp.Listnlbvmsresponse.NLBVM) < 1 {
+		newErr := fmt.Errorf("Failed to Find Any VM from NLB VM list!!")
+		cblogger.Error(newErr.Error())
+		return irs.HealthInfo{}, newErr
+	}
+	// cblogger.Info("\n\n### nlbResp.Listnlbsresponse : ")
+	// spew.Dump(nlbResp.Listnlbvmsresponse)
+
+	vmHandler := KtCloudVMHandler{
+		RegionInfo: nlbHandler.RegionInfo,
+		Client:   	nlbHandler.Client,
+	}
+
+	var allVMs []irs.IID
+	var healthVMs []irs.IID
+	var unHealthVMs []irs.IID
+
+	for _, vm := range nlbResp.Listnlbvmsresponse.NLBVM {
+		vmName, err := vmHandler.GetVmNameWithId(vm.VMId)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the VM Name with the VM ID : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return irs.HealthInfo{}, newErr
+		}
+		
+		allVMs = append(allVMs, irs.IID{NameId: vmName, SystemId: vm.VMId})
+
+		if strings.EqualFold(vm.State, "UP") {
+			cblogger.Infof("\n### [%s] is Healthy VM.", vmName)
+			healthVMs = append(healthVMs, irs.IID{NameId: vmName, SystemId: vm.VMId})
+		} else {
+			cblogger.Infof("\n### [%s] is Unhealthy VM.", vmName)
+			unHealthVMs = append(unHealthVMs, irs.IID{NameId: vmName, SystemId: vm.VMId})  // In case of "DOWN"
+		}
+
+		time.Sleep(time.Second * 1)
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+	}
+
+	vmGroupHealthInfo := irs.HealthInfo{
+		AllVMs:       &allVMs,
+		HealthyVMs:   &healthVMs,
+		UnHealthyVMs: &unHealthVMs,
+	}
+	return vmGroupHealthInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, healthChecker irs.HealthCheckerInfo) (irs.HealthCheckerInfo, error) {
+	cblogger.Info("KT Cloud Driver: called ChangeHealthCheckerInfo()")
+
+	return irs.HealthCheckerInfo{}, fmt.Errorf("KT Cloud does not support ChangeHealthCheckerInfo() yet!!")
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetListenerInfo(nlb *ktsdk.NLB) (irs.ListenerInfo, error) {
+	cblogger.Info("KT Cloud Driver: called GetListenerInfo()")
+	nlbId := strconv.Itoa(nlb.NLBId)
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "GetListenerInfo()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid Load-Balancer ID. The LB does Not Exit!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.ListenerInfo{}, newErr
+	}
+	
+	listenerInfo := irs.ListenerInfo{
+		Protocol: 	nlb.ServiceType,
+		IP: 		nlb.ServiceIP,
+		Port: 		nlb.ServicePort,
+		DNSName:	"N/A",
+		CspID: 		"N/A",
+	}
+	listenerKVList := []irs.KeyValue{
+		// {Key: "NLB_DomainName", Value: *nlb.DomainName},
+	}
+	listenerInfo.KeyValueList = listenerKVList
+	return listenerInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetHealthCheckerInfo(nlb *ktsdk.NLB) (irs.HealthCheckerInfo, error) {
+	cblogger.Info("KT Cloud Driver: called GetHealthCheckerInfo()")
+	nlbId := strconv.Itoa(nlb.NLBId)
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "GetHealthCheckerInfo()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid Load-Balancer ID. The LB does Not Exit!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.HealthCheckerInfo{}, newErr
+	}
+
+	healthCheckerInfo := irs.HealthCheckerInfo{
+		Protocol: 	nlb.HealthCheckType,
+		Port:     	nlb.ServicePort,
+		CspID: 		"N/A",
+	}
+	return healthCheckerInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetVMGroupInfo(nlbId string) (irs.VMGroupInfo, error) {
+	cblogger.Info("KT Cloud Driver: called GetVMGroupInfo()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "GetVMGroupInfo()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID")
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+	
+	ktNLB, err := nlbHandler.GetKTCloudNLB(nlbId)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get KT Cloud NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	serviceProtocol := ktNLB.ServiceType
+
+	// Get KT Cloud NLB VM list
+	start := call.Start()
+	nlbResp, err := nlbHandler.NLBClient.ListNLBVMs(nlbId) // Not 'Client'
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB VM list : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+	LoggingInfo(callLogInfo, start)
+	// spew.Dump(nlbResp)
+
+	time.Sleep(time.Second * 1) // Before the next if ...
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbResp.Listnlbvmsresponse.NLBVM) < 1 {
+		cblogger.Info("# NLB VM does Not Exist Yet!!")
+		return irs.VMGroupInfo{}, nil // Not Return Error
+	}
+	// cblogger.Info("\n\n### nlbResp.Listnlbsresponse : ")
+	// spew.Dump(nlbResp.Listnlbvmsresponse)
+	
+	vmGroupInfo := irs.VMGroupInfo{
+		Protocol: 	serviceProtocol, // Caution!!
+		Port: 		nlbResp.Listnlbvmsresponse.NLBVM[0].PublicPort,
+		CspID:    	"N/A",
+	}
+
+	vmHandler := KtCloudVMHandler{
+		RegionInfo: nlbHandler.RegionInfo,
+		Client:   	nlbHandler.Client,
+	}
+
+	vmIIds := []irs.IID{}
+	keyValueList := []irs.KeyValue{}
+	for _, vm := range nlbResp.Listnlbvmsresponse.NLBVM {
+		vmName, err := vmHandler.GetVmNameWithId(vm.VMId)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the VM Name with the VM ID : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return irs.VMGroupInfo{}, newErr
+		}
+
+		vmIIds = append(vmIIds, irs.IID{
+			NameId:   vmName,
+			SystemId: vm.VMId,
+		})
+
+		keyValueList = append(keyValueList, irs.KeyValue{
+			Key: 	vmName + "_ServiceId",
+			Value: 	strconv.Itoa(vm.ServiceId),				
+		})
+
+		time.Sleep(time.Second * 1)
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+	}
+	vmGroupInfo.VMs = &vmIIds
+	vmGroupInfo.KeyValueList = keyValueList
+	return vmGroupInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetServiceIdWithVMId(nlbId string, vmId string) (int, error) {
+	cblogger.Info("KT Cloud cloud driver: called GetServiceIdWithVMId()!")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID")
+		cblogger.Error(newErr.Error())
+		return 0, newErr
+	}
+
+	if strings.EqualFold(vmId, "") {
+		newErr := fmt.Errorf("Invalid VM ID")
+		cblogger.Error(newErr.Error())
+		return 0, newErr
+	}
+
+	// Get KT Cloud NLB VM list
+	nlbResp, err := nlbHandler.NLBClient.ListNLBVMs(nlbId) // Not 'Client'
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB VM list : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return 0, newErr
+	}
+
+	time.Sleep(time.Second * 1) // Before the next if ...
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbResp.Listnlbvmsresponse.NLBVM) < 1 {
+		newErr := fmt.Errorf("Failed to Find Any VM from NLB VM list!!")
+		cblogger.Error(newErr.Error())
+		return 0, newErr
+	}
+	// cblogger.Info("\n\n### nlbResp.Listnlbsresponse : ")
+	// spew.Dump(nlbResp.Listnlbvmsresponse)
+
+	var serviceId int // Not 'string'
+	for _, vm := range nlbResp.Listnlbvmsresponse.NLBVM {
+		if strings.EqualFold(vm.VMId, vmId) {
+			serviceId = vm.ServiceId
+			break
+		}
+	}
+
+	if serviceId == 0 {
+		newErr := fmt.Errorf("Failed to Find the ServiceId with the NLB VMId %s", vmId)
+		cblogger.Error(newErr.Error())
+		return 0, newErr
+	} else {
+	return serviceId, nil
+	}
+}
+
+func (nlbHandler *KtCloudNLBHandler) MappingNlbInfo(nlb *ktsdk.NLB) (irs.NLBInfo, error) {
+	cblogger.Info("KT Cloud Driver: called MappingNlbInfo()")
+	// cblogger.Info("\n\n### nlb : ")
+	// spew.Dump(nlb)	
+
+	nlbInfo := irs.NLBInfo{
+		IId: irs.IID{
+			NameId:   nlb.Name,
+			SystemId: strconv.Itoa(nlb.NLBId),
+		},
+		VpcIID: irs.IID{
+			NameId:   "N/A",
+			SystemId: "N/A",
+		},
+		Type:         "PUBLIC",
+		Scope:        "REGION",
+	}
+
+	keyValueList := []irs.KeyValue{
+		{Key: "NLB_Method", Value: nlb.NLBOption},
+		{Key: "NLB_State", Value: nlb.State},
+		{Key: "NLB_ServiceIP", Value: nlb.ServiceIP},
+		{Key: "NLB_ServicePort", Value: nlb.ServicePort},
+		{Key: "ZoneName", Value: nlb.ZoneName},
+	}
+	nlbInfo.KeyValueList = keyValueList
+
+	if !strings.EqualFold(nlb.ServiceIP, "") {
+		listenerInfo, err := nlbHandler.GetListenerInfo(nlb)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the Listener Info : [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			return irs.NLBInfo{}, newErr
+		}
+		nlbInfo.Listener = listenerInfo
+	}
+
+	if !strings.EqualFold(nlb.HealthCheckType, "") {
+		healthCheckerInfo, err := nlbHandler.GetHealthCheckerInfo(nlb)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get HealthChecker Info. frome the NLB. [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			return irs.NLBInfo{}, newErr
+		}
+		nlbInfo.HealthChecker = healthCheckerInfo
+	}
+
+	vmGroupInfo, err := nlbHandler.GetVMGroupInfo(strconv.Itoa(nlb.NLBId))
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get VM Group Info with the NLB ID : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.NLBInfo{}, newErr
+	}
+	nlbInfo.VMGroup = vmGroupInfo
+	return nlbInfo, nil
+}
+
+func (nlbHandler *KtCloudNLBHandler) GetKTCloudNLB(nlbId string) (*ktsdk.NLB, error) {
+	cblogger.Info("KT Cloud Driver: called GetKTCloudNLB()")
+	InitLog()
+	callLogInfo := GetCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "GetKTCloudNLB()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return nil, newErr
+	}
+
+	lbReq := ktsdk.ListNLBsReqInfo{
+		ZoneId: nlbHandler.RegionInfo.Zone,
+		NLBId: 	nlbId,
+	}
+	start := call.Start()
+	nlbResp, err := nlbHandler.NLBClient.ListNLBs(lbReq) // Not 'Client'
+	if err != nil {
+		cblogger.Error("Failed to Get KT Cloud NLB list : [%v]", err)
+		return nil, err
+	}
+	LoggingInfo(callLogInfo, start)
+	// cblogger.Info("\n# nlbResp : ")
+	// spew.Dump(nlbResp)
+
+	time.Sleep(time.Second * 1) // Before the next if ... 
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbResp.Listnlbsresponse.NLB) < 1 {
+		newErr := fmt.Errorf("Failed to Find the NLB info with the ID on the zone!!")
+		cblogger.Error(newErr.Error())
+		return nil, newErr
+	}
+	// cblogger.Info("\n\n### result.Listnlbsresponse : ")
+	// spew.Dump(result.Listnlbsresponse)
+
+	return &nlbResp.Listnlbsresponse.NLB[0], nil
+}

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 require (
 	github.com/IBM/platform-services-go-sdk v0.30.0
 	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.6
-	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240116154332-e1c0c726d5b5
+	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240119134447-46f90aa8d02f
 	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20231114133737-f29e6fddb736
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/cloud-barista/cb-log v0.8.0 h1:ArWCs1EgpoD3ZnBgcC4cAw5ufI/JHmFKfJswlv
 github.com/cloud-barista/cb-log v0.8.0/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240116154332-e1c0c726d5b5 h1:y+qC1tawDnSSVuTcgCyFGnOcyVCsaqPWWeSkjyITlW4=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240116154332-e1c0c726d5b5/go.mod h1:ZIrUxItUvMIGZyX6Re7tUdcS3cwBIzBPcL+Pk/6lt/8=
+github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240119134447-46f90aa8d02f h1:DvXmUu+d5QiuZ/oIURDaacpiyWnE91ZR3TQRu7bsjP0=
+github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240119134447-46f90aa8d02f/go.mod h1:ZIrUxItUvMIGZyX6Re7tUdcS3cwBIzBPcL+Pk/6lt/8=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20231114133737-f29e6fddb736 h1:6cc5BVWPZAo1gW7Mjfd74XAK4Wv/J6vLc3CSSMuRXd0=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20231114133737-f29e6fddb736/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
- Add KT Cloud Classic NLBHandler methods
- Add KT Cloud Classic NLBHandler test codes
- Update KtCloudDriver.go
  -  Add NLBClient
- Update KtCloud_Connection.go
  -  Add Connection to NLBHandler
- Update VMHandler
  - Add GetVmNameWithId() method
- Update go.mod/go.sum
  - Update ktcloud-sdk-go version