### PR TITLE
[+Price, +Region] [Azure, IBM] Make filtering to work as a full matching, Fix resources are not showing in some regions

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/PriceInfoHandler.go
@@ -151,7 +151,7 @@ func isPicked(structVal any, fields []string, filterList []irs.KeyValue) bool {
 				fieldValue := reflect.Indirect(val).FieldByName(field).String()
 				fieldValueToLower := strings.ToLower(fieldValue)
 				valueToLower := strings.ToLower(filter.Value)
-				if strings.Contains(fieldValueToLower, valueToLower) {
+				if fieldValueToLower == valueToLower {
 					return true
 				}
 			}

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/PriceInfoHandler.go
@@ -253,7 +253,7 @@ func isPicked(structVal any, fields []string, filterList []irs.KeyValue) bool {
 				fieldValue := reflect.Indirect(val).FieldByName(field).String()
 				fieldValueToLower := strings.ToLower(fieldValue)
 				valueToLower := strings.ToLower(filter.Value)
-				if strings.Contains(fieldValueToLower, valueToLower) {
+				if fieldValueToLower == valueToLower {
 					return true
 				}
 			}


### PR DESCRIPTION
## Azure
- [Azure: Make filtering to work as a full matching](https://github.com/cloud-barista/cb-spider/commit/aced0c290afe2b8ea0550365ae529ee1e89e9ba3)
- [Azure: Get only physical regions](https://github.com/cloud-barista/cb-spider/pull/1092/commits/bbc4319a955275c1275ebedf1a4dd1edea53cce3)
   ```
  This will fix the issue of resources not showing in some regions.
      
  Got the hint from : https://stackoverflow.com/questions/69508883/azure-regions-what-does-stage-mean
  Regions can be referenced from : https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/#geographies
  
  As of February 23, 2024, resources are still not available in the regions below.
  - brazilus
  - eastusstg
   ```

## IBM
- [IBM: Make filtering to work as a full matching](https://github.com/cloud-barista/cb-spider/commit/beb49886252fa8fb0df8e35a96dab8a8c2a1985e)

