### PR TITLE
[NCP Classic/VPC] Update VMSpecHandler - Update ListVMSpec() / GetVMSpec() and Enhance Supported VM Spec Info

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/README.md
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/README.md
@@ -122,6 +122,10 @@ ssh -i /private_key_경로/private_key_파일명(~~.pem) cb-user@VM의_public_ip
    - Security Group 생성/삭제시에는 NCP console에서 생성/삭제하고, Cloud-Barista에서 생성, 조회, 삭제 요청시 console에서 생성한 그 'Security Group 이름을 그대로' 사용함.
       - Console에서 생성시, 이름은 최소 6자/최대 30자의 소문자만 가능하고, 숫자, '-' 기호 사용 가능
 
+  ​O NCP Classic driver를 이용해 VM 생성시 VMSpec ID를 지정할때 다음 사항을 주의
+   - VM 생성을 위해 입력하는 VM Image와 호환되는 VM Spec을 지정해야함.
+     - Driver를 통해 조회된 VMSpec 목록의 부가정보들 중 'CorrespondingImageIds'에 그 Image ID가 포함되어 있는 VMSpec을 지정해야함.
+
 ​	O NCP Classic 서비스는 cloud-init script를 삭제하는 API를 지원하지 않아, 연동 드라이버 내부적으로 VM 생성시 생성하여 적용한 cloud-init script가 삭제되지 않고 남아있으니 console에서 삭제해야함.
    - NCP Classic console : Server > 'Init Script' 메뉴에서 삭제 필요
    - (참고) NCP VPC 플랫폼은 cloud-init script를 삭제하는 API를 지원하여 드라이버에서 VM 생성 후 cloud-init script를 삭제함.

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ImageHandler.go
@@ -49,14 +49,14 @@ func (imageHandler *NcpImageHandler) GetImage(imageIID irs.IID) (irs.ImageInfo, 
 		return irs.ImageInfo{}, newErr
 	}
 
-	ncpImageInfo, err := imageHandler.GetNcpImageInfo(imageIID)
+	ncpImageInfo, err := imageHandler.getNcpImageInfo(imageIID)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the Image Info from NCP : [%v]", err)
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return irs.ImageInfo{}, newErr
 	}	
-	imageInfo := MappingImageInfo(*ncpImageInfo)
+	imageInfo := mappingImageInfo(*ncpImageInfo)
 	return imageInfo, nil
 }
 
@@ -102,15 +102,15 @@ func (imageHandler *NcpImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 
 	var vmImageList []*irs.ImageInfo
 	for _, image := range result.ProductList {
-		imageInfo := MappingImageInfo(*image)
+		imageInfo := mappingImageInfo(*image)
 		vmImageList = append(vmImageList, &imageInfo)
 	}
 	cblogger.Info("# Supported Image Product count : ", len(vmImageList))
 	return vmImageList, nil
 }
 
-func MappingImageInfo(serverImage server.Product) irs.ImageInfo {
-	cblogger.Info("NCP Classic Cloud Driver: called MappingImageInfo()!")
+func mappingImageInfo(serverImage server.Product) irs.ImageInfo {
+	cblogger.Info("NCP Classic Cloud Driver: called mappingImageInfo()!")
 
 	var osPlatform irs.OSPlatform 
 	if serverImage.ProductType != nil {
@@ -119,8 +119,7 @@ func MappingImageInfo(serverImage server.Product) irs.ImageInfo {
 				osPlatform = irs.Windows
 			} else {
 				osPlatform = irs.PlatformNA
-			}
-			
+			}			
 		} else {
 			osPlatform = irs.PlatformNA
 		}
@@ -193,7 +192,7 @@ func (imageHandler *NcpImageHandler) CheckWindowsImage(imageIID irs.IID) (bool, 
 		return false, newErr
 	}
 
-	ncpImageInfo, err := imageHandler.GetNcpImageInfo(imageIID)
+	ncpImageInfo, err := imageHandler.getNcpImageInfo(imageIID)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the Image Info from NCP : [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -218,10 +217,10 @@ func (imageHandler *NcpImageHandler) DeleteImage(imageIID irs.IID) (bool, error)
 	return false, fmt.Errorf("Does not support DeleteImage() yet!!")
 }
 
-func (imageHandler *NcpImageHandler) GetNcpImageInfo(imageIID irs.IID) (*server.Product, error) {
-	cblogger.Info("NCP Classic Cloud Driver: called GetNcpImageInfo()!!")
+func (imageHandler *NcpImageHandler) getNcpImageInfo(imageIID irs.IID) (*server.Product, error) {
+	cblogger.Info("NCP Classic Cloud Driver: called getNcpImageInfo()!!")
 	InitLog()
-	callLogInfo := GetCallLogScheme(imageHandler.RegionInfo.Zone, call.VMIMAGE, imageIID.SystemId, "GetNcpImageInfo()")
+	callLogInfo := GetCallLogScheme(imageHandler.RegionInfo.Zone, call.VMIMAGE, imageIID.SystemId, "getNcpImageInfo()")
 
 	if strings.EqualFold(imageIID.SystemId, "") {
 		createErr := fmt.Errorf("Invalid Image SystemId")
@@ -282,7 +281,7 @@ func (imageHandler *NcpImageHandler) isPublicImage(imageIID irs.IID) (bool, erro
 		return false, newErr
 	}
 
-	ncpImageInfo, err := imageHandler.GetNcpImageInfo(imageIID)
+	ncpImageInfo, err := imageHandler.getNcpImageInfo(imageIID)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the Image Info from NCP : [%v]", err)
 		cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -1678,7 +1678,7 @@ func (vmHandler *NcpVMHandler) createLinuxInitUserData(imageIID irs.IID, keyPair
 		VMClient:    vmHandler.VMClient,
 	}
 	var getErr error
-	originImagePlatform, getErr := myImageHandler.GetOriginImageOSPlatform(imageIID)
+	originImagePlatform, getErr := myImageHandler.getOriginImageOSPlatform(imageIID)
 	if getErr != nil {
 		newErr := fmt.Errorf("Failed to Get OriginImageOSPlatform of the Image : [%v]", getErr)
 		cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/ncpvpc/README.md
+++ b/cloud-control-manager/cloud-driver/drivers/ncpvpc/README.md
@@ -123,6 +123,10 @@ ssh -i /private_key_경로/private_key_파일명(~~.pem) cb-user@VM의_public_ip
    - VM 생성시 ImageType을 'MyImage'로 지정하면, MyImage 기능으로 VM에 대해 snapshot을 하여 VM의 RootDisk와 DataDisk들을 image로 생성하여 만든 image를 사용하여 VM을 생성할 수 있음.
      - MyImage를 이용하여 VM을 생성한 경우, snapshot 대상이었던 VM의 모든 disk가 그대로 신규 VM의 disk로 생성됨.
 
+  ​O NCP VPC driver를 이용해 VM 생성시 VMSpec ID를 지정할때 다음 사항을 주의
+   - VM 생성을 위해 입력하는 VM Image와 호환되는 VM Spec을 지정해야함.
+     - Driver를 통해 조회된 VMSpec 목록의 부가정보들 중 'CorrespondingImageIds'에 그 Image ID가 포함되어 있는 VMSpec을 지정해야함.
+
   ​O NCP VPC driver를 이용해 VM 생성시 Root disk에 대해 다음 사항을 참고
    - VM 생성시 option으로 RootDiskSize 및 RootDiskType 지정은 지원하지 않음.
    - NCP VPC는 고정된 disk size로서, Linux 계열은 50GB, Windows 계열은 100GB를 지원함.


### PR DESCRIPTION
- Update NCP Classic VMSpecHandler
  - Update GetVMSpec() to include 'CorrespondingImageIds' parameter for return value
- Update NCP VPC VMSpecHandler
  - Update ListVMSpec() : Remove duplicate VMSpec info
  - Update GetVMSpec() to include 'CorrespondingImageIds' parameter for return value
  - Enhance Supported VM Spec Info
    - Related issue) https://github.com/cloud-barista/cb-spider/issues/1396 
- Update NCP Classic/VPC README.md
  - Add caveats for specifying VMSpec when creating a VM
- Update NCP Classic ImageHandler, MyImageHandler
  - Change the first letter of non-major functions to lowercase