### PR TITLE
[NCP Classic/VPC] Update VMHandler GetRegionNo()/GetZoneNo() and Adjust the Time Sleep to Reduce CSP API calls

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/DiskHandler.go
@@ -153,7 +153,7 @@ func (diskHandler *NcpDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
 		RegionInfo:     	diskHandler.RegionInfo,
 		VMClient:         	diskHandler.VMClient,
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(diskHandler.RegionInfo.Region, diskHandler.RegionInfo.Zone) // Region/Zone info of diskHandler
 	if err != nil {
 		rtnErr := logAndReturnError(callLogInfo, "Failed to Get NCP Zone No of the Zone Code : ", err)
 		return nil, rtnErr
@@ -458,7 +458,7 @@ func (diskHandler *NcpDiskHandler) GetNcpDiskInfo(diskIID irs.IID) (*server.Bloc
 		RegionInfo:     	diskHandler.RegionInfo,
 		VMClient:         	diskHandler.VMClient,
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(diskHandler.RegionInfo.Region, diskHandler.RegionInfo.Zone) // Region/Zone info of diskHandler
 	if err != nil {
 		rtnErr := logAndReturnError(callLogInfo, "Failed to Get NCP Zone No of the Zone Code : ", err)
 		return nil, rtnErr
@@ -705,7 +705,7 @@ func (diskHandler *NcpDiskHandler) GetNcpVMList() ([]*server.ServerInstance, err
 		rtnErr := logAndReturnError(callLogInfo, "Failed to Get NCP Region No of the Region Code : ", err)
 		return nil, rtnErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(diskHandler.RegionInfo.Region, diskHandler.RegionInfo.Zone) // Region/Zone info of diskHandler
 	if err != nil {
 		rtnErr := logAndReturnError(callLogInfo, "Failed to Get NCP Zone No of the Zone Code : ", err)
 		return nil, rtnErr

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/NLBHandler.go
@@ -107,7 +107,7 @@ func (nlbHandler *NcpNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB ir
 		LoggingError(callLogInfo, newErr)
 		return irs.NLBInfo{}, newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Region, nlbHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -250,7 +250,7 @@ func (nlbHandler *NcpNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 		LoggingError(callLogInfo, newErr)
 		return nil, newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Region, nlbHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -782,7 +782,7 @@ func (nlbHandler *NcpNLBHandler) GetNcpNlbInfo(nlbIID irs.IID) (*lb.LoadBalancer
 		LoggingError(callLogInfo, newErr)
 		return nil, newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(nlbHandler.RegionInfo.Region, nlbHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
@@ -51,7 +51,7 @@ func (vmSpecHandler *NcpVMSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, error) {
 		LoggingError(callLogInfo, newErr)
 		return nil, newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Region, vmSpecHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -127,7 +127,7 @@ func (vmSpecHandler *NcpVMSpecHandler) GetVMSpec(Name string) (irs.VMSpecInfo, e
 		LoggingError(callLogInfo, newErr)
 		return irs.VMSpecInfo{}, newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Region, vmSpecHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -202,7 +202,7 @@ func (vmSpecHandler *NcpVMSpecHandler) ListOrgVMSpec() (string, error) {
 		LoggingError(callLogInfo, newErr)
 		return "", newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Region, vmSpecHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -281,7 +281,7 @@ func (vmSpecHandler *NcpVMSpecHandler) GetOrgVMSpec(Name string) (string, error)
 		LoggingError(callLogInfo, newErr)
 		return "", newErr
 	}
-	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Zone)
+	zoneNo, err := vmHandler.GetZoneNo(vmSpecHandler.RegionInfo.Region, vmSpecHandler.RegionInfo.Zone)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NCP Zone No of the Zone Code : [%v]", err)
 		cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/RegionZoneHandler.go
@@ -13,6 +13,7 @@ package resources
 
 import (
 	// "errors"
+	"fmt"
 	"sync"
 	"strings"
 	// "github.com/davecgh/go-spew/spew"
@@ -191,8 +192,10 @@ func (regionZoneHandler *NcpRegionZoneHandler) ListOrgZone() (string, error) {
 
 	ncpVpcZoneList, err := regionZoneHandler.getNcpVpcZoneList(&regionZoneHandler.RegionInfo.Region, "ListOrgZone()")
 	if err != nil {
-		rtnErr := logAndReturnError(callLogInfo, "Failed to Get ZoneList from NCP Cloud : ", err)
-		return "", rtnErr
+		newErr := fmt.Errorf("Failed to Get ZoneList from NCP Cloud : [%v]", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return "", newErr
 	}
 
 	ncpZoneList := Zones{
@@ -200,8 +203,10 @@ func (regionZoneHandler *NcpRegionZoneHandler) ListOrgZone() (string, error) {
 	}
 	jsonString, cvtErr := ConvertJsonString(ncpZoneList)
 	if cvtErr != nil {
-		rtnErr := logAndReturnError(callLogInfo, "Failed to Convert the ZoneList to Json format string.", cvtErr)
-		return "", rtnErr
+		newErr := fmt.Errorf("Failed to Convert the ZoneList to Json format string. : [%v]", cvtErr)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return "", newErr
 	}
 	return jsonString, cvtErr
 }


### PR DESCRIPTION
[ NCP Classic ]
- Update VMHandler, VMSpecHandler, DiskHandler, NLBHandler
  - Update GetRegionNo()
    - Add checkAndSetRegionNoList()
       : Set as global map parameter to get region num. of each region code to reduce CSP API calls
  - Update GetZoneNo()
    - Add checkAndSetZoneNoList()
       : Set as global map parameter to get zone num. of each zone code to reduce CSP API calls
  
[ NCP VPC ]
- Update VMHandler
  - Adjust the Time Sleep to reduce CSP API calls
- Update RegionZoneHandler
  - Update logging