### PR TITLE
Issue 1396 metadata vmspec for tencent

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ImageHandler.go
@@ -14,12 +14,14 @@ package resources
 import (
 	"context"
 	"errors"
+	"regexp"
 	"strconv"
 	"strings"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/sirupsen/logrus"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -28,6 +30,23 @@ type GCPImageHandler struct {
 	Ctx        context.Context
 	Client     *compute.Service
 	Credential idrv.CredentialInfo
+}
+
+var arrImageProjectList = []string{
+	"gce-uefi-images", // 보안 VM을 지원하는 이미지
+
+	//보안 VM을 지원하지 않는 이미지들
+	"centos-cloud",
+	"cos-cloud",
+	"coreos-cloud",
+	"debian-cloud",
+	"rhel-cloud",
+	"rhel-sap-cloud",
+	"suse-cloud",
+	"suse-sap-cloud",
+	"ubuntu-os-cloud",
+	"windows-cloud",
+	"windows-sql-cloud",
 }
 
 /*
@@ -80,22 +99,6 @@ func (imageHandler *GCPImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 	cblogger.Debug("Retrieve All VM Images")
 
 	//https://cloud.google.com/compute/docs/images?hl=ko
-	arrImageProjectList := []string{
-		"gce-uefi-images", // 보안 VM을 지원하는 이미지
-
-		//보안 VM을 지원하지 않는 이미지들
-		"centos-cloud",
-		"cos-cloud",
-		"coreos-cloud",
-		"debian-cloud",
-		"rhel-cloud",
-		"rhel-sap-cloud",
-		"suse-cloud",
-		"suse-sap-cloud",
-		"ubuntu-os-cloud",
-		"windows-cloud",
-		"windows-sql-cloud",
-	}
 
 	var imageList []*irs.ImageInfo
 
@@ -215,6 +218,11 @@ func (imageHandler *GCPImageHandler) ConvertGcpImageInfoToCbImageInfo(imageInfo 
 func (imageHandler *GCPImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, error) {
 	cblogger.Debug(imageIID)
 
+	// if 1 == 1 {
+	// 	//return imageHandler.GetImageN("ubuntu-1204-precise-v20141031")
+	// 	return imageHandler.GetImageN("ubuntu-1804-bionic-v20220505")
+	// }
+
 	//"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20200415"
 	//projectId := imageHandler.Credential.ProjectID
 	projectId := ""
@@ -258,6 +266,73 @@ func (imageHandler *GCPImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, 
 	callogger.Info(call.String(callLogInfo))
 	imageInfo := mappingImageInfo(image)
 	return imageInfo, nil
+}
+
+// getImage by name
+func (imageHandler *GCPImageHandler) GetImageN(imageName string) (irs.ImageInfo, error) {
+	projectId := ""
+	imageInfo := irs.ImageInfo{}
+
+	cblogger.SetLevel(logrus.InfoLevel)
+
+	targetOs := strings.Split(imageName, "-")[0]
+	cblogger.Debug("targetOs = ", targetOs)
+
+	// logger for HisCall
+	callogger := call.GetLogger("HISCALL")
+	callLogInfo := call.CLOUDLOGSCHEMA{
+		CloudOS:      call.GCP,
+		RegionZone:   imageHandler.Region.Zone,
+		ResourceType: call.VMIMAGE,
+		ResourceName: imageName,
+		CloudOSAPI:   "Images.Get()",
+		ElapsedTime:  "",
+		ErrorMSG:     "",
+	}
+	callLogStart := call.Start()
+
+	// ubuntu, window ....
+	for _, imgageProjectId := range arrImageProjectList {
+		if strings.Contains(imgageProjectId, targetOs) {
+			projectId = imgageProjectId
+			break
+		}
+	}
+	cblogger.Debug("projectId = ", projectId)
+	// if found
+	if projectId != "" {
+		gcpImage, err := imageHandler.Client.Images.Get(projectId, imageName).Do()
+		callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+		if err != nil {
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Info(call.String(callLogInfo))
+			cblogger.Info("try to get image by projectId ", projectId)
+		}
+
+		if gcpImage != nil {
+			imageInfo = mappingImageInfo(gcpImage)
+			return imageInfo, nil
+		}
+	}
+
+	callogger.Info("image not found at specific project url. try all project.")
+	// if not. query all
+	for _, imgageProjectId := range arrImageProjectList {
+		gcpImage, err := imageHandler.Client.Images.Get(imgageProjectId, imageName).Do()
+		callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+		if err != nil {
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Info(call.String(callLogInfo))
+			cblogger.Info("try to get image by all projectId ", projectId)
+			continue
+		}
+		imageInfo = mappingImageInfo(gcpImage)
+		return imageInfo, nil
+	}
+
+	// not found Image
+	return imageInfo, errors.New("Image not found." + imageName)
+
 }
 
 // 이슈 #239에 의해 Name 기반에서 URL 기반으로 로직 변경
@@ -619,41 +694,140 @@ func (imageHandler *GCPImageHandler) FindImageInfo(projectId string, reqImageNam
 }
 */
 
-// @TODO : 나중에 시스템아이디 값 변경해야 함.(현재 이미지 핸들러는 이름 기반으로 변경되어 있기 때문...)
 func mappingImageInfo(imageInfo *compute.Image) irs.ImageInfo {
 	//lArr := strings.Split(imageInfo.Licenses[0], "/")
 	//os := lArr[len(lArr)-1]
 
 	//cblogger.Info("===================================")
 
-	imageList := irs.ImageInfo{
-		IId: irs.IID{
-			NameId: imageInfo.SelfLink,
-			//NameId: imageInfo.Name, //2020-07-23 이미지 핸들러는 아직 생성 기능을 지원하지 않기 때문에 NameId대신 SystemId로 통일
-			//SystemId: imageInfo.Name, //자체 기능 구현을 위해 Name 기반으로 리턴함. - 2020-05-14 다음 버전에 적용 예정
-			SystemId: imageInfo.SelfLink, //2020-05-14 카푸치노는 VM 생성시 URL 방식을 사용하기 때문에 임의로 맞춤(이미지 핸들러의 다른 함수에는 적용 못함)
-			//SystemId: strconv.FormatUint(imageInfo.Id, 10), //이 값으로는 VM생성 안됨.
+	//"description": "Canonical, Ubuntu, 12.04 LTS,	amd64 precise image built on 2016-03-02",
+	//"description": "Microsoft, Windows Server, version 1709 Core for Containers (Beta), Server Core, x64 built on 2017-12-12",
+	//"description": "Canonical, Ubuntu, 18.04 LTS, amd64 bionic image built on 2022-05-05, supports Shielded VM features",
 
-			//SystemId: imageInfo.SourceImage, //imageInfo.SourceImage의 경우 공백("")인 경우가 있음
-		},
-		//Id:      strconv.FormatUint(imageInfo.Id, 10),
-		//Id:      imageInfo.SelfLink,
-		//Name:    imageInfo.Name,
-		GuestOS: imageInfo.Family,
-		Status:  imageInfo.Status,
-		KeyValueList: []irs.KeyValue{
-			{"Name", imageInfo.Name},
-			{"SourceImage", imageInfo.SourceImage}, // VM생성 시에는 SourceImage나 SelfLink 값을 이용해야 함.
-			{"SourceType", imageInfo.SourceType},
-			{"SelfLink", imageInfo.SelfLink},
-			//{"GuestOsFeature", imageInfo.GuestOsFeatures[0].Type},	//Data가 없는 경우가 있어서 필요한 경우 체크해야 함.
-			{"Family", imageInfo.Family},
-			{"DiskSizeGb", strconv.FormatInt(imageInfo.DiskSizeGb, 10)},
-		},
+	// 2024-12-23 ImageInfo changed for meta. IID, GuestOS, Status deprecated.
+	returnImageInfo := irs.ImageInfo{
+		// IId: irs.IID{
+		// 	NameId:   imageInfo.SelfLink,
+		// 	SystemId: imageInfo.SelfLink,
+		// },
+		// GuestOS: imageInfo.Family,
+		// Status:  imageInfo.Status,
+
+		Name:           imageInfo.Name,
+		OSArchitecture: extractOsArchitecture(imageInfo),
+		OSPlatform:     extractOsPlatform(imageInfo), // imageInfo.Description
+		OSDistribution: extractOsDistribution(imageInfo),
+		OSDiskType:     "NA",
+		OSDiskSizeInGB: strconv.FormatInt(imageInfo.DiskSizeGb, 10),
+		ImageStatus:    extractImageAvailability(imageInfo.Status),
 	}
 
-	return imageList
+	imageInfo.ShieldedInstanceInitialState = nil // 너무 길어 임시로 주석처리함.
+	convertKeyValueList, err := ConvertKeyValueList(imageInfo)
+	if err != nil {
+		returnImageInfo.KeyValueList = nil
+		cblogger.Error(err)
+	}
+	returnImageInfo.KeyValueList = convertKeyValueList
 
+	return returnImageInfo
+
+}
+
+// OS Platform (contains description or family, name)
+// "name": "ubuntu-1804-bionic-arm64-v20220712",
+func extractOsPlatform(orgImage *compute.Image) irs.OSPlatform {
+	platformInfo := orgImage.Name
+
+	osPlatform := irs.PlatformNA
+	if strings.Contains(strings.ToLower(platformInfo), "windows") {
+		osPlatform = irs.Windows
+	} else if strings.Contains(strings.ToLower(platformInfo), "ubuntu") ||
+		strings.Contains(strings.ToLower(platformInfo), "linux") ||
+		strings.Contains(strings.ToLower(platformInfo), "centos") ||
+		strings.Contains(strings.ToLower(platformInfo), "debian") ||
+		strings.Contains(strings.ToLower(platformInfo), "fedora") ||
+		strings.Contains(strings.ToLower(platformInfo), "rhel") ||
+		strings.Contains(strings.ToLower(platformInfo), "rocky") ||
+		strings.Contains(strings.ToLower(platformInfo), "unix") {
+		osPlatform = irs.Linux_UNIX
+	}
+
+	// "centos-cloud",
+	// "cos-cloud",
+	// "coreos-cloud",
+	// "debian-cloud",
+	// "rhel-cloud",
+	// "rhel-sap-cloud",
+	// "suse-cloud",
+	// "suse-sap-cloud",
+	// "ubuntu-os-cloud",
+	// "windows-cloud",
+	// "windows-sql-cloud",
+	return osPlatform
+}
+
+// OS Architecture
+// 2024-12 MAC OS not supported(ARM64, X86_64 from compute.Image)
+func extractOsArchitecture(orgImage *compute.Image) irs.OSArchitecture {
+	// if Architecture exists
+	if orgImage.Architecture != "" {
+		arch := strings.ToLower(orgImage.Architecture)
+		switch arch {
+		case "arm64":
+			return irs.OSArchitecture(orgImage.Architecture)
+		case "x86_64", "amd64":
+			return irs.OSArchitecture(orgImage.Architecture)
+		}
+	}
+
+	//
+	description := orgImage.Description
+	archRegex := regexp.MustCompile(`(?i)\b(mac|x64|amd64|x86|arm64|arm)\b`)
+
+	archMatch := archRegex.FindString(description)
+
+	osArchitecture := irs.ArchitectureNA
+	switch archMatch {
+	case "arm64":
+		if strings.Contains(strings.ToLower(description), "mac") {
+			osArchitecture = irs.ARM64_MAC
+		} else {
+			osArchitecture = irs.ARM64
+		}
+	case "x64", "amd64":
+		if strings.Contains(strings.ToLower(description), "mac") {
+			osArchitecture = irs.X86_64_MAC
+		} else {
+			osArchitecture = irs.X86_64
+		}
+	default:
+		osArchitecture = irs.ArchitectureNA
+	}
+
+	return osArchitecture
+}
+
+func extractOsDistribution(orgImage *compute.Image) string {
+	if orgImage.Description != "" {
+		return orgImage.Description
+	} else {
+		return orgImage.Name
+	}
+}
+
+// Image Status 추출
+func extractImageAvailability(status string) irs.ImageStatus {
+	//FAILED, PENDING, or READY
+	imageStatus := irs.ImageNA
+	if strings.Contains(strings.ToLower(status), "READY") {
+		imageStatus = irs.ImageAvailable
+	} else if strings.Contains(strings.ToLower(status), "FAILED") ||
+		strings.Contains(strings.ToLower(status), "PENDING") {
+		imageStatus = irs.ImageUnavailable
+	}
+
+	return imageStatus
 }
 
 // windows os 여부 return

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
@@ -3,7 +3,9 @@ package resources
 import (
 	"errors"
 	"reflect"
+	"regexp"
 	"strconv"
+	"strings"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -40,7 +42,8 @@ func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeInstanceTypeConfigsRequest()
+	request := cvm.NewDescribeZoneInstanceConfigInfosRequest()
+	// request := cvm.NewDescribeInstanceTypeConfigsRequest()
 	request.Filters = []*cvm.Filter{
 		&cvm.Filter{
 			Name:   common.StringPtr("zone"),
@@ -48,7 +51,9 @@ func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 		},
 	}
 	callLogStart := call.Start()
-	response, err := vmSpecHandler.Client.DescribeInstanceTypeConfigs(request)
+	//DescribeInstanceTypes 로 바뀐것인가?
+	response, err := vmSpecHandler.Client.DescribeZoneInstanceConfigInfos(request)
+	// response, err := vmSpecHandler.Client.DescribeInstanceTypeConfigs(request)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 
 	if err != nil {
@@ -64,21 +69,31 @@ func (vmSpecHandler *TencentVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 	callogger.Info(call.String(callLogInfo))
 
 	var vmSpecInfoList []*irs.VMSpecInfo
-	for _, curSpec := range response.Response.InstanceTypeConfigSet {
+	for _, curSpec := range response.Response.InstanceTypeQuotaSet {
 		cblogger.Debugf("[%s] VM Spec Information Processing", *curSpec.InstanceType)
 
-		vmSpecInfo := ExtractVMSpecInfo(curSpec)
+		vmSpecInfo := extractVmSpec(curSpec)
 		vmSpecInfoList = append(vmSpecInfoList, &vmSpecInfo)
 	}
+
+	// for _, curSpec := range response.Response.InstanceTypeConfigSet {
+	// 	cblogger.Debugf("[%s] VM Spec Information Processing", *curSpec.InstanceType)
+
+	// 	vmSpecInfo := ExtractVMSpecInfo(curSpec)
+	// 	vmSpecInfoList = append(vmSpecInfoList, &vmSpecInfo)
+	// }
 
 	cblogger.Debug(vmSpecInfoList)
 	//cblogger.Debug(vmSpecInfoList)
 	return vmSpecInfoList, nil
 }
 
-func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInfo, error) {
+func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(name string) (irs.VMSpecInfo, error) {
 	//cblogger.Infof("Start GetVMSpec(ZoneId:[%s], Name:[%s])", Region, Name)
-	cblogger.Infof("Spec Name:[%s]", Name)
+	//name = "MA5.LARGE32"
+	//name = "S2.SMALL1"
+	name = "GN7.20XLARGE320"
+	cblogger.Infof("Spec Name:[%s]", name)
 
 	zoneId := vmSpecHandler.Region.Zone
 	//zoneId := Region
@@ -93,13 +108,14 @@ func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 		CloudOS:      call.TENCENT,
 		RegionZone:   vmSpecHandler.Region.Zone,
 		ResourceType: call.VMSPEC,
-		ResourceName: Name,
+		ResourceName: name,
 		CloudOSAPI:   "DescribeInstanceTypeConfigs()",
 		ElapsedTime:  "",
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeInstanceTypeConfigsRequest()
+	//request := cvm.NewDescribeInstanceTypeConfigsRequest()
+	request := cvm.NewDescribeZoneInstanceConfigInfosRequest()
 	request.Filters = []*cvm.Filter{
 		&cvm.Filter{
 			Name:   common.StringPtr("zone"), //존으로 검색
@@ -107,11 +123,13 @@ func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 		},
 		&cvm.Filter{
 			Name:   common.StringPtr("instance-type"), //인스턴스 타입으로 검색
-			Values: common.StringPtrs([]string{Name}),
+			Values: common.StringPtrs([]string{name}),
 		},
 	}
 	callLogStart := call.Start()
-	response, err := vmSpecHandler.Client.DescribeInstanceTypeConfigs(request)
+	//response, err := vmSpecHandler.Client.DescribeInstanceTypeConfigs(request)
+	response, err := vmSpecHandler.Client.DescribeZoneInstanceConfigInfos(request)
+
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 
 	if err != nil {
@@ -126,8 +144,15 @@ func (vmSpecHandler *TencentVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 	//cblogger.Debug(response.ToJsonString())
 	callogger.Info(call.String(callLogInfo))
 
-	if len(response.Response.InstanceTypeConfigSet) > 0 {
-		vmSpecInfo := ExtractVMSpecInfo(response.Response.InstanceTypeConfigSet[0])
+	// if len(response.Response.InstanceTypeConfigSet) > 0 {
+	// 	vmSpecInfo := ExtractVMSpecInfo(response.Response.InstanceTypeConfigSet[0])
+	// 	cblogger.Debug(vmSpecInfo)
+	// 	return vmSpecInfo, nil
+	// } else {
+	// 	return irs.VMSpecInfo{}, errors.New("No information found")
+	// }
+	if len(response.Response.InstanceTypeQuotaSet) > 0 { // 요금제만 다른 같은 값이 오므로 0번째 선택해도 무방
+		vmSpecInfo := extractVmSpec(response.Response.InstanceTypeQuotaSet[0])
 		cblogger.Debug(vmSpecInfo)
 		return vmSpecInfo, nil
 	} else {
@@ -252,6 +277,92 @@ func (vmSpecHandler *TencentVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 		return "", errors.New("Unable to find information")
 
 	}
+}
+
+func extractVmSpec(instanceTypeInfo *cvm.InstanceTypeQuotaItem) irs.VMSpecInfo {
+	vCpuInfo := irs.VCpuInfo{}
+	// gpuInfoList := []irs.GpuInfo{}
+
+	//기본 정보
+	vmSpecInfo := irs.VMSpecInfo{
+		Name:   *instanceTypeInfo.InstanceType,
+		Region: *instanceTypeInfo.Zone,
+	}
+
+	//Memory 정보 처리
+	if !reflect.ValueOf(instanceTypeInfo.Memory).IsNil() {
+		vmSpecInfo.Mem = strconv.FormatInt(*instanceTypeInfo.Memory*1024, 10) // GB->MB로 변환
+	}
+
+	//VCPU 정보 처리 - Count
+	if !reflect.ValueOf(instanceTypeInfo.Cpu).IsNil() {
+		vCpuInfo.Count = strconv.FormatInt(*instanceTypeInfo.Cpu, 10)
+
+		// Clock 추출
+		//"Frequency": "-/3.1GHz", "Frequency": "2.5GHz/-", "Frequency": "2.5GHz/3.1GHz",
+
+		parts := strings.Split(*instanceTypeInfo.Frequency, "/")
+		var targetClock string
+
+		if parts[0] != "-" {
+			targetClock = parts[0] // 기본 주파수 우선
+		} else if len(parts) > 1 && parts[1] != "-" {
+			targetClock = parts[1] // 최대 터보 주파수 사용
+		} else {
+			targetClock = "-1"
+		}
+
+		re := regexp.MustCompile(`[-+]?([0-9]*\.[0-9]+|[0-9]+)`)
+		match := re.FindString(targetClock)
+
+		if match != "" {
+			targetClock = match
+		}
+		vCpuInfo.Clock = targetClock
+
+	}
+	vmSpecInfo.VCpu = vCpuInfo
+
+	cblogger.Info("instanceTypeInfo.Gpu ", *instanceTypeInfo.Gpu)
+	gpuInfoList := []irs.GpuInfo{}
+	//GPU 정보가 있는 인스터스는 GPU 처리
+	val := reflect.ValueOf(*instanceTypeInfo.Gpu)
+	//val int64 :: int64 ::: 4
+	cblogger.Info("instanceTypeInfo.Gpu val ", val.Kind(), " :: ", reflect.Int64, " ::: ", val.Int())
+	//if !reflect.ValueOf(*instanceTypeInfo.Gpu).IsNil() {
+	if val.Kind() == reflect.Int64 && val.Int() > 0 {
+		//vmSpecInfo.Gpu = []irs.GpuInfo{irs.GpuInfo{Count: strconv.FormatInt(*instanceTypeInfo.GPU, 10)}}
+		//GPUInfo
+
+		// 기본 값 설정
+		gpuInfo := irs.GpuInfo{
+			Count: "-1",
+			Model: "NA",
+			Mfr:   "NA",
+			Mem:   "0",
+		}
+		gpuInfo.Count = strconv.FormatInt(*instanceTypeInfo.Gpu, 10)
+
+		gpuInfoList = append(gpuInfoList, gpuInfo)
+	} else {
+		cblogger.Info("val.Kind() == reflect.Int64", val.Kind() == reflect.Int64)
+		cblogger.Info("val.Int() > 0", val.Int() > 0)
+	}
+	vmSpecInfo.Gpu = gpuInfoList
+
+	// Disk   string    `json:"Disk" validate:"required" example:"8"`           // Disk size in GB, "-1" when not applicable
+	vmSpecInfo.Disk = "-1"
+
+	//KeyValue 목록 처리
+	keyValueList, errKeyValue := ConvertKeyValueList(instanceTypeInfo)
+	if errKeyValue != nil {
+
+		cblogger.Error(errKeyValue)
+
+	}
+	vmSpecInfo.KeyValueList = keyValueList
+
+	return vmSpecInfo
 }
 
 // 인스턴스 스펙 정보를 추출함

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/swaggo/swag v1.16.3
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.0.415
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.964
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.493
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1064
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.0.206
 	golang.org/x/crypto v0.31.0
 	golang.org/x/oauth2 v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -648,11 +648,11 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.0.415 h1:ylKa86l
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.0.415/go.mod h1:XswWFMZ7ekTOWvZlUXr7I21pKyLuRAyZGgR5fMDTCyM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.415/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.492/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.493/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.964 h1:ET3EulYQvWrdD5FNwOP+196w5Vbniy/uRGucM5ILExQ=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.964/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.493 h1:AF2MJgVPvMYNCQSQ/UsiGgKokMZ2JQreYyjz/VKrNEI=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.493/go.mod h1:4c9rz1avM3qvpv6IrrWqe+j6LefpE0reUUwIUomzFg4=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1064 h1:cf/1W3Qh8/lHNkT0Y7Z8sVO+oaVApb0VKO+aiZ4vEgg=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1064/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064 h1:6WUrKJwDKao+kzT4cOj2HRi9hjOP6JC9g/25CYYXPyk=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064/go.mod h1:N7W89ge68ClQl0/EtEQtDhvkqziMw2NhcTiWtKKztI0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.964 h1:YxlaK/2zEyC6cL+1Cz0ZmN6lKghx46QgbdzEFddh9qM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.964/go.mod h1:2aiGewiAyHVnXdFT/PwYV0CNQt2Fq0sXcPiwhNtzbbE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.0.206 h1:O2leTYORlZlpVLHXUA6p1hqupEwaHtkHHvA7MGtDiUA=


### PR DESCRIPTION
Tencent 는 

- Spec 정보에 Disk 지원하지 않음.
- Spec 정보에 GPU의 count 외 정보가 없음. 별도의 gpu info api도 없음
- cpu clock의 경우 CPU의 기본 주파수(Base Frequency)와 최대 터보 주파수(Max Turbo Frequency) 를 병기하고 있음
    ex) 기본주파수/터보주파수 :   "Frequency": "-/3.1GHz", "Frequency": "2.5GHz/-", "Frequency": "2.5GHz/3.1GHz",
   기본주파수를 base로 둘다 있으면 기본주파수,  터보주파수만 있으면 터보주파수를 사용하도록
 
 api 버전 변경 : 기존 DescribeInstanceTypeConfigs가 DescribeZoneInstanceConfigInfos로 변경됨.
 as-is 
github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.964
github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.493

to-be
github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1064
github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064
