### PR TITLE
[Alibaba] Resolve issue : Default RootDiskType Option When Creating VM

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
@@ -208,6 +208,36 @@ func DescribeAvailableResource(client *ecs.Client, regionId string, zoneId strin
 }
 
 /*
+리전별로 AvailableResource 중에서 InstanceType 별로 사용 가능한 SystemDisk 목록 조회
+*/
+func DescribeAvailableSystemDisksByInstanceType(client *ecs.Client, regionId string, zoneId string, instanceChargeType string, destinationResource string, insTanceType string) (ecs.AvailableZonesInDescribeAvailableResource, error) {
+	request := ecs.CreateDescribeAvailableResourceRequest()
+	request.Scheme = "https"
+
+	request.RegionId = regionId
+	request.ZoneId = zoneId
+
+	request.DestinationResource = destinationResource
+	request.InstanceChargeType = instanceChargeType
+	request.InstanceType = insTanceType
+
+	result, err := client.DescribeAvailableResource(request)
+	cblogger.Info(result)
+	if err != nil {
+		cblogger.Errorf("DescribeAvailableResource %v.", err)
+	}
+
+	metaValue := reflect.ValueOf(result).Elem()
+	fieldAvailableZones := metaValue.FieldByName("AvailableZones")
+	if fieldAvailableZones == (reflect.Value{}) {
+		cblogger.Errorf("Field not exist")
+		cblogger.Errorf("Not available in this region")
+		return ecs.AvailableZonesInDescribeAvailableResource{}, errors.New("Not available in this region")
+	}
+	return result.AvailableZones, nil
+}
+
+/*
 *
 Instance에 Disk Attach
 한번에 1개씩.

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
@@ -31,19 +31,6 @@ type AlibabaVMHandler struct {
 	Client *ecs.Client
 }
 
-type AlibabaSupportedResource struct {
-	Status string `json:"Status" xml:"Status"`
-	Value  string `json:"Value" xml:"Value"`
-	Max    int    `json:"Max" xml:"Max"`
-	Unit   string `json:"Unit" xml:"Unit"`
-	Min    int    `json:"Min" xml:"Min"`
-}
-type AlibabaAvailableResourceResp struct {
-	RequestId      string            `json:"RequestId"`
-	AvailableZones ecs.AvailableZone `json:"AvailableZones"`
-	RegionId       string            `json:"RegionId"`
-}
-
 // 주어진 이미지 id에 대한 이미지 사이즈 조회
 // -1 : 정보 조회 실패
 // deprecated


### PR DESCRIPTION
# Alibaba 드라이버 특이사항

Related Issue - #1149 

### CommonHandler.go

[DescribeAvailableSystemDisksByInstanceType]

- DescribeAvailableResource Api로 인스턴스 타입 별 사용 가능한 SystemDisk목록을 가져온다

### VMHandler.go

[StartVM]

- RootDiskType : Default 일 때
    - DescribeAvailableSystemDisksByInstanceType API로 입력받은 InstanceType의 사용 가능한 DiskType 목록을 받아온다
    - 받아온 DiskType 목록과 Alibaba Meta 정보의 RootDiskType 목록과 비교하여
    - Meta 정보의 리스트 중에 지원 가능한 DiskType 중 처음으로 오는 값을 찾아 세팅한다
- RootDiskType : 설정 값이 있을 때
    - 받은 Disk타입이 위에서 받은 지원 가능한 Disk목록을 이용해여 유효한지 체크한다
    - 있다면 세팅하고 없다면 에러 리턴

---

### CommonHandler.go

[DescribeAvailableSystemDisksByInstanceType]

- Get a list of available SystemDisk by instance type with DescriptAvailableResourceApi

### VMHandler.go

[StartVM]

- RootDiskType : Default 일 때
   - Obtain a list of available disk types of InstanceType entered by the DescriptAvailableSystemDisksByInstanceType API
   - Compare the received disktype list with the rootdisktype list in the Alibaba Meta information
   - Find and set the first available disk type in the list of Meta information
- RootDiskType: When there is a setting value
   - Check that the disk type received is valid using the list of supported disks received above
   - If yes, if not, error return