### PR TITLE
[NCP VPC] Prevent an error due to abnormal response value of '~.totalrows' parameter, and Prevent the State as '~ instance does Not Exist' during VM Termination

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-VM.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-VM.go
@@ -558,6 +558,9 @@ func VM(c echo.Context) error {
 	case "NCP":
 		imageName = "SPSW0LINUX000130"
 		specName = "SPSVRHICPUSSD002"
+	case "NCPVPC":
+		imageName = "SW.VSVR.OS.LNX64.UBNTU.SVR1804.B050"
+		specName = "SVR.VSVR.HICPU.C004.M008.NET.SSD.B050.G002"
 	case "KTCLOUD":
 		imageName = "97ef0091-fdf7-44e9-be79-c99dc9b1a0ad"
 		specName = "d3530ad2-462b-43ad-97d5-e1087b952b7d!87c0a6f6-c684-4fbe-a393-d8412bcf788d_disk100GB"

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
@@ -631,7 +631,6 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 
 		// If the NCP instance has a 'Public IP', delete it after termination of the instance.
 		if !strings.EqualFold(vmInfo.PublicIP, "") {
-			// PublicIP 삭제
 			vmStatus, err := vmHandler.DeletePublicIP(vmInfo)
 			if err != nil {
 				cblogger.Error(err)
@@ -697,7 +696,6 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 
 		// If the NCP instance has a 'Public IP', delete it after termination of the instance.
 		if !strings.EqualFold(vmInfo.PublicIP, "") {
-			// PublicIP 삭제
 			vmStatus, err := vmHandler.DeletePublicIP(vmInfo)
 			if err != nil {
 				cblogger.Error(err)
@@ -1354,8 +1352,8 @@ func (vmHandler *NcpVpcVMHandler) WaitToDelPublicIp(vmIID irs.IID) (irs.VMStatus
 				return irs.VMStatus("Failed"), errors.New("Despite waiting for a long time, the VM status is 'Creating', so it is forcibly finishied.")
 			}
 
-		case "Not Exist!!": // Caution!!
-			break
+		case "Not Exist!!":
+			return irs.VMStatus(curStatus), nil
 
 		default:
 			cblogger.Infof("===>### The VM Termination is finished, so stopping the waiting.")

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
@@ -384,8 +384,9 @@ func (vmHandler *NcpVpcVMHandler) SuspendVM(vmIID irs.IID) (irs.VMStatus, error)
 
 	vmStatus, err := vmHandler.GetVMStatus(vmIID)
 	if err != nil {
-		cblogger.Errorf("Failed to Get the VM Status of [%s]", vmIID.SystemId)
-		cblogger.Error(err)
+		newErr := fmt.Errorf("Failed to Get the VM Status with the VM ID : [%s], [%v]", vmIID.SystemId, err)
+		cblogger.Debug(newErr.Error())
+		return irs.VMStatus("Failed"), newErr
 	} else {
 		cblogger.Infof("Succeed in Getting the VM Status of [%s] : [%s]", vmIID.SystemId, vmStatus)
 	}
@@ -449,8 +450,9 @@ func (vmHandler *NcpVpcVMHandler) ResumeVM(vmIID irs.IID) (irs.VMStatus, error) 
 
 	vmStatus, err := vmHandler.GetVMStatus(vmIID)
 	if err != nil {
-		cblogger.Errorf("Failed to Get the VM Status of [%s]", vmIID.SystemId)
-		cblogger.Error(err)
+		newErr := fmt.Errorf("Failed to Get the VM Status with the VM ID : [%s], [%v]", vmIID.SystemId, err)
+		cblogger.Debug(newErr.Error())
+		return irs.VMStatus("Failed"), newErr
 	} else {
 		cblogger.Infof("Succeed in Getting the VM Status of [%s] : [%s]", vmIID.SystemId, vmStatus)
 	}
@@ -521,8 +523,9 @@ func (vmHandler *NcpVpcVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, error) 
 
 	vmStatus, err := vmHandler.GetVMStatus(vmIID)
 	if err != nil {
-		cblogger.Errorf("Failed to Get the VM Status of [%s]", vmIID.SystemId)
-		cblogger.Error(err)
+		newErr := fmt.Errorf("Failed to Get the VM Status with the VM ID : [%s], [%v]", vmIID.SystemId, err)
+		cblogger.Debug(newErr.Error())
+		return irs.VMStatus("Failed"), newErr
 	} else {
 		cblogger.Infof("Succeed in Getting the VM Status of [%s] : [%s]", vmIID.SystemId, vmStatus)
 	}
@@ -594,9 +597,9 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 
 	vmStatus, err := vmHandler.GetVMStatus(vmIID)
 	if err != nil {
-		LoggingError(callLogInfo, err)
-		cblogger.Errorf("Failed to Get the VM Status of [%s]", vmIID.SystemId)
-		cblogger.Error(err)
+		newErr := fmt.Errorf("Failed to Get the VM Status with the VM ID : [%s], [%v]", vmIID.SystemId, err)
+		cblogger.Error(newErr.Error())
+		return irs.VMStatus("Failed"), newErr
 	} else {
 		cblogger.Infof("Succeed in Getting the VM Status of [%s] : [%s]", vmIID.SystemId, vmStatus)
 	}
@@ -705,10 +708,15 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 
 		return irs.VMStatus("Terminating"), nil
 
+	case "Not Exist!!":
+		newErr := fmt.Errorf("The VM instance does Not Exist!!")
+		cblogger.Error(newErr.Error())
+		return irs.VMStatus("Failed to Terminate!!"), newErr
+
 	default:
-		resultStatus := "The VM status is not 'Running' or 'Suspended' yet. so it Can NOT be Terminated!! Run or Suspend the VM before terminating."
-		cblogger.Error(resultStatus)
-		return irs.VMStatus("Failed. " + resultStatus), err
+		newErr := fmt.Errorf("The VM status is not 'Running' or 'Suspended' yet. so it Can NOT be Terminated!! Run or Suspend the VM before terminating.")
+		cblogger.Error(newErr.Error())
+		return irs.VMStatus("Failed to Terminate!!"), newErr
 	}
 }
 
@@ -802,8 +810,9 @@ func (vmHandler *NcpVpcVMHandler) GetVMStatus(vmIID irs.IID) (irs.VMStatus, erro
 	LoggingInfo(callLogInfo, callLogStart)
 
 	if len(result.ServerInstanceList) < 1 {
-		cblogger.Info("The VM instance does Not Exist!!")
-		return irs.VMStatus("Not Exist!!"), nil //Caution!!
+		newErr := fmt.Errorf("The VM instance does Not Exist!!")
+		cblogger.Debug(newErr.Error())
+		return irs.VMStatus("Not Exist!!"), newErr
 	} else {
 		cblogger.Info("Succeeded in Getting ServerInstanceList from NCP VPC!!")
 	}
@@ -1334,9 +1343,9 @@ func (vmHandler *NcpVpcVMHandler) WaitToDelPublicIp(vmIID irs.IID) (irs.VMStatus
 	for {
 		curStatus, statusErr := vmHandler.GetVMStatus(vmIID)
 		if statusErr != nil {
-			cblogger.Errorf("Failed to Get the VM Status of : [%s]", vmIID.SystemId)
-			cblogger.Error(statusErr.Error())
-			// return irs.VMStatus("Failed. "), errors.New("Failed to Get the VM Status.")   // Caution!!
+			newErr := fmt.Errorf("Failed to Get the VM Status with the VM ID : [%s], [%v]", vmIID.SystemId, statusErr)
+			cblogger.Debug(newErr.Error())
+			return irs.VMStatus("Not Exist!!"), newErr
 		} else {
 			cblogger.Infof("Succeeded in Getting the VM Status of [%s]", vmIID.SystemId)
 		}
@@ -1381,8 +1390,8 @@ func (vmHandler *NcpVpcVMHandler) DeletePublicIP(vmInfo irs.VMInfo) (irs.VMStatu
 	//=========================================
 	curStatus, statusErr := vmHandler.WaitToDelPublicIp(vmInfo.IId)
 	if statusErr != nil {
-		cblogger.Error(statusErr.Error())
-		// return irs.VMStatus("Failed. "), statusErr   // Caution!!
+		cblogger.Debug(statusErr.Error())
+		// return irs.VMStatus("Failed. "), statusErr   // Caution!! For in case 'VM instance does Not Exist' after VM Termination finished
 	}
 	cblogger.Infof("==> VM status of [%s] : [%s]", vmInfo.IId.NameId, curStatus)
 

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VPCHandler.go
@@ -84,7 +84,7 @@ func (vpcHandler *NcpVpcVPCHandler) CreateVPC(vpcReqInfo irs.VPCReqInfo) (irs.VP
 	}
 	LoggingInfo(callLogInfo, callLogStart)
 
-	if *vpcResult.TotalRows < 1 {
+	if len(vpcResult.VpcList) < 1 {
 		newErr := fmt.Errorf("Failed to Create any VPC. Neww VPC does Not Exist!!")
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
@@ -189,7 +189,7 @@ func (vpcHandler *NcpVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	LoggingInfo(callLogInfo, callLogStart)
 
 	var vpcInfoList []*irs.VPCInfo
-	if *result.TotalRows < 1 {
+	if len(result.VpcList) < 1 {
 		cblogger.Info("### VPC does Not Exist!!")
 	} else {
 		for _, vpc := range result.VpcList {
@@ -265,7 +265,7 @@ func (vpcHandler *NcpVpcVPCHandler) GetNcpVpcInfo(vpcId *string) (*vpc.Vpc, erro
 	}
 	LoggingInfo(callLogInfo, callLogStart)
 
-	if *result.TotalRows < 1 {
+	if len(result.VpcList) < 1 {
 		newErr := fmt.Errorf("Failed to Find Any VPC Info with the ID!!")
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
@@ -571,7 +571,7 @@ func (vpcHandler *NcpVpcVPCHandler) CreateSubnet(vpcIID irs.IID, netAclNo *strin
 	}
 	LoggingInfo(callLogInfo, callLogStart)
 
-	if *subnet.TotalRows < 1 {
+	if len(subnet.SubnetList) < 1 {
 		newErr := fmt.Errorf("Failed to Create the Subnet. New Subnet does Not Exist!!")
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
@@ -609,7 +609,7 @@ func (vpcHandler *NcpVpcVPCHandler) GetNcpSubnetInfo(sunbnetId *string) (*vpc.Su
 	}
 	LoggingInfo(callLogInfo, callLogStart)
 
-	if *result.TotalRows < 1 {
+	if len(result.SubnetList) < 1 {
 		newErr := fmt.Errorf("Failed to Get any Subnet Info with the ID!!")
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
@@ -643,7 +643,7 @@ func (vpcHandler *NcpVpcVPCHandler) ListSubnet(vpcNo *string) ([]*irs.SubnetInfo
 	}
 
 	var subnetInfoList []*irs.SubnetInfo
-	if *result.TotalRows < 1 {
+	if len(result.SubnetList) < 1 {
 		cblogger.Infof("### The VPC has No Subnet!!")
 	} else {
 		cblogger.Infof("Succeeded in Getting SubnetList!! : ")		
@@ -688,7 +688,7 @@ func (vpcHandler *NcpVpcVPCHandler) GetDefaultNetworkAclNo(vpcIID irs.IID) (*str
 	LoggingInfo(callLogInfo, callLogStart)
 
 	var netACLNo *string
-	if *netAclResult.TotalRows < 1 {
+	if len(netAclResult.NetworkAclList) < 1 {
 		cblogger.Info("# NetworkACL does Not Exist!!")
 	} else {
 		for _, netACL := range netAclResult.NetworkAclList {


### PR DESCRIPTION
- Update NCP VPC driver VPCHandler and VMHandler
  - Change how to check whether resources exist
  - Related issue) https://github.com/cloud-barista/cb-spider/issues/1086