### PR TITLE
Enable linux/arm for the continuous-delivery image build

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -115,7 +115,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           target: prod
-          platforms: linux/amd64 # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
+          platforms: linux/amd64,linux/arm # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
[Enable linux/arm for the continuous-delivery image build](https://github.com/cloud-barista/cb-spider/commit/04a12592d593a79d1b71b66f91d514efd18ea454) for Mac users.