### PR TITLE
Update workflows to check Korean texts on PR

### DIFF
--- a/.github/workflows/korean-checker-post-comment.yaml
+++ b/.github/workflows/korean-checker-post-comment.yaml
@@ -1,0 +1,87 @@
+# This workflow will make a comment on the pull request
+# about the part where Korean was found.
+name: Post handler of korean checker
+on:
+  workflow_run:
+    workflows: ["Korean checker"]
+    types:
+      - completed
+
+env:
+  ARTIFACT_NAME: results-to-check-korean
+  FILE_KOREAN_CHECKING_RESULT: "korean-check-results.md"
+  FILE_REPORT: "checking-report.md"
+
+jobs:
+  make-comment-on-the-pr:
+    name: Make a comment on the PR
+    
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    
+    # Permissions for the GITHUB_TOKEN
+    # Ref. https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      # issues: write 
+      pull-requests: write
+      actions: read
+
+    steps:    
+    - name: Download results
+      uses: actions/download-artifact@v4
+      with: 
+        name: ${{ env.ARTIFACT_NAME }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+
+    - name: Display structure of downloaded files for debugging
+      shell: bash
+      run: ls -R
+
+    - name: Make a report
+      shell: bash
+      run: |
+        REPORT="${FILE_REPORT}"
+        if [ -s "${FILE_KOREAN_CHECKING_RESULT}" ]; then
+          echo "(DEBUG) Korean texts are detected."
+
+          echo "**Could you please check and revise Korean texts?**" > $REPORT
+          echo "Note - All output of print and log statements should be in English. :wink:" >> $REPORT
+          echo "" >> $REPORT
+          cat "${FILE_KOREAN_CHECKING_RESULT}" >> "$REPORT"
+        else
+          echo "(DEBUG) No Korean texts are detected."
+          
+          echo "Good news! All print and log statements are in English, as per our guidelines. :blush:" > $REPORT
+        fi
+      
+    - name: Comment PR with results
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          // Read PR number
+          const prNumberPath = path.join(process.env.GITHUB_WORKSPACE, 'pr-number.txt');
+          let prNumber = '';
+          if (fs.existsSync(prNumberPath)) {
+            prNumber = fs.readFileSync(prNumberPath, 'utf8').trim();
+          }
+          
+          // Read results to check Korean
+          const resultsPath = path.join(process.env.GITHUB_WORKSPACE, '${{env.FILE_REPORT}}');            
+          if (fs.existsSync(resultsPath)) {
+            const results = fs.readFileSync(resultsPath, 'utf8');
+            if (results.trim().length > 0 && prNumber.length > 0) {
+              github.rest.issues.createComment({
+                issue_number: parseInt(prNumber, 10),
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: results
+              });
+            }
+          }

--- a/.github/workflows/korean-checker.yaml
+++ b/.github/workflows/korean-checker.yaml
@@ -1,10 +1,17 @@
 name: Korean checker
+
+# Controls/triggers when the action will run.
 on: 
   pull_request:
     branches:
       - 'master'
     paths:
       - '**.go'
+
+# Environment variables
+env:
+  OUTPUT_DIR: "./output"
+  OUTPUT_FILE: "korean-check-results.md"
 
 jobs:
   check-if-Korean-is-included:
@@ -14,8 +21,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
+    
+      - name: Setup to check Korean and upload the results
+        run: |
+          # Make an output directory
+          if [[ ! -e $OUTPUT_DIR ]]; then
+              mkdir -p $OUTPUT_DIR
+          elif [[ ! -d $OUTPUT_DIR ]]; then
+              echo "$OUTPUT_DIR already exists but is not a directory" 1>&2
+          fi
+          echo ${{ github.event.number }} > ${OUTPUT_DIR}/pr-number.txt
 
-      - name: Check for Korean characters in quotes
+      - name: Check Korean in quotes
         id: check-korean
         run: |
           set -x
@@ -29,15 +46,15 @@ jobs:
           PR_BRANCH=${GITHUB_REF#refs/}              # pull/xx/merge
           echo "Base branch: ${BASE_BRANCH}"
           echo "Extract branch: ${GITHUB_REF#refs/}"
-                    
+          
           # `github` context information
           echo "(DEBUG) github.ref: ${{github.ref}}"
           echo "(DEBUG) github.head_ref: ${{github.head_ref}}"
           echo "(DEBUG) github.base_ref: ${{github.base_ref}}"
           #####################################################
-
+          
           temp_output="temp.md"
-          output="korean_check_results.md"
+          OUTPUT="${OUTPUT_DIR}/${OUTPUT_FILE}"
           
           # Get changed files in the PR
           files=$(git diff --name-only ${BASE_BRANCH}...${PR_BRANCH} | grep '\.go$')
@@ -48,7 +65,7 @@ jobs:
           # Process each changed file
           for file in $files; do              
             found_korean=false
-        
+
             # Extract changed lines
             changed_lines=$(git diff ${BASE_BRANCH}...${PR_BRANCH} -- $file | grep "^+")
             echo "(DEBUG) Changed lines in $file:"
@@ -69,57 +86,39 @@ jobs:
               echo "" >> $temp_output
             fi          
           done
-
-          # Check if the file exists
+          
+          # Output the results to check if Korean exists
+          # Check if the temp_output exists and has content
           if [ -s "$temp_output" ]; then
-            # Trim
+            
+            # Trim before checking if the file has content
             trimmed_temp_outputs=$(cat "$temp_output" | xargs)
             echo "(DEBUG) Trimmed temp_output:"
             echo "$trimmed_temp_outputs"
               
             if [ -n "$trimmed_temp_outputs" ]; then
               echo "(DEBUG) Korean content detected."
-              echo "## Result to check if Korean is included" > $output
-              echo "All output of print and log must be written in English :wink:" >> $output
-              echo "Please check and correct the following" >> $output 
-              cat "$temp_output" >> "$output"
-              echo "KOREAN_EXISTS=true" >> $GITHUB_OUTPUT
+              cat "$temp_output" > "$OUTPUT"
+              # echo "KOREAN_EXISTS=true" >> $GITHUB_OUTPUT
             else
               echo "(DEBUG) No Korean content detected."
-              echo "KOREAN_EXISTS=false" >> $GITHUB_OUTPUT
+              # echo "KOREAN_EXISTS=false" >> $GITHUB_OUTPUT
             fi
-          fi
+          fi          
           
-          # # Check if the file exists
-          # if [ -s "$output" ]; then
-          #   # Display output path
-          #   echo "[(Debug) Results saved in $output]"
-          #   cat "$output"
-          # fi
-
-      - name: Comment PR with results
-        if: steps.check-korean.outputs.KOREAN_EXISTS == 'true'
-        uses: actions/github-script@v7
+      - name: Upload Korean check results
+        # if: steps.check-korean.outputs.KOREAN_EXISTS == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{secrets.CB_GITHUB_ROBOT_PAT}}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const resultsPath = path.join(process.env.GITHUB_WORKSPACE, 'korean_check_results.md');            
-            if (fs.existsSync(resultsPath)) {
-                const results = fs.readFileSync(resultsPath, 'utf8');
-                if (results.trim().length > 0) {
-                    github.rest.issues.createComment({
-                      issue_number: context.issue.number,
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      body: results
-                    });
-                }
-            }
+          name: results-to-check-korean
+          path: ${{ env.OUTPUT_DIR }}
 
-      - name: Fail on Korean Content
-        if: steps.check-korean.outputs.KOREAN_EXISTS == 'true'
-        run: |
-          echo "Korean content detected. Failing the workflow on purpose."
-          exit 1
+      # - name: Fail on Korean Content
+      #   if: steps.check-korean.outputs.KOREAN_EXISTS == 'true'
+      #   run: |
+      #     echo "Korean content detected. Failing the workflow on purpose."
+      #     exit 1
+
+# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# https://github.com/actions/upload-artifact
+# https://github.com/actions/download-artifact


### PR DESCRIPTION
Related to #1070, #1080

This PR will resolve a secrets (e.g., GITHUB_TOKEN) access permission issue of korean-checker workflow.

**Cause of issue**
- When a PR is opened from the forked repo, there is no permission to access secrets on the upstream repo.
- The secret was needed to leave a PR comment, but an error occurred because it could not be accessed.

**To resolve this issue securely, 2 workflows are needed.**
- `korean-checker.yaml` workflow: it has read permission and checks Korean text.
- `korean-checker-post-comment.yaml` workflow: it has write permission and leaves a comment on a PR.

(See [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/))

<ins>Afterwards, `Korean-checker` will leave helpful information in comments **rather than exposing success or failure**.</ins>

(Example)
![image](https://github.com/cloud-barista/cb-spider/assets/7975459/aaeccba4-b844-47ef-ad00-1ebcfb2d9fd7)

Note - [GitHub Actions: Maintainers must approve first time contributor workflow runs](https://github.blog/changelog/2021-04-22-github-actions-maintainers-must-approve-first-time-contributor-workflow-runs/)