### PR TITLE
[NCP Classic/VPC on AdminWeb] Update VMImage Name for VM Creation Testing

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-VM.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-VM.go
@@ -590,10 +590,10 @@ func VM(c echo.Context) error {
 		imageName = "16681742-f408-444d-a430-dd21a4bef42c"
 		specName = "ETRI-small-2"
 	case "NCP":
-		imageName = "SPSW0LINUX000130"
+		imageName = "SPSW0LINUX000052"
 		specName = "SPSVRHICPUSSD002"
 	case "NCPVPC":
-		imageName = "SW.VSVR.OS.LNX64.UBNTU.SVR1804.B050"
+		imageName = "SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050"
 		specName = "SVR.VSVR.HICPU.C004.M008.NET.SSD.B050.G002"
 	case "KTCLOUD":
 		imageName = "87838094-af4f-449f-a2f4-f5b4b581eb29"


### PR DESCRIPTION
- Update NCP Classic/VPC VMImage Name for VM Creation Testing on CB-Spider AdminWeb
  - Corresponding region/zone :  KR/KR-1