### PR TITLE
[Azure, IBM, NHN, OpenStack] Force set test's log level to info

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
@@ -130,6 +130,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("CB-SPIDER")
+	cblog.SetLevel("info")
 }
 
 func readConfigFile() Config {

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/main/Test_Resources.go
@@ -223,6 +223,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("CB-SPIDER")
+	cblog.SetLevel("info")
 }
 
 func readConfigFile() Config {

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/main/Test_Resources.go
@@ -128,6 +128,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("CB-SPIDER")
+	cblog.SetLevel("info")
 }
 
 func readConfigFile() Config {

--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/Test_Resources.go
@@ -25,6 +25,7 @@ var cblogger *logrus.Logger
 func init() {
 	// cblog is a global variable.
 	cblogger = cblog.GetLogger("CB-SPIDER")
+	cblog.SetLevel("info")
 }
 
 func testImageHandlerListPrint() {


### PR DESCRIPTION
- Fix blank console ouput issue when global log level is set to error.