### PR TITLE
[NHN Cloud] Update Credential Info > identity_endpoint URL

### DIFF
--- a/api-runtime/rest-runtime/test/connect-config/13.nhncloud-conn-config.sh
+++ b/api-runtime/rest-runtime/test/connect-config/13.nhncloud-conn-config.sh
@@ -8,7 +8,7 @@ curl -X POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: applica
     "CredentialName":"nhncloud-credential01",
     "ProviderName":"NHNCLOUD",
     "KeyValueInfoList": [
-        {"Key":"IdentityEndpoint", "Value":"https://api-identity.infrastructure.cloud.toast.com"},
+        {"Key":"IdentityEndpoint", "Value":"https://api-identity-infrastructure.nhncloudservice.com"},
         {"Key":"Username", "Value":"XXXXX@XXXXXXXXXXXXXXXX"},
         {"Key":"Password", "Value":"XXXXXXXXXXXXXXXXXX"},
         {"Key":"DomainName", "Value":"default"},

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/main/conf/config.yaml.sample
@@ -1,6 +1,6 @@
 ## Config for NHN Cloud ##
 nhncloud:
-  identity_endpoint: https://api-identity.infrastructure.cloud.toast.com
+  identity_endpoint: https://api-identity-infrastructure.nhncloudservice.com
   nhn_username: ex) ~~~@~~~.com
   api_password: 
     # API 비밀번호 값 입력

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -131,7 +131,7 @@ KTCLOUDVPC:
   disktype: HDD / SSD
   disksize: HDD|10|2000|GB / SSD|10|2000|GB
   # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage
-  idmaxlength: 300 / 300 / 30 / 100 / 300 / 50 / 300 / 50
+  idmaxlength: 300 / 300 / 30 / 100 / 300 / 50 / 30 / 50
 
 #--- PoC
 


### PR DESCRIPTION
- Update NHN Cloud Credential Info > API identity_endpoint URL
  - Ref) https://www.nhncloud.com/kr/support/notice/detail/4145
  - Related issue) https://github.com/cloud-barista/cb-spider/issues/1195
  - Note) For reference, cloud resources end-point information (for each zone) are found in the provider client information after first authentication in NHN Cloud Go SDK.
- Update Cloud OS Meta info for KT Cloud VPC NLB name length to create NLB successfully through API call


