### PR TITLE
[NHN Cloud] Add 'VMSpecType' info to VMSpec KeyValue info

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMSpecHandler.go
@@ -163,7 +163,8 @@ func (vmSpecHandler *NhnCloudVMSpecHandler) mappingVMSpecInfo(vmSpec flavors.Fla
 		// Gpu:          []irs.GpuInfo{{Count: "N/A", Mfr: "N/A", Model: "N/A", Mem: "N/A"}},
 
 		KeyValueList: []irs.KeyValue{
-			{Key: "Region", Value: vmSpecHandler.RegionInfo.Region},
+			{Key: "Region", 		   Value: vmSpecHandler.RegionInfo.Region},
+			{Key: "VMSpecType", 	   Value: vmSpec.ExtraSpecs.FlavorType},			
 			{Key: "LocalDiskSize(GB)", Value: strconv.Itoa(vmSpec.Disk)},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/alibabacloud-go/vpc-20160428/v6 v6.4.0
 	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240123114820-8684cfc5deeb
 	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0
-	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240625103041-e12be4707a93
+	github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240709053216-536bc37fa6c9
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jeremywohl/flatten v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0 h1
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20240524035950-e31ad87778e0/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240625103041-e12be4707a93 h1:LuBViHtI740uRg6U5g/m//HXsaHLxnTdQIuk85S4XNc=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240625103041-e12be4707a93/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
+github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240709053216-536bc37fa6c9 h1:br7+CBDJEXofGPWUj79sldxuvrj4GNktmF6T8zVrVOk=
+github.com/cloud-barista/nhncloud-sdk-go v0.0.0-20240709053216-536bc37fa6c9/go.mod h1:G+VjfmHi5IUt0oe14A5UXmbrGFlMTMQjLonBuvjy8Yc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
- Update NHN Cloud VMSpecHandler
  - Add 'VMSpecType' info to VMSpec KeyValue info
![image](https://github.com/cloud-barista/cb-spider/assets/51111668/0241cc70-ae8e-4f7f-afcd-491fba2fcb94)

- Update go.mod and go.sum
  - Update nhncloud-sdk-go version