### PR TITLE
feature isseu1073 240219

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/KeyPairHandler.go
@@ -371,21 +371,21 @@ func (keyPairHandler *AlibabaKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, er
 	return true, nil
 }
 
-//=================================
+// =================================
 // 공개 키 변환 및 키 정보 로컬 보관 로직 추가
-//=================================
+// =================================
 func (keyPairHandler *AlibabaKeyPairHandler) CheckKeyPairFolder(keyPairPath string) error {
 	//키페어 생성 시 폴더가 존재하지 않으면 생성 함.
 	_, errChkDir := os.Stat(keyPairPath)
 	if os.IsNotExist(errChkDir) {
-		cblogger.Errorf("[%s] Path가 존재하지 않아서 생성합니다.", keyPairPath)
+		cblogger.Errorf("[%s] The path does not exist, so we are creating it.", keyPairPath)
 
 		//errDir := os.MkdirAll(keyPairPath, 0755)
 		errDir := os.MkdirAll(keyPairPath, 0700)
 		//errDir := os.MkdirAll(keyPairPath, os.ModePerm) // os.ModePerm : 0777	//os.ModeDir
 		if errDir != nil {
 			//log.Fatal(err)
-			cblogger.Errorf("[%s] Path가 생성 실패", keyPairPath)
+			cblogger.Errorf("[%s] Path creation failed.", keyPairPath)
 			cblogger.Error(errDir)
 			return errDir
 		}

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/MyImageHandler.go
@@ -212,11 +212,11 @@ func (myImageHandler AlibabaMyImageHandler) DeleteMyImage(myImageIID irs.IID) (b
 		}
 
 		curRetryCnt++
-		cblogger.Errorf("MyImage의 상태 1초 대기후 조회합니다. 현재 [%s]", aliImageState)
+		cblogger.Errorf(" will check the status of MyImage after waiting for 1 second. What is the current status?[%s]", aliImageState)
 		time.Sleep(time.Second * 1)
 		if curRetryCnt > maxRetryCnt {
-			cblogger.Errorf("장시간(%d 초) 대기해도 MyImage의 Status 값이 [%s]으로 변경되지 않아서 강제로 중단합니다.", maxRetryCnt)
-			return false, errors.New("장시간 기다렸으나 생성된 MyImage의 상태가 [" + string(aliImageState) + "]으로 바뀌지 않아서 중단 합니다.")
+			cblogger.Debugf("I waited for a long time (%d seconds), but the Status value of MyImage still... [%s]으로 변경되지 않아서 강제로 중단합니다.", maxRetryCnt)
+			return false, errors.New("I waited for a long time, but the status of the created MyImage is still...[" + string(aliImageState) + "]으로 바뀌지 않아서 중단 합니다.")
 		}
 	}
 	cblogger.Info("MyImage deleted. requestId =" + response.RequestId)

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
@@ -77,9 +77,9 @@ type AliInstanceType struct {
 	InstanceType string  `json:"InstanceTypeId,omitempty"`
 	Vcpu         int64   `json:"CpuCoreCount,omitempty"`
 	Memory       float64 `json:"MemorySize,omitempty"`
-	Storage      string  `json:"LocalStorageCategory,omitempty"`
-	Gpu          string  `json:"GPUSpec,omitempty"`
-	GpuMemory    int64   `json:"GPUAmount,omitempty"`
+	//Storage      string  `json:"LocalStorageCategory,omitempty"`
+	Gpu       string `json:"GPUSpec,omitempty"`
+	GpuMemory int64  `json:"GPUAmount,omitempty"`
 }
 
 type AliInstanceTypesResponse struct {
@@ -515,7 +515,9 @@ func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, regionName
 			productInfo.InstanceType = resultProduct.InstanceType
 			productInfo.Vcpu = strconv.FormatInt(resultProduct.Vcpu, 10)
 			productInfo.Memory = strconv.FormatFloat(resultProduct.Memory, 'f', -1, 64)
-			productInfo.Storage = resultProduct.Storage
+			//resultProduct.Storage 데이터가 없는데 왜 데이터를 이렇게 맵핑을 해놓았는지 확인필요
+			//productInfo.Storage = resultProduct.Storage
+			productInfo.Storage = "NA"
 			productInfo.Gpu = resultProduct.Gpu
 			productInfo.GpuMemory = strconv.FormatInt(resultProduct.GpuMemory, 10)
 			productInfo.OperatingSystem = "NA"

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
@@ -77,7 +77,7 @@ type AliInstanceType struct {
 	InstanceType string  `json:"InstanceTypeId,omitempty"`
 	Vcpu         int64   `json:"CpuCoreCount,omitempty"`
 	Memory       float64 `json:"MemorySize,omitempty"`
-	//Storage      string  `json:"LocalStorageCategory,omitempty"`
+	// Storage      string  `json:"LocalStorageCategory,omitempty"` 잘못된 데이터 맵핑
 	Gpu       string `json:"GPUSpec,omitempty"`
 	GpuMemory int64  `json:"GPUAmount,omitempty"`
 }
@@ -296,7 +296,7 @@ func (priceInfoHandler *AlibabaPriceInfoHandler) GetPriceInfo(productFamily stri
 							aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), priceResponseStr)
 							priceMap[productId] = aPrice
 						} else { // product가 없으면 price 추가
-							newProductInfo, err := GetDescribeInstanceTypesForPricing(priceInfoHandler.BssClient, regionName, attr.Value, filter)
+							newProductInfo, err := GetDescribeInstanceTypesForPricing(priceInfoHandler.BssClient, regionName, attr.Value, filter, productFamily)
 							if err != nil {
 								cblogger.Errorf("[%s] instanceType is Empty", attr.Value)
 								continue
@@ -408,7 +408,7 @@ func (priceInfoHandler *AlibabaPriceInfoHandler) GetPriceInfo(productFamily stri
 								aPrice.PriceInfo.CSPPriceInfo = append(aPrice.PriceInfo.CSPPriceInfo.([]string), priceResponseStr)
 								priceMap[productId] = aPrice
 							} else { // product가 없으면 price 추가
-								newProductInfo, err := GetDescribeInstanceTypesForPricing(priceInfoHandler.BssClient, regionName, attr.Value, filter)
+								newProductInfo, err := GetDescribeInstanceTypesForPricing(priceInfoHandler.BssClient, regionName, attr.Value, filter, productFamily)
 								if err != nil {
 									cblogger.Errorf("[%s] instanceType is Empty", attr.Value)
 									continue
@@ -459,7 +459,7 @@ func (priceInfoHandler *AlibabaPriceInfoHandler) GetPriceInfo(productFamily stri
 
 // region의 특정 instanceType의 내용조회
 // func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, instanceType string) (map[string]interface{}, error) {
-func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, regionName string, instanceType string, filter map[string]*string) (irs.ProductInfo, error) {
+func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, regionName string, instanceType string, filter map[string]*string, productFamily string) (irs.ProductInfo, error) {
 	DescribeInstanceRequest := requests.NewCommonRequest()
 	DescribeInstanceRequest.Method = "POST"
 	DescribeInstanceRequest.Scheme = "https" // https | http
@@ -519,18 +519,23 @@ func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, regionName
 			//productInfo.Storage = resultProduct.Storage
 			productInfo.Storage = "NA"
 			productInfo.Gpu = resultProduct.Gpu
+			if productInfo.Gpu == "" {
+				productInfo.Gpu = "NA"
+			}
 			productInfo.GpuMemory = strconv.FormatInt(resultProduct.GpuMemory, 10)
 			if productInfo.GpuMemory == "" {
-				productInfo.GpuMemory = ""
+				productInfo.GpuMemory = "NA"
 			}
 			productInfo.GpuMemory = resultProduct.Gpu
 			productInfo.OperatingSystem = "NA"
 			productInfo.PreInstalledSw = "NA"
-			productInfo.VolumeType = "NA"
-			productInfo.StorageMedia = "NA"
-			productInfo.MaxVolumeSize = "NA"
-			productInfo.MaxIOPSVolume = "NA"
-			productInfo.MaxThroughputVolume = "NA"
+			if productFamily != "ecs" {
+				productInfo.VolumeType = "NA"
+				productInfo.StorageMedia = "NA"
+				productInfo.MaxVolumeSize = "NA"
+				productInfo.MaxIOPSVolume = "NA"
+				productInfo.MaxThroughputVolume = "NA"
+			}
 			productInfo.Description = "NA"
 		} else {
 			return productInfo, errors.New("there is no instanceType")

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
@@ -515,11 +515,15 @@ func GetDescribeInstanceTypesForPricing(bssClient *bssopenapi.Client, regionName
 			productInfo.InstanceType = resultProduct.InstanceType
 			productInfo.Vcpu = strconv.FormatInt(resultProduct.Vcpu, 10)
 			productInfo.Memory = strconv.FormatFloat(resultProduct.Memory, 'f', -1, 64)
-			//resultProduct.Storage 데이터가 없는데 왜 데이터를 이렇게 맵핑을 해놓았는지 확인필요
+			//resultProduct.Storage ==  LocalStorageCategory 관계가없는 데이터 맵핑 NA 처리
 			//productInfo.Storage = resultProduct.Storage
 			productInfo.Storage = "NA"
 			productInfo.Gpu = resultProduct.Gpu
 			productInfo.GpuMemory = strconv.FormatInt(resultProduct.GpuMemory, 10)
+			if productInfo.GpuMemory == "" {
+				productInfo.GpuMemory = ""
+			}
+			productInfo.GpuMemory = resultProduct.Gpu
 			productInfo.OperatingSystem = "NA"
 			productInfo.PreInstalledSw = "NA"
 			productInfo.VolumeType = "NA"


### PR DESCRIPTION
### **이슈 (https://github.com/cloud-barista/cb-spider/issues/1073) ###
***
- GPU가 없을 경우: GPU 및 GPU Memory 값 통일 필요
- 둘다 값을 제공하지 않던지, 둘다 0 값으로 제공하든지
- VolumeType: NA ~ 이후 값은 productFamily 입력값이 Storage 관련된 값일 경우 제공하는 정보로 compute인 'ecs'의 경우 삭제 필요
- 무시해도 되는 메시지라면 로그 출력시 Error() 대신, Info() 또는 Debug()등 처리하도록 수정 필요  
 ***

### 작업내용
***
-  Storage 맵핑시 빠트린 것인지, NA인지 확인 필요 : NA 처리
- GPU 및 GPU Memory 값 통일 필요  : 값 없으면 NA 처리 
![스크린샷 2024-02-27 오후 1 23 12](https://github.com/cloud-barista/cb-spider/assets/71921309/b0ce48e8-6183-43f6-b975-1f56a8116c1d)
- 무시해도 되는 메시지라면 로그 출력시 Error() 대신, Info() 또는 Debug()등 처리하도록 : 수정 완료
- 추가로 Alibaba 작업 진행시 한글 -> 영문명 변경 처리  및 무시 메시지라면 error - > info 또는 Debug 변경 작업 

***
