### PR TITLE
Modify workflow to make comments only when Korean texts are included

### DIFF
--- a/.github/workflows/korean-checker-post-comment.yaml
+++ b/.github/workflows/korean-checker-post-comment.yaml
@@ -39,8 +39,9 @@ jobs:
     - name: Display structure of downloaded files for debugging
       shell: bash
       run: ls -R
-
-    - name: Make a report
+    
+    - name: Check and make a report
+      id: check-and-make-report
       shell: bash
       run: |
         REPORT="${FILE_REPORT}"
@@ -51,13 +52,18 @@ jobs:
           echo "Note - All output of print and log statements should be in English. :wink:" >> $REPORT
           echo "" >> $REPORT
           cat "${FILE_KOREAN_CHECKING_RESULT}" >> "$REPORT"
-        else
-          echo "(DEBUG) No Korean texts are detected."
-          
-          echo "Good news! All print and log statements are in English, as per our guidelines. :blush:" > $REPORT
+
+          echo "KOREAN_EXISTS=true" >> $GITHUB_OUTPUT
         fi
+        # else
+        #   echo "(DEBUG) No Korean texts are detected."
+        #   
+        #   echo "Good news! All print and log statements are in English, as per our guidelines. :blush:" > $REPORT
+        #   echo "KOREAN_EXISTS=false" >> $GITHUB_OUTPUT
+        # fi
       
     - name: Comment PR with results
+      if: steps.check-and-make-report.outputs.KOREAN_EXISTS == 'true'
       uses: actions/github-script@v7
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This PR will modify the workflow to make comments only when Korean texts are included in later PRs.

<ins>I'd like to open this PR in advance.</ins> (I think it's okay if it will be decided later.)

**Why it is needed**
: In the current workflow, comments are left both when the PR contains Korean text and when it does not.
: There are definitely pros and cons to leaving a comment, even when it doesn't include Korean text.
  - Pros: Check results clearly
  - Cons: Too many comments

**Proposal**
: I think it would be good **to merge or close this PR at an appropriate time later**.
- If merged: Only make a comment if Korean texts are included.
- If closed: Make a comment both when Korean texts are included and when it does not.

Note - no conflict with other PR is expected.