### PR TITLE
Resolved SnapshotId bug when deleting MyImage (Issue #1314)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -2258,13 +2258,13 @@ func readConfigFile() Config {
 }
 
 func main() {
-	//handleMyImage()
+	handleMyImage()
 	// myimage
 	//handleTag()
 	// handlePublicIP() // PublicIP 생성 후 conf
 	// handleDisk()
 
-	handleKeyPair()
+	//handleKeyPair()
 	//handleVPC()
 	//handleSecurity()
 	//handleVM()

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
@@ -564,8 +564,14 @@ func GetSnapshotIdFromEc2Image(ec2Image *ec2.Image) ([]string, error) {
 		// }
 		for _, blockDevice := range ec2Image.BlockDeviceMappings {
 			if !reflect.ValueOf(blockDevice.Ebs).IsNil() {
-				snapshotId := *blockDevice.Ebs.SnapshotId
-				snapshotIds = append(snapshotIds, snapshotId)
+				if !reflect.ValueOf(blockDevice.Ebs.SnapshotId).IsNil() {
+					snapshotId := *blockDevice.Ebs.SnapshotId
+					snapshotIds = append(snapshotIds, snapshotId)
+				} else {
+					cblogger.Error("SnapshotId information not found.")
+					// return snapshotIds, errors.New("SnapshotId information not found. Try again in a few minutes")
+					return snapshotIds, errors.New("The SnapshotId information could not be found in the block device mapping(Ebs) information, please try again in a moment")
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
[[AWS:MyImage] Access Nil Pointer](https://github.com/cloud-barista/cb-spider/issues/1314) bug fixed.

If the SnapshotId cannot be retrieved, it delivers the message below.
"The SnapshotId information could not be found in the block device mapping(Ebs) information, please try again in a moment"