### PR TITLE
[Domestic Cloud Drivers] Remove fmt.Print and spew.Dump statements

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/CommonKtCloudFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/CommonKtCloudFunc.go
@@ -15,20 +15,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	// "reflect"
-	// "crypto/aes"
-	// "crypto/cipher"
-	// "crypto/rand"
-	// "io"
 	"os"
-	"os/exec"
-
-	// "errors"
-	// "encoding/hex"
-	// "encoding/base64"
-	// "hash"
-	// "hash/fnv"
 	// "github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 
@@ -111,33 +98,6 @@ func logAndReturnError(callLogInfo call.CLOUDLOGSCHEMA, givenErrString string, v
 	cblogger.Error(newErr.Error())
 	LoggingError(callLogInfo, newErr)
 	return newErr
-}
-
-func RunCommand(cmdName string, cmdArgs []string) (string, error) {
-	/*
-	Ref)
-	var (
-		cmdOut []byte
-		cmdErr   error		
-	)
-	*/
-
-	cblogger.Infof("cmdName : %s", cmdName)
-	cblogger.Infof("cmdArgs : %s", cmdArgs)
-
-	//if cmdOut, cmdErr = exec.Command(cmdName, cmdArgs...).Output(); cmdErr != nil {
-	if cmdOut, cmdErr := exec.Command(cmdName, cmdArgs...).CombinedOutput(); cmdErr != nil {
-		fmt.Fprintln(os.Stderr, "There was an error running command: ", cmdErr)
-		//panic("Can't exec the command: " + cmdErr1.Error())
-		fmt.Println(fmt.Sprint(cmdErr) + ": " + string(cmdOut))
-		os.Exit(1)
-
-		return string(cmdOut), cmdErr
-	} else {
-	fmt.Println("cmdOut : ", string(cmdOut))
-
-	return string(cmdOut), nil
-	}
 }
 
 func CheckFolder(folderPath string) error {

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/KeyPairHandler.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"errors"
 	"strings"
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	ktsdk "github.com/cloud-barista/ktcloud-sdk-go"
 
@@ -144,8 +144,9 @@ func (keyPairHandler *KtCloudKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPair
 	cblogger.Infof("keyName : [%s]", keyIID.NameId)
 	result, err := keyPairHandler.Client.ListSSHKeyPairs(keyIID.NameId)
 	if err != nil {
-		cblogger.Errorf("Failed to Get the KeyPair with the keyName : ", err)
-		return irs.KeyPairInfo{}, err
+		newErr := fmt.Errorf("Failed to Get the KeyPair with the keyName : ", err)
+		cblogger.Error(newErr.Error())
+		return irs.KeyPairInfo{}, newErr
 	}
 	// spew.Dump(result)
 
@@ -180,16 +181,16 @@ func (keyPairHandler *KtCloudKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, er
 	//It is necessary to check in advance because it succeeds unconditionally without Keypair.
 	_, keyError := keyPairHandler.GetKey(keyIID)
 	if keyError != nil {
-		cblogger.Errorf("Failed to Get the KeyPair : [%s]", keyIID.SystemId)
-		cblogger.Error(keyError)
-		return false, keyError
+		newErr := fmt.Errorf("Failed to Get the KeyPair : [%s], [%v]", keyIID.SystemId, keyError)
+		cblogger.Error(newErr.Error())
+		return false, newErr
 	}
 
 	result, err := keyPairHandler.Client.DeleteSSHKeyPair(keyIID.NameId)
 	if err != nil {
-		cblogger.Errorf("Failed to Delete the KeyPair : %s, %v", keyIID.NameId, err)
-		spew.Dump(err)
-		return false, err
+		newErr := fmt.Errorf("Failed to Delete the KeyPair : %s, %v", keyIID.NameId, err)
+		cblogger.Error(newErr.Error())
+		return false, newErr
 	}
 	cblogger.Infof("Deletion result on KT Cloud : %s", result.Deletesshkeypairresponse.Success)
 

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/VMHandler.go
@@ -18,11 +18,10 @@ import (
 	"fmt"
 	"strconv"
 	// "encoding/base64"
-	// "log"
 	"io"
 	"strings"
 	"time"
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	cblog "github.com/cloud-barista/cb-log"
@@ -308,15 +307,15 @@ func (vmHandler *KtCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 	LoggingInfo(callLogInfo, callLogStart)
 	//spew.Dump(newVM)
 	
-	jobResult, err := vmHandler.Client.QueryAsyncJobResult(newVM.Deployvirtualmachineresponse.JobId)
-	if err != nil {
-		cblogger.Errorf("Failed to Get the Job Result: [%v]", err)
-		return irs.VMInfo{}, err
+	// jobResult, queryErr := vmHandler.Client.QueryAsyncJobResult(newVM.Deployvirtualmachineresponse.JobId)
+	_, queryErr := vmHandler.Client.QueryAsyncJobResult(newVM.Deployvirtualmachineresponse.JobId)
+	if queryErr != nil {
+		newErr := fmt.Errorf("Failed to Get the Job Result: [%v]", queryErr)
+		cblogger.Error(newErr.Error())
+		return irs.VMInfo{}, newErr
 	}
-	cblogger.Info("\n### QueryAsyncJobResultResponse : ")
-	// spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult.Virtualmachine[0])
-	spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
-	// spew.Dump(jobResult)
+	// cblogger.Info("\n### QueryAsyncJobResultResponse : ")
+	// spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
 
 	if strings.EqualFold(newVM.Deployvirtualmachineresponse.ID, "") {
 		newErr := fmt.Errorf("Failed to Find the VM Instance ID!!")
@@ -721,8 +720,9 @@ func (vmHandler *KtCloudVMHandler) GetVM(vmIID irs.IID) (irs.VMInfo, error) {
 	
 	vmInfo, err := vmHandler.mappingVMInfo(&result.Listvirtualmachinesresponse.Virtualmachine[0])
 	if err != nil {
-		cblogger.Errorf("Failed to Map the VM info: [%v]", err)
-		return irs.VMInfo{}, err
+		newErr := fmt.Errorf("Failed to Map the VM info: [%v]", err)
+		cblogger.Error(newErr.Error())
+		return irs.VMInfo{}, newErr
 	}
 	return vmInfo, nil
 }
@@ -772,12 +772,14 @@ func (vmHandler *KtCloudVMHandler) SuspendVM(vmIID irs.IID) (irs.VMStatus, error
 			return "", err
 		}
 		
-		jobResult, err := vmHandler.Client.QueryAsyncJobResult(result.Stopvirtualmachineresponse.JobId)
-		if err != nil {
-			cblogger.Errorf("Failed to Get Job Result: [%v]", err)	
-			return "", err
-		}		
-		spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
+		// jobResult, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Stopvirtualmachineresponse.JobId)
+		_, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Stopvirtualmachineresponse.JobId)
+		if queryErr != nil {
+			newErr := fmt.Errorf("Failed to Get Job Result: [%v]", queryErr)
+			cblogger.Error(newErr.Error())
+			return "", newErr
+		}
+		// spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
 
 		//===================================
 		// 15-second wait for Suspending
@@ -858,12 +860,14 @@ func (vmHandler *KtCloudVMHandler) ResumeVM(vmIID irs.IID) (irs.VMStatus, error)
 			return "", err
 		}
 		
-		jobResult, err := vmHandler.Client.QueryAsyncJobResult(result.Startvirtualmachineresponse.JobId)
-		if err != nil {
-			cblogger.Errorf("Failed to Get the Job Result : [%v]", err)	
-			return "", err
-		}		
-		spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
+		// jobResult, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Startvirtualmachineresponse.JobId)
+		_, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Startvirtualmachineresponse.JobId)
+		if queryErr != nil {
+			newErr := fmt.Errorf("Failed to Get Job Result: [%v]", queryErr)
+			cblogger.Error(newErr.Error())
+			return "", newErr
+		}
+		// spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
 
 		//===================================
 		// 60-second wait for Suspending
@@ -937,12 +941,14 @@ func (vmHandler *KtCloudVMHandler) RebootVM(vmIID irs.IID) (irs.VMStatus, error)
 			return "", err
 		}
 		
-		jobResult, err := vmHandler.Client.QueryAsyncJobResult(result.Rebootvirtualmachineresponse.JobId)
-		if err != nil {
-			cblogger.Errorf("Failed to Get the Job Result : [%v]", err)	
-			return "", err
-		}		
-		spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
+		// jobResult, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Rebootvirtualmachineresponse.JobId)
+		_, queryErr := vmHandler.Client.QueryAsyncJobResult(result.Rebootvirtualmachineresponse.JobId)
+		if queryErr != nil {
+			newErr := fmt.Errorf("Failed to Get Job Result: [%v]", queryErr)
+			cblogger.Error(newErr.Error())
+			return "", newErr
+		}
+		// spew.Dump(jobResult.Queryasyncjobresultresponse.JobResult)
 
 		// ===================================
 		// 15-second wait for Rebooting
@@ -1709,7 +1715,8 @@ func (vmHandler *KtCloudVMHandler) associateIpAddress() (string, string, error) 
 		if len(resp.Listpublicipaddressesresponse.PublicIpAddress) > 0 {
 			publicIp = resp.Listpublicipaddressesresponse.PublicIpAddress[0].IpAddress
 			ipState := resp.Listpublicipaddressesresponse.PublicIpAddress[0].State
-			fmt.Printf("New Public IP : %s, IP State : %s\n", publicIp, ipState)
+
+			cblogger.Infof("New Public IP : %s, IP State : %s\n", publicIp, ipState)
 		} else {
 			return "", "", errors.New("Failed to Find the Public IP!!\n")
 		}
@@ -1817,15 +1824,17 @@ func (vmHandler *KtCloudVMHandler) createPortForwardingFirewallRules(sgSystemIDs
 					pfRulesReqInfo := ktsdk.ListPortForwardingRulesReqInfo {
 						ID:			pfRuleResponse.Createportforwardingruleresponse.ID,
 					}					
-					pfRulesResult, err := vmHandler.Client.ListPortForwardingRules(pfRulesReqInfo)
-					if err != nil {
-						cblogger.Errorf("Failed to Get PortForwarding Rule List : [%v]", err)
-						return false, err
+					// pfRulesResult, listErr := vmHandler.Client.ListPortForwardingRules(pfRulesReqInfo)
+					_, listErr := vmHandler.Client.ListPortForwardingRules(pfRulesReqInfo)
+					if listErr != nil {
+						newErr := fmt.Errorf("Failed to Get PortForwarding Rule List : [%v]", listErr)
+						cblogger.Error(newErr.Error())
+						return false, newErr
 					} else {
 						cblogger.Info("# Succeeded in Getting PortForwarding Rule List!!")
 					}
-					cblogger.Info("### PortForwarding Rule List : ")
-					spew.Dump(pfRulesResult.Listportforwardingrulesresponse.PortForwardingRule)
+					// cblogger.Info("### PortForwarding Rule List : ")
+					// spew.Dump(pfRulesResult.Listportforwardingrulesresponse.PortForwardingRule)
 				}
 
 				// ### KT Cloud 'Firewall Rules' Setting for 'ICMP' protocol
@@ -1855,14 +1864,16 @@ func (vmHandler *KtCloudVMHandler) createPortForwardingFirewallRules(sgSystemIDs
 					firewallListReqInfo := ktsdk.ListFirewallRulesReqInfo {
 						ID:	firewallRuleResponse.Createfirewallruleresponse.ID,
 					}					
-					firewallRulesResult, err := vmHandler.Client.ListFirewallRules(firewallListReqInfo)
-					if err != nil {
-						cblogger.Errorf("Failed to Get List of Firewall Rules : [%v]", err)
-						return false, err
+					// firewallRulesResult, listError := vmHandler.Client.ListFirewallRules(firewallListReqInfo)
+					_, listError := vmHandler.Client.ListFirewallRules(firewallListReqInfo)
+					if listError != nil {
+						newErr := fmt.Errorf("Failed to Get Firewall Rule List : [%v]", listError)
+						cblogger.Error(newErr.Error())
+						return false, newErr
 					} else {
 						cblogger.Info("# Succeeded in Getting List of Firewall Rules!!")
 					}
-					spew.Dump(firewallRulesResult.Listfirewallrulesresponse.FirewallRule)
+					// spew.Dump(firewallRulesResult.Listfirewallrulesresponse.FirewallRule)
 				}
 			}
 		}

--- a/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloud/resources/VMSpecHandler.go
@@ -15,7 +15,6 @@ import (
 	ktsdk "github.com/cloud-barista/ktcloud-sdk-go"
 
 	"errors"
-	"fmt"
 	"strings"
 	"strconv"
 	// "github.com/davecgh/go-spew/spew"
@@ -195,7 +194,7 @@ func mappingVMSpecInfo(ZoneId string, ImageId string, ktServerProductType ktsdk.
 	// Split 함수로 문자열을 " "(공백) 기준으로 분리
 	specSlice := strings.Split(ktVMSpecString, " ")
 	for _, str := range specSlice {
-		fmt.Println(str)
+		cblogger.Infof("Splited string : [%s]", str)
 	}
 
 	// KT Cloud에서 core 수를 '4vcore' or '16vCore'와 같은 형태로 제공함.(String 처리시 자리수, 대수문자 주의 필요)

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/CommonKTCloudFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/CommonKTCloudFunc.go
@@ -12,7 +12,6 @@ package resources
 
 import (
 	"os"
-	"os/exec"
 	"fmt"
 	"strings"
 	"sync"
@@ -179,32 +178,6 @@ func reverse(s string) (result string) {
 		result = string(v) + result
 	}
 	return 
-}
-
-func runCommand(cmdName string, cmdArgs []string) (string, error) {
-	/*
-	Ref)
-	var (
-		cmdOut []byte
-		cmdErr   error		
-	)
-	*/
-	cblogger.Infof("cmdName : %s", cmdName)
-	cblogger.Infof("cmdArgs : %s", cmdArgs)
-
-	//if cmdOut, cmdErr = exec.Command(cmdName, cmdArgs...).Output(); cmdErr != nil {
-	if cmdOut, cmdErr := exec.Command(cmdName, cmdArgs...).CombinedOutput(); cmdErr != nil {
-		fmt.Fprintln(os.Stderr, "There was an Error running command : ", cmdErr)
-		//panic("Can't exec the command: " + cmdErr1.Error())
-		fmt.Println(fmt.Sprint(cmdErr) + ": " + string(cmdOut))
-		os.Exit(1)
-
-		return string(cmdOut), cmdErr
-	} else {
-	fmt.Println("cmdOut : ", string(cmdOut))
-
-	return string(cmdOut), nil
-	}
 }
 
 // Convert Cloud Object to JSON String type

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/DiskHandler.go
@@ -579,7 +579,7 @@ func (diskHandler *KTVpcDiskHandler) mappingDiskInfo(volume volumes2.Volume) (ir
         // fmt.Printf("Image Name: %s\n", imageName)
 		keyValue = irs.KeyValue{Key: "ImageName", Value: imageName}		
     } else {
-        fmt.Println("Image Name not found in volume info.")
+		cblogger.Info("Image Name not found in volume info.")
     }
 	keyValueList = append(keyValueList, keyValue)
 	diskInfo.KeyValueList = keyValueList
@@ -613,13 +613,13 @@ func (diskHandler *KTVpcDiskHandler) getImageNameandIDWithDiskID(diskId string) 
 		// Extract the image name
 		imageName, ok := diskResult.VolumeImageMetadata["image_name"]
 		if !ok {
-			fmt.Println("Image Name not found")
+			cblogger.Info("Image Name not found")
 		}
 
 		// Extract the image id
 		imageId, ok := diskResult.VolumeImageMetadata["image_id"]
 		if !ok {
-			fmt.Println("Image ID not found")
+			cblogger.Info("Image ID not found")
 		}
 		
 		if !strings.EqualFold(imageName, "") && !strings.EqualFold(imageId, "") {

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/MyImageHandler.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 	_ "time/tzdata" // To prevent 'unknown time zone Asia/Seoul' error
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	ktvpcsdk 	"github.com/cloud-barista/ktcloudvpc-sdk-go"
 	// volumes2 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/blockstorage/v2/volumes"
@@ -68,9 +68,9 @@ func (myImageHandler *KTVpcMyImageHandler) SnapshotVM(snapshotReqInfo irs.MyImag
 	loggingInfo(callLogInfo, start)
 	cblogger.Infof("\n\n# snapShotImageId : [%s]\n", volumeImage.ImageID)
 
-	cblogger.Info("\n\n### volumeImage : ")
-	spew.Dump(volumeImage)
-	cblogger.Info("\n")
+	// cblogger.Info("\n\n### volumeImage : ")
+	// spew.Dump(volumeImage)
+	// cblogger.Info("\n")
 
 	// To Wait for Creating a Snapshot Image
 	newImageIID := irs.IID{SystemId: volumeImage.ImageID}
@@ -138,9 +138,9 @@ func (myImageHandler *KTVpcMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, er
 	}
 	loggingInfo(callLogInfo, start)
 	
-	cblogger.Info("\n\n### ktImageList : ")
-	spew.Dump(ktImageList)
-	cblogger.Info("# ktImage count : ", len(ktImageList))
+	// cblogger.Info("\n\n### ktImageList : ")
+	// spew.Dump(ktImageList)
+	// cblogger.Info("# ktImage count : ", len(ktImageList))
 
 	// Note) Public image : ktImage.Visibility == "public", MyImage : ktImage.Visibility == "shared"
 	var imageInfoList []*irs.MyImageInfo

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/NLBHandler.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"strconv"
 	"time"
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -1063,10 +1063,9 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatForNLB(ktNLB *ktvpclb.LoadBala
 	}
 	cblogger.Info("\n### Creating the Static NAT to the NLB!!")
 	time.Sleep(time.Second * 3)
+	// cblogger.Info("\n\n### natResult")
+	// spew.Dump(natResult)
 	cblogger.Infof("\n# Static NAT ID : [%s]", natResult.ID)
-
-	cblogger.Info("\n\n### natResult")
-	spew.Dump(natResult)
 
 	// ### Set FireWall Rules ("Inbound" FireWall Rules)
 	vpcHandler := KTVpcVPCHandler{
@@ -1096,7 +1095,7 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatForNLB(ktNLB *ktvpclb.LoadBala
 		cblogger.Errorf("Failed to Get Dest Net Band : [%v]", err)			
 		return "", "", err
 	} else {
-		fmt.Println(destCIDR)
+		cblogger.Infof("Dest CIDR : %s", destCIDR)
 	}
 
 	tierId, getError := vpcHandler.getTierIdWithOsNetworkId(vpcId, ktNLB.NetworkID)

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/SecurityHandler.go
@@ -299,15 +299,11 @@ func (securityHandler *KTVpcSecurityHandler) DeleteSecurity(securityIID irs.IID)
 	}
 
 	// To Remove the S/G file on the Local machine.
-	cmdName := "rm"
-	cmdArgs := []string{sgFileName}
-
-	if cmdOut, cmdErr := runCommand(cmdName, cmdArgs); cmdErr != nil {
-		cblogger.Errorf("Failed to run the command to remove the S/G file.")
-		return false, cmdErr
-	} else {
-		cblogger.Infof("Succeeded in Deleting the S/G File!!")
-		cblogger.Infof("cmdOut : " + cmdOut)
+	delErr := os.Remove(sgFileName) 
+	if delErr != nil {
+		newErr := fmt.Errorf("Failed to Delete the file : %s, [%v]", sgFileName, delErr)
+		cblogger.Error(newErr.Error())
+		return false, newErr
 	}
 	cblogger.Infof("Succeeded in Deleting the SecurityGroup : " + securityIID.SystemId)
 

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/VMHandler.go
@@ -970,8 +970,8 @@ func (vmHandler *KTVpcVMHandler) createPortForwardingFirewallRules(vpcIID irs.II
 					if err != nil {
 						cblogger.Errorf("Failed to Get Dest Net Band : [%v]", err)			
 						return false, err
-					} else {
-						fmt.Println(destCIDR)
+					} else {						
+						cblogger.Infof("Dest CIDR : %s", destCIDR)
 					}
 
 					// After Port-Forwarding Creation!!
@@ -1051,10 +1051,10 @@ func (vmHandler *KTVpcVMHandler) createPortForwardingFirewallRules(vpcIID irs.II
 
 					srcCIDR, err := ipToCidr32(privateIP) // Output format ex) "172.25.1.5/32",  ipToCidr24() : Output format ex) "172.25.1.0/24"
 					if err != nil {
-						cblogger.Errorf("Failed to Get Dest Net Band : [%v]", err)			
+						cblogger.Errorf("Failed to Get Source Net Band : [%v]", err)			
 						return false, err
 					} else {
-						fmt.Println(srcCIDR)
+						cblogger.Infof("Source CIDR : %s", srcCIDR)
 					}
 
 					// Set FireWall Rules

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/CommonNcpFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/CommonNcpFunc.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 	"os"
-	"os/exec"
 	"strings"
 	"math/rand"
 
@@ -118,34 +117,6 @@ func Reverse(s string) (result string) {
 		result = string(v) + result
 	}
 	return 
-}
-
-func RunCommand(cmdName string, cmdArgs []string) (string, error) {
-
-	/*
-	Ref)
-	var (
-		cmdOut []byte
-		cmdErr   error		
-	)
-	*/
-
-	cblogger.Infof("cmdName : %s", cmdName)
-	cblogger.Infof("cmdArgs : %s", cmdArgs)
-
-	//if cmdOut, cmdErr = exec.Command(cmdName, cmdArgs...).Output(); cmdErr != nil {
-	if cmdOut, cmdErr := exec.Command(cmdName, cmdArgs...).CombinedOutput(); cmdErr != nil {
-		fmt.Fprintln(os.Stderr, "There was an error running command: ", cmdErr)
-		//panic("Can't exec the command: " + cmdErr1.Error())
-		fmt.Println(fmt.Sprint(cmdErr) + ": " + string(cmdOut))
-		os.Exit(1)
-
-		return string(cmdOut), cmdErr
-	} else {
-	fmt.Println("cmdOut : ", string(cmdOut))
-
-	return string(cmdOut), nil
-	}
 }
 
 func convertTimeFormat(inputTime string) (time.Time, error) {

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/NLBHandler.go
@@ -581,18 +581,22 @@ func (nlbHandler *NcpNLBHandler) GetListenerInfo(nlb lb.LoadBalancerInstance) (i
 		Port: 		strconv.FormatInt(int64(*nlb.LoadBalancerRuleList[0].LoadBalancerPort), 10),
 		DNSName:	*nlb.DomainName,
 	}
-	virtualIPs := strings.Split(*nlb.VirtualIp, ",")	
+
+	virtualIPs := strings.Split(*nlb.VirtualIp, ",")
+
 	if len(virtualIPs) >= 2 {
-		fmt.Println("First part:", virtualIPs[0])
+		cblogger.Infof("First part: %s", virtualIPs[0])
 		listenerInfo.IP = virtualIPs[0]
 	} else {
-		fmt.Println("nlb.VirtualIp does not contain a comma.")
+		cblogger.Info("nlb.VirtualIp does not contain a comma.")
 		listenerInfo.IP = *nlb.VirtualIp
 	}
+
 	listenerKVList := []irs.KeyValue{
 		// {Key: "NLB_DomainName", Value: *nlb.DomainName},
 	}
 	listenerInfo.KeyValueList = listenerKVList
+	
 	return listenerInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/PriceInfoHandler.go
@@ -238,7 +238,7 @@ func (priceInfoHandler *NcpPriceInfoHandler) GetPriceInfo(productFamily string, 
 		}
 	}
 	if found {
-		fmt.Printf("The ProductFamily '%s' is Included in the ProductFamily.\n", productFamily)
+		cblogger.Infof("The ProductFamily '%s' is Included in the ProductFamily.\n", productFamily)
 	} else {
 		newErr := fmt.Errorf("The ProductFamily '%s' is Not Included in the ProductFamily.\n", productFamily)
 		cblogger.Error(newErr.Error())
@@ -284,7 +284,7 @@ func (priceInfoHandler *NcpPriceInfoHandler) GetPriceInfo(productFamily string, 
 					regionCode = price.Region.RegionCode
 					break
 				}
-				fmt.Printf("RegionCode: %s\n", price.Region.RegionCode)
+				cblogger.Infof("RegionCode: %s\n", price.Region.RegionCode)
 			}
 
 			var pricingPolicies []irs.PricingPolicies
@@ -344,7 +344,7 @@ func (priceInfoHandler *NcpPriceInfoHandler) GetPriceInfo(productFamily string, 
 					regionCode = price.Region.RegionCode
 					break
 				}
-				fmt.Printf("RegionCode: %s\n", price.Region.RegionCode)
+				cblogger.Infof("RegionCode: %s\n", price.Region.RegionCode)
 			}
 
 			var pricingPolicies []irs.PricingPolicies

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -248,7 +248,7 @@ func (vmHandler *NcpVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 
 	// Create a Public IP for the New VM
 	// Caution!!) The number of Public IPs cannot be more than the number of instances on NCP cloud default service.
-	time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 5)
 	cblogger.Info("### Start Creating a Public IP!!")
 	publicIpReq := server.CreatePublicIpInstanceRequest{
 		ServerInstanceNo: 	runResult.ServerInstanceList[0].ServerInstanceNo,
@@ -358,7 +358,7 @@ func (vmHandler *NcpVMHandler) MappingServerInfo(NcpInstance *server.ServerInsta
 		cblogger.Errorf("Failed to Find Any BlockStorageInstance!!")
 		return irs.VMInfo{}, errors.New("Failed to Find Any BlockStorageInstance.")
 	}
-	cblogger.Infof("Succeeded in Getting Block Storage InstanceList!!")
+	cblogger.Info("Succeeded in Getting Block Storage InstanceList!!")
 	// spew.Dump(blockStorageResult.BlockStorageInstanceList[0])
 
 	var sgList []irs.IID
@@ -367,7 +367,7 @@ func (vmHandler *NcpVMHandler) MappingServerInfo(NcpInstance *server.ServerInsta
 			sgList = append(sgList, irs.IID{NameId: *acg.AccessControlGroupName, SystemId: *acg.AccessControlGroupConfigurationNo})
 		}
 	} else {
-		fmt.Println("AccessControlGroupList is empty or nil")
+		cblogger.Info("AccessControlGroupList is empty or nil")
 	}
 
 	// To Get the VM resources Info.
@@ -1795,7 +1795,7 @@ func (vmHandler *NcpVMHandler) checkAndSetZoneNoList(regionNo string, zoneCode s
 			}
 		}
 	} else {
-		fmt.Printf("Region No '%s' not found from the Map. So Set ZoneNo List!!\n", regionNo)
+		cblogger.Infof("Region No '%s' not found from the Map. So Set ZoneNo List!!\n", regionNo)
 
 		err := vmHandler.setZoneNoList()
 		if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/ImageHandler.go
@@ -12,8 +12,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 	cblog "github.com/cloud-barista/cb-log"
@@ -83,28 +82,28 @@ func (imageHandler *NcpVpcImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	ncpVpcRegion := imageHandler.RegionInfo.Region
 	cblogger.Infof("imageHandler.RegionInfo.Region : [%s}", ncpVpcRegion)
 
-	// Search NCP VPC All Region
-	if len(ncpVpcRegion) > 0 {
-		regionListReq := vserver.GetRegionListRequest{}
+	// // Search NCP VPC All Region
+	// if len(ncpVpcRegion) > 0 {
+	// 	regionListReq := vserver.GetRegionListRequest{}
 
-		regionListResult, err := imageHandler.VMClient.V2Api.GetRegionList(&regionListReq)
-		if err != nil {
-			cblogger.Error(*regionListResult.ReturnMessage)
-			newErr := fmt.Errorf("Failed to Get Region list!! : [%v]", err)
-			cblogger.Error(newErr.Error())
-			LoggingError(callLogInfo, newErr)
-		}
+	// 	regionListResult, err := imageHandler.VMClient.V2Api.GetRegionList(&regionListReq)
+	// 	if err != nil {
+	// 		cblogger.Error(*regionListResult.ReturnMessage)
+	// 		newErr := fmt.Errorf("Failed to Get Region list!! : [%v]", err)
+	// 		cblogger.Error(newErr.Error())
+	// 		LoggingError(callLogInfo, newErr)
+	// 	}
 
-		if *regionListResult.TotalRows < 1 {
-			cblogger.Info("### Region info does Not Exist!!")
-		}  else {
-			cblogger.Infof("Succeeded in Getting NCP VPC Region list!! : ")
-		}
+	// 	if *regionListResult.TotalRows < 1 {
+	// 		cblogger.Info("### Region info does Not Exist!!")
+	// 	}  else {
+	// 		cblogger.Infof("Succeeded in Getting NCP VPC Region list!! : ")
+	// 	}
 
-		cblogger.Infof("# Supporting All Region (by NCP VPC) Count : [%d]", len(regionListResult.RegionList))
-		cblogger.Info("\n# Supporting All Region (by NCP VPC) List : ")
-		spew.Dump(regionListResult.RegionList)
-	}
+	// 	cblogger.Infof("# Supporting All Region (by NCP VPC) Count : [%d]", len(regionListResult.RegionList))
+	// 	cblogger.Info("\n# Supporting All Region (by NCP VPC) List : ")
+	// 	spew.Dump(regionListResult.RegionList)
+	// }
 
 	imageReq := vserver.GetServerImageProductListRequest{
 		ProductCode:  	nil,

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/NLBHandler.go
@@ -15,8 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	ncloud "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
@@ -159,8 +158,8 @@ func (nlbHandler *NcpVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB
 
 	// To Get Subnet No list
 	subnetNoList := []*string{ncloud.String(lbTypeSubnetId)}
-	cblogger.Infof("\n### ID list of 'LB Type' Subnet : ")
-	spew.Dump(subnetNoList)
+	// cblogger.Infof("\n### ID list of 'LB Type' Subnet : ")
+	// spew.Dump(subnetNoList)
 
 	// Note!! : SubnetNoList[] : Range constraints: Minimum range of 1. Maximum range of 2.
 	if len(subnetNoList) < 1 || len(subnetNoList) > 2 {

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/PriceInfoHandler.go
@@ -220,7 +220,7 @@ func (priceInfoHandler *NcpVpcPriceInfoHandler) GetPriceInfo(productFamily strin
 		}
 	}
 	if found {
-		fmt.Printf("The ProductFamily '%s' is Included in the ProductFamily.\n", productFamily)
+		cblogger.Infof("The ProductFamily '%s' is Included in the ProductFamily.\n", productFamily)
 	} else {
 		newErr := fmt.Errorf("The ProductFamily '%s' is Not Included in the ProductFamily.\n", productFamily)
 		cblogger.Error(newErr.Error())
@@ -254,7 +254,7 @@ func (priceInfoHandler *NcpVpcPriceInfoHandler) GetPriceInfo(productFamily strin
 					regionCode = price.Region.RegionCode
 					break
 				}
-				fmt.Printf("RegionCode: %s\n", price.Region.RegionCode)
+				cblogger.Infof("RegionCode: %s\n", price.Region.RegionCode)
 			}
 
 			var pricingPolicies []irs.PricingPolicies
@@ -310,7 +310,7 @@ func (priceInfoHandler *NcpVpcPriceInfoHandler) GetPriceInfo(productFamily strin
 					regionCode = price.Region.RegionCode
 					break
 				}
-				fmt.Printf("RegionCode: %s\n", price.Region.RegionCode)
+				cblogger.Infof("RegionCode: %s\n", price.Region.RegionCode)
 			}
 
 			var pricingPolicies []irs.PricingPolicies

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/SecurityHandler.go
@@ -17,10 +17,10 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	// "github.com/davecgh/go-spew/spew"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
-	"github.com/davecgh/go-spew/spew"
 
 	cblog "github.com/cloud-barista/cb-log"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
@@ -1012,14 +1012,14 @@ func (securityHandler *NcpVpcSecurityHandler) RemoveRules(sgIID irs.IID, securit
 		}
 	}
 
-	// Return Current S/G Info.
-	sgInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: sgNo})
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(callLogInfo, err)
-		return false, err
-	}
-	spew.Dump(sgInfo)
+	// // Return Current S/G Info.
+	// sgInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: sgNo})
+	// if err != nil {
+	// 	cblogger.Error(err.Error())
+	// 	LoggingError(callLogInfo, err)
+	// 	return false, err
+	// }
+	// spew.Dump(sgInfo)
 
 	return true, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/resources/VMHandler.go
@@ -37,6 +37,10 @@ type NcpVpcVMHandler struct {
 	VMClient       *vserver.APIClient
 }
 
+type nicOrderInt32 struct {
+	nicOrder *int32
+}
+
 const (
 	lnxUserName string = "cb-user"
 	winUserName string = "Administrator"
@@ -203,15 +207,7 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 		securityGroupIds = append(securityGroupIds, ncloud.String(sgID.SystemId))
 	}
 
-	type intType struct {
-		nicOrder *int32
-	}
-
-	temp := int32(0) // Convert Int data type to Int32 !!
-	i32 := intType{
-		nicOrder: &temp,
-	}
-	fmt.Println(*i32.nicOrder)
+	nicOrderInt32 := getNicOrderInt32(0)
 
 	//=========================================================
 	// VM Creation info. setting
@@ -230,7 +226,7 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 
 		// ### Caution!! : AccessControlGroup은 NCPVPC console의 VPC > 'Network ACL'이 아닌 Server > 'ACG'에 해당됨.
 		NetworkInterfaceList: 		[]*vserver.NetworkInterfaceParameter{
-			{ NetworkInterfaceOrder: i32.nicOrder, AccessControlGroupNoList: securityGroupIds}, 
+			{ NetworkInterfaceOrder: nicOrderInt32, AccessControlGroupNoList: securityGroupIds}, 
 			// NetworkInterfaceNo를 입력하지 않으면 NetworkInterface가 자동 생성되어 적용됨.
 		},
 
@@ -1673,4 +1669,14 @@ func countSgKvList(sg sim.SecurityGroupInfo) int {
         return 0
     }
     return len(sg.KeyValueInfoList)
+}
+
+// Convert Int data type to Int32 type!!
+func getNicOrderInt32(initInt int) *int32 {
+	temp := int32(initInt)
+	i32 := nicOrderInt32{
+		nicOrder: &temp,
+	}
+	cblogger.Infof("NicOrderInt32 : [%d]", *i32.nicOrder)
+	return i32.nicOrder
 }

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/CommonNhnCloudFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/CommonNhnCloudFunc.go
@@ -14,8 +14,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
-
 	"strings"
 	"sync"
 	"time"
@@ -268,34 +266,6 @@ func reverse(s string) (result string) {
 		result = string(v) + result
 	}
 	return
-}
-
-func runCommand(cmdName string, cmdArgs []string) (string, error) {
-
-	/*
-		Ref)
-		var (
-			cmdOut []byte
-			cmdErr   error
-		)
-	*/
-
-	cblogger.Infof("cmdName : %s", cmdName)
-	cblogger.Infof("cmdArgs : %s", cmdArgs)
-
-	//if cmdOut, cmdErr = exec.Command(cmdName, cmdArgs...).Output(); cmdErr != nil {
-	if cmdOut, cmdErr := exec.Command(cmdName, cmdArgs...).CombinedOutput(); cmdErr != nil {
-		fmt.Fprintln(os.Stderr, "There was an Error running command : ", cmdErr)
-		//panic("Can't exec the command: " + cmdErr1.Error())
-		fmt.Println(fmt.Sprint(cmdErr) + ": " + string(cmdOut))
-		os.Exit(1)
-
-		return string(cmdOut), cmdErr
-	} else {
-		fmt.Println("cmdOut : ", string(cmdOut))
-
-		return string(cmdOut), nil
-	}
 }
 
 // Convert Cloud Object to JSON String type

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/NLBHandler.go
@@ -16,8 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -175,9 +174,10 @@ func (nlbHandler *NhnCloudNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLB
 	cblogger.Info("\n\n#### Waiting for Provisioning the New Pool!!")
 	time.Sleep(25 * time.Second)
 
-	newHealthMonitor, err := nlbHandler.createHealthMonitor(newPool.ID, nlbReqInfo)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Create HealthMonitor. [%v]", err.Error())
+	// newHealthMonitor, createErr := nlbHandler.createHealthMonitor(newPool.ID, nlbReqInfo)
+	_, createErr := nlbHandler.createHealthMonitor(newPool.ID, nlbReqInfo)
+	if createErr != nil {
+		newErr := fmt.Errorf("Failed to Create HealthMonitor. [%v]", createErr.Error())
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 
@@ -193,15 +193,16 @@ func (nlbHandler *NhnCloudNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLB
 
 		return irs.NLBInfo{}, newErr
 	}
-	cblogger.Info("\n\n# New Health Monitor : ")
-	spew.Dump(newHealthMonitor)
+	// cblogger.Info("\n\n# New Health Monitor : ")
+	// spew.Dump(newHealthMonitor)
 
 	cblogger.Info("\n\n#### Waiting for Provisioning the New Health Monitor!!")
 	time.Sleep(25 * time.Second)
 
-	newMembers, err := nlbHandler.createVMMembers(newPool.ID, nlbReqInfo.VMGroup)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", err.Error())
+	// newMembers, createError := nlbHandler.createVMMembers(newPool.ID, nlbReqInfo.VMGroup)
+	_, createError := nlbHandler.createVMMembers(newPool.ID, nlbReqInfo.VMGroup)
+	if createError != nil {
+		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", createError.Error())
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 
@@ -217,8 +218,8 @@ func (nlbHandler *NhnCloudNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (irs.NLB
 
 		return irs.NLBInfo{}, newErr
 	}
-	cblogger.Info("\n\n# New Members : ")
-	spew.Dump(newMembers)
+	// cblogger.Info("\n\n# New Members : ")
+	// spew.Dump(newMembers)
 
 	newFloatingIp, err := nlbHandler.createPublicIP(newNlb.VipPortID)
 	if err != nil {
@@ -407,15 +408,16 @@ func (nlbHandler *NhnCloudNLBHandler) ChangeVMGroupInfo(nlbIID irs.IID, vmGroup 
 		vmGroup.VMs = oldVMGroupInfo.VMs
 	}
 
-	newMembers, err := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, vmGroup)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", err.Error())
+	// newMembers, createErr := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, vmGroup)
+	_, createErr := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, vmGroup)
+	if createErr != nil {
+		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", createErr.Error())
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return irs.VMGroupInfo{}, newErr
 	}
-	cblogger.Info("\n\n# New Members : ")
-	spew.Dump(newMembers)
+	// cblogger.Info("\n\n# New Members : ")
+	// spew.Dump(newMembers)
 
 	newVMGroupNlbInfo, err := nlbHandler.GetNLB(nlbIID)
 	if err != nil {
@@ -472,15 +474,16 @@ func (nlbHandler *NhnCloudNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) 
 	}
 
 	newVMsInfo.VMs = vmIIDs
-	newMembers, err := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, newVMsInfo)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", err.Error())
+	// newMembers, createErr := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, newVMsInfo)
+	_, createErr := nlbHandler.createVMMembers(nlbInfo.VMGroup.CspID, newVMsInfo)
+	if createErr != nil {
+		newErr := fmt.Errorf("Failed to Create NLB Pool Members. [%v]", createErr.Error())
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return irs.VMGroupInfo{}, newErr
 	}
-	cblogger.Info("\n\n# New VM Members : ")
-	spew.Dump(newMembers)
+	// cblogger.Info("\n\n# New VM Members : ")
+	// spew.Dump(newMembers)
 
 	newVMGroupNlbInfo, err := nlbHandler.GetNLB(nlbIID)
 	if err != nil {


### PR DESCRIPTION
- Update NCP Classic/VPC driver, NHN Cloud driver, KT Cloud Classic/VPC driver
  - Remove fmt.Print and spew.Dump statements
  - Related issue : https://github.com/cloud-barista/cb-spider/issues/1207