### PR TITLE
[KT Cloud VPC(D platform)] Change Disk Size value in VMImage and VMSpec info

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/ImageHandler.go
@@ -192,13 +192,13 @@ func (imageHandler *KTVpcImageHandler) mappingImageInfo(image *images.Image) (*i
 		imageStatus = irs.ImageNA
 	}
 
-	// # Note) image.SizeBytes is not Root Disk Size
+	// ### Note) 'image.SizeBytes' is not Root Disk Size
 	// valueInGB := float64(image.SizeBytes) / (1024 * 1024 * 1024)	
 	// diskSizeInGB := strconv.FormatFloat(valueInGB, 'f', 0, 64)
 
 	imageInfo := &irs.ImageInfo {
 		IId: irs.IID{
-			NameId:   image.ID, // Caution!!
+			NameId:   image.ID,   // Caution!!
 			SystemId: image.ID,
 		},
 		GuestOS:      image.Name, // Caution!!
@@ -209,7 +209,7 @@ func (imageHandler *KTVpcImageHandler) mappingImageInfo(image *images.Image) (*i
 		OSPlatform: 	osPlatform,		
 		OSDistribution: image.Name,
 		OSDiskType: 	"NA",
-		OSDiskSizeInGB: "NA",
+		OSDiskSizeInGB: "-1",
 		ImageStatus: 	imageStatus,
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktcloudvpc/resources/VMSpecHandler.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 
 	ktvpcsdk "github.com/cloud-barista/ktcloudvpc-sdk-go"
 	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/compute/v2/flavors"
@@ -174,8 +174,8 @@ func (vmSpecHandler *KTVpcVMSpecHandler) getVMSpecIdWithName(specName string) (s
 
 func (vmSpecHandler *KTVpcVMSpecHandler) mappingVMSpecInfo(flavor *flavors.Flavor) *irs.VMSpecInfo {
 	cblogger.Info("KT Cloud VPC Driver: called mappingVMSpecInfo()!")
-	cblogger.Info("\n\n### flavor : ")
-	spew.Dump(flavor)
+	// cblogger.Info("\n\n### flavor : ")
+	// spew.Dump(flavor)
 
 	vmSpecInfo := irs.VMSpecInfo {
 		Region:       vmSpecHandler.RegionInfo.Zone,
@@ -183,7 +183,7 @@ func (vmSpecHandler *KTVpcVMSpecHandler) mappingVMSpecInfo(flavor *flavors.Flavo
 		VCpu:         irs.VCpuInfo{Count: strconv.Itoa(flavor.VCPUs), Clock: "-1"},
 		Mem:          strconv.Itoa(flavor.RAM),
 		Gpu:          []irs.GpuInfo{{Count: "-1", Mfr: "NA", Model: "NA", Mem: "-1"}},
-		Disk: 		  "NA",
+		Disk: 		  "-1",
 
 		KeyValueList: []irs.KeyValue{
 			{Key: "Zone", Value: vmSpecHandler.RegionInfo.Zone},


### PR DESCRIPTION
[KT Cloud VPC(D platform)]
- Update ImageHander
  - Change OS Disk Size value in VM Image info
  - Related issue) https://github.com/cloud-barista/cb-spider/issues/1463
- Update VMSpecHandler
  - Change Disk Size value in VMSpec info