### PR TITLE
[NHN Cloud] Add Windows OS Image Supporting features (Login with 'cb-user' account)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/main/Test_MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/main/Test_MyImageHandler.go
@@ -62,8 +62,8 @@ func handleMyImage() {
 		var commandNum int
 
 		myImageIId := irs.IID{
-			NameId: "nhn-disk-01",
-			SystemId: "8fed0323-34a5-418a-99d3-999a6c322649",
+			NameId: "nhn-myImage-01",
+			SystemId: "adb48ac1-9355-45e5-a18a-84e0e647f98f",
 			// SystemId: "c44fe242-b51a-4d7b-be28-7b8028de3847",
 		}
 

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ImageHandler.go
@@ -172,3 +172,31 @@ func (imageHandler *NhnCloudImageHandler) mappingImageInfo(image images.Image) *
 	imageInfo.KeyValueList = keyValueList
 	return imageInfo
 }
+
+func (imageHandler *NhnCloudImageHandler) isPublicImage(imageIID irs.IID) (bool, error) {
+	cblogger.Info("NHN Cloud Driver: called isPublicImage()")
+	callLogInfo := getCallLogScheme(imageHandler.RegionInfo.Region, call.VMIMAGE, imageIID.SystemId, "isPublicImage()")
+
+	if strings.EqualFold(imageIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid SystemId!!")
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	start := call.Start()
+	nhnImage, err := images.Get(imageHandler.ImageClient, imageIID.SystemId).Extract() // Image Client
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NHN Cloud Image Info. [%v]", err.Error())
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+	LoggingInfo(callLogInfo, start)
+
+	isPublicImage := false
+	if strings.EqualFold(string(nhnImage.Visibility), "public") {
+		isPublicImage = true
+	}
+	return isPublicImage, nil
+}

--- a/cloud-driver-libs/.cloud-init-nhncloud/cloud-init-windows
+++ b/cloud-driver-libs/.cloud-init-nhncloud/cloud-init-windows
@@ -1,4 +1,6 @@
 <powershell>
-net user "Administrator" "{{PASSWORD}}"
+#ps1_sysnative
+New-LocalUser "{{username}}" -Password (ConvertTo-SecureString "{{PASSWORD}}" -AsPlainText -Force)
+Add-LocalGroupMember -Group "Administrators" -Member "{{username}}"    
 </powershell>
 <persist>true</persist>


### PR DESCRIPTION
- Update NHN Cloud ImageHandler
  - Add isPublicImage() method
- Update NHN Cloud MyImageHandler
  - Add isPublicImage() method
  - Add CheckWindowsImage() method
- Update NHN Cloud VMHandler
 - Add Windows OS Image Supporting features
  : Support Windows VM Login with 'cb-user' account using cloud-init
- Update NHN Cloud 'cloud-init-windows' script
- Related issue : https://github.com/cloud-barista/cb-spider/issues/1136