### PR TITLE
AWS Matching the corresponding ProductFamily values

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -442,33 +442,6 @@ func GetZoneStatus(status string) irs.ZoneStatus {
 }
 
 // ReplaceEmptyWithNA 함수는 구조체의 빈 값이나 nil 값을 "NA"로 바꿉니다.
-func ReplaceEmptyWithNA(obj interface{}) {
-	val := reflect.ValueOf(obj).Elem()
-	// for i := 0; i < val.NumField(); i++ {
-	// 	field := val.Field(i)
-
-	// 	if field.Kind() == reflect.String {
-	// 		// 빈 문자열 필드 무시
-	// 	}
-	// }
-	for i := 0; i < val.NumField(); i++ {
-		field := val.Field(i)
-
-		switch field.Kind() {
-		case reflect.String:
-			if field.String() == "" {
-				field.SetString("NA")
-			}
-		case reflect.Ptr:
-			if field.IsNil() {
-				// If the field is a pointer and is nil, set it to "NA"
-				field.Set(reflect.New(field.Type().Elem()))
-				field.Elem().SetString("NA")
-			}
-		}
-	}
-}
-
 func ReplaceEmptyWithNAforComputeInstance(obj interface{}) {
 	val := reflect.ValueOf(obj).Elem()
 	for _, fieldName := range []string{"InstanceType", "Vcpu", "Memory", "Storage", "Gpu", "GpuMemory", "OperatingSystem", "PreInstalledSw"} {

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -444,7 +444,13 @@ func GetZoneStatus(status string) irs.ZoneStatus {
 // ReplaceEmptyWithNA 함수는 구조체의 빈 값이나 nil 값을 "NA"로 바꿉니다.
 func ReplaceEmptyWithNA(obj interface{}) {
 	val := reflect.ValueOf(obj).Elem()
+	// for i := 0; i < val.NumField(); i++ {
+	// 	field := val.Field(i)
 
+	// 	if field.Kind() == reflect.String {
+	// 		// 빈 문자열 필드 무시
+	// 	}
+	// }
 	for i := 0; i < val.NumField(); i++ {
 		field := val.Field(i)
 
@@ -459,6 +465,55 @@ func ReplaceEmptyWithNA(obj interface{}) {
 				field.Set(reflect.New(field.Type().Elem()))
 				field.Elem().SetString("NA")
 			}
+		}
+	}
+}
+
+func ReplaceEmptyWithNAforComputeInstance(obj interface{}) {
+	val := reflect.ValueOf(obj).Elem()
+	for _, fieldName := range []string{"InstanceType", "Vcpu", "Memory", "Storage", "Gpu", "GpuMemory", "OperatingSystem", "PreInstalledSw"} {
+		field := val.FieldByName(fieldName)
+		switch field.Kind() {
+		case reflect.String:
+			if field.String() == "" {
+				field.SetString("NA")
+			}
+		case reflect.Ptr:
+			if field.IsNil() {
+				// If the field is a pointer and is nil, set it to "NA"
+				field.Set(reflect.New(field.Type().Elem()))
+				field.Elem().SetString("NA")
+			}
+		}
+	}
+}
+
+func ReplaceEmptyWithNAforStorage(obj interface{}) {
+	val := reflect.ValueOf(obj).Elem()
+	for _, fieldName := range []string{"VolumeType", "StorageMedia", "MaxVolumeSize", "MaxIOPSVolume", "MaxThroughputVolume"} {
+		field := val.FieldByName(fieldName)
+		switch field.Kind() {
+		case reflect.String:
+			if field.String() == "" {
+				field.SetString("NA")
+			}
+		case reflect.Ptr:
+			if field.IsNil() {
+				// If the field is a pointer and is nil, set it to "NA"
+				field.Set(reflect.New(field.Type().Elem()))
+				field.Elem().SetString("NA")
+			}
+		}
+	}
+}
+
+func ReplaceEmptyWithNAforLoadBalancerNetwork(obj interface{}) {
+	val := reflect.ValueOf(obj).Elem()
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+
+		if field.Kind() == reflect.String {
+			// 빈 문자열 필드 무시
 		}
 	}
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -442,6 +442,28 @@ func GetZoneStatus(status string) irs.ZoneStatus {
 }
 
 // ReplaceEmptyWithNA 함수는 구조체의 빈 값이나 nil 값을 "NA"로 바꿉니다.
+func ReplaceEmptyWithNA(obj interface{}) {
+	val := reflect.ValueOf(obj).Elem()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+
+		switch field.Kind() {
+		case reflect.String:
+			if field.String() == "" {
+				field.SetString("NA")
+			}
+		case reflect.Ptr:
+			if field.IsNil() {
+				// If the field is a pointer and is nil, set it to "NA"
+				field.Set(reflect.New(field.Type().Elem()))
+				field.Elem().SetString("NA")
+			}
+		}
+	}
+}
+
+// ProductInfo 구조체의 Compute Instance 해당 값만 출력
 func ReplaceEmptyWithNAforComputeInstance(obj interface{}) {
 	val := reflect.ValueOf(obj).Elem()
 	for _, fieldName := range []string{"InstanceType", "Vcpu", "Memory", "Storage", "Gpu", "GpuMemory", "OperatingSystem", "PreInstalledSw"} {
@@ -461,6 +483,7 @@ func ReplaceEmptyWithNAforComputeInstance(obj interface{}) {
 	}
 }
 
+// ProductInfo 구조체의 Storage 해당 값만 출력
 func ReplaceEmptyWithNAforStorage(obj interface{}) {
 	val := reflect.ValueOf(obj).Elem()
 	for _, fieldName := range []string{"VolumeType", "StorageMedia", "MaxVolumeSize", "MaxIOPSVolume", "MaxThroughputVolume"} {
@@ -480,6 +503,7 @@ func ReplaceEmptyWithNAforStorage(obj interface{}) {
 	}
 }
 
+// ProductInfo 구조체의 Load Balancer-Network 해당 값만 출력
 func ReplaceEmptyWithNAforLoadBalancerNetwork(obj interface{}) {
 	val := reflect.ValueOf(obj).Elem()
 	for i := 0; i < val.NumField(); i++ {

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -126,7 +126,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 		cblogger.Info("get Products response", priceInfos)
 
 		for _, awsPrice := range priceInfos.PriceList {
-			productInfo, err := ExtractProductInfo(awsPrice)
+			productInfo, err := ExtractProductInfo(awsPrice, productFamily)
 
 			if err != nil {
 				cblogger.Error(err)
@@ -254,7 +254,7 @@ func (priceInfoHandler *AwsPriceInfoHandler) GetPriceInfo(productFamily string, 
 }
 
 // 가져온 결과에서 product 추출
-func ExtractProductInfo(jsonValue aws.JSONValue) (irs.ProductInfo, error) {
+func ExtractProductInfo(jsonValue aws.JSONValue, productFamily string) (irs.ProductInfo, error) {
 	var productInfo irs.ProductInfo
 
 	jsonString, err := json.MarshalIndent(jsonValue["product"].(map[string]interface{})["attributes"], "", "    ")
@@ -262,8 +262,18 @@ func ExtractProductInfo(jsonValue aws.JSONValue) (irs.ProductInfo, error) {
 		cblogger.Error(err)
 		return productInfo, err
 	}
+	//ReplaceEmptyWithNA(&productInfo)
+	switch productFamily {
+	case "Compute Instance":
+		ReplaceEmptyWithNAforComputeInstance(&productInfo)
+	case "Storage":
+		ReplaceEmptyWithNAforStorage(&productInfo)
+	case "Load Balancer-Network":
+		ReplaceEmptyWithNAforLoadBalancerNetwork(&productInfo)
+	default:
+		ReplaceEmptyWithNA(&productInfo)
+	}
 
-	ReplaceEmptyWithNA(&productInfo)
 	err = json.Unmarshal(jsonString, &productInfo)
 	if err != nil {
 		cblogger.Error(err)

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/PriceInfoHandler.go
@@ -262,7 +262,6 @@ func ExtractProductInfo(jsonValue aws.JSONValue, productFamily string) (irs.Prod
 		cblogger.Error(err)
 		return productInfo, err
 	}
-	//ReplaceEmptyWithNA(&productInfo)
 	switch productFamily {
 	case "Compute Instance":
 		ReplaceEmptyWithNAforComputeInstance(&productInfo)


### PR DESCRIPTION
Issue - #1089 

# AWS 드라이버 특이사항

- Product Family(Compute Instance, Storage, Load Balancer-Network)에 해당하는 ProductInfo 값 매칭 및 불필요한 값 제거

### GetPriceInfo

- CommonAwsFunc.go
    - func ReplaceEmptyWithNAforComputeInstance()
    - func ReplaceEmptyWithNAforStorage()
    - func ReplaceEmptyWithNAforLoadBalancerNetwork()
- 각 ProductFamily에 해당하는 값들만 출력

### ProductInfo

- Compute Instance ProductFamily 반환값

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/16f9f43b-bdda-4341-bd4d-4e237afa0f3b)


- Storage ProductFamily 반환값

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/59d32e0e-94de-405b-b179-541ba1efc209)


- Load Balancer-Network 반환값

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/73b94f43-bb9e-49a6-81c0-6d905b38eee7)

---

- Matching ProductInfo values and removing unnecessary values for the Compute Family (Compute Instance, Storage, Load Balancer-Network)

### GetPriceInfo

- CommonAwsFunc.go
    - func ReplaceEmptyWithNAforComputeInstance()
    - func ReplaceEmptyWithNAforStorage()
    - func ReplaceEmptyWithNAforLoadBalancerNetwork()
- Output only values corresponding to each ProductFamily

### ProductInfo

- Output Compute Instance ProductFamily
![image](https://github.com/cloud-barista/cb-spider/assets/99646153/6ac7ed0e-5a52-4dad-bb34-37a82f8e5432)


- Output Storage ProductFamily 
![image](https://github.com/cloud-barista/cb-spider/assets/99646153/515a84a2-30fe-4601-a002-d273d817f4f0)


- Output Load Balancer-Network 

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/7d36e92f-da00-4d89-9016-82ee7e54b3fc)
