### PR TITLE
Replace the GITHUB_TOKEN with a PAT

### DIFF
--- a/.github/workflows/korean-checker.yaml
+++ b/.github/workflows/korean-checker.yaml
@@ -101,7 +101,7 @@ jobs:
         if: steps.check-korean.outputs.KOREAN_EXISTS == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.CB_GITHUB_ROBOT_PAT}}
           script: |
             const fs = require('fs');
             const path = require('path');


### PR DESCRIPTION
This PR will replace `secret.GITHUB_TOKEN` with `secret.CB_GITHUB_ROBOT_PAT`.

(Summary)
- The `GITHUB_TOKEN` is scoped to the current repository (i.e., forked repo). 
- The `GITHUB_TOKEN` does **NOT have permission to add comments on PRs opened in the upstream repo** from the forked repo.
- On the other hand, `CB_GITHUB_ROBOT_PAT` can be scoped as desired (`repo` scope is assigned)
- **Therefore, comments can be added on the PR with `CB_GITHUB_ROBOT_PAT`**.

Ref: https://github.com/actions/github-script?tab=readme-ov-file#using-a-separate-github-token

In my opinion, this PR should be merged as is. And then, we can check for permission issues in the next PR.

(Until then, I'd like to keep #1070 open.)