### PR TITLE
Prevent to access index out of range [0] with length 0

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -639,26 +639,28 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 		auto_scale_enalbed = true
 	}
 
-	nodeGroupInfo = &irs.NodeGroupInfo{
-		IId: irs.IID{
-			NameId:   *res.Response.NodePool.Name,
-			SystemId: *res.Response.NodePool.NodePoolId,
-		},
-		ImageIID: irs.IID{
-			NameId:   "",
-			SystemId: *launch_config.Response.LaunchConfigurationSet[0].ImageId,
-		},
-		VMSpecName:      *launch_config.Response.LaunchConfigurationSet[0].InstanceType,
-		RootDiskType:    *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskType,
-		RootDiskSize:    fmt.Sprintf("%d", *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskSize),
-		KeyPairIID:      irs.IID{NameId: "", SystemId: *launch_config.Response.LaunchConfigurationSet[0].LoginSettings.KeyIds[0]},
-		Status:          status,
-		OnAutoScaling:   auto_scale_enalbed,
-		MinNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MinSize),
-		MaxNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MaxSize),
-		DesiredNodeSize: int(*auto_scaling_group.Response.AutoScalingGroupSet[0].DesiredCapacity),
-		Nodes:           []irs.IID{}, // to be implemented
-		KeyValueList:    []irs.KeyValue{},
+	if len(launch_config.Response.LaunchConfigurationSet) > 0 || len(auto_scaling_group.Response.AutoScalingGroupSet) > 0 {
+		nodeGroupInfo = &irs.NodeGroupInfo{
+			IId: irs.IID{
+				NameId:   *res.Response.NodePool.Name,
+				SystemId: *res.Response.NodePool.NodePoolId,
+			},
+			ImageIID: irs.IID{
+				NameId:   "",
+				SystemId: *launch_config.Response.LaunchConfigurationSet[0].ImageId,
+			},
+			VMSpecName:      *launch_config.Response.LaunchConfigurationSet[0].InstanceType,
+			RootDiskType:    *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskType,
+			RootDiskSize:    fmt.Sprintf("%d", *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskSize),
+			KeyPairIID:      irs.IID{NameId: "", SystemId: *launch_config.Response.LaunchConfigurationSet[0].LoginSettings.KeyIds[0]},
+			Status:          status,
+			OnAutoScaling:   auto_scale_enalbed,
+			MinNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MinSize),
+			MaxNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MaxSize),
+			DesiredNodeSize: int(*auto_scaling_group.Response.AutoScalingGroupSet[0].DesiredCapacity),
+			Nodes:           []irs.IID{}, // to be implemented
+			KeyValueList:    []irs.KeyValue{},
+		}
 	}
 
 	nodes, err := tencent.DescribeClusterInstances(access_key, access_secret, region_id, cluster_id)


### PR DESCRIPTION
RemoveNodeGroup API 호출 후 바로 GetCluster API 호출한 경우 관련 노드 정보가 없는 경우 0 인덱스 접근을 차단합니다.

fix #1012