### PR TITLE
GCP Driver - Remove unnecessary code lines.

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/main/conf/Test_Config.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/main/conf/Test_Config.go
@@ -58,16 +58,12 @@ func GetResourceHandler(handlerType string) (interface{}, error) {
 	//region := "europe-west1"
 	region := "asia-northeast3"
 	zone := "asia-northeast3-a"
-	// 필요 시 BillingAccountID 셋팅 필요 "billingAccounts/xxxxxx-xxxxxx-xxxxxx"
-	billingAccountID := "billingAccounts/"
 
 	connectionInfo := idrv.ConnectionInfo{
 		CredentialInfo: idrv.CredentialInfo{
 			PrivateKey:  config.PrivateKey,
 			ProjectID:   config.ProjectID,
 			ClientEmail: config.ClientEmail,
-			
-			BillingAccountID: billingAccountID,
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: region,

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/PriceInfoHandler.go
@@ -61,9 +61,6 @@ func init() {
 			validFilterKey[camelCaseFieldName] = true
 		}
 	}
-
-	fmt.Printf("valid key is this %+v\n", validFilterKey)
-
 }
 
 type GCPPriceInfoHandler struct {


### PR DESCRIPTION
## 작업 내용
- Credential Info 에서 BillingAccountID 가 참조되는 코드가 테스트 파일에 존재해서 해당 부분 삭제했습니다.
- GCP PriceInfoHandler.go 에 개발용으로 추가된 프린트문을 삭제했습니다.(#1031 )
