### PR TITLE
Prevent to access to container-infra in nhncloud's jpn region

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/NHNCloudDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/NHNCloudDriver.go
@@ -13,6 +13,9 @@ package nhncloud
 
 import (
 	// "github.com/davecgh/go-spew/spew"
+
+	"errors"
+
 	nhnsdk "github.com/cloud-barista/nhncloud-sdk-go"
 	ostack "github.com/cloud-barista/nhncloud-sdk-go/openstack"
 
@@ -98,7 +101,13 @@ func (driver *NhnCloudDriver) ConnectCloud(connInfo idrv.ConnectionInfo) (icon.C
 
 	ClusterClient, err := getClusterClient(providerClient, connInfo)
 	if err != nil {
-		return nil, err
+		var endpointErr *nhnsdk.ErrEndpointNotFound
+		if errors.As(err, &endpointErr) {
+			// If a certain region(ex. JPN) do not provide a cluster service, there is no endpoint for that.
+			// In this case it is not an error.
+		} else {
+			return nil, err
+		}
 	}
 
 	iConn := nhncon.NhnCloudConnection{

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/connect/NHN_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/connect/NHN_CloudConnection.go
@@ -103,6 +103,13 @@ func (cloudConn *NhnCloudConnection) CreateDiskHandler() (irs.DiskHandler, error
 
 func (cloudConn *NhnCloudConnection) CreateClusterHandler() (irs.ClusterHandler, error) {
 	cblogger.Info("NhnCloud Cloud Driver: called CreateClusterHandler()!")
+
+	if cloudConn.ClusterClient == nil {
+		// Some regions(ex. JPN) do not support a cluster service.
+		err := fmt.Errorf("ClusterClient is invalid, indicating that no suitable endpoint was found in the service catalog.")
+		return nil, err
+	}
+
 	clusterHandler := nhnrs.NhnCloudClusterHandler{RegionInfo: cloudConn.RegionInfo, VMClient: cloudConn.VMClient, ImageClient: cloudConn.ImageClient, NetworkClient: cloudConn.NetworkClient, ClusterClient: cloudConn.ClusterClient}
 
 	return &clusterHandler, nil
@@ -129,7 +136,7 @@ func (cloudConn *NhnCloudConnection) CreateRegionZoneHandler() (irs.RegionZoneHa
 }
 
 func (cloudConn *NhnCloudConnection) CreatePriceInfoHandler() (irs.PriceInfoHandler, error) {
-	
+
 	return nil, errors.New("NHN Cloud Driver: not implemented")
 }
 

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb h1:
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb/go.mod h1:ZIrUxItUvMIGZyX6Re7tUdcS3cwBIzBPcL+Pk/6lt/8=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd h1:kqSI4usVl5or7+nSvt4IpEG+iTPRxuBavYzoOBkeJ6s=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
-github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240403130402-131df63a24b4 h1:hQUzGiMvk7agfONh0aLr9d9tuFArxeUc6bOjKNufGQo=
-github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240403130402-131df63a24b4/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1 h1:o6RVnxI2E6o3l7Sc285gg45S6hcepAklfPPDDmlvKHY=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
NHNCloud 중 NKS를 지원하는 리전만 container-infra를 접근할 수 있도록 수정하였습니다.

fix #1161