### PR TITLE
alibaba fix price data is nil

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
@@ -585,7 +585,9 @@ func BindpricingPolicy(priceResp AliPriceInfo, subscriptionType string, pricingM
 		resultModuleDetailPrice := priceResp.Data.ModuleDetails.ModuleDetail[0]
 		pricingPolicy.Price = strconv.FormatFloat(resultModuleDetailPrice.Price, 'f', -1, 64)
 	} else {
-		return irs.PricingPolicies{}, errors.New("No Price Data")
+		// return irs.PricingPolicies{}, errors.New("No Price Data") // https://github.com/cloud-barista/cb-spider/issues/1274
+		cblogger.Infof("No Price Data at PricingId[%s]", pricingPolicy.PricingId)
+		return pricingPolicy, nil
 	}
 
 	if len(priceResp.Data.PromotionDetails.PromotionDetail) > 0 {


### PR DESCRIPTION
https://github.com/cloud-barista/cb-spider/issues/1274

- Price 정책은 존재하지만, detail price 데이터가 없을때, 발생하는 오류 입니다.
- Infof 로 에러 대신하도록 수정했습니다.

```
cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
...
	} else {
		// return irs.PricingPolicies{}, errors.New("No Price Data") // https://github.com/cloud-barista/cb-spider/issues/1274
		cblogger.Infof("No Price Data at PricingId[%s]", pricingPolicy.PricingId)
		return pricingPolicy, nil
	}
...
```