### PR TITLE
Update KT Cloud Classic NLBHandler - Remove 'NameID: "N/A"' code

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/NLBHandler.go
@@ -716,10 +716,10 @@ func (nlbHandler *KtCloudNLBHandler) mappingNlbInfo(nlb *ktsdk.NLB) (irs.NLBInfo
 			NameId:   nlb.Name,
 			SystemId: strconv.Itoa(nlb.NLBId),
 		},
-		VpcIID: irs.IID{
-			NameId:   "N/A",
-			SystemId: "N/A",
-		},
+		// VpcIID: irs.IID{
+		// 	NameId:   "N/A", // Cauton!!) 'NameId: "N/A"' makes an Error on CB-Spider
+		// 	SystemId: "N/A",
+		// },
 		Type:         "PUBLIC",
 		Scope:        "REGION",
 	}


### PR DESCRIPTION
- Update KT Cloud Classic NLBHandler
  - Remove 'NameID: "N/A"' code
    : This makes an error on CB-Spider