### PR TITLE
[OpenStack] Fix zone control

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/DiskHandler.go
@@ -415,6 +415,13 @@ func (diskHandler *OpenstackDiskHandler) setterDisk(rawVolume volumes3.Volume) (
 	default:
 		info.Status = irs.DiskAttached
 	}
+
+	if diskHandler.Region.TargetZone != "" {
+		info.Zone = diskHandler.Region.TargetZone
+	} else if diskHandler.Region.Zone != "" {
+		info.Zone = diskHandler.Region.Zone
+	}
+
 	return info, nil
 }
 


### PR DESCRIPTION
## OpenStack
- [Add support to get VM's zone information](https://github.com/cloud-barista/cb-spider/commit/efbfbb2ff3633927ff72d055058d6dc295c8c9ac)
- [Fix floatingip API issue](https://github.com/cloud-barista/cb-spider/commit/8657aae1a829084cd44e4f02069474c56541c0a6)
- [Set target zone in disk handler](https://github.com/cloud-barista/cb-spider/commit/4c079bf121f6fbe832849f4a15d177845556477a)


- 특이사항
  - OpenStack에서 Disk는 Zone에 의존되지 않음.
  - AdminWeb을 통해 다른 Zone에 생성한 Disk도 드라이버 수준에서 Test_Resources.go를 통해 정상적으로 Attach 됨.
  - AdminWeb의 VM Provisioning Info에서도 생성한 VM의 Zone 정보와 Attach된 다른 존에 있는 Data Disk 정보가 올바르게 표시됨

   <img width="471" alt="image" src="https://github.com/user-attachments/assets/6914947d-c391-4e2e-90a2-77d20b90de44">
