### PR TITLE
IBM: Fix loadbalancer connection issue

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
@@ -175,22 +175,6 @@ func (nlbHandler *IbmNLBHandler) DeleteNLB(nlbIID irs.IID) (bool, error) {
 		return false, delErr
 	}
 
-	securityHandler := IbmSecurityHandler{
-		CredentialInfo: nlbHandler.CredentialInfo,
-		Region:         nlbHandler.Region,
-		VpcService:     nlbHandler.VpcService,
-		Ctx:            nlbHandler.Ctx,
-		TaggingService: nlbHandler.TaggingService,
-		SearchService:  nlbHandler.SearchService,
-	}
-	_, err = securityHandler.DeleteSecurity(irs.IID{
-		NameId: "sg-" + nlbIID.NameId,
-	})
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-	}
-
 	LoggingInfo(hiscallInfo, start)
 
 	deleteUnusedTags(nlbHandler.TaggingService)
@@ -1495,6 +1479,22 @@ func (nlbHandler *IbmNLBHandler) cleanerNLB(nlbIID irs.IID) (bool, error) {
 	if !exist {
 		return false, errors.New("not found nlb")
 	}
+
+	securityHandler := IbmSecurityHandler{
+		CredentialInfo: nlbHandler.CredentialInfo,
+		Region:         nlbHandler.Region,
+		VpcService:     nlbHandler.VpcService,
+		Ctx:            nlbHandler.Ctx,
+		TaggingService: nlbHandler.TaggingService,
+		SearchService:  nlbHandler.SearchService,
+	}
+	_, err = securityHandler.DeleteSecurity(irs.IID{
+		NameId: "sg-" + nlbIID.NameId,
+	})
+	if err != nil {
+		cblogger.Error(err.Error())
+	}
+
 	rawNLB, err := nlbHandler.getRawNLBByName(nlbIID.NameId)
 	if err != nil {
 		return false, err

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
@@ -1229,6 +1229,21 @@ func (nlbHandler *IbmNLBHandler) createNLB(nlbReqInfo irs.NLBInfo) (vpcv1.LoadBa
 		},
 	}
 
+	poolArray, err := nlbHandler.getCreatePoolOptions(nlbReqInfo)
+	if err != nil {
+		return vpcv1.LoadBalancer{}, err
+	}
+	poolName := poolArray[0].Name
+
+	listenerArray, err := getCreateListenerOptions(nlbReqInfo, poolName)
+	if err != nil {
+		return vpcv1.LoadBalancer{}, err
+	}
+
+	createNLBOptions.SetSubnets(subnetArray)
+	createNLBOptions.SetPools(poolArray)
+	createNLBOptions.SetListeners(listenerArray)
+
 	securityHandler := IbmSecurityHandler{
 		CredentialInfo: nlbHandler.CredentialInfo,
 		Region:         nlbHandler.Region,
@@ -1270,21 +1285,6 @@ func (nlbHandler *IbmNLBHandler) createNLB(nlbReqInfo irs.NLBInfo) (vpcv1.LoadBa
 	securityGroupIdentityModel.ID = core.StringPtr(sg.IId.SystemId)
 
 	createNLBOptions.SetSecurityGroups([]vpcv1.SecurityGroupIdentityIntf{securityGroupIdentityModel})
-
-	poolArray, err := nlbHandler.getCreatePoolOptions(nlbReqInfo)
-	if err != nil {
-		return vpcv1.LoadBalancer{}, err
-	}
-	poolName := poolArray[0].Name
-
-	listenerArray, err := getCreateListenerOptions(nlbReqInfo, poolName)
-	if err != nil {
-		return vpcv1.LoadBalancer{}, err
-	}
-
-	createNLBOptions.SetSubnets(subnetArray)
-	createNLBOptions.SetPools(poolArray)
-	createNLBOptions.SetListeners(listenerArray)
 
 	nlb, _, err := nlbHandler.VpcService.CreateLoadBalancerWithContext(nlbHandler.Ctx, &createNLBOptions)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/NLBHandler.go
@@ -272,9 +272,9 @@ func (nlbHandler *IbmNLBHandler) ChangeListener(nlbIID irs.IID, listener irs.Lis
 	}, &[]irs.SecurityRuleInfo{
 		{
 			Direction:  "inbound",
-			IPProtocol: listener.Protocol,
-			FromPort:   listener.Port,
-			ToPort:     info.VMGroup.Port,
+			IPProtocol: info.Listener.Protocol,
+			FromPort:   info.Listener.Port,
+			ToPort:     info.Listener.Port,
 			CIDR:       "0.0.0.0/0",
 		},
 	})
@@ -290,9 +290,9 @@ func (nlbHandler *IbmNLBHandler) ChangeListener(nlbIID irs.IID, listener irs.Lis
 	}, &[]irs.SecurityRuleInfo{
 		{
 			Direction:  "inbound",
-			IPProtocol: info.Listener.Protocol,
-			FromPort:   info.Listener.Port,
-			ToPort:     info.VMGroup.Port,
+			IPProtocol: listener.Protocol,
+			FromPort:   listener.Port,
+			ToPort:     listener.Port,
 			CIDR:       "0.0.0.0/0",
 		},
 	})
@@ -1278,7 +1278,7 @@ func (nlbHandler *IbmNLBHandler) createNLB(nlbReqInfo irs.NLBInfo) (vpcv1.LoadBa
 				Direction:  "inbound",
 				IPProtocol: nlbReqInfo.Listener.Protocol,
 				FromPort:   nlbReqInfo.Listener.Port,
-				ToPort:     nlbReqInfo.VMGroup.Port,
+				ToPort:     nlbReqInfo.Listener.Port,
 				CIDR:       "0.0.0.0/0",
 			},
 		},

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
@@ -175,18 +175,10 @@ func (securityHandler *IbmSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 			}
 
 			if securityInfo.TagList != nil && len(securityInfo.TagList) > 0 {
-				var checkNLBName bool
-				var checkNLBId bool
 				for _, tag := range securityInfo.TagList {
-					if tag.Key == "nlb_name" {
-						checkNLBName = true
-					} else if tag.Key == "nlb_id" {
-						checkNLBId = true
+					if tag.Key == "nlb_name" || tag.Key == "nlb_id" {
+						continue
 					}
-				}
-
-				if checkNLBName && checkNLBId {
-					continue
 				}
 			}
 

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/SecurityHandler.go
@@ -173,6 +173,23 @@ func (securityHandler *IbmSecurityHandler) ListSecurity() ([]*irs.SecurityInfo, 
 				LoggingError(hiscallInfo, getErr)
 				return nil, getErr
 			}
+
+			if securityInfo.TagList != nil && len(securityInfo.TagList) > 0 {
+				var checkNLBName bool
+				var checkNLBId bool
+				for _, tag := range securityInfo.TagList {
+					if tag.Key == "nlb_name" {
+						checkNLBName = true
+					} else if tag.Key == "nlb_id" {
+						checkNLBId = true
+					}
+				}
+
+				if checkNLBName && checkNLBId {
+					continue
+				}
+			}
+
 			securityGroupList = append(securityGroupList, &securityInfo)
 		}
 		nextstr, _ := getSecurityGroupNextHref(securityGroups.Next)

--- a/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibmcloud-vpc/resources/TagHandler.go
@@ -460,7 +460,7 @@ func (tagHandler *IbmTagHandler) ListTag(resType irs.RSType, resIID irs.IID) ([]
 	}
 
 	if len(scanResult.Items) == 0 {
-		return []irs.KeyValue{}, errors.New("resource not found")
+		return []irs.KeyValue{}, nil
 	}
 
 	searchOptions.SearchCursor = scanResult.SearchCursor


### PR DESCRIPTION
## IBM
- Fix loadbalancer connection issue

### What was the issue?
- 로드밸런서에서도 Security Group을 지정하도록 되어 있었습니다.
- 기존에는 Default Security Group으로 설정되면서 내부 통신만 허용이 되면서 외부 접근이 차단되었습니다.
- VM에서 사용중인 첫번째 Security Group을 지정하도록 하여 문제를 해결하였습니다.
- IBM SDK로는 로드밸런서 생성시 1개의 Security Group만 지정 가능합니다.

### Fixed
- [IBM: Need to set security group when creating NLB](https://github.com/ish-hcc/cb-spider/commit/40acce2cef6aea59dd619de3501577371e201026)
- [IBM: Make available to check security group by system ID](https://github.com/ish-hcc/cb-spider/commit/bf6a537bc2f3626dbb41d76df787aa16eadd92d3)

### Remained Issue
- SSH 22번 포트 기준 LoadBalancer를 생성할때
- VM의 22번 포트를 기존 VM의 Public IP 로 접근이 가능하다가
- LoadBalancer를 생성하고 나면 LoadBalancer Public IP로만 22번 포트 접근이 가능합니다
- VM 내에서 nginx를 구동하여 테스트를 추가로 해보았는데, 기존 VM Public IP로 nginx 80포트 접근은 가능합니다.
- 테스트 구성
  - LoadBalancer - 퍼블릭
  - DNS - 퍼블릭
  - Security Group -  Inbound All Allow / Outboubd All Allow
- IBM 기본 정책인지 확인이 필요합니다.

### Related Issue
#1438 

### Tested with
@suahlingo 