### PR TITLE
[Tencent] Remove storage ProductFamily and add SPOTPAID missing

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonHandler.go
@@ -58,15 +58,15 @@ func WaitForDelete(client *cvm.Client, imageIID irs.IID) (bool, error) {
 		}
 
 		if len(imageList) == 0 {
-			cblogger.Info("Image의 삭제가 완료되어 대기를 중단합니다.")
+			cblogger.Info("Image deletion is complete and stops waiting.")
 			break
 		}
 
 		curRetryCnt++
-		cblogger.Info("Image의 삭제가 완료되지 않아 1초 대기후 조회합니다.")
+		cblogger.Info("Image deletion has not been completed, so we will look up the climate for 1 second.")
 		time.Sleep(time.Second * 1)
 		if curRetryCnt > maxRetryCnt {
-			cblogger.Errorf("장시간(%d 초) 대기해도 Image의 삭제가 완료되지 않아서 강제로 중단합니다.", maxRetryCnt)
+			cblogger.Errorf("If you wait for a long time (%d seconds), the deletion of the image does not complete, so forcefully stop.", maxRetryCnt)
 			return false, errors.New("Failed to delete image")
 		}
 	}
@@ -95,16 +95,16 @@ func WaitForDone(client *cbs.Client, diskIID irs.IID, status string) (string, er
 		cblogger.Info("===>Disk Status : ", curStatus)
 
 		if curStatus == waitStatus {
-			cblogger.Infof("===>Disk 상태가 [%s]라서 대기를 중단합니다.", curStatus)
+			cblogger.Infof("===>Suspends standby because disk state is [%s].", curStatus)
 			break
 		}
 
 		curRetryCnt++
-		cblogger.Infof("Disk 상태가 [%s]이 아니라서 1초 대기후 조회합니다.", waitStatus)
+		cblogger.Infof("Disk status is not [%s] and climate lookup is performed in 1 second.", waitStatus)
 		time.Sleep(time.Second * 1)
 		if curRetryCnt > maxRetryCnt {
-			cblogger.Errorf("장시간(%d 초) 대기해도 Disk Status 값이 [%s]으로 변경되지 않아서 강제로 중단합니다.", maxRetryCnt, waitStatus)
-			return "Failed", errors.New("장시간 기다렸으나 생성된 Disk의 상태가 [" + waitStatus + "]으로 바뀌지 않아서 중단 합니다.")
+			cblogger.Errorf("Waiting for a long time (%d seconds) does not change the disk status value to [%s] and forces it to stop.", maxRetryCnt, waitStatus)
+			return "Failed", errors.New("After waiting a long time, the status of the created disk does not change to [" + waitStatus + "] and it is interrupted.")
 		}
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonTencentFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonTencentFunc.go
@@ -115,7 +115,7 @@ func ConvertJsonStringNoEscape(v interface{}) (string, error) {
 	encoder.SetEscapeHTML(false)
 	errJson := encoder.Encode(v)
 	if errJson != nil {
-		cblogger.Error("JSON 변환 실패")
+		cblogger.Error("JSON conversion failed")
 		cblogger.Error(errJson)
 		return "", errJson
 	}
@@ -136,7 +136,7 @@ func ConvertJsonString(v interface{}) (string, error) {
 	jsonBytes, errJson := json.Marshal(v)
 
 	if errJson != nil {
-		cblogger.Error("JSON 변환 실패")
+		cblogger.Error("JSON conversion failed")
 		cblogger.Error(errJson)
 		return "", errJson
 	}
@@ -180,7 +180,7 @@ func ConvertKeyValueList(v interface{}) ([]irs.KeyValue, error) {
 
 	jsonBytes, errJson := json.Marshal(v)
 	if errJson != nil {
-		cblogger.Error("KeyValue 변환 실패")
+		cblogger.Error("KeyValue conversion failed")
 		cblogger.Error(errJson)
 		return nil, errJson
 	}
@@ -201,7 +201,7 @@ func ConvertKeyValueList(v interface{}) ([]irs.KeyValue, error) {
 		value, errString := ConvertToString(v)
 		if errString != nil {
 			//cblogger.Errorf("Key[%s]의 값은 변환 불가 - [%s]", k, errString)
-			cblogger.Debugf("Key[%s]의 값은 변환 불가 - [%s]", k, errString) //요구에 의해서 Error에서 Warn으로 낮춤
+			cblogger.Debugf("Key[%s] values are not convertible - [%s]", k, errString) //요구에 의해서 Error에서 Warn으로 낮춤
 			continue
 		}
 		keyValueList = append(keyValueList, irs.KeyValue{k, value})

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
@@ -427,6 +427,6 @@ func (DiskHandler *TencentDiskHandler) diskExist(chkName string) (bool, error) {
 		return false, nil
 	}
 
-	cblogger.Infof("Disk 정보 찾음 - DiskId:[%s] / DiskName:[%s]", *response.Response.DiskSet[0].DiskId, *response.Response.DiskSet[0].DiskName)
+	cblogger.Infof("Found disk information - DiskId:[%s] / DiskName:[%s]", *response.Response.DiskSet[0].DiskId, *response.Response.DiskSet[0].DiskName)
 	return true, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ImageHandler.go
@@ -144,7 +144,7 @@ func ExtractImageDescribeInfo(image *cvm.Image) irs.ImageInfo {
 	//KeyValue 목록 처리
 	keyValueList, errKeyValue := ConvertKeyValueList(image)
 	if errKeyValue != nil {
-		cblogger.Errorf("[%]의 KeyValue 추출 실패", *image.ImageId)
+		cblogger.Errorf("KeyValue extraction failed for [%]", *image.ImageId)
 		cblogger.Error(errKeyValue)
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/MyImageHandler.go
@@ -322,7 +322,7 @@ func (myImageHandler *TencentMyImageHandler) myImageExist(chkName string) (bool,
 		return false, nil
 	}
 
-	cblogger.Infof("MyImage 정보 찾음 - MyImageId:[%s] / MyImageName:[%s]", *response.Response.ImageSet[0].ImageId, *response.Response.ImageSet[0].ImageName)
+	cblogger.Infof("Found MyImage information - MyImageId:[%s] / MyImageName:[%s]", *response.Response.ImageSet[0].ImageId, *response.Response.ImageSet[0].ImageName)
 	return true, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
@@ -50,8 +50,8 @@ const (
 )
 
 /*
-	NLB 생성
-	vpc required
+NLB 생성
+vpc required
 */
 func (NLBHandler *TencentNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLBInfo, error) {
 	////// validation check area //////
@@ -244,7 +244,7 @@ func (NLBHandler *TencentNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLBI
 }
 
 /*
-	NLB 모든 목록 조회 : TCP/UDP
+NLB 모든 목록 조회 : TCP/UDP
 */
 func (NLBHandler *TencentNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	cblogger.Info("Start")
@@ -298,7 +298,7 @@ func (NLBHandler *TencentNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 }
 
 /*
-	NLB 조회
+NLB 조회
 */
 func (NLBHandler *TencentNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error) {
 	cblogger.Info("NLB IID : ", nlbIID.SystemId)
@@ -762,7 +762,7 @@ func (NLBHandler *TencentNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, hea
 
 }
 
-//CLB instance status (creating, running)
+// CLB instance status (creating, running)
 func (NLBHandler *TencentNLBHandler) WaitForRun(nlbIID irs.IID) (string, error) {
 
 	waitStatus := "Running"
@@ -783,23 +783,23 @@ func (NLBHandler *TencentNLBHandler) WaitForRun(nlbIID irs.IID) (string, error) 
 		cblogger.Info("===>NLB Status : ", curStatus)
 
 		if curStatus == LoadBalancerSet_Status_Running {
-			cblogger.Infof("===>NLB 상태가 [%d]라서 대기를 중단합니다.", curStatus)
+			cblogger.Infof("===>The NLB state is [%d] so it stops waiting.", curStatus)
 			break
 		}
 
 		curRetryCnt++
-		cblogger.Infof("NLB 상태가 [%s]이 아니라서 1초 대기후 조회합니다.", waitStatus)
+		cblogger.Infof("NLB status is not [%s] so I'm checking the climate for a second.", waitStatus)
 		time.Sleep(time.Second * 1)
 		if curRetryCnt > maxRetryCnt {
-			cblogger.Errorf("장시간(%d 초) 대기해도 NLB Status 값이 [%s]으로 변경되지 않아서 강제로 중단합니다.", maxRetryCnt, waitStatus)
-			return "Failed", errors.New("장시간 기다렸으나 생성된 NLB의 상태가 [" + waitStatus + "]으로 바뀌지 않아서 중단 합니다.")
+			cblogger.Errorf("The NLB Status value does not change to [%s] even after waiting for a long time (%d seconds), so it is forced to stop.", maxRetryCnt, waitStatus)
+			return "Failed", errors.New("I waited for a long time, but the generated NLB status did not change to [" + waitStatus + "] so I will stop.")
 		}
 	}
 
 	return waitStatus, nil
 }
 
-//Current status of a task (succeeded==Done, failed, in progress)
+// Current status of a task (succeeded==Done, failed, in progress)
 func (NLBHandler *TencentNLBHandler) WaitForDone(requestId string) (string, error) {
 
 	waitStatus := "Done"
@@ -821,16 +821,16 @@ func (NLBHandler *TencentNLBHandler) WaitForDone(requestId string) (string, erro
 		cblogger.Info("===>request status : ", requestStatus)
 
 		if requestStatus == Request_Status_Succeeded {
-			cblogger.Infof("===>request 상태가 [%s]라서 대기를 중단합니다.", waitStatus)
+			cblogger.Infof("===>The request state is [%s] and will stop waiting.", waitStatus)
 			break
 		}
 
 		curRetryCnt++
-		cblogger.Infof("request 상태가 [%s]이 아니라서 1초 대기후 조회합니다.", waitStatus)
+		cblogger.Infof("The request status is not [%s], so I'm checking the climate for a second.", waitStatus)
 		time.Sleep(time.Second * 1)
 		if curRetryCnt > maxRetryCnt {
-			cblogger.Errorf("장시간(%d 초) 대기해도 request Status 값이 [%s]으로 변경되지 않아서 강제로 중단합니다.", maxRetryCnt, waitStatus)
-			return "Failed", errors.New("장시간 기다렸으나 생성된 request 상태가 [" + waitStatus + "]으로 바뀌지 않아서 중단 합니다.")
+			cblogger.Errorf("Waiting for a long time (%d seconds) does not change the request status value to [%s] and forces it to stop.", maxRetryCnt, waitStatus)
+			return "Failed", errors.New("I waited for a long time, but the generated request status did not change to [" + waitStatus + "] so I will stop.")
 		}
 	}
 
@@ -838,8 +838,8 @@ func (NLBHandler *TencentNLBHandler) WaitForDone(requestId string) (string, erro
 }
 
 /*
-	nlb가 존재하는지 check
-	동일이름이 없으면 false, 있으면 true
+nlb가 존재하는지 check
+동일이름이 없으면 false, 있으면 true
 */
 func (NLBHandler *TencentNLBHandler) nlbExist(chkName string) (bool, error) {
 	cblogger.Debugf("chkName : %s", chkName)
@@ -862,7 +862,7 @@ func (NLBHandler *TencentNLBHandler) nlbExist(chkName string) (bool, error) {
 }
 
 /*
-	조회한 결과에서 Spider의 NLBInfo 값으로 변환
+조회한 결과에서 Spider의 NLBInfo 값으로 변환
 */
 func (NLBHandler *TencentNLBHandler) ExtractNLBDescribeInfo(nlbInfo *clb.LoadBalancer) (irs.NLBInfo, error) {
 
@@ -908,10 +908,9 @@ func (NLBHandler *TencentNLBHandler) ExtractNLBDescribeInfo(nlbInfo *clb.LoadBal
 	return resNLBInfo, nil
 }
 
-
 /*
-	NLB Name으로 Listener를 조회하여 NLBInfo.Listener 값으로 변환
-	NLB 를 조회하여 Listener에 사용할 IP인 VIP 추출
+NLB Name으로 Listener를 조회하여 NLBInfo.Listener 값으로 변환
+NLB 를 조회하여 Listener에 사용할 IP인 VIP 추출
 */
 func (NLBHandler *TencentNLBHandler) ExtractListenerInfo(nlbIID irs.IID) (irs.ListenerInfo, error) {
 	cblogger.Info("NLB IID : ", nlbIID.SystemId)
@@ -945,7 +944,7 @@ func (NLBHandler *TencentNLBHandler) ExtractListenerInfo(nlbIID irs.IID) (irs.Li
 }
 
 /*
-	VM Group 정보 조회
+VM Group 정보 조회
 */
 func (NLBHandler *TencentNLBHandler) ExtractVMGroupInfo(nlbIID irs.IID) (irs.VMGroupInfo, error) {
 	cblogger.Info("NLB IID : ", nlbIID.SystemId)
@@ -986,7 +985,7 @@ func (NLBHandler *TencentNLBHandler) ExtractVMGroupInfo(nlbIID irs.IID) (irs.VMG
 }
 
 /*
-	Health Checker 정보 조회
+Health Checker 정보 조회
 */
 func (NLBHandler *TencentNLBHandler) ExtractHealthCheckerInfo(nlbIID irs.IID) (irs.HealthCheckerInfo, error) {
 	cblogger.Info("NLB IID : ", nlbIID.SystemId)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/PriceInfoHandler.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"bytes"
 	"encoding/json"
-	"hash/fnv"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -66,7 +66,6 @@ func (t *TencentPriceInfoHandler) GetPriceInfo(productFamily string, regionName 
 
 		//Common Instance Price calculator
 		standardInfo, err := describeZoneInstanceConfigInfos(t.Client, filterKeyValueMap)
-
 		if err != nil {
 			return "", err
 		}
@@ -167,108 +166,51 @@ func mappingToComputeStruct(regionName string, instanceModel *TencentInstanceMod
 	// standardInfo
 	if instanceModel.standardInfo != nil {
 		for _, v := range instanceModel.standardInfo.Response.InstanceTypeQuotaSet {
-			productId := computeInstanceKeyGeneration(*v.Zone, *v.InstanceType, *v.CpuType, strconv.FormatInt(*v.Memory, 10))
 
+			productId := computeInstanceKeyGeneration(*v.Zone, *v.InstanceType, *v.CpuType, strconv.FormatInt(*v.Memory, 10))
 			price, ok := priceMap[productId]
 			if ok { // 있으면
 				// policies 추출
 				policy := mappingPricingPolicy(v.InstanceChargeType, v.Price)
 
-				if priceValidateFilter(&policy, filterMap) {
+				if priceFilter(&policy, filterMap) {
 					continue
 				}
-
 				// append policy
-				pricePicies := price.PriceInfo.PricingPolicies
-				pricePicies = append(pricePicies, policy)
-
+				pricePolicies := price.PriceInfo.PricingPolicies
+				pricePolicies = append(pricePolicies, policy)
+				price.PriceInfo.PricingPolicies = pricePolicies
 				priceMap[productId] = price // price 재할당
+
+				cblogger.Info("add policy ", price)
 			} else { // 없으면
 				// product 추출
 				productInfo := mappingProductInfo(regionName, *v)
-				if validateFilter(filterMap, &productInfo) {
+				if productFilter(filterMap, &productInfo) {
 					continue
 				}
 
-				// pricePicies 추출
+				// pricePolicies 추출
 				policy := mappingPricingPolicy(v.InstanceChargeType, *v.Price)
 
-				if priceValidateFilter(&policy, filterMap) {
+				if priceFilter(&policy, filterMap) {
 					continue
 				}
 
 				aPrice := irs.Price{}
 				priceInfo := irs.PriceInfo{}
 
-				pricePicies := []irs.PricingPolicies{}
-				pricePicies = append(pricePicies, policy)
+				pricePolicies := []irs.PricingPolicies{}
+				pricePolicies = append(pricePolicies, policy)
 
-				priceInfo.PricingPolicies = pricePicies
+				priceInfo.PricingPolicies = pricePolicies
 
 				aPrice.ProductInfo = productInfo
 				aPrice.PriceInfo = priceInfo
 
 				priceMap[productId] = aPrice
 			}
-
-		}
-	}
-	// reservedInfo
-	if instanceModel.reservedInfo != nil {
-		for _, v := range instanceModel.reservedInfo.Response.ReservedInstanceConfigInfos {
-			for _, info := range v.InstanceFamilies {
-				for _, iType := range info.InstanceTypes {
-					for _, p := range iType.Prices {
-						productId := computeInstanceKeyGeneration(*p.Zone, *iType.InstanceType, *iType.CpuModelName, strconv.FormatUint(*iType.Memory, 10))
-
-						price, ok := priceMap[productId]
-						if ok { // 있으면
-							// policies 추출
-							policy := mappingPricingPolicy(common.StringPtr("RESERVED"), iType.Prices)
-
-							if priceValidateFilter(&policy, filterMap) {
-								continue
-							}
-
-							// append policy
-							pricePicies := price.PriceInfo.PricingPolicies
-							pricePicies = append(pricePicies, policy)
-
-							priceMap[productId] = price // price 재할당
-						} else { // 없으면
-							// product 추출
-							productInfo := mappingProductInfo(regionName, *iType)
-							if validateFilter(filterMap, &productInfo) {
-								continue
-							}
-
-							//	for _, val := range *v.price.Res {
-
-							// pricePicies 추출
-							policy := mappingPricingPolicy(common.StringPtr("RESERVED"), *p)
-
-							if priceValidateFilter(&policy, filterMap) {
-								continue
-							}
-							aPrice := irs.Price{}
-							priceInfo := irs.PriceInfo{}
-
-							pricePicies := []irs.PricingPolicies{}
-							pricePicies = append(pricePicies, policy)
-
-							priceInfo.PricingPolicies = pricePicies
-
-							aPrice.ProductInfo = productInfo
-							aPrice.PriceInfo = priceInfo
-
-							priceMap[productId] = aPrice
-							//	}
-						}
-
-					} // end of itype.Prices for
-				} // end of itype for
-			} // end of instanceFamilies for
-		} // end of reservedInstanceConfigInfos for
+		} // end of for
 	}
 
 	priceList := make([]irs.Price, 0)
@@ -294,145 +236,8 @@ func mappingToComputeStruct(regionName string, instanceModel *TencentInstanceMod
 
 }
 
-// Mapper Start Function -- X
-// func mappingToComputeStruct(regionName string, instanceModel *TencentInstanceModel, filterMap map[string]string) (*irs.CloudPriceData, error) {
-// 	priceMap := make(map[string]*TencentInstanceInformation, 0)
-
-// 	if instanceModel.standardInfo != nil {
-// 		for _, v := range instanceModel.standardInfo.Response.InstanceTypeQuotaSet {
-
-// 			//변수값이 충분한지 고려할 필요가 있음, reservedInstance ReturnValue와 비교하여, 최대한 고유하게 가져갈 수 있는 것들은
-// 			//가져가도록 수정
-// 			key := computeInstanceKeyGeneration(*v.Zone, *v.InstanceType, *v.CpuType, strconv.FormatInt(*v.Memory, 10))
-
-// 			if pp, ok := priceMap[key]; !ok {
-// 				productInfo := mappingProductInfo(regionName, *v)
-
-// 				if validateFilter(filterMap, &productInfo) {
-// 					continue
-// 				}
-// 				sp := make([]TencentCommonInstancePrice, 0)
-// 				sp = append(sp, TencentCommonInstancePrice{InstanceChargeType: v.InstanceChargeType, Price: v.Price})
-
-// 				priceMap[key] = &TencentInstanceInformation{
-// 					PriceList: &irs.Price{
-// 						ProductInfo: productInfo,
-// 					},
-// 					StandardPrices: &sp,
-// 				}
-// 			} else {
-// 				newSlice := append(*pp.StandardPrices, TencentCommonInstancePrice{InstanceChargeType: v.InstanceChargeType, Price: v.Price})
-// 				pp.StandardPrices = &newSlice
-// 			}
-// 		}
-// 	}
-
-// 	//TODO reserved Instance Info Mapping
-// 	if instanceModel.reservedInfo != nil {
-// 		for _, v := range instanceModel.reservedInfo.Response.ReservedInstanceConfigInfos {
-// 			for _, info := range v.InstanceFamilies {
-// 				for _, iType := range info.InstanceTypes {
-// 					for _, p := range iType.Prices {
-// 						key := computeInstanceKeyGeneration(*p.Zone, *iType.InstanceType, *iType.CpuModelName, strconv.FormatUint(*iType.Memory, 10))
-// 						if pp, ok := priceMap[key]; !ok {
-// 							productInfo := mappingProductInfo(regionName, *iType)
-
-// 							if validateFilter(filterMap, &productInfo) {
-// 								continue
-// 							}
-
-// 							rp := make([]TencentReservedInstancePrice, 0)
-// 							rp = append(rp, TencentReservedInstancePrice{Price: p})
-
-// 							priceMap[key] = &TencentInstanceInformation{
-// 								PriceList: &irs.Price{
-// 									ProductInfo: productInfo,
-// 								},
-
-// 								ReservedPrices: &rp,
-// 							}
-// 						} else {
-// 							newSlice := append(*pp.ReservedPrices, TencentReservedInstancePrice{Price: p})
-// 							pp.ReservedPrices = &newSlice
-// 						}
-// 					}
-
-// 				}
-// 			}
-// 		}
-// 	}
-// 	generatePriceInfo(priceMap, filterMap)
-
-// 	priceList := make([]irs.Price, 0)
-
-// 	if priceMap != nil && len(priceMap) > 0 {
-// 		for _, v := range priceMap {
-// 			priceList = append(priceList, *v.PriceList)
-// 		}
-// 	}
-
-// 	x := &irs.CloudPriceData{
-// 		Meta: irs.Meta{
-// 			Version:     "v0.1",
-// 			Description: "Multi-Cloud Price Info Api",
-// 		},
-// 		CloudPriceList: []irs.CloudPrice{
-// 			{
-// 				CloudName: "TENCENT",
-// 				PriceList: priceList,
-// 			},
-// 		},
-// 	}
-// 	return x, nil
-// }
-
-// TencentSDK VM Product & Pricing struct to irs Struct
-func generatePriceInfo(priceMap map[string]*TencentInstanceInformation, filterMap map[string]string) {
-	if priceMap != nil && len(priceMap) > 0 {
-		for _, v := range priceMap {
-			pl := v.PriceList
-			policies := make([]irs.PricingPolicies, 0)
-			prices := make([]any, 0)
-
-			if v.StandardPrices != nil && len(*v.StandardPrices) > 0 {
-				for _, val := range *v.StandardPrices {
-
-					policy := mappingPricingPolicy(val.InstanceChargeType, *val.Price)
-
-					if priceValidateFilter(&policy, filterMap) {
-						continue
-					}
-					prices = append(prices, val.Price)
-					policies = append(policies, policy)
-				}
-			}
-
-			if v.ReservedPrices != nil && len(*v.ReservedPrices) > 0 {
-				for _, val := range *v.ReservedPrices {
-					policy := mappingPricingPolicy(common.StringPtr("RESERVED"), *val.Price)
-
-					if priceValidateFilter(&policy, filterMap) {
-						continue
-					}
-					prices = append(prices, val.Price)
-					policies = append(policies, policy)
-				}
-			}
-			// //mar, err := json.Marshal(prices)
-			// mar, err := ConvertJsonStringNoEscape(prices)
-
-			// if err != nil {
-			// 	continue
-			// }
-
-			pl.PriceInfo = irs.PriceInfo{
-				PricingPolicies: policies,
-				CSPPriceInfo:    prices,
-			}
-		}
-	}
-}
-func validateFilter(filterMap map[string]string, productInfo *irs.ProductInfo) bool {
+// product 항목에 대해 필터 맵에 값이 있으면 true반환 -> true면 해당 값 필터링
+func productFilter(filterMap map[string]string, productInfo *irs.ProductInfo) bool {
 	if len(filterMap) <= 0 {
 		return false
 	}
@@ -462,7 +267,8 @@ func validateFilter(filterMap map[string]string, productInfo *irs.ProductInfo) b
 	return false
 }
 
-func priceValidateFilter(policy *irs.PricingPolicies, filterMap map[string]string) bool {
+// price 항목에 대해 필터 맵에 값이 있으면 true반환 -> true면 해당 값 필터링
+func priceFilter(policy *irs.PricingPolicies, filterMap map[string]string) bool {
 	if len(filterMap) <= 0 {
 		return false
 	}
@@ -496,6 +302,8 @@ func priceValidateFilter(policy *irs.PricingPolicies, filterMap map[string]strin
 }
 
 // TencentSDK VM Product & Pricing struct to irs ProductPolicies
+// storage 출력 항목 삭제
+// compute infra 관련 정보만 매핑
 func mappingProductInfo(regionName string, i interface{}) irs.ProductInfo {
 	productInfo := irs.ProductInfo{
 		//ProductId:      "NA",
@@ -520,13 +328,7 @@ func mappingProductInfo(regionName string, i interface{}) irs.ProductInfo {
 		productInfo.OperatingSystem = strPtrNilCheck(nil)
 		productInfo.PreInstalledSw = strPtrNilCheck(nil)
 
-		// not suit for compute instance
-		productInfo.VolumeType = strPtrNilCheck(nil)
-		productInfo.StorageMedia = strPtrNilCheck(nil)
-		productInfo.MaxVolumeSize = strPtrNilCheck(nil)
-		productInfo.MaxIOPSVolume = strPtrNilCheck(nil)
-		productInfo.MaxThroughputVolume = strPtrNilCheck(nil)
-
+		// storage 관련 정보 삭제
 		return productInfo
 
 	case cvm.ReservedInstanceTypeItem:
@@ -545,13 +347,7 @@ func mappingProductInfo(regionName string, i interface{}) irs.ProductInfo {
 		productInfo.OperatingSystem = strPtrNilCheck(nil)
 		productInfo.PreInstalledSw = strPtrNilCheck(nil)
 
-		// not suit for compute instance
-		productInfo.VolumeType = strPtrNilCheck(nil)
-		productInfo.StorageMedia = strPtrNilCheck(nil)
-		productInfo.MaxVolumeSize = strPtrNilCheck(nil)
-		productInfo.MaxIOPSVolume = strPtrNilCheck(nil)
-		productInfo.MaxThroughputVolume = strPtrNilCheck(nil)
-
+		// storage 관련 정보 삭제
 		return productInfo
 	default:
 		spew.Dump(v)
@@ -573,10 +369,23 @@ func mappingPricingPolicy(instanceChargeType *string, price any) irs.PricingPoli
 		Currency:          "USD",
 		PricingPolicyInfo: &policyInfo,
 	}
+	// POSTPAID -> v20170312.ItemPrice 반환 / SPOTPAID -> *v20170312.ItemPrice 포인터 반환
+	// 포인터가 가리키는 실제 타입을 확인하여 포인터와 비 포인터를 동일하게 처리하기 위함
+	objType := reflect.TypeOf(price)
+	isPointer := false
 
-	switch v := price.(type) {
-	case cvm.ItemPrice:
+	if objType.Kind() == reflect.Ptr {
+		objType = objType.Elem()
+		isPointer = true
+	}
+	switch objType {
+	case reflect.TypeOf(cvm.ItemPrice{}):
+		// 포인터일 경우, 실제 값을 가져온다
+		if isPointer {
+			price = reflect.ValueOf(price).Elem().Interface()
+		}
 		p := price.(cvm.ItemPrice)
+
 		policy.Unit = strPtrNilCheck(p.ChargeUnit)
 		policy.Price = floatPtrNilCheck(p.UnitPrice)
 
@@ -587,8 +396,9 @@ func mappingPricingPolicy(instanceChargeType *string, price any) irs.PricingPoli
 		policyInfo.OfferingClass = strPtrNilCheck(nil)
 		policyInfo.PurchaseOption = strPtrNilCheck(nil)
 
-	case cvm.ReservedInstancePriceItem:
+	case reflect.TypeOf(cvm.ReservedInstancePriceItem{}):
 		p := price.(cvm.ReservedInstancePriceItem)
+
 		policy.PricingId = strPtrNilCheck(p.ReservedInstancesOfferingId)
 		policy.Unit = strPtrNilCheck(common.StringPtr("Yrs"))
 		policy.Price = floatPtrNilCheck(p.FixedPrice)
@@ -608,7 +418,7 @@ func mappingPricingPolicy(instanceChargeType *string, price any) irs.PricingPoli
 		policyInfo.OfferingClass = strPtrNilCheck(nil)
 
 	default:
-		spew.Dump(v)
+		spew.Dump(objType)
 	}
 
 	return policy
@@ -616,17 +426,21 @@ func mappingPricingPolicy(instanceChargeType *string, price any) irs.PricingPoli
 
 // Instance Type 별 고유 key 생성
 func computeInstanceKeyGeneration(hashingKeys ...string) string {
-	h := fnv.New32a()
+	// h := fnv.New32a()
 
+	keys := ""
 	for _, key := range hashingKeys {
 		if len(strings.TrimSpace(key)) > 0 {
-			_, err := h.Write([]byte(key))
-			if err != nil {
-				return ""
-			}
+			keys += strings.TrimSpace(key)
+			// _, err := h.Write([]byte(key))
+			// if err != nil {
+			// 	return ""
+			// }
 		}
 	}
-	return strconv.FormatUint(uint64(h.Sum32()), 10)
+	return keys
+
+	//return strconv.FormatUint(uint64(h.Sum32()), 10)
 }
 
 // function 에 대한 explain 추가 작성

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
@@ -65,7 +65,7 @@ func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 
 	var vmSpecInfoList []*irs.VMSpecInfo
 	for _, curSpec := range response.Response.InstanceTypeConfigSet {
-		cblogger.Debugf("[%s] VM Spec 정보 처리", *curSpec.InstanceType)
+		cblogger.Debugf("[%s] VM Spec Information Processing", *curSpec.InstanceType)
 		vmSpecInfo := ExtractVMSpecInfo(curSpec)
 		vmSpecInfoList = append(vmSpecInfoList, &vmSpecInfo)
 	}
@@ -130,7 +130,7 @@ func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 		cblogger.Debug(vmSpecInfo)
 		return vmSpecInfo, nil
 	} else {
-		return irs.VMSpecInfo{}, errors.New("정보를 찾을 수 없습니다")
+		return irs.VMSpecInfo{}, errors.New("No information found")
 	}
 }
 
@@ -247,7 +247,7 @@ func (vmSpecHandler *TencentVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 		cblogger.Debug(jsonString)
 		return jsonString, errJson
 	} else {
-		return "", errors.New("정보를 찾을 수 없습니다")
+		return "", errors.New("No information found")
 	}
 }
 
@@ -285,8 +285,8 @@ func ExtractVMSpecInfo(instanceTypeInfo *cvm.InstanceTypeConfig) irs.VMSpecInfo 
 	//KeyValue 목록 처리
 	keyValueList, errKeyValue := ConvertKeyValueList(instanceTypeInfo)
 	if errKeyValue != nil {
-		cblogger.Errorf("[%]의 KeyValue 추출 실패", *instanceTypeInfo.InstanceType)
-		cblogger.Error(errKeyValue)
+		cblogger.Debugf("[%]의 KeyValue 추출 실패", *instanceTypeInfo.InstanceType)
+		cblogger.Debug(errKeyValue)
 	}
 	vmSpecInfo.KeyValueList = keyValueList
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
@@ -184,7 +184,7 @@ func (VPCHandler *TencentVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 		}
 	}
 
-	cblogger.Debugf("리턴 결과 목록 수 : [%d]", len(vpcInfoList))
+	cblogger.Debugf("Number of Return Results List : [%d]", len(vpcInfoList))
 	// spew.Dump(vpcInfoList)
 	return vpcInfoList, nil
 }
@@ -211,7 +211,7 @@ func (VPCHandler *TencentVPCHandler) isExist(chkName string) (bool, error) {
 		return false, nil
 	}
 
-	cblogger.Infof("VPC 정보 찾음 - VpcId:[%s] / VpcName:[%s]", *response.Response.VpcSet[0].VpcId, *response.Response.VpcSet[0].VpcName)
+	cblogger.Infof("VPC information found - VpcId:[%s] / VpcName:[%s]", *response.Response.VpcSet[0].VpcId, *response.Response.VpcSet[0].VpcName)
 	return true, nil
 }
 
@@ -245,7 +245,7 @@ func (VPCHandler *TencentVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error)
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	cblogger.Debug("VPC 개수 : ", *response.Response.TotalCount)
+	cblogger.Debug("Number of VPCs : ", *response.Response.TotalCount)
 	if *response.Response.TotalCount < 1 {
 		return irs.VPCInfo{}, errors.New("Notfound: '" + vpcIID.SystemId + "' VPC Not found")
 	}
@@ -340,7 +340,7 @@ func (VPCHandler *TencentVPCHandler) ListSubnet(reqVpcId string) ([]irs.SubnetIn
 	// callogger.Info(call.String(callLogInfo))
 
 	for _, curSubnet := range response.Response.SubnetSet {
-		cblogger.Infof("[%s] Subnet 정보 조회", *curSubnet.SubnetId)
+		cblogger.Infof("[%s] Check Subnet Information", *curSubnet.SubnetId)
 		resSubnetInfo := irs.SubnetInfo{
 			IId:       irs.IID{SystemId: *curSubnet.SubnetId, NameId: *curSubnet.SubnetName},
 			IPv4_CIDR: *curSubnet.CidrBlock,
@@ -389,7 +389,7 @@ func (VPCHandler *TencentVPCHandler) isExistSubnet(reqSubnetNameId string) (bool
 }
 
 func (VPCHandler *TencentVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.SubnetInfo) (irs.VPCInfo, error) {
-	cblogger.Infof("[%s] Subnet 추가 - CIDR : %s", subnetInfo.IId.NameId, subnetInfo.IPv4_CIDR)
+	cblogger.Infof("[%s] Add Subnet - CIDR : %s", subnetInfo.IId.NameId, subnetInfo.IPv4_CIDR)
 
 	zoneId := VPCHandler.Region.Zone
 	cblogger.Infof("Zone : %s", zoneId)
@@ -399,7 +399,7 @@ func (VPCHandler *TencentVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 	}
 
 	if subnetInfo.IId.NameId == "" {
-		return irs.VPCInfo{}, errors.New("생성할 SubnetId 정보가 없습니다.")
+		return irs.VPCInfo{}, errors.New("No SubnetId information to create.")
 	}
 
 	isExit, errSubnetInfo := VPCHandler.isExistSubnet(subnetInfo.IId.NameId)
@@ -408,11 +408,11 @@ func (VPCHandler *TencentVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 		return irs.VPCInfo{}, errSubnetInfo
 	}
 
-	cblogger.Info("Subnet 존재여부 : ")
+	cblogger.Info("Subnet presence or absence : ")
 	cblogger.Info(isExit)
 
 	if isExit {
-		cblogger.Errorf("이미 [%S] Subnet이 존재하기 때문에 생성하지 않고 기존 정보와 함께 에러를 리턴함.", subnetInfo.IId.NameId)
+		cblogger.Errorf("[%S] returns an error with existing information without creating it because Subnet already exists.", subnetInfo.IId.NameId)
 		return irs.VPCInfo{}, errors.New("InvalidVNetwork.Duplicate: The Subnet '" + subnetInfo.IId.NameId + "' already exists.")
 	}
 
@@ -461,7 +461,7 @@ func (VPCHandler *TencentVPCHandler) AddSubnet(vpcIID irs.IID, subnetInfo irs.Su
 }
 
 func (VPCHandler *TencentVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.IID) (bool, error) {
-	cblogger.Infof("[%s] VPC의 [%s] Subnet 삭제", vpcIID.SystemId, subnetIID.SystemId)
+	cblogger.Infof("[%s] Delete [%s] Subnet on VPC", vpcIID.SystemId, subnetIID.SystemId)
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")


### PR DESCRIPTION
# Tencent 드라이버 특이사항

Related Issue - https://github.com/cloud-barista/cb-spider/issues/1090

### [GerPriceInfo]

1. Price 조회 결과 개수 확인

- 236개 규모 확인 → O
- 총 pricing policy개수 : 610개이지만 중복 price가 374로 확인 610-374 = 236
- 236개의 규모 O
- 텐센트 클라우드에서는 각각의 pricing policy로 보지만 spider의 price는 인스턴스 타입별로 묶이기 때문

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/bea67fbf-03fb-4a5c-9c84-4741941211f4)

- Policy - SPOTPAID가 누락되어 수정
- Price조회 결과에서 POSTPAID, SPOTPAID 값이 정상적으로 인식되지 않아 결과값에서 누락됨
- 처리완료
    - POSTPAID → cvm.ItemPrice 객체 반환
    - SPOTPAID → *cvm.ItenPrice 포인터 반환

2. Price 조회 결과 목록 수정

- ProductFamily - Storage 관련 Product Info값 제거
    
![image](https://github.com/cloud-barista/cb-spider/assets/99646153/55b91992-c97b-44a3-9e9a-8b8c7317dedd)
    

**[기타]**

- log level 수정 : error 가 아닌 부분 → cblogger.Debug()

---

### [GerPriceInfo]

1. Check the number of Price lookup results

- 236 Size Check → O
- Total number of pricing policies: 610 but duplicate price is 374 confirmed 610-374 = 236
- 236 magnitude O
- In Tencent Cloud, each pricing policy is viewed, but the price of spider is grouped by instance type

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/d7f05d46-c286-4f3a-ab61-be1465d3671b)

- Policy - fix due to missing SPOTPAID during verification
- Missing due to different return value
- POSTPAID → cvm.ItemPrice object return
- SPOTPAID → *cvm.ItemPrice pointer return

2. Modify Price Lookup Results List

- - ProductFamily - Delete Storage  Product Info

![image](https://github.com/cloud-barista/cb-spider/assets/99646153/d4f881a1-3391-4a74-a60e-e7dbfedb249a)


**[Other]**

- Modify log level: non-error part → cblogger.Debug()