### PR TITLE
Bugfix on CD workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -64,7 +64,7 @@ jobs:
             # type=semver,pattern={{major}}.{{minor}}
             ## Tags for a push branch event
             # Tags to reflect the last commit of the active branch
-            type=edge,enable=true,branch=main
+            type=edge,enable=true
             ## Other types (currently the followings may be out of scope in this project)
             ## Tags for a push branch event
             # minimal (short sha)


### PR DESCRIPTION
* Remove `branch=main` to apply default value (branch=$repo.default_branch)

(원인) 
CB-Spider repo의 기본 브랜치는 master인데, edge 태그의 대상 브랜치가 main으로 되어있어 오류가 발생한 것으로 보입니다.

(관련 에러 메시지) 
Error: buildx failed with: ERROR: tag is needed when pushing to registry

(해소 방안) 
정상적인 컨테이너 이미지 태그 생성 및 적용을 위해, `branch=main` 삭제 처리하여 CB-Spider repo의 기본 브랜치가 적용되도록 수정