### PR TITLE
[NHN Cloud] Appy Renamed package name and function name to NLBHandler (according to updated go SDK)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/connect/NHN_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/connect/NHN_CloudConnection.go
@@ -15,7 +15,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 
 	cblog "github.com/cloud-barista/cb-log"
@@ -96,10 +96,6 @@ func (cloudConn *NhnCloudConnection) CreateNLBHandler() (irs.NLBHandler, error) 
 
 func (cloudConn *NhnCloudConnection) CreateDiskHandler() (irs.DiskHandler, error) {
 	cblogger.Info("NhnCloud Cloud Driver: called CreateDiskHandler()!")
-	cblogger.Info("\n### cloudConn.RegionInfo : ")
-	spew.Dump(cloudConn.RegionInfo)
-	cblogger.Info("\n")
-
 	diskHandler := nhnrs.NhnCloudDiskHandler{RegionInfo: cloudConn.RegionInfo, VMClient: cloudConn.VMClient, VolumeClient: cloudConn.VolumeClient}
 
 	return &diskHandler, nil
@@ -127,9 +123,14 @@ func (cloudConn *NhnCloudConnection) CreateAnyCallHandler() (irs.AnyCallHandler,
 
 func (cloudConn *NhnCloudConnection) CreateRegionZoneHandler() (irs.RegionZoneHandler, error) {
 	cblogger.Info("NhnCloud Cloud Driver: called CreateRegionZoneHandler()!")
-
 	regionZoneHandler := nhnrs.NhnCloudRegionZoneHandler{CredentialInfo: cloudConn.CredentialInfo, RegionInfo: cloudConn.RegionInfo, VMClient: cloudConn.VMClient}
+
 	return &regionZoneHandler, nil
+}
+
+func (cloudConn *NhnCloudConnection) CreatePriceInfoHandler() (irs.PriceInfoHandler, error) {
+	
+	return nil, errors.New("NHN Cloud Driver: not implemented")
 }
 
 func (cloudConn *NhnCloudConnection) IsConnected() (bool, error) {
@@ -143,8 +144,4 @@ func (cloudConn *NhnCloudConnection) IsConnected() (bool, error) {
 func (cloudConn *NhnCloudConnection) Close() error {
 
 	return nil
-}
-
-func (*NhnCloudConnection) CreatePriceInfoHandler() (irs.PriceInfoHandler, error) {
-	return nil, errors.New("NHN Cloud Driver: not implemented")
 }

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/NLBHandler.go
@@ -7,6 +7,7 @@
 // This is a Cloud Driver Example for PoC Test.
 //
 // by ETRI Team, 2022.07.
+// by ETRI Team, 2024.04.
 
 package resources
 
@@ -25,7 +26,6 @@ import (
 	nhnsdk "github.com/cloud-barista/nhncloud-sdk-go"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/loadbalancer/v2/listeners"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/loadbalancer/v2/loadbalancers"
-	"github.com/cloud-barista/nhncloud-sdk-go/openstack/networking/v2/subnets"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/networking/v2/vpcs"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/networking/v2/vpcsubnets"
 
@@ -33,7 +33,6 @@ import (
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/loadbalancer/v2/monitors"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/loadbalancer/v2/pools"
 
-	// "github.com/cloud-barista/nhncloud-sdk-go/openstack/loadbalancer/v2/providers"
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/networking/v2/extensions/layer3/floatingips"
 )
 
@@ -1005,7 +1004,7 @@ func (nlbHandler *NhnCloudNLBHandler) getFirstSubnetIdWithVPCName(vpcName string
 			cblogger.Error(newErr.Error())
 			return "", newErr
 		}
-		subnetList, err := subnets.ExtractSubnets(allPages)
+		subnetList, err := vpcsubnets.ExtractVpcsubnets(allPages)
 		if err != nil {
 			newErr := fmt.Errorf("Failed to Get Subnet List from NHN Cloud!! : [%v]", err)
 			cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
@@ -232,7 +232,7 @@ func (vmHandler *NhnCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo
 			}
 		}
 	}
-	cblogger.Infof("init UserData : [%s]", *initUserData)
+	// cblogger.Infof("init UserData : [%s]", *initUserData)
 
 	// Preparing VM Creation Options
 	serverCreateOpts := servers.CreateOpts{
@@ -385,7 +385,7 @@ func (vmHandler *NhnCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo
 				// Note) In case of 'MyImage', SourceType is 'SourceImage', too.  Not 'bootfromvolume.SourceSnapshot'
 				VolumeType:          reqDiskType,
 				VolumeSize:          reqDiskSizeInt,
-				DestinationType:     bootfromvolume.DestinationVolume, // Destination_type must be 'Volume'. Not 'bootfromvolume.DestinationLocal'
+				DestinationType:     bootfromvolume.DestinationVolume, // Destination_type must be 'Volume'. Not 'bootfromvolume.DestinationLocal' when Not u2 type.
 				DeleteOnTermination: true,
 			},
 		}

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/alibabacloud-go/vpc-20160428/v6 v6.4.0
 	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb
 	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd
-	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240403130402-131df63a24b4
+	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jeremywohl/flatten v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd h1
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240403130402-131df63a24b4 h1:hQUzGiMvk7agfONh0aLr9d9tuFArxeUc6bOjKNufGQo=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240403130402-131df63a24b4/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
+github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1 h1:o6RVnxI2E6o3l7Sc285gg45S6hcepAklfPPDDmlvKHY=
+github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
- Update NLBHandler > getFirstSubnetIdWithVPCName() method
  - Appy Renamed package name and function name (according to updated go SDK)
  - Related go SDK PR : https://github.com/cloud-barista/nhncloud-sdk-go/pull/37
- Update VMHandler
  - Update Comment/Notice of BlockDevice DestinationType parameter (When Not u2 type of VMSpec)
- Update NHN_CloudConnection.go
  - Remove spew.Dump() code
- Update go.mod and go.sum
  - Update go SDK verion