### PR TITLE
Add billing account id from credential to CredentialInfo struct

### DIFF
--- a/cloud-control-manager/CloudDriverHandler_common.go
+++ b/cloud-control-manager/CloudDriverHandler_common.go
@@ -94,6 +94,7 @@ func GetCloudConnection(cloudConnectName string) (icon.CloudConnection, error) {
 			MockName:         getValue(crdInfo.KeyValueInfoList, "MockName"),
 			ApiKey:           getValue(crdInfo.KeyValueInfoList, "ApiKey"),
 			ClusterId:        getValue(crdInfo.KeyValueInfoList, "ClusterId"),
+			BillingAccountID: getValue(crdInfo.KeyValueInfoList, "BillingAccountID"),
 			ConnectionName:   cloudConnectName,
 		},
 		RegionInfo: idrv.RegionInfo{ // @todo powerkim


### PR DESCRIPTION
## 작업 개요
- GCP price info 를 가지고 오기 위해서 BillingAccountID 를 CredentialInfo 에 셋팅이 필요합니다.
- GCP Credential 을 등록 시 key value 에 아래 정보 추가하고 등록을 하였습니다.
`{"Key":"BillingAccountID", "Value":"billingAccounts/xxxxxx-xxxxxx-xxxxxx"}` 
- 사용자가 입력한 credential 정보를 CredentialInfo struct 로 매핑하는 부분에서
- BillingAccountID 를 매핑하는 코드가 누락되어 있는 것을 확인하였습니다.
- 원활한 웹 테스트를 위해 해당 부분 코드 추가하였습니다.
