### PR TITLE
[GCP:GPU] Fix to Provision VMs with GPU Accelerators

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -458,7 +458,7 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		} else {
 			callLogInfo.ErrorMSG = err1.Error()
 			callogger.Error(call.String(callLogInfo))
-			cblogger.Error("VM 생성 실패")
+			cblogger.Error("failed to create vm")
 			cblogger.Error(err1)
 			return irs.VMInfo{}, err1
 		}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -439,10 +439,12 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 
 	if err1 != nil {
 		e, ok := err1.(*googleapi.Error)
-		
+
 		// Setting 'OnHostMaintenance' to 'TERMINATE' prevents live migration
-		if ok && e.Code == http.StatusBadRequest && strings.Contains(err1.Error(), "not support live migration") {	
-			cblogger.Info("vm creating with Scheduling")
+		errorLower := strings.ToLower(err1.Error())
+		liveMigrationNotSupport := strings.Contains(errorLower, strings.ToLower("must be set to TERMINATE")) || strings.Contains(errorLower, strings.ToLower("not support live migration"))
+		if ok && e.Code == http.StatusBadRequest && liveMigrationNotSupport {
+			cblogger.Info("vm creating with Scheduling struct to set live migration to TERMINATE")
 			instance.Scheduling = &compute.Scheduling{
 				OnHostMaintenance: "TERMINATE",
 			}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -451,7 +451,7 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			if err1 != nil {
 				callLogInfo.ErrorMSG = err1.Error()
 				callogger.Error(call.String(callLogInfo))
-				cblogger.Error("fail to create vm with guest accelerator")
+				cblogger.Error("fail to create vm which does not support live migration")
 				cblogger.Error(err1)
 				return irs.VMInfo{}, err1
 			}


### PR DESCRIPTION
# GCP 에서 GPU 와 같은 게스트 가속기가 포함되지 않은 머신 타입에 대한 프로비저닝 불가 개선 작업(#1125 )

**[작업 방향]**
- 제안해주신 방법처럼 
- 400 bad request `~not support live migration` 에러 발생하는 경우
- OnHostMaintenance 설정을 TERMINATE 로 변경하여 
- 재요청을 하는 방식으로 수정했습니다.
- 다만 google 에서 `not support live migration` 에러 메시지를 변경하는 경우 정상 작동하지 않을 리스크가 있습니다.

<br>

**[작업 내용]**
- GPU 기능을 테스트하기 위한 임시 조치 코드를 제거
- 게스트 가속기가 있는 인스턴스 인스턴스 생성시 400 에러와 함께 'not support live migration' 구문이 에러에 포함되어 있는 경우 'OnHostMaintenance'를 'TERMINATE'로 설정하여 VM 생성 요청을 다시 보내는 코드를 추가

<br>

**[테스트]**
- 로컬 spider admin web 에서
    1. `machine type: e2-standard-2`
    2. `machine type: g2-standard-4` -> GPU 머신 유형
- 상기 2개의 머신 타입으로 프로비저닝 -> 기대 동작대로 작동 확인

<br>

**[참고사항]**
- 인스턴스 유지 보수 중 라이브 마이그레이션 제한 사항의 경우 GPU 가 연결된 vm 뿐만 아니라,
- 다른 조건의 vm 도 포함되는 것으로 보입니다. ([링크](https://cloud.google.com/compute/docs/instances/live-migration-process?hl=ko#limitations))
