### PR TITLE
[Bug Fix] Does not include RootDisk in DataDisk List in NHN Cloud VMHandler

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
@@ -920,9 +920,9 @@ func (vmHandler *NhnCloudVMHandler) mappingVMInfo(server servers.Server) (irs.VM
 
 				vmInfo.RootDiskSize = strconv.Itoa(nhnVolume.Size)
 				vmInfo.RootDeviceName = nhnVolume.Attachments[0].Device
+			} else {
+				diskIIDs = append(diskIIDs, irs.IID{NameId: nhnVolume.Name, SystemId: nhnVolume.ID})
 			}
-
-			diskIIDs = append(diskIIDs, irs.IID{NameId: nhnVolume.Name, SystemId: nhnVolume.ID})
 		}
 	}
 	vmInfo.DataDiskIIDs = diskIIDs


### PR DESCRIPTION
- [Bug Fix] Does not include RootDisk in DataDisk List in NHN Cloud VMHandler
  - Before : Includes RootDisk in DataDisk List
- Related issue) https://github.com/cloud-barista/cb-spider/issues/1063