### PR TITLE
AWS Region/Zone list lookup error in AdminWeb

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
@@ -34,7 +34,8 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 			defer wg.Done()
 
 			sess, err := session.NewSession(&aws.Config{
-				Region: region.RegionName,
+				Credentials: regionZoneHandler.Client.Config.Credentials,
+				Region:      region.RegionName,
 			})
 			if err != nil {
 				cblogger.Error(err)
@@ -94,7 +95,8 @@ func (regionZoneHandler *AwsRegionZoneHandler) GetRegionZone(Name string) (irs.R
 	for _, region := range responseRegions.Regions {
 		cblogger.Debug("#################### region.RegionName", region.RegionName)
 		sess, err := session.NewSession(&aws.Config{
-			Region: region.RegionName,
+			Credentials: regionZoneHandler.Client.Config.Credentials,
+			Region:      region.RegionName,
 		})
 		if err != nil {
 			cblogger.Error(err)
@@ -155,7 +157,8 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListOrgZone() (string, error) {
 	for _, region := range responseRegions.Regions {
 
 		sess, err := session.NewSession(&aws.Config{
-			Region: region.RegionName,
+			Credentials: regionZoneHandler.Client.Config.Credentials,
+			Region:      region.RegionName,
 		})
 		if err != nil {
 			cblogger.Errorf("NewSession err %s", *region.RegionName)


### PR DESCRIPTION
@dev4unet @powerkimhub 
https://github.com/cloud-barista/cb-spider/issues/1292
```
	sess, err := session.NewSession(&aws.Config{
		+ Credentials: regionZoneHandler.Client.Config.Credentials,
		Region:      region.RegionName,
	})
	if err != nil {
		cblogger.Error(err)
	}
	tempclient := ec2.New(sess)
```

Credentials: regionZoneHandler.Client.Config.Credentials 추가하여 기존 세션만 생성되던 부분 수정했습니다.