### PR TITLE
[Tencent] Change All Error Messages to English #1053

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -68,7 +68,8 @@ func getVMClient(connectionInfo idrv.ConnectionInfo) (*ec2.EC2, error) {
 	//spew.Dump(connectionInfo)
 
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(connectionInfo.RegionInfo.Region),
+		CredentialsChainVerboseErrors: aws.Bool(true),
+		Region:                        aws.String(connectionInfo.RegionInfo.Region),
 		//Region:      aws.String("ap-northeast-2"),
 		Credentials: credentials.NewStaticCredentials(connectionInfo.CredentialInfo.ClientId, connectionInfo.CredentialInfo.ClientSecret, "")},
 	)

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1926,7 +1926,6 @@ func readConfigFile() Config {
 	rootPath := os.Getenv("CBSPIDER_PATH")
 	cblogger.Infof("Test Data 설정파일 : [%s]", rootPath+"/config/config.yaml")
 	data, err := ioutil.ReadFile(rootPath + "/config/config.yaml")
-	data, err = ioutil.ReadFile("/home/ubuntu/workspace/cb-spider/test_priceinfo_mhlee_240124/cloud-control-manager/cloud-driver/drivers/aws/main/Sample/config/config.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1926,6 +1926,7 @@ func readConfigFile() Config {
 	rootPath := os.Getenv("CBSPIDER_PATH")
 	cblogger.Infof("Test Data 설정파일 : [%s]", rootPath+"/config/config.yaml")
 	data, err := ioutil.ReadFile(rootPath + "/config/config.yaml")
+	data, err = ioutil.ReadFile("/home/ubuntu/workspace/cb-spider/test_priceinfo_mhlee_240124/cloud-control-manager/cloud-driver/drivers/aws/main/Sample/config/config.yaml")
 	if err != nil {
 		panic(err)
 	}

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
@@ -733,6 +733,8 @@ func DescribeRegions(client *ec2.EC2, AllRegionsBool bool, regionName string) (*
 	resp, err := client.DescribeRegions(RegionsInput)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
+	callogger.Info("########################")
+	callogger.Info(resp.Regions)
 
 	if err != nil {
 		cblogger.Error(err)
@@ -762,6 +764,7 @@ func DescribeAvailabilityZones(client *ec2.EC2, AllRegionsBool bool) (*ec2.Descr
 	respZones, err := client.DescribeAvailabilityZones(ZonesInput)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
+	callogger.Info(respZones.AvailabilityZones)
 
 	if err != nil {
 		cblogger.Error(err)

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
@@ -18,7 +18,8 @@ type AwsRegionZoneHandler struct {
 }
 
 func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZoneInfo, error) {
-	responseRegions, err := DescribeRegions(regionZoneHandler.Client, true, "")
+
+	responseRegions, err := DescribeRegions(regionZoneHandler.Client, false, "")
 	if err != nil {
 		cblogger.Error(err)
 		return nil, err
@@ -41,8 +42,10 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 
 			responseZones, err := DescribeAvailabilityZones(tempclient, true)
 			if err != nil {
-				cblogger.Errorf("AuthFailure on [%s]", *region.RegionName)
-				cblogger.Error(err)
+				cblogger.Infof("AuthFailure on [%s]", *region.RegionName)
+				cblogger.Infof(err.Error())
+				// cblogger.Errorf("AuthFailure on [%s]", *region.RegionName)
+				// cblogger.Error(err)
 			} else {
 				var zoneInfoList []irs.ZoneInfo
 				for _, zone := range responseZones.AvailabilityZones {

--- a/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
@@ -68,7 +68,7 @@ func getVmClient(connectionInfo idrv.ConnectionInfo) (*cvm.Client, error) {
 
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
 		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
 	}
 
@@ -99,7 +99,7 @@ func getVpcClient(connectionInfo idrv.ConnectionInfo) (*vpc.Client, error) {
 
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
 		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
 	}
 
@@ -130,7 +130,7 @@ func getClbClient(connectionInfo idrv.ConnectionInfo) (*clb.Client, error) {
 
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
 		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
 	}
 
@@ -161,7 +161,7 @@ func getCbsClient(connectionInfo idrv.ConnectionInfo) (*cbs.Client, error) {
 
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
 		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
@@ -69,7 +69,7 @@ func getVmClient(connectionInfo idrv.ConnectionInfo) (*cvm.Client, error) {
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
 		cblogger.Error("Connection information does not contain Zone information.")
-		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
+		return nil, errors.New("Connection information does not contain Zone information.")
 	}
 
 	credential := common.NewCredential(
@@ -100,7 +100,7 @@ func getVpcClient(connectionInfo idrv.ConnectionInfo) (*vpc.Client, error) {
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
 		cblogger.Error("Connection information does not contain Zone information.")
-		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
+		return nil, errors.New("Connection Connection information does not contain Zone information.")
 	}
 
 	credential := common.NewCredential(
@@ -131,7 +131,7 @@ func getClbClient(connectionInfo idrv.ConnectionInfo) (*clb.Client, error) {
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
 		cblogger.Error("Connection information does not contain Zone information.")
-		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
+		return nil, errors.New("Connection Connection information does not contain Zone information.")
 	}
 
 	credential := common.NewCredential(
@@ -162,7 +162,7 @@ func getCbsClient(connectionInfo idrv.ConnectionInfo) (*cbs.Client, error) {
 	zoneId := connectionInfo.RegionInfo.Zone
 	if len(zoneId) < 1 {
 		cblogger.Error("Connection information does not contain Zone information.")
-		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다")
+		return nil, errors.New("Connection Connection information does not contain Zone information.")
 	}
 
 	credential := common.NewCredential(

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -73,7 +73,7 @@ func (vmHandler *TencentVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 	cblogger.Debugf("Zone : %s", zoneId)
 	if zoneId == "" {
 		cblogger.Error("Connection information does not contain Zone information.")
-		return irs.VMInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다")
+		return irs.VMInfo{}, errors.New("Connection Connection information does not contain Zone information.")
 	}
 
 	//=================================================

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -72,7 +72,7 @@ func (vmHandler *TencentVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 	zoneId := vmHandler.Region.Zone
 	cblogger.Debugf("Zone : %s", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
 		return irs.VMInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다")
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
@@ -17,7 +17,7 @@ type TencentVmSpecHandler struct {
 	Client *cvm.Client
 }
 
-//@TODO : Region : zone id(Region이 아닌 zone id로 조회해야 함.)
+// @TODO : Region : zone id(Region이 아닌 zone id로 조회해야 함.)
 func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, error) {
 	//cblogger.Infof("ListVMSpec(ZoneId:[%s])", Region)
 
@@ -25,8 +25,8 @@ func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 	//zoneId := Region
 	cblogger.Infof("Session Zone : [%s]", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return nil, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return nil, errors.New("Connection information does not contain Zone information.")
 	}
 
 	callogger := call.GetLogger("HISCALL")
@@ -83,8 +83,8 @@ func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 	//zoneId := Region
 	cblogger.Infof("Session Zone : [%s]", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return irs.VMSpecInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return irs.VMSpecInfo{}, errors.New("Connection information does not contain Zone information.")
 	}
 
 	callogger := call.GetLogger("HISCALL")
@@ -141,8 +141,8 @@ func (vmSpecHandler *TencentVmSpecHandler) ListOrgVMSpec() (string, error) {
 	//zoneId := Region
 	cblogger.Infof("Session Zone : [%s]", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return "", errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return "", errors.New("Connection information does not contain Zone information.")
 	}
 
 	callogger := call.GetLogger("HISCALL")
@@ -196,8 +196,8 @@ func (vmSpecHandler *TencentVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 	//zoneId := Region
 	cblogger.Infof("Session Zone : [%s]", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return "", errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return "", errors.New("Connection information does not contain Zone information.")
 	}
 
 	callogger := call.GetLogger("HISCALL")
@@ -251,7 +251,7 @@ func (vmSpecHandler *TencentVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 	}
 }
 
-//인스턴스 스펙 정보를 추출함
+// 인스턴스 스펙 정보를 추출함
 func ExtractVMSpecInfo(instanceTypeInfo *cvm.InstanceTypeConfig) irs.VMSpecInfo {
 	cblogger.Debugf("ExtractVMSpecInfo : SpecName:[%s]", *instanceTypeInfo.InstanceType)
 	//spew.Dump(instanceTypeInfo)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
@@ -46,8 +46,8 @@ func (VPCHandler *TencentVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.V
 	zoneId := VPCHandler.Region.Zone
 	cblogger.Infof("Zone : %s", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return irs.VPCInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return irs.VPCInfo{}, errors.New("Connection information does not contain Zone information.")
 	}
 
 	// logger for HisCall
@@ -124,7 +124,7 @@ func (VPCHandler *TencentVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.V
 	return retVpcInfo, nil
 }
 
-//VPC 정보를 추출함
+// VPC 정보를 추출함
 func ExtractVpcDescribeInfo(vpcInfo *vpc.Vpc) irs.VPCInfo {
 	// cblogger.Debug("전달 받은 내용")
 	// spew.Dump(vpcInfo)
@@ -394,8 +394,8 @@ func (VPCHandler *TencentVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 	zoneId := VPCHandler.Region.Zone
 	cblogger.Infof("Zone : %s", zoneId)
 	if zoneId == "" {
-		cblogger.Error("Connection 정보에 Zone 정보가 없습니다.")
-		return irs.VPCInfo{}, errors.New("Connection 정보에 Zone 정보가 없습니다.")
+		cblogger.Error("Connection information does not contain Zone information.")
+		return irs.VPCInfo{}, errors.New("Connection information does not contain Zone information.")
 	}
 
 	if subnetInfo.IId.NameId == "" {


### PR DESCRIPTION
- 출력 되는 로그 메시지 영어로 변경하였습니다.
- The output log message has been changed to English.

```
##AS-IS
     cblogger.Error("Connection 정보에 Zone 정보가 없습니다.") 

##TO-BE
     cblogger.Error("Connection information does not contain Zone information.") 
```