### PR TITLE
Simplify the CreatePortForWarding Preliminary process, and Apply KT Cloud constraints on Root Disk Type/Size

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/README.md
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/README.md
@@ -70,7 +70,7 @@ $GOPATH/src/github.com/cloud-barista/ktcloud/ktcloud/main/
 ```
 <p><br>
 
-#### # 참고 사항
+#### # KT Cloud Classic (G1/G2) 드라이버 이용시 참고 사항
 ​	O KT Cloud Classic 버전(G1/G2) CSP 인프라 서비스는 물리적 네트워크 기반으로 운영되므로, KT에서 VPC/Subnet 생성 등의 제어 기능 및 관련 API를 지원하지 않음.
    - 따라서, 본 driver를 통해 VPC 및 Subnet 관련 제어가 실행될때, VPC 및 Subnet 정보는 driver 자체에서 임의적으로 local에서 JSON 파일 형태로 관리됨.(VPC 및 Subnet 생성시 어떤 Name이든 가능)
 <p><br>
@@ -92,9 +92,31 @@ $GOPATH/src/github.com/cloud-barista/ktcloud/ktcloud/main/
      - 예를들어, 현재 버전의 드라이버를 기준으로, VM 생성 후 드라이버 내부적으로 Security Group 적용시에 TCP 22번 port를 open하는 rule을 적용하고, TCP 모든 port를 open하는 rule을 적용할 수 없음.
 <p><br>
 
-​	O Disk 추가 볼륨 생성 방법
+  O 생성되는 VM의 root disk(volume) type 및 size (KT Cloud Classic(G1/G2) 기준)
+   - VM 생성시, root disk type으로 'Seoul-M2' zone은 SSD type만 지원하고, 나머지 zone은 HDD type만 지원함.​
+   - Root disk(volume) size는 default로 Linux 20G, Windows 50G로 지원됨.(향후 변경될 수 있음)
+<p><br>
+
+  O 'VM 생성시', Data disk (추가 volume) 생성 방법
    - VM Spec 조회시, Spec 이름의 맨 뒤에 붙은 disk 크기가 기본(Root) disk volume과 추가 volume을 합한 크기임.
       - 본 드라이버를 통해 조회되는 VM Spec 예) 97359d1d-a7b1-49d9-b435-14608543f00b#097b63d7-e725-4db7-b4dd-a893b0c76cb0_disk100GB
       - 위의 예의 경우, Linux 계열에서는 기본 volume 20GB에 80GB의 추가 볼륨이 생성되어 총 100GB가 됨.
    - VM 생성시 원하는 총 disk 크기에 따라 Spec을 결정해서 입력하면됨.
+<p><br>
+
+  O 일반적인 Data disk (추가 volume) 생성 방법
+   - 본 드라이버에서 data disk 생성시, disk type은 'HDD'와 'SSD-Provisioned'를 지원함.
+     - 참고) Zone별로 가용한 disk type이 다르므로, 본 드라이버에서는 현재 모든 zone에서 가용한 위의 두가지만 지원함.(향후 변경 가능)
+   - Disk size 지정시, type별로 아래의 기준으로 지정해야함.
+     - HHD : 10 ~ 300G(10G 단위 지정) (단, Seoul-M2 존은 400G 및 500G 지정 가능)
+     - SSD-Provisioned : 100 ~ 800G(100G 단위 지정)
+     - 아래의 link에서 'Volume : 생성' 부분 > 'diskofferingid' 표 참고
+       - https://cloud.kt.com/docs/open-api-guide/g/computing/disk-volume
+<p><br>
+
+#### # KT Cloud Classic (G1/G2) 드라이버 개발시 참고 사항
+​	O 생성되는 VM의 root disk(volume) type 정보
+   - KT Cloud Volume 정보에서 root disk의 type 정보는 제공하지 않음.
+     - 아래의 기준을 드라이버에 반영함.
+       - Seoul M2 zone은 SSD type으로 root volume이 생성되고, 나머지 zone은 HDD type으로 생성됨.​
 <p><br>

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_VMHandler.go
@@ -67,7 +67,7 @@ func handleVM() {
 		fmt.Println("============================================================================================")
 
 		//config := readConfigFile()
-		VmID := irs.IID{SystemId: "db02bc57-d481-42e8-bf43-738becb14d03"}
+		VmID := irs.IID{SystemId: "8e217114-d5dc-4c18-b285-7960852aa892"}
 
 		var commandNum int
 		inputCnt, err := fmt.Scan(&commandNum)
@@ -86,20 +86,20 @@ func handleVM() {
 					// ImageType:	irs.MyImage,
 					ImageType:	irs.PublicImage,
 
-					VMUserPasswd: "cb-user-cb-user",
+					VMUserPasswd: "cbuser357505**", // No Simple PW!!
 
-					IId: irs.IID{NameId: "kt-win-vm-10"},
+					IId: irs.IID{NameId: "kt-vm-18"},
 					// IId: irs.IID{NameId: "kt-win-vm-02"},
 
 					// # Zone: KOR-Central A
-					ImageIID: irs.IID{NameId: "WIN 2019 STD 64bit [Korean]", SystemId: "f22c7425-81b5-4cd8-b8e8-6e525070cf19"},
-					VMSpecName: "d3530ad2-462b-43ad-97d5-e1087b952b7d!097b63d7-e725-4db7-b4dd-a893b0c76cb0_disk100GB",				
+					// ImageIID: irs.IID{NameId: "WIN 2019 STD 64bit [Korean]", SystemId: "f22c7425-81b5-4cd8-b8e8-6e525070cf19"},
+					// VMSpecName: "d3530ad2-462b-43ad-97d5-e1087b952b7d!097b63d7-e725-4db7-b4dd-a893b0c76cb0_disk100GB",				
 					// WIN 2019 STD 64bit [Korean] image와 호환
 
 					// # Zone: KOR-Central A
-					// ImageIID: irs.IID{NameId: "Ubuntu 20.04 64bit", SystemId: "87838094-af4f-449f-a2f4-f5b4b581eb29"},
-					// VMSpecName: "d3530ad2-462b-43ad-97d5-e1087b952b7d!_disk20GB",
-					// Ubuntu 20.04 64bit image와 호환
+					ImageIID: irs.IID{NameId: "Ubuntu 20.04 64bit", SystemId: "87838094-af4f-449f-a2f4-f5b4b581eb29"},
+					VMSpecName: "d3530ad2-462b-43ad-97d5-e1087b952b7d!_disk20GB",
+					// 상기 Ubuntu 20.04 64bit image와 호환
 
 					// VMSpecName: "543b1f26-eddf-4521-9cbd-f3744aa2cc52!cc85e4dd-bfd9-4cec-aa22-cf226c1da92f_disk100GB",
 							
@@ -138,8 +138,8 @@ func handleVM() {
 					// SecurityGroupIIDs: []irs.IID{{SystemId: "CB-Security5"},{SystemId: "CB-Security6"}},
 
 					// KT Cloud Disk(diskofferingid 지정하지 않을때) : Default : 20 GB
-					RootDiskType: "SSD-Provisioned",
-					// RootDiskType: "default",
+					// RootDiskType: "SSD",
+					RootDiskType: "default",
 
 					RootDiskSize: "200",
 					// RootDiskSize: "default",

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -113,9 +113,15 @@ NHNCLOUD:
 KTCLOUD:
   region: Region / Zone
   credential: ClientId / ClientSecret
+  rootdisktype: HDD / SSD
+  rootdisksize: HDD|20|50|GB / SSD|20|50|GB
+  disktype: HDD / SSD-Provisioned
+  disksize: HDD|10|500|GB / SSD-Provisioned|100|800|GB
+    # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage
+  idmaxlength: 0 / 0 / 0 / 100 / 100 / 50 / 30 / 32
 
 KTCLOUDVPC:
-  region: Zone
+  region: Region / Zone
   credential: IdentityEndpoint / Username / Password / DomainName / ProjectID
   rootdisktype: HDD / SSD
   rootdisksize: HDD|50|100|GB / SSD|50|100|GB


### PR DESCRIPTION
- Update KT Cloud Classic VMHandler 
  - Simplify the CreatePortForWarding Preliminary process and Add Time-sleep after Creation of a Public IP
  - Related issue) https://github.com/cloud-barista/cb-spider/issues/1061
  - Update Validation checking process for Root disk Type/Size specification
    : Apply KT Cloud constraints on Root Disk Type/Size
- Update KT Cloud Classic DiskHandler  
  - Update related to supporting Data Disk Type
- Update KT Cloud Classic README.md
  - Add Root/Data disk Type/Size related notices
    : Apply KT Cloud constraints on Root Disk Type/Size
- Update CloudOS Meta-info for KT Cloud Classic
  - Related issue) https://github.com/cloud-barista/cb-spider/issues/1060