### PR TITLE
[+Price, +Region/Zone] Fix Price and Region/Zone handlers of Azure, IBM and OpenStack

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
@@ -12,6 +12,7 @@ import (
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -121,6 +122,10 @@ func (regionZoneHandler *AzureRegionZoneHandler) ListRegionZone() ([]*irs.Region
 	}
 
 	LoggingInfo(hiscallInfo, start)
+
+	sort.Slice(regionZoneInfo, func(i, j int) bool {
+		return strings.Compare(regionZoneInfo[i].Name, regionZoneInfo[j].Name) < 0
+	})
 
 	return regionZoneInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/PriceInfoHandler.go
@@ -379,18 +379,36 @@ func (priceInfoHandler *IbmPriceInfoHandler) GetPriceInfo(productFamily string, 
 	var priceList []irs.Price
 
 	for _, resource := range resources {
-		vCPUs := "NA"
-		memoryGB := "NA"
+		productInfo := irs.ProductInfo{
+			ProductId:      resource.Id,
+			RegionName:     regionName,
+			Description:    resource.OverviewUI.EN.Description,
+			CSPProductInfo: resource,
+		}
 
 		if strings.ToLower(productFamily) == "is.instance" {
+			productInfo.InstanceType = resource.Name
+			productInfo.Vcpu = "NA"
+			productInfo.Memory = "NA"
+			productInfo.Gpu = "NA"
+			productInfo.GpuMemory = "NA"
+			productInfo.OperatingSystem = "NA"
+			productInfo.PreInstalledSw = "NA"
+
 			splitedSpec := strings.Split(resource.Name, "-")
 			if len(splitedSpec) == 2 {
 				splitedCPUMemory := strings.Split(splitedSpec[1], "x")
 				if len(splitedCPUMemory) == 2 {
-					vCPUs = splitedCPUMemory[0]
-					memoryGB = splitedCPUMemory[1] + " GiB"
+					productInfo.Vcpu = splitedCPUMemory[0]
+					productInfo.Memory = splitedCPUMemory[1] + " GiB"
 				}
 			}
+		} else if strings.ToLower(productFamily) == "is.volume" {
+			productInfo.VolumeType = resource.Name
+			productInfo.StorageMedia = "NA"
+			productInfo.MaxVolumeSize = "NA"
+			productInfo.MaxIOPSVolume = "NA"
+			productInfo.MaxThroughputVolume = "NA"
 		}
 
 		var planResourceInfoTemp ResourceInfo
@@ -509,25 +527,7 @@ func (priceInfoHandler *IbmPriceInfoHandler) GetPriceInfo(productFamily string, 
 		}
 
 		priceList = append(priceList, irs.Price{
-			ProductInfo: irs.ProductInfo{
-				ProductId:           resource.Id,
-				RegionName:          regionName,
-				InstanceType:        resource.Name,
-				Vcpu:                vCPUs,
-				Memory:              memoryGB,
-				Storage:             "NA",
-				Gpu:                 "NA",
-				GpuMemory:           "NA",
-				OperatingSystem:     "NA",
-				PreInstalledSw:      "",
-				VolumeType:          "NA",
-				StorageMedia:        "NA",
-				MaxVolumeSize:       "",
-				MaxIOPSVolume:       "",
-				MaxThroughputVolume: "",
-				Description:         resource.OverviewUI.EN.DisplayName,
-				CSPProductInfo:      resource,
-			},
+			ProductInfo: productInfo,
 			PriceInfo: irs.PriceInfo{
 				PricingPolicies: pricingPolicies,
 				CSPPriceInfo:    priceInfo.Metrics,

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/RegionZoneHandler.go
@@ -9,6 +9,8 @@ import (
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"sort"
+	"strings"
 	"sync"
 )
 
@@ -104,6 +106,10 @@ func (regionZoneHandler *IbmRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 	}
 
 	LoggingInfo(hiscallInfo, start)
+
+	sort.Slice(regionZoneInfo, func(i, j int) bool {
+		return strings.Compare(regionZoneInfo[i].Name, regionZoneInfo[j].Name) < 0
+	})
 
 	return regionZoneInfo, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/RegionZoneHandler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
+	"sort"
+	"strings"
 	"sync"
 )
 
@@ -142,6 +144,10 @@ func (regionZoneHandler *OpenStackRegionZoneHandler) ListRegionZone() ([]*irs.Re
 	}
 
 	LoggingInfo(hiscallInfo, start)
+
+	sort.Slice(regionZoneInfo, func(i, j int) bool {
+		return strings.Compare(regionZoneInfo[i].Name, regionZoneInfo[j].Name) < 0
+	})
 
 	return regionZoneInfo, nil
 }


### PR DESCRIPTION
## Azure
- [Azure: Sort order of regions](https://github.com/ish-hcc/cb-spider/commit/d2445545413863499acbfb2a7a3d808d73c2ae2a)
- [Azure: Fix parsing of price data](https://github.com/ish-hcc/cb-spider/commit/b7712ec11bc0d8deb8d6f7ddfbf435398b01bda7)

## IBM
- [IBM: Show only resource specific attributes](https://github.com/ish-hcc/cb-spider/commit/bcde993ea26e51bec7d33f8bb05f1660d068868f)
- [IBM: Sort order of regions](https://github.com/ish-hcc/cb-spider/commit/4748d7fa6d7c6cf1650cfead934dde4cd82ac9b5)

## OpenStack
- [OpenStack: Sort order of regions](https://github.com/ish-hcc/cb-spider/commit/e4f58b8bcc48fe72beb3eab81c87f867c2af4bec)