### PR TITLE
Set default container runtime as containerd (fix #1011)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -40,6 +40,10 @@ import (
 // 	})
 // }
 
+const (
+	defaultContainerRuntime = "containerd"
+)
+
 type TencentClusterHandler struct {
 	RegionInfo     idrv.RegionInfo
 	CredentialInfo idrv.CredentialInfo
@@ -756,6 +760,9 @@ func getCreateClusterRequest(clusterHandler *TencentClusterHandler, clusterInfo 
 		ClusterDescription: common.StringPtr(desc_str),            // option, #CB-SPIDER:PMKS:SECURITYGROUP:sg-c00t00ih
 	}
 	request.ClusterType = common.StringPtr("MANAGED_CLUSTER") //default value
+	request.ClusterAdvancedSettings = &tke.ClusterAdvancedSettings{
+		ContainerRuntime: common.StringPtr(defaultContainerRuntime),
+	}
 
 	return request, err
 }


### PR DESCRIPTION
Tencent에서는 default container runtime을 docker로 지정되어 있기에 별도의 설정이 없는 경우 container runtime이 docker로 설정되고 있습니다.
현재 K8s 1.24 이후 containerd만 지원하고 있기 때문에 기본값을 containerd로 설정하도록 업데이트하였습니다.

fix #1011