### PR TITLE
Add SecurityGroup Info to VM Info, and  Add StaticNAT and Firewall Features for NLB to Connect the NLB from External Network

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/10.list_lb.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/10.list_lb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ./1.export.env_mine
+source ./1.export.env
 
 echo "### OS_LB_API - LB List"
 echo "curl -v $OS_LB_API?command=listLoadBalancers&zoneid=DX-M1&response=json"

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/11.list_lb-vm.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/11.list_lb-vm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ./1.export.env_mine
+source ./1.export.env
 
 echo "### OS_LB_API - LB List"
 echo "curl -v $OS_LB_API?command=listLoadBalancerWebServers&loadbalancerid=38288&response=json"

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/12.create_lb.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/12.create_lb.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source ./1.export.env_mine
+source ./1.export.env
 
 echo "### OS_LB_API - Creatge LB"
 echo "curl -v $OS_LB_API?command=createLoadBalancer&name=LbDxApi07&healthchecktype=TCP&healthcheckurl=abc.kt.com&loadbalanceroption=roundrobin&serviceport=80&servicetype=TCP&zoneid=DX-M1"

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/13.create_tag_to_lb.sh
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/main/REST_API_test/13.create_tag_to_lb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source ./1.export.env
+
+echo "### OS_LB_API - Creatge Tag to LB"
+echo "curl -v $OS_LB_API?command=createTag&loadbalancerid=41268&tag=123.0.0.0"
+
+curl -v -H "X-Auth-Token: $OS_TOKEN" $OS_LB_API?command=createTag&loadbalancerid=41268&tag=123.0.0.0&response=json
+
+# 뒤에 &response=json 않붙여도됨.
+
+echo -e "\n"

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/CommonKTCloudFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/CommonKTCloudFunc.go
@@ -28,8 +28,8 @@ import (
 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/networking/v2/ports"
 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/networking/v2/subnets"
 	
-	cblog "github.com/cloud-barista/cb-log"
-	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	cblog 	 "github.com/cloud-barista/cb-log"
+	call 	 "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 )
 
 var once sync.Once

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/DiskHandler.go
@@ -531,6 +531,7 @@ func (diskHandler *KTVpcDiskHandler) mappingDiskInfo(volume volumes2.Volume) (ir
 		IId: irs.IID{
 			SystemId: volume.ID,
 		},
+		Zone: 		 volume.AvailabilityZone,
 		DiskSize:    strconv.Itoa(volume.Size),
 		Status:		 convertDiskStatus(volume.Status),
 		CreatedTime: convertedTime,
@@ -566,7 +567,7 @@ func (diskHandler *KTVpcDiskHandler) mappingDiskInfo(volume volumes2.Volume) (ir
 	}
 
 	keyValueList := []irs.KeyValue{
-		{Key: "AvailabilityZone",   Value: volume.AvailabilityZone},		 
+		// {Key: "AvailabilityZone",   Value: volume.AvailabilityZone},		 
 		{Key: "IsBootable",   		Value: volume.Bootable},
 		{Key: "IsMultiattached", 	Value: strconv.FormatBool(volume.Multiattach)},
 		{Key: "IsEncrypted", 		Value: strconv.FormatBool(volume.Encrypted)},
@@ -613,16 +614,12 @@ func (diskHandler *KTVpcDiskHandler) getImageNameandIDWithDiskID(diskId string) 
 		imageName, ok := diskResult.VolumeImageMetadata["image_name"]
 		if !ok {
 			fmt.Println("Image Name not found")
-		} else {
-			fmt.Println("Image Name:", imageName)
 		}
 
 		// Extract the image id
 		imageId, ok := diskResult.VolumeImageMetadata["image_id"]
 		if !ok {
 			fmt.Println("Image ID not found")
-		} else {
-			fmt.Println("Image ID:", imageId)
 		}
 		
 		if !strings.EqualFold(imageName, "") && !strings.EqualFold(imageId, "") {

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/ImageHandler.go
@@ -94,7 +94,7 @@ func (imageHandler *KTVpcImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo
 
 	ktImage, err := imageHandler.getKTImage(imageIID)
 	if err != nil {
-		newErr := fmt.Errorf("MyImage(Image Template) having the ID does Not Exist!! [%v]", err)
+		newErr := fmt.Errorf("Failed to Find the Image info with the ID!! [%v]", err)
 		cblogger.Error(newErr.Error())
 		return irs.ImageInfo{}, newErr
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/NLBHandler.go
@@ -15,14 +15,17 @@ import (
 	"strings"
 	"strconv"
 	"time"
-	// "github.com/davecgh/go-spew/spew"
+	"github.com/davecgh/go-spew/spew"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
-	ktvpcsdk "github.com/cloud-barista/ktcloudvpc-sdk-go"
-	ktvpclb "github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/loadbalancer/v1/loadbalancers"
+	ktvpcsdk 	"github.com/cloud-barista/ktcloudvpc-sdk-go"
+	ktvpclb 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/loadbalancer/v1/loadbalancers"
+	staticnat 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/networking/v2/extensions/layer3/staticnat"
+	rules       "github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/networking/v2/extensions/fwaas_v2/rules"
+	nim 		"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/info_manager/nlb_info_manager"
 )
 
 type KTVpcNLBHandler struct {
@@ -36,6 +39,7 @@ const (
 	DefaultNLBOption 		string  = "roundrobin" // NLBOption : roundrobin / leastconnection / leastresponse / sourceiphash / 
 	DefaultHealthCheckURL	string  = "abc.kt.com"
 	NlbSubnetName			string  = "NLB-SUBNET" // Subnet for NLB
+	DefaultVMGroupPort 		string  = "80"
 )
 
 func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB irs.NLBInfo, newErr error) {
@@ -76,7 +80,7 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 	}
 	OsNetId, getError := vpcHandler.getOsNetworkIdWithTierName(NlbSubnetName)
 	if getError != nil {
-		newErr := fmt.Errorf("Failed to Get the OsNetwork ID of the Subnet : [%v]", getError)
+		newErr := fmt.Errorf("Failed to Get the OsNetwork ID of the 'NLB-Subnet' : [%v]", getError)
 		cblogger.Error(newErr.Error())
 		return irs.NLBInfo{}, newErr
 	} else {
@@ -106,8 +110,8 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 	loggingInfo(callLogInfo, start)
 	cblogger.Infof("# New NLBId : %s", resp.Createnlbresponse.NLBId)
 
-	cblogger.Info("\n### Creating New NLB Now!!")
-	time.Sleep(time.Second * 15)
+	cblogger.Info("\n### Creating New NLB!!")
+	time.Sleep(time.Second * 10)
 
 	ktNLB, err := nlbHandler.getKTCloudNlbWithName(nlbReqInfo.IId.NameId)
 	if err != nil {
@@ -116,7 +120,64 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 		loggingError(callLogInfo, newErr)
 		return irs.NLBInfo{}, newErr
 	}
-	nlbIID := irs.IID{SystemId: strconv.Itoa(ktNLB.NlbID)}	
+	nlbIID := irs.IID{SystemId: strconv.Itoa(ktNLB.NlbID)}
+
+	// cblogger.Info("\n\n### ktNLB : ")
+	// spew.Dump(ktNLB)
+	// cblogger.Info("\n")
+
+	if countVMs(nlbReqInfo.VMGroup) > 0 {
+		_, addErr := nlbHandler.AddVMs(nlbIID, nlbReqInfo.VMGroup.VMs)
+		if addErr != nil {
+			newErr := fmt.Errorf("Failed to Add the VMGroup VMs!! [%v]", addErr)
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return irs.NLBInfo{}, newErr
+		}
+	}
+	
+	staticNatId, publicIp, natErr := nlbHandler.createStaticNatForNLB(ktNLB)
+	if natErr != nil {
+		newErr := fmt.Errorf("Failed to Add the VMGroup VMs!! [%v]", natErr)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+	
+	var keyValueList []irs.KeyValue
+	keyValueList = append(keyValueList, irs.KeyValue{
+		Key: 	"StaticNatID", 
+		Value: 	staticNatId,
+	})
+	keyValueList = append(keyValueList, irs.KeyValue{
+		Key: 	"PublicIP", 
+		Value: 	publicIp,
+	})
+
+	// Register SecurityGroupInfo to DB
+	providerName := "KTVPC"
+	nlbDbInfo, regErr := nim.RegisterNlb(strconv.Itoa(ktNLB.NlbID), providerName, keyValueList)
+	if regErr != nil {
+		cblogger.Error(regErr)
+		return irs.NLBInfo{}, regErr
+	}
+	cblogger.Infof(" === NLB Info to Register to DB : [%v]", nlbDbInfo)
+
+	// createTagOpts := ktvpclb.CreateTagOpts{
+	// 	NlbID:           	strconv.Itoa(ktNLB.NlbID),  			// Required
+	// 	Tag:         		publicIp, 								// Required
+	// }
+	// _, tagErr := ktvpclb.CreateTag(nlbHandler.NLBClient, createTagOpts).Extract() // Not 'NetworkClient'
+	// if tagErr != nil {
+	// 	newErr := fmt.Errorf("Failed to Create the Tag : [%v]", tagErr.Error())
+	// 	cblogger.Error(newErr.Error())
+	// 	loggingError(callLogInfo, newErr)
+	// 	return irs.NLBInfo{}, newErr
+	// }
+	// loggingInfo(callLogInfo, start)
+
+	// cblogger.Info("\n### Creating New Tag!!")
+	// time.Sleep(time.Second * 3)
 
 	nlbInfo, getErr := nlbHandler.GetNLB(nlbIID)
 	if getErr != nil {
@@ -216,14 +277,92 @@ func (nlbHandler *KTVpcNLBHandler) DeleteNLB(nlbIID irs.IID) (bool, error) {
 	cblogger.Info("KT Cloud Driver: called DeleteNLB()")
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "DeleteNLB()")
 
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return false, newErr
+	}
+
+	ktNLB, err := nlbHandler.getKTCloudNlb(nlbIID.SystemId)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get KT Cloud NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+	
+	// Get NLB PublicIP Info from DB
+	nlbDbInfo, getSGErr := nim.GetNlb(nlbIID.SystemId)
+	if getSGErr != nil {
+		cblogger.Debug(getSGErr)
+		// return irs.VMInfo{}, getSGErr
+	}
+
+	var staticNatId string
+	var publicIp string
+	if countNlbKvList(*nlbDbInfo) > 0 {
+		for _, kv := range nlbDbInfo.KeyValueInfoList {
+			if kv.Key == "StaticNatID" {
+				staticNatId = kv.Value				
+			}
+			if kv.Key == "PublicIP" {
+				publicIp = kv.Value
+			}
+		}
+	}
+
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		VMClient:   	nlbHandler.VMClient,
+		NetworkClient:  nlbHandler.NetworkClient, // Need!!
+	}
+
+	if !strings.EqualFold(publicIp, "") {
+		// Delete FirewallRules
+		_, dellFwErr := vmHandler.removeFirewallRule(publicIp, ktNLB.ServiceIP)
+		if dellFwErr != nil {
+			cblogger.Error(dellFwErr.Error())
+			loggingError(callLogInfo, dellFwErr)
+			return false, dellFwErr
+		}
+
+		// Delete Static NAT
+		if !strings.EqualFold(staticNatId, "") {
+			cblogger.Info("Deleting the Static NAT of the NLB!!")		
+			err := staticnat.Delete(nlbHandler.NetworkClient, staticNatId).ExtractErr() // NetworkClient
+			if err != nil {
+				cblogger.Error(err.Error())
+				return false, err
+			}
+			time.Sleep(time.Second * 3)
+		}
+
+		// Delete PublicIP
+		_, dellIpErr := vmHandler.removePublicIP(publicIp)
+		if dellIpErr != nil {
+			cblogger.Error(dellIpErr.Error())
+			loggingError(callLogInfo, dellIpErr)
+			return false, dellIpErr
+		}
+	} else {
+		cblogger.Info("The NLB doesn't have a Pulbic IP!! Waitting for Deletion!!")
+	}
+
+	// Delete the NLB info from DB
+	_, unRegErr := nim.UnRegisterNlb(nlbIID.SystemId)
+	if unRegErr != nil {
+		cblogger.Debug(unRegErr.Error())
+		loggingError(callLogInfo, unRegErr)
+		// return irs.Failed, unRegErr
+	}	
+
 	deleteOpts := ktvpclb.DeleteOpts{
 		NlbID: 	nlbIID.SystemId,
 	}
-
 	start := call.Start()
 	delErr := ktvpclb.Delete(nlbHandler.NLBClient, deleteOpts).ExtractErr()
 	if delErr != nil {
-		newErr := fmt.Errorf("Failed to Delete the KeyPair : [%v]", delErr)
+		newErr := fmt.Errorf("Failed to Delete the NLB : [%v]", delErr)
 		cblogger.Error(newErr.Error())
 		loggingError(callLogInfo, newErr)
 		return false, newErr
@@ -246,23 +385,250 @@ func (nlbHandler *KTVpcNLBHandler) ChangeVMGroupInfo(nlbIID irs.IID, vmGroup irs
 }
 
 func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (irs.VMGroupInfo, error) {
+	cblogger.Info("KT Cloud Driver: called AddVMs()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbIID.SystemId, "AddVMs()")
 
-	return irs.VMGroupInfo{}, fmt.Errorf("Does not support yet!!")
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+	if len(*vmIIDs) < 1 {
+		newErr := fmt.Errorf("Failded to Find any VM to Add to the VMGroup!!")
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+
+	type VMInfo struct {
+		VmID 		string
+		PrivateIP 	string
+	}
+
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		VMClient:   	nlbHandler.VMClient,
+		NetworkClient:  nlbHandler.NetworkClient, // Need!!
+	}
+
+	var vmInfo VMInfo
+	var vmInfoList []VMInfo
+	if len(*vmIIDs) > 0 {
+		for _, vmIID := range *vmIIDs {
+			var err error
+			vmInfo.VmID, vmInfo.PrivateIP, err = vmHandler.getVmIdAndPrivateIPWithName(vmIID.NameId)
+			if err != nil {
+				newErr := fmt.Errorf("Failed to Get the VM ID with the VM Name : [%v]", err)
+				cblogger.Error(newErr.Error())
+				return irs.VMGroupInfo{}, newErr
+			}
+			vmInfoList = append(vmInfoList, vmInfo)
+
+			time.Sleep(time.Second * 1)
+			// To Prevent API timeout error
+		}
+	} else {
+		newErr := fmt.Errorf("Failded to Find any VM NameId to Add to the NLB!!")
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+
+	for _, vm := range vmInfoList {
+		addOpts := ktvpclb.AddServerOpts{
+			NlbID:           	nlbIID.SystemId,  			// Required
+			VMID:				vm.VmID,					// Required
+			IPAddress: 			vm.PrivateIP,				// Required
+			PublicPort: 		DefaultVMGroupPort,			// Required
+		}	
+		start := call.Start()
+		_, err := ktvpclb.AddServer(nlbHandler.NLBClient, addOpts).Extract() // Not 'NetworkClient'
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Add VM to NLB. [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return irs.VMGroupInfo{}, newErr
+		}
+		loggingInfo(callLogInfo, start)
+
+		cblogger.Info("\n### Adding the VM to the NLB!!")
+			// cblogger.Infof("# New NLBId : %s", resp.Createnlbresponse.NLBId)
+		time.Sleep(time.Second * 5)
+
+		// cblogger.Info("\n\n### resp : ")
+		// spew.Dump(resp)
+		// cblogger.Info("\n")
+	}
+
+	nlbInfo, getErr := nlbHandler.GetNLB(nlbIID)
+	if getErr != nil {
+		newErr := fmt.Errorf("Failed to Get New NLB Info : [%v]", getErr)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	return nlbInfo.VMGroup, nil
 }
 
 func (nlbHandler *KTVpcNLBHandler) RemoveVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (bool, error) {
+	cblogger.Info("KT Cloud Driver: called RemoveVMs()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", nlbIID.SystemId, "RemoveVMs()")
 
-	return false, fmt.Errorf("Does not support yet!!")
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return false, newErr
+	}
+	if len(*vmIIDs) < 1 {
+		newErr := fmt.Errorf("Failded to Find any VM to Add to the VMGroup!!")
+		cblogger.Error(newErr.Error())
+		return false, newErr
+	}
+
+	type VMInfo struct {
+		VmID 		string
+		PrivateIP 	string
+	}
+
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		VMClient:   	nlbHandler.VMClient,
+		NetworkClient:  nlbHandler.NetworkClient, // Need!!
+	}
+
+	var vmInfo VMInfo
+	var vmInfoList []VMInfo
+	if len(*vmIIDs) > 0 {
+		for _, vmIID := range *vmIIDs {
+			var err error
+			vmInfo.VmID, vmInfo.PrivateIP, err = vmHandler.getVmIdAndPrivateIPWithName(vmIID.NameId)
+			if err != nil {
+				newErr := fmt.Errorf("Failed to Get the VM ID with the VM Name : [%v]", err)
+				cblogger.Error(newErr.Error())
+				return false, newErr
+			}
+			vmInfoList = append(vmInfoList, vmInfo)
+
+			time.Sleep(time.Second * 1)
+			// To Prevent API timeout error
+		}
+	} else {
+		newErr := fmt.Errorf("Failded to Find any VM NameId to Add to the NLB!!")
+		cblogger.Error(newErr.Error())
+		return false, newErr
+	}
+
+	for _, vm := range vmInfoList {
+		serviceId, err := nlbHandler.getNlbServiceIdWithVMId(nlbIID.SystemId, vm.VmID)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the Service ID of the VM on the NLB. [%v]", err.Error())
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return false, newErr
+		}
+
+		removeOpts := ktvpclb.RemoveServerOpts{
+			ServiceID:			serviceId, // Required. Not VMID
+		}
+		start := call.Start()
+		_, rmErr := ktvpclb.RemoveServer(nlbHandler.NLBClient, removeOpts).Extract() // Not 'NetworkClient'
+		if rmErr != nil {
+			newErr := fmt.Errorf("Failed to Add VM to NLB. [%v]", rmErr.Error())
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return false, newErr
+		}
+		loggingInfo(callLogInfo, start)
+		// cblogger.Infof("# New NLBId : %s", resp.Createnlbresponse.NLBId)
+
+		cblogger.Info("\n### Removing the VM from the NLB!!")
+		time.Sleep(time.Second * 5)
+		
+		// cblogger.Info("\n\n### resp : ")
+		// spew.Dump(resp)
+		// cblogger.Info("\n")
+	}
+
+	return true, nil
 }
 
 func (nlbHandler *KTVpcNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs.HealthInfo, error) {
 	cblogger.Info("KT Cloud Driver: called GetVMGroupHealthInfo()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", nlbIID.SystemId, "GetVMGroupHealthInfo()")
 
-	return irs.HealthInfo{}, nil
+	if strings.EqualFold(nlbIID.SystemId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID!!")
+		cblogger.Error(newErr.Error())
+		return irs.HealthInfo{}, newErr
+	}
+
+	listLbServerOpts := ktvpclb.ListOpts{
+		NlbID: 	nlbIID.SystemId,  			// Required
+	}
+	start := call.Start()
+	firstPage, err := ktvpclb.ListLbServer(nlbHandler.NLBClient, listLbServerOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()' 
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB List from KT Cloud : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.HealthInfo{}, newErr
+	}	
+	nlbVmList, err := ktvpclb.ExtractLbServers(firstPage)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Extract NLB List : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.HealthInfo{}, newErr
+	}
+	loggingInfo(callLogInfo, start)
+
+	// cblogger.Info("\n\n# nlb VM List from KT Cloud VPC : ")
+	// spew.Dump(nlbVmList)
+	// cblogger.Info("\n")
+
+	time.Sleep(time.Second * 1) // Before 'return'
+	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+
+	if len(nlbVmList) < 1 {
+		cblogger.Info("# NLB VM does Not Exist!!")
+		return irs.HealthInfo{}, nil // Not Return Error
+	}
+
+	var allVMs []irs.IID
+	var healthVMs []irs.IID
+	var unHealthVMs []irs.IID
+
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		VMClient:   	nlbHandler.VMClient,
+	}
+
+	for _, vm := range nlbVmList {
+		vmName, err := vmHandler.getVmNameWithId(vm.VmID)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the VM Name with the VM ID : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return irs.HealthInfo{}, newErr
+		}
+		
+		allVMs = append(allVMs, irs.IID{NameId: vmName, SystemId: vm.VmID}) 
+
+		if strings.EqualFold(vm.VmState, "UP") {
+			// cblogger.Infof("\n### [%s] is Healthy VM.", vm.Name)
+			healthVMs = append(healthVMs, irs.IID{NameId: vmName, SystemId: vm.VmID})
+		} else {
+			// cblogger.Infof("\n### [%s] is Unhealthy VM.", vm.Name)
+			unHealthVMs = append(unHealthVMs, irs.IID{NameId: vmName, SystemId: vm.VmID}) // In case of "DOWN", ...
+		}
+	}
+
+	vmGroupHealthInfo := irs.HealthInfo{
+		AllVMs:       &allVMs,
+		HealthyVMs:   &healthVMs,
+		UnHealthyVMs: &unHealthVMs,
+	}
+	return vmGroupHealthInfo, nil
 }
 
 func (nlbHandler *KTVpcNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, healthChecker irs.HealthCheckerInfo) (irs.HealthCheckerInfo, error) {
-
 	return irs.HealthCheckerInfo{}, fmt.Errorf("KT Cloud does not support ChangeHealthCheckerInfo() yet!!")
 }
 
@@ -284,8 +650,8 @@ func (nlbHandler *KTVpcNLBHandler) getListenerInfo(nlb *ktvpclb.LoadBalancer) (i
 		Protocol: 	nlb.ServiceType,
 		IP: 		nlb.ServiceIP,
 		Port: 		nlb.ServicePort,
-		// DNSName:	"N/A",
-		// CspID: 		"N/A",
+		// DNSName:	"NA",
+		// CspID: 		"NA",
 	}
 	listenerKVList := []irs.KeyValue{
 		// {Key: "NLB_DomainName", Value: *nlb.DomainName},
@@ -311,23 +677,177 @@ func (nlbHandler *KTVpcNLBHandler) getHealthCheckerInfo(nlb *ktvpclb.LoadBalance
 	healthCheckerInfo := irs.HealthCheckerInfo{
 		Protocol: 	nlb.HealthCheckType,
 		Port:     	nlb.ServicePort,
-		// CspID: 		"N/A",
+		// CspID: 		"NA",
 	}
 	return healthCheckerInfo, nil
 }
 
+func (nlbHandler *KTVpcNLBHandler) getVMGroupInfo(nlbId string) (irs.VMGroupInfo, error) {
+	cblogger.Info("KT Cloud Driver: called getVMGroupInfo()")
+	InitLog()
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "getVMGroupInfo()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID")
+		cblogger.Error(newErr.Error())
+		return irs.VMGroupInfo{}, newErr
+	}
+	
+	ktNLB, err := nlbHandler.getKTCloudNlb(nlbId)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get KT Cloud NLB info!! [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+
+	listLbServerOpts := ktvpclb.ListOpts{
+		NlbID: 	nlbId,  			// Required
+	}
+	start := call.Start()
+	firstPage, err := ktvpclb.ListLbServer(nlbHandler.NLBClient, listLbServerOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()' 
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB List from KT Cloud : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}	
+	nlbVmList, err := ktvpclb.ExtractLbServers(firstPage)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Extract NLB List : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	loggingInfo(callLogInfo, start)
+
+	// cblogger.Info("\n\n# nlb VM List from KT Cloud VPC : ")
+	// spew.Dump(nlbVmList)
+	// cblogger.Info("\n")
+	
+	vmIIds := []irs.IID{}
+	keyValueList := []irs.KeyValue{}
+	
+	if len(nlbVmList) < 1 {
+		cblogger.Debug("# NLB VM does Not Exist!!")
+		vmGroupInfo := irs.VMGroupInfo{
+			Protocol: 	"NA",
+			Port: 		"NA",
+			CspID:    	"NA",
+		}
+		vmIIds = append(vmIIds, irs.IID{
+			NameId:   "NA",
+			SystemId: "NA",
+		})
+		vmGroupInfo.VMs = &vmIIds
+		return vmGroupInfo, nil // Not Return Error
+	}
+
+	vmGroupInfo := irs.VMGroupInfo{
+		Protocol: 	ktNLB.ServiceType, // Caution!!
+		Port: 		nlbVmList[0].PublicPort, // In case, Any VM exists
+		// CspID:    	"NA",
+	}		
+
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: nlbHandler.RegionInfo,
+		VMClient:  	nlbHandler.VMClient,
+	}
+	for _, vm := range nlbVmList {
+		vmName, err := vmHandler.getVmNameWithId(vm.VmID)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get the VM Name with the VM ID : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return irs.VMGroupInfo{}, newErr
+		}
+
+		vmIIds = append(vmIIds, irs.IID{
+			NameId:   vmName,
+			SystemId: vm.VmID,
+		})
+
+		keyValueList = append(keyValueList, irs.KeyValue{
+			Key: 	vmName + "_ServiceId",
+			Value: 	strconv.Itoa(vm.ServiceID),		
+		})
+
+		time.Sleep(time.Second * 1)
+		// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
+	}
+	vmGroupInfo.VMs = &vmIIds
+	vmGroupInfo.KeyValueList = keyValueList
+	return vmGroupInfo, nil
+}
+
+func (nlbHandler *KTVpcNLBHandler) getNlbServiceIdWithVMId(nlbId string, vmId string) (string, error) {
+	cblogger.Info("KT Cloud Driver: called getNlbServiceIdWithVMId()")
+	InitLog()
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "getNlbServiceIdWithVMId()")
+
+	if strings.EqualFold(nlbId, "") {
+		newErr := fmt.Errorf("Invalid NLB ID")
+		cblogger.Error(newErr.Error())
+		return "", newErr
+	}
+
+	if strings.EqualFold(vmId, "") {
+		newErr := fmt.Errorf("Invalid VM ID")
+		cblogger.Error(newErr.Error())
+		return "", newErr
+	}
+	
+	listLbServerOpts := ktvpclb.ListOpts{
+		NlbID: 	nlbId,  			// Required
+	}
+	start := call.Start()
+	firstPage, err := ktvpclb.ListLbServer(nlbHandler.NLBClient, listLbServerOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()' 
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get NLB List from KT Cloud : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return "", newErr
+	}	
+	nlbVmList, err := ktvpclb.ExtractLbServers(firstPage)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Extract NLB List : [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return "", newErr
+	}
+	loggingInfo(callLogInfo, start)
+
+	// cblogger.Info("\n\n# nlb VM List from KT Cloud VPC : ")
+	// spew.Dump(nlbVmList)
+	// cblogger.Info("\n")
+
+	if len(nlbVmList) < 1 {		
+		newErr := fmt.Errorf("Failed to Find Any VM on the NLB!!",)
+		cblogger.Error(newErr.Error())
+		return "", newErr
+	}
+	
+	var serviceID string
+	for _, vm := range nlbVmList {
+		if strings.EqualFold(vm.VmID, vmId) {
+		serviceID = strconv.Itoa(vm.ServiceID)
+		break
+		}
+	}
+
+	if strings.EqualFold(serviceID, "") {
+		newErr := fmt.Errorf("Failed to Find the Service ID with the VM ID!!",)
+		cblogger.Error(newErr.Error())
+		return "", newErr
+	}
+
+	return serviceID, nil
+}
+
 func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (irs.NLBInfo, error) {
 	cblogger.Info("KT Cloud VPC Driver: called mappingNlbInfo()")
+
 	// cblogger.Info("\n\n### nlb : ")
 	// spew.Dump(nlb)
-
-	// // # Get ImageInfo frome the Disk Volume
-	// diskHandler := KTVpcDiskHandler{
-	// 	RegionInfo:    vmHandler.RegionInfo,
-	// 	VMClient:      vmHandler.VMClient,
-	// 	VolumeClient:  vmHandler.VolumeClient,
-	// }
-
 
 	// vpcId, subnetId, publicIp, _, err := vmHandler.getNetIDsWithPrivateIP(vmInfo.PrivateIP)
 	// if err != nil {
@@ -339,15 +859,28 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 	// vmInfo.SubnetIID.SystemId = subnetId // Caution!!) Need modification. Not Tier 'ID' but 'OsNetworkID' to Create VM through REST API!!
 	// vmInfo.PublicIP			  = publicIp
 
+
+	vpcHandler := KTVpcVPCHandler{
+		RegionInfo:    		nlbHandler.RegionInfo,
+		NetworkClient:     	nlbHandler.NetworkClient,
+	}
+
+	vpcId, err := vpcHandler.getVPCIdWithOsNetworkID(nlb.NetworkID)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get PortForwarding Info. [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.NLBInfo{}, newErr
+	}
+
 	nlbInfo := irs.NLBInfo{
 		IId: irs.IID{
 			NameId:   nlb.Name,
 			SystemId: strconv.Itoa(nlb.NlbID),
 		},
-		// VpcIID: irs.IID{
-		// 	NameId:   "N/A", // Cauton!!) 'NameId: "N/A"' makes an Error on CB-Spider
-		// 	SystemId: "N/A",
-		// },
+		VpcIID: irs.IID{
+			// NameId:   "N/A", // Cauton!!) 'NameId: "N/A"' makes an Error on CB-Spider
+			SystemId: vpcId,
+		},
 		Type:         "PUBLIC",
 		Scope:        "REGION",
 	}
@@ -371,6 +904,24 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 		nlbInfo.Listener = listenerInfo
 	}
 
+	// Get NLB Info from DB
+	nlbDbInfo, getSGErr := nim.GetNlb(strconv.Itoa(nlb.NlbID))
+	if getSGErr != nil {
+		cblogger.Debug(getSGErr)
+		// return irs.VMInfo{}, getSGErr
+	}
+
+	var publicIp string
+	if countNlbKvList(*nlbDbInfo) > 0 {
+		for _, kv := range nlbDbInfo.KeyValueInfoList {
+			if kv.Key == "PublicIP" {
+				publicIp = kv.Value
+				break
+			}
+		}
+	}
+	nlbInfo.Listener.IP = publicIp
+
 	if !strings.EqualFold(nlb.HealthCheckType, "") {
 		healthCheckerInfo, err := nlbHandler.getHealthCheckerInfo(nlb)
 		if err != nil {
@@ -381,13 +932,13 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 		nlbInfo.HealthChecker = healthCheckerInfo
 	}
 
-	// vmGroupInfo, err := nlbHandler.getVMGroupInfo(strconv.Itoa(nlb.NLBId))
-	// if err != nil {
-	// 	newErr := fmt.Errorf("Failed to Get VM Group Info with the NLB ID : [%v]", err)
-	// 	cblogger.Error(newErr.Error())
-	// 	return irs.NLBInfo{}, newErr
-	// }
-	// nlbInfo.VMGroup = vmGroupInfo
+	vmGroupInfo, err := nlbHandler.getVMGroupInfo(strconv.Itoa(nlb.NlbID))
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get VM Group Info with the NLB ID : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.NLBInfo{}, newErr
+	}
+	nlbInfo.VMGroup = vmGroupInfo
 	return nlbInfo, nil
 }
 
@@ -465,7 +1016,7 @@ func (nlbHandler *KTVpcNLBHandler) getKTCloudNlbWithName(nlbName string) (*ktvpc
 	// To Prevent the Error : "Unable to execute API command listTags due to ratelimit timeout"
 
 	if len(nlbList) < 1 {
-		newErr := fmt.Errorf("Failed to Find the NLB info with the Name on the zone!!")
+		newErr := fmt.Errorf("Failed to Find the NLB with the Name on the zone!!")
 		cblogger.Error(newErr.Error())
 		return nil, newErr
 	}
@@ -473,4 +1024,147 @@ func (nlbHandler *KTVpcNLBHandler) getKTCloudNlbWithName(nlbName string) (*ktvpc
 	// spew.Dump(result.Listnlbsresponse)
 
 	return &nlbList[0], nil
+}
+
+func countVMs(vmGroup irs.VMGroupInfo) int {
+    if vmGroup.VMs == nil {
+        return 0
+    }
+    return len(*vmGroup.VMs)
+}
+
+func (nlbHandler *KTVpcNLBHandler) createStaticNatForNLB(ktNLB *ktvpclb.LoadBalancer) (string, string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called createStaticNatForNLB()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", ktNLB.Name, "createStaticNatForNLB()")
+
+	// Static NAT allocation is required after new Public IP creation to be connected from the outside of the network.
+	// # Create a Public IP
+	var publicIP string
+	var publicIPId string
+	var creatErr error
+	var ok bool
+
+	cblogger.Info("\n### Creating New Public IP!!")
+	vmHandler := KTVpcVMHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		VMClient:   	nlbHandler.VMClient,
+		NetworkClient:  nlbHandler.NetworkClient, // Need!!
+	}
+	if ok, publicIP, publicIPId, creatErr = vmHandler.createPublicIP(); !ok {
+		newErr := fmt.Errorf("Failed to Create a PublicIP : [%v]", creatErr)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return "", "", newErr
+	}
+	cblogger.Infof("# New PublicIP : [%s]\n", publicIP)
+	time.Sleep(time.Second * 1)
+
+	// ### Set Static NAT
+	createNatOpts := &staticnat.CreateOpts{
+		PrivateIpAddr: 	ktNLB.ServiceIP,
+		SubnetID: 		ktNLB.NetworkID,
+		PublicIpID: 	publicIPId,
+	}
+	natResult, err := staticnat.Create(nlbHandler.NetworkClient, createNatOpts).ExtractInfo()
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Create Static NAT : [%v]", err)
+		cblogger.Error(newErr.Error())
+		return "", "", newErr
+	}
+	cblogger.Info("\n### Creating the Static NAT to the NLB!!")
+	time.Sleep(time.Second * 3)
+	cblogger.Infof("\n# Static NAT ID : [%s]", natResult.ID)
+
+	cblogger.Info("\n\n### natResult")
+	spew.Dump(natResult)
+
+	// ### Set FireWall Rules ("Inbound" FireWall Rules)
+	vpcHandler := KTVpcVPCHandler{
+		RegionInfo: 	nlbHandler.RegionInfo,
+		NetworkClient:  nlbHandler.NetworkClient, // Required!!
+	}
+	vpcId, err := vpcHandler.getVPCIdWithOsNetworkID(ktNLB.NetworkID)
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get the VPC ID with teh OsNetwork ID. [%v]", err)
+		cblogger.Error(newErr.Error())
+		return "", "", newErr
+	}
+
+	externalNetId, getErr := vpcHandler.getExtSubnetId( irs.IID{SystemId: vpcId})
+	if getErr != nil {
+		newErr := fmt.Errorf("Failed to Get the VPC Info : [%v]", getErr)
+		cblogger.Error(newErr.Error())
+		return "", "", newErr
+	} else {
+		cblogger.Infof("# ExternalNet ID : %s", externalNetId)
+	}
+
+	cblogger.Info("### Start to Create Firewall 'inbound' Rules!!")
+
+	destCIDR, err := ipToCidr24(ktNLB.ServiceIP) // Output format ex) "172.25.1.0/24"
+	if err != nil {
+		cblogger.Errorf("Failed to Get Dest Net Band : [%v]", err)			
+		return "", "", err
+	} else {
+		fmt.Println(destCIDR)
+	}
+
+	tierId, getError := vpcHandler.getTierIdWithOsNetworkId(vpcId, ktNLB.NetworkID)
+	if getError != nil {
+		newErr := fmt.Errorf("Failed to Get the OsNetwork ID of the Tier : [%v]", getError)
+		cblogger.Error(newErr.Error())
+		return "", "", newErr
+	} else {
+		cblogger.Infof("# Tier ID : %s", tierId)
+	}
+
+	protocol := ktNLB.ServiceType
+
+	var convertedProtocol rules.Protocol
+	if strings.EqualFold(protocol, "tcp") {
+		convertedProtocol = rules.ProtocolTCP
+	} else if strings.EqualFold(protocol, "udp") {
+		convertedProtocol = rules.ProtocolUDP
+	} else if strings.EqualFold(protocol, "icmp") {
+		convertedProtocol = rules.ProtocolICMP
+	}
+
+	inboundFWOpts := &rules.InboundCreateOpts{
+		SourceNetID: 		externalNetId, 			// ExternalNet
+		PortFordingID: 		natResult.ID,			// Caution!!
+		DestIPAdds: 	    destCIDR,				// Destination network band (10.1.1.0/24, etc.)					
+		StartPort: 		    ktNLB.ServicePort,
+		EndPort:   			ktNLB.ServicePort,
+		Protocol:           convertedProtocol,
+		DestNetID:			tierId,					// Tier ID
+		Action:             rules.ActionAllow, 		// "allow"
+	}
+
+	fwResult, err := rules.Create(vmHandler.NetworkClient, inboundFWOpts).ExtractJobInfo() // Not ~.Extract()
+	if err != nil {
+		cblogger.Errorf("Failed to Create the FireWall 'inbound' Rules : [%v]", err)
+		return "", "", err
+	}
+	// cblogger.Infof("\n# fwResult.JopID : [%s]", fwResult.JopID)
+	// cblogger.Info("\n")
+
+	cblogger.Info("### Waiting for FireWall 'inbound' Rules to be Created(600sec) !!")
+
+	// To prevent - json: cannot unmarshal string into Go struct field AsyncJobResult.nc_queryasyncjobresultresponse.result of type job.JobResult
+	time.Sleep(time.Second * 3)
+
+	jobWaitErr := vmHandler.waitForAsyncJob(fwResult.JopID, 600000000000)
+	if jobWaitErr != nil {
+		cblogger.Errorf("Failed to Wait the Job : [%v]", jobWaitErr)			
+		return "", "", jobWaitErr
+	}					
+
+	return natResult.ID, publicIP, nil
+}
+
+func countNlbKvList(nlb nim.NlbInfo) int {
+    if nlb.KeyValueInfoList == nil {
+        return 0
+    }
+    return len(nlb.KeyValueInfoList)
 }

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/info_manager/nlb_info_manager/NlbInfoManager.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/info_manager/nlb_info_manager/NlbInfoManager.go
@@ -1,0 +1,120 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// by ETRI, 2024.05.
+
+package nlbinfomanager
+
+import (
+	"fmt"
+	"strings"
+	"github.com/sirupsen/logrus"
+
+	idrv 		"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	infostore 	"github.com/cloud-barista/cb-spider/info-store"	
+
+	cblog 		"github.com/cloud-barista/cb-log"
+)
+
+const KEY_COLUMN_NAME = "nlb_id"
+
+type NlbInfo struct {
+	NlbID   			string          	`gorm:"primaryKey"`
+	ProviderName      	string               // ex) "KTVPC"
+	KeyValueInfoList  	infostore.KVList 	`gorm:"type:text"`
+}
+
+var cblogger *logrus.Logger
+func init() {
+	cblogger = cblog.GetLogger("CB-SPIDER")
+	db, err := infostore.Open()
+	if err != nil {
+		panic("failed to connect database")
+	}
+	db.AutoMigrate(&NlbInfo{})
+	infostore.Close(db)
+}
+
+func RegisterNlbInfo(nlbInfo NlbInfo) (*NlbInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called RegisterNlbInfo()")
+
+	cblogger.Debug("check params")
+	err := checkParams(nlbInfo.NlbID, nlbInfo.ProviderName, nlbInfo.KeyValueInfoList)
+	if err != nil {
+		return nil, err
+	}
+
+	// trim user inputs
+	nlbInfo.NlbID = strings.TrimSpace(nlbInfo.NlbID)
+	nlbInfo.ProviderName = strings.ToUpper(strings.TrimSpace(nlbInfo.ProviderName))
+
+	cblogger.Debug("insert metainfo into store")
+
+	err = infostore.Insert(&nlbInfo)
+	if err != nil {
+		cblogger.Error(err)
+		return nil, err
+	}
+
+	return &nlbInfo, nil
+}
+
+// Register GetNlbInfo to info-store (DB)
+func RegisterNlb(nlbID string, providereName string, keyValueInfoList []idrv.KeyValue) (*NlbInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called RegisterNlb()")
+
+	return RegisterNlbInfo(NlbInfo{nlbID, providereName, keyValueInfoList})
+}
+
+func checkParams(nlbID string, providerName string, keyValueInfoList []idrv.KeyValue) error {
+	if nlbID == "" {
+		return fmt.Errorf("NlbID is empty!")
+	}
+	if providerName == "" {
+		return fmt.Errorf("providerName is empty!")
+	}
+	if keyValueInfoList == nil {
+		return fmt.Errorf("KeyValue List is nil!")
+	}
+
+	return nil
+}
+
+// Get GetNlbInfo from info-store (DB)
+func GetNlb(nlbID string) (*NlbInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called GetNlb()")
+
+	if nlbID == "" {
+		return nil, fmt.Errorf("NlbID is empty!")
+	}
+
+	var nlbInfo NlbInfo
+	err := infostore.Get(&nlbInfo, KEY_COLUMN_NAME, nlbID)
+	if err != nil {
+		cblogger.Debug(err)
+		// return nil, err
+	}
+
+	return &nlbInfo, err
+}
+
+func UnRegisterNlb(nlbID string) (bool, error) {
+	cblogger.Info("KT Cloud VPC Driver: called UnRegisterNlb()")
+
+	if nlbID == "" {
+		return false, fmt.Errorf("NlbID is empty!")
+	}
+
+	result, err := infostore.Delete(&NlbInfo{}, KEY_COLUMN_NAME, nlbID)
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
+
+	return result, nil
+}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/info_manager/security_group_info_manager/SecurityGroupInfoManager.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/info_manager/security_group_info_manager/SecurityGroupInfoManager.go
@@ -1,0 +1,120 @@
+// Proof of Concepts of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is a Cloud Driver Example for PoC Test.
+//
+// by ETRI, 2024.05.
+
+package securitygroupinfomanager
+
+import (
+	"fmt"
+	"strings"
+	"github.com/sirupsen/logrus"
+
+	idrv 		"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	infostore 	"github.com/cloud-barista/cb-spider/info-store"	
+
+	cblog 		"github.com/cloud-barista/cb-log"
+)
+
+const KEY_COLUMN_NAME = "vm_id"
+
+type SecurityGroupInfo struct {
+	VmID   				string          	`gorm:"primaryKey"`
+	ProviderName      	string               // ex) "KTVPC"
+	KeyValueInfoList  	infostore.KVList 	`gorm:"type:text"`
+}
+
+var cblogger *logrus.Logger
+func init() {
+	cblogger = cblog.GetLogger("CB-SPIDER")
+	db, err := infostore.Open()
+	if err != nil {
+		panic("failed to connect database")
+	}
+	db.AutoMigrate(&SecurityGroupInfo{})
+	infostore.Close(db)
+}
+
+func RegisterSecurityGroupInfo(sgInfo SecurityGroupInfo) (*SecurityGroupInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called RegisterSecurityGroupInfo()")
+
+	cblogger.Debug("check params")
+	err := checkParams(sgInfo.VmID, sgInfo.ProviderName, sgInfo.KeyValueInfoList)
+	if err != nil {
+		return nil, err
+	}
+
+	// trim user inputs
+	sgInfo.VmID = strings.TrimSpace(sgInfo.VmID)
+	sgInfo.ProviderName = strings.ToUpper(strings.TrimSpace(sgInfo.ProviderName))
+
+	cblogger.Debug("insert metainfo into store")
+
+	err = infostore.Insert(&sgInfo)
+	if err != nil {
+		cblogger.Error(err)
+		return nil, err
+	}
+
+	return &sgInfo, nil
+}
+
+// Register GetSecurityGroupInfo to info-store (DB)
+func RegisterSecurityGroup(vmID string, providereName string, keyValueInfoList []idrv.KeyValue) (*SecurityGroupInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called RegisterSecurityGroup()")
+
+	return RegisterSecurityGroupInfo(SecurityGroupInfo{vmID, providereName, keyValueInfoList})
+}
+
+func checkParams(vmID string, providerName string, keyValueInfoList []idrv.KeyValue) error {
+	if vmID == "" {
+		return fmt.Errorf("vmID is empty!")
+	}
+	if providerName == "" {
+		return fmt.Errorf("providerName is empty!")
+	}
+	if keyValueInfoList == nil {
+		return fmt.Errorf("KeyValue List is nil!")
+	}
+
+	return nil
+}
+
+// Get GetSecurityGroupInfo from info-store (DB)
+func GetSecurityGroup(vmID string) (*SecurityGroupInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called GetSecurityGroup()")
+
+	if vmID == "" {
+		return nil, fmt.Errorf("vmID is empty!")
+	}
+
+	var sgInfo SecurityGroupInfo
+	err := infostore.Get(&sgInfo, KEY_COLUMN_NAME, vmID)
+	if err != nil {
+		cblogger.Debug(err)
+		// return nil, err
+	}
+
+	return &sgInfo, err
+}
+
+func UnRegisterSecurityGroup(vmID string) (bool, error) {
+	cblogger.Info("KT Cloud VPC Driver: called UnRegisterSecurityGroup()")
+
+	if vmID == "" {
+		return false, fmt.Errorf("vmID is empty!")
+	}
+
+	result, err := infostore.Delete(&SecurityGroupInfo{}, KEY_COLUMN_NAME, vmID)
+	if err != nil {
+		cblogger.Error(err)
+		return false, err
+	}
+
+	return result, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/alibabacloud-go/tea v1.2.2
 	github.com/alibabacloud-go/vpc-20160428/v6 v6.4.0
 	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb
-	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd
+	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0
 	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/cloud-barista/cb-log v0.8.0 h1:ArWCs1EgpoD3ZnBgcC4cAw5ufI/JHmFKfJswlv
 github.com/cloud-barista/cb-log v0.8.0/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb h1:JAQQ/wBdkcoGCeim+J84F8hIuxbtn/XTe/iDYRsr+t0=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb/go.mod h1:ZIrUxItUvMIGZyX6Re7tUdcS3cwBIzBPcL+Pk/6lt/8=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd h1:kqSI4usVl5or7+nSvt4IpEG+iTPRxuBavYzoOBkeJ6s=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240403081203-a0af52c7c7cd/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0 h1:mnQnZHMwt8V/WihpgnIDcqK9fsLE8A+uTdVSGdPaQ+Q=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1 h1:o6RVnxI2E6o3l7Sc285gg45S6hcepAklfPPDDmlvKHY=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240415072030-38f4f47c26a1/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
- Update VMHandler
  - Add and Apply SecurityGroupInfoManager to Save Info to DB
  - Add SecurityGroup Info to VM Info
    : Related issue) https://github.com/cloud-barista/cb-spider/issues/1191  
  - Add getVmPrivateIpAndNetIdWithVMId() method
- Update NLBHandler
  - Add Static NAT and Firewall Features to Connect the NLB from External Network
  - Add and Apply NLBInfoManager to Save Info to DB
- Update VPCHandler
  - Add getTierIdWithOsNetworkId() method
  - Add getVPCIdWithOsNetworkID() method
- Update DiskHandler
  - Add zone info to Disk Info
    : Related issue) https://github.com/cloud-barista/cb-spider/issues/1067
- Update go.mod and go.sum
  - Update KT Cloud VPC Go SDK version