### PR TITLE
Ibm: add Disk, GPU information in VMSpec

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/VMSpecHandler.go
@@ -165,7 +165,7 @@ func getGpuCount(name string) string {
 	gpuDetails := specDetails[len(specDetails)-1]
 	for i, char := range gpuDetails {
 		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' {
-			return gpuDetails[:i] // 숫자 부분 반환
+			return gpuDetails[:i]
 		}
 	}
 	return "-1"


### PR DESCRIPTION
- Return Gpu Info data based on Profile Name pattern
- [Mfr]-[?]-[Mem(GB)]x[Count][Mdoel]
- gx2-16x128x2v100 -> 2 NIVIDIA V100 131072(MB)