### PR TITLE
[KT Cloud Classic] Update ImageHandler : In case Failed to find the Image, returns an error, and Remove HA(KimHae) region

### DIFF
--- a/api-runtime/rest-runtime/test/connect-config/11.ktcloud-conn-config.sh
+++ b/api-runtime/rest-runtime/test/connect-config/11.ktcloud-conn-config.sh
@@ -19,8 +19,6 @@ curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application
 
 curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"ktcloud-korea-cheonan2","ProviderName":"KTCLOUD", "KeyValueInfoList": [{"Key":"Region", "Value":"KOR-Central"}, {"Key":"Zone", "Value":"9845bd17-d438-4bde-816d-1b12f37d5080"}]}'
 
-curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"ktcloud-korea-kimhae","ProviderName":"KTCLOUD", "KeyValueInfoList": [{"Key":"Region", "Value":"KOR-HA"}, {"Key":"Zone", "Value":"dfd6f03d-dae5-458e-a2ea-cb6a55d0d994"}]}'
-
 # Cloud Connection Config Info
 curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloud-korea-seoul1-config","ProviderName":"KTCLOUD", "DriverName":"ktcloud-driver01", "CredentialName":"ktcloud-credential01", "RegionName":"ktcloud-korea-seoul1"}'
 
@@ -29,5 +27,3 @@ curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: a
 curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloud-korea-cheonan1-config","ProviderName":"KTCLOUD", "DriverName":"ktcloud-driver01", "CredentialName":"ktcloud-credential01", "RegionName":"ktcloud-korea-cheonan1"}'
 
 curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloud-korea-cheonan2-config","ProviderName":"KTCLOUD", "DriverName":"ktcloud-driver01", "CredentialName":"ktcloud-credential01", "RegionName":"ktcloud-korea-cheonan2"}'
-
-curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"ktcloud-korea-kimhae-config","ProviderName":"KTCLOUD", "DriverName":"ktcloud-driver01", "CredentialName":"ktcloud-credential01", "RegionName":"ktcloud-korea-kimhae"}'

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_ImageHandler.go
@@ -63,32 +63,13 @@ func handleImage() {
 
 		imageReqInfo := irs.ImageReqInfo{
 			// Zone : KOR-Central A
-			IId: irs.IID{NameId: "WIN 2019 STD [Korean] MSSQL 2019 ENT", SystemId: "297b2872-7ba9-4e6f-a8b7-e7f81fffc5f3"},
+			IId: irs.IID{NameId: "WIN 2019 STD [Korean] MSSQL 2019 ENT", SystemId: "297b2872-7ba9-4e6f-a8b7-e7f81fffc5f3-"},
 			
 			// Zone : KOR-Seoul M2
 			// IId: irs.IID{NameId: "Ubuntu 20.04 64bit", SystemId: "23bc4025-8a16-4ebf-aa49-3160ee2ac24b"},
-			// # KT Cloud : Ubuntu 20.04 64bit
 
-			// IId: irs.IID{NameId: "Test OS Image", SystemId: "528fdf79-c57f-4f9a-b8ea-c887b9fed003"},
-			// # KT Cloud : ubuntu-18.04, Ubuntu Server 64-bit
+			// IId: irs.IID{NameId: "ubuntu-18.04, Ubuntu Server 64-bit", SystemId: "528fdf79-c57f-4f9a-b8ea-c887b9fed003"},			
 		}
-
-		/*
-		(*resources.ImageInfo)(0xc000576300)({
-			IId: (resources.IID) {
-			 NameId: (string) (len=36) "23bc4025-8a16-4ebf-aa49-3160ee2ac24b",
-			 SystemId: (string) (len=36) "23bc4025-8a16-4ebf-aa49-3160ee2ac24b"
-			},
-			GuestOS: (string) (len=18) "Ubuntu 20.04 64bit",
-			Status: (string) (len=9) "available",
-			KeyValueList: ([]resources.KeyValue) (len=1 cap=1) {
-			 (resources.KeyValue) {
-			  Key: (string) (len=4) "Zone",
-			  Value: (string) (len=12) "KOR-Seoul M2"
-			 }
-			}
-		   }),
-		*/
 
 		if inputCnt == 1 {
 			switch commandNum {
@@ -96,22 +77,21 @@ func handleImage() {
 				return
 
 			case 1:
-				cblogger.Infof("Image list 조회 테스트")
+				cblogger.Infof("Image list inquiry test")
 
 				result, err := handler.ListImage()
 				if err != nil {
-					cblogger.Error(err)
-					cblogger.Error("Image list 조회 실패 : ", err)
+					cblogger.Error("Failed to Get Image list : ", err)
 				} else {
 					fmt.Println("\n==================================================================================================================")
-					cblogger.Info("Image list 조회 결과")
+					cblogger.Info("Image list inquiry Result")
 					//cblogger.Info(result)
-					cblogger.Info("출력 결과 수 : ", len(result))
+					cblogger.Info("Image Info Count : ", len(result))
 
 					fmt.Println("\n")
 					spew.Dump(result)
 
-					cblogger.Info("출력 결과 수 : ", len(result))
+					cblogger.Info("Image Info Count : ", len(result))
 
 					//조회및 삭제 테스트를 위해 리스트의 첫번째 정보의 ID를 요청ID로 자동 갱신함.
 					if result != nil {
@@ -119,32 +99,29 @@ func handleImage() {
 					}
 				}
 
-				cblogger.Info("\nListImage Test Finished")
+				cblogger.Info("\nListImage() Test Finished")
 
 			case 2:
-				cblogger.Infof("[%s] Image 조회 테스트", imageReqInfo.IId)
+				cblogger.Infof("[%s] Image inquiry test with an ID", imageReqInfo.IId)
 
 				result, err := handler.GetImage(imageReqInfo.IId)
 				if err != nil {
-					cblogger.Error(err)
-					cblogger.Error("[%s] Image 조회 실패 : ", imageReqInfo.IId.SystemId, err)
+					cblogger.Error("Failed to Get Image Info : ", err)
 				} else {
 					fmt.Println("\n==================================================================================================================")
-					cblogger.Infof("[%s] Image 조회 결과 : \n[%s]", imageReqInfo.IId.SystemId, result)
-
-					fmt.Println("\n")
+					cblogger.Infof("[%s] Image Info inquiry Result : ", imageReqInfo.IId.SystemId)
 					spew.Dump(result)
 				}
 
-				cblogger.Info("\nGetImage Test Finished")
+				cblogger.Info("\nGetImage() Test Finished")
 
 				// case 3:
-				// 	cblogger.Infof("[%s] Image 생성 테스트", imageReqInfo.IId.NameId)
+				// 	cblogger.Infof("[%s] Image Creation 테스트", imageReqInfo.IId.NameId)
 				// 	result, err := handler.CreateImage(imageReqInfo)
 				// 	if err != nil {
-				// 		cblogger.Infof(imageReqInfo.IId.NameId, " Image 생성 실패 : ", err)
+				// 		cblogger.Infof(imageReqInfo.IId.NameId, " Image Creation 실패 : ", err)
 				// 	} else {
-				// 		cblogger.Infof("Image 생성 결과 : ", result)
+				// 		cblogger.Infof("Image Creation 결과 : ", result)
 				// 		imageReqInfo.IId = result.IId // 조회 및 삭제를 위해 생성된 ID로 변경
 				// 		spew.Dump(result)
 				// 	}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/Test_ImageHandler.go
@@ -63,7 +63,7 @@ func handleImage() {
 
 		imageReqInfo := irs.ImageReqInfo{
 			// Zone : KOR-Central A
-			IId: irs.IID{NameId: "WIN 2019 STD [Korean] MSSQL 2019 ENT", SystemId: "297b2872-7ba9-4e6f-a8b7-e7f81fffc5f3-"},
+			IId: irs.IID{NameId: "WIN 2019 STD [Korean] MSSQL 2019 ENT", SystemId: "297b2872-7ba9-4e6f-a8b7-e7f81fffc5f3"},
 			
 			// Zone : KOR-Seoul M2
 			// IId: irs.IID{NameId: "Ubuntu 20.04 64bit", SystemId: "23bc4025-8a16-4ebf-aa49-3160ee2ac24b"},
@@ -116,23 +116,23 @@ func handleImage() {
 				cblogger.Info("\nGetImage() Test Finished")
 
 				// case 3:
-				// 	cblogger.Infof("[%s] Image Creation 테스트", imageReqInfo.IId.NameId)
+				// 	cblogger.Infof("[%s] Image Creation Test", imageReqInfo.IId.NameId)
 				// 	result, err := handler.CreateImage(imageReqInfo)
 				// 	if err != nil {
 				// 		cblogger.Infof(imageReqInfo.IId.NameId, " Image Creation 실패 : ", err)
 				// 	} else {
-				// 		cblogger.Infof("Image Creation 결과 : ", result)
+				// 		cblogger.Infof("Image Creation Result : ", result)
 				// 		imageReqInfo.IId = result.IId // 조회 및 삭제를 위해 생성된 ID로 변경
 				// 		spew.Dump(result)
 				// 	}
 
 				// case 4:
-				// 	cblogger.Infof("[%s] Image 삭제 테스트", imageReqInfo.IId.NameId)
+				// 	cblogger.Infof("[%s] Image Deletion Test", imageReqInfo.IId.NameId)
 				// 	result, err := handler.DeleteImage(imageReqInfo.IId)
 				// 	if err != nil {
-				// 		cblogger.Infof("[%s] Image 삭제 실패 : ", imageReqInfo.IId.NameId, err)
+				// 		cblogger.Infof("Failed to Delete the Image : ", err)
 				// 	} else {
-				// 		cblogger.Infof("[%s] Image 삭제 결과 : [%s]", imageReqInfo.IId.NameId, result)
+				// 		cblogger.Infof("Image Deletion Result : ", result)
 				// 	}
 			}
 		}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/main/config/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/main/config/config.yaml.sample
@@ -24,6 +24,9 @@ ktcloud:
   #zone: 9845bd17-d438-4bde-816d-1b12f37d5080
   # (참고) Zone name : KOR-Central B
 
-  # region: KOR-HA
-  # zone: dfd6f03d-dae5-458e-a2ea-cb6a55d0d994
-  # (참고) Zone name : KOR-HA
+  # Resources
+  ###########################################################
+  vm_id: ec0c4549-1782-4283-91f9-70ffedced7a2
+  req_vm_name: m2-vm-3
+
+  disk_id: 28ee704d-d005-4705-86ed-c6001de514ff

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/ImageHandler.go
@@ -11,9 +11,10 @@
 package resources
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"strings"
+
 	//"github.com/davecgh/go-spew/spew"
 
 	ktsdk "github.com/cloud-barista/ktcloud-sdk-go"
@@ -59,15 +60,20 @@ func (imageHandler *KtCloudImageHandler) GetImage(imageIID irs.IID) (irs.ImageIn
 	}
 
 	if len(result.Listavailableproducttypesresponse.ProductTypes) < 1 {
-		return irs.ImageInfo{}, errors.New("Failed to Find Product Types!!")
+		return irs.ImageInfo{}, errors.New("Failed to Get Any Product Types!!")
 	}
 
+	var foundImgId string
 	for _, productType := range result.Listavailableproducttypesresponse.ProductTypes {
-		cblogger.Info("# Search criteria of Image Template ID : ", imageIID.SystemId)
-		if productType.TemplateId == imageIID.SystemId {
+		// cblogger.Info("# Search criteria of Image Template ID : ", imageIID.SystemId)
+		if strings.EqualFold(productType.TemplateId, imageIID.SystemId) {
+			foundImgId = productType.TemplateId
 			resultImageInfo = mappingImageInfo(productType)
 			break
 		}
+	}
+	if strings.EqualFold(foundImgId, "") {
+		return irs.ImageInfo{}, fmt.Errorf("Failed to Find Any Image(Template) info with the ID.")
 	}
 	return resultImageInfo, nil
 }
@@ -89,34 +95,6 @@ func (imageHandler *KtCloudImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	if len(result.Listavailableproducttypesresponse.ProductTypes) < 1 {
 		return []*irs.ImageInfo{}, errors.New("Failed to Find Product Types!!")
 	}
-
-	// ### 아래는 사용자가 생성한 image만 해당함. ###
-	// //templatefilter := "selfexecutable"
-	// templatefilter := "self"
-	// listall := true
-
-	// result, err := imageHandler.Client.ListTemplates(templatefilter, "", listall)
-	// if err != nil {
-	// 	cblogger.Error("Error listing images: %s", err)
-
-	// 	return []*irs.ImageInfo{}, err
-	// }
-
-	// spew.Dump(result)
-
-	// if len(result.Listtemplatesresponse.Template) < 1 {
-	// 	return []*irs.ImageInfo{}, errors.New("Image list Not found!!")
-	// }
-
-
-	// ### Without Deduplication of Templates
-	// for _, productType := range result.Listavailableproducttypesresponse.Producttypes {
-	// 	var serverProductType ktsdk.Producttypes
-	// 	serverProductType = productType
-
-	// 	imageInfo := mappingImageInfo(serverProductType)
-	// 	vmImageList = append(vmImageList, &imageInfo)
-	// }	
 
 	// ### In order to remove the list of identical duplicates over and over again
 	tempID := ""

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/ImageHandler.go
@@ -83,7 +83,6 @@ func (imageHandler *KtCloudImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	
 	var vmImageList []*irs.ImageInfo
 	zoneId := imageHandler.RegionInfo.Zone
-	cblogger.Info("RegionInfo.Zone : ", zoneId)
 
 	result, err := imageHandler.Client.ListAvailableProductTypes(zoneId)
 	if err != nil {
@@ -105,7 +104,7 @@ func (imageHandler *KtCloudImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 			vmImageList = append(vmImageList, &imageInfo)
 
 			tempID = productType.TemplateId
-			cblogger.Infof("\nImage Template Id : " + tempID)
+			// cblogger.Infof("\nImage Template Id : " + tempID)
 		}
 	}
 	cblogger.Info("# Supported Image Product Count : ", len(vmImageList))

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/RegionZoneHandler.go
@@ -43,9 +43,6 @@ func getSupportedRegions() []KtRegionInfo {
 		{	RegionCode: 	"KOR-Central",
 			RegionName: 	"천안",
 		},
-		{	RegionCode: 	"KOR-HA",
-			RegionName: 	"김해",
-		},
 	}
 	return regionInfoList
 }


### PR DESCRIPTION
- Update KT Cloud Classic ImageHandler and Test Code of it
  - In case, Failed to find the Image, returns an error
  - Remove Unnecessary Logs during Find an Image Info with Image(Template) ID
  - Related issue : https://github.com/cloud-barista/cb-spider/issues/1160
- Remove HA(KimHae) region from RegionZoneHandler, Connection config and config.yaml
  - Related issue : https://github.com/cloud-barista/cb-spider/issues/1145