### PR TITLE
Vmspec Meta. set clock default value as -1 #1396

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMSpecHandler.go
@@ -70,6 +70,7 @@ func (vmSpecHandler *GCPVMSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, error) {
 			Name:   i.Name,
 			VCpu: irs.VCpuInfo{
 				Count: strconv.FormatInt(i.GuestCpus, 10),
+				Clock: "-1",
 			},
 			Mem:  strconv.FormatInt(i.MemoryMb, 10),
 			Disk: "-1",
@@ -127,7 +128,7 @@ func (vmSpecHandler *GCPVMSpecHandler) GetVMSpec(Name string) (irs.VMSpecInfo, e
 		Name:   Name,
 		VCpu: irs.VCpuInfo{
 			Count: strconv.FormatInt(info.GuestCpus, 10),
-			Clock: "",
+			Clock: "-1",
 		},
 		Mem:  strconv.FormatInt(info.MemoryMb, 10),
 		Disk: "-1",
@@ -232,7 +233,7 @@ func acceleratorsToGPUInfoList(accerators []*compute.MachineTypeAccelerators) []
 		if len(accrType) >= 3 {
 			// 첫 번째 요소를 Mfr에 할당
 			gpuInfo.Mfr = strings.ToUpper(accrType[0])
-
+			gpuInfo.Mem = "-1"
 			// 마지막 요소를 확인
 			lastElement := accrType[len(accrType)-1]
 			if strings.HasSuffix(lastElement, "gb") {
@@ -247,7 +248,7 @@ func acceleratorsToGPUInfoList(accerators []*compute.MachineTypeAccelerators) []
 				}
 			} else {
 				// 마지막 요소가 "gb"로 끝나지 않는 경우
-				gpuInfo.Mem = "" // Mem은 빈 문자열로 설정
+				gpuInfo.Mem = "-1" // Mem은 빈 문자열로 설정
 				if len(accrType) > 1 {
 					// 첫 번째 요소를 제외한 나머지를 Model에 할당
 					gpuInfo.Model = strings.ToUpper(strings.Join(accrType[1:], " "))

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMSpecHandler.go
@@ -316,9 +316,11 @@ func extractVmSpec(instanceTypeInfo *cvm.InstanceTypeQuotaItem) irs.VMSpecInfo {
 		match := re.FindString(targetClock)
 
 		if match != "" {
-			targetClock = match
+			//targetClock = match
+			vCpuInfo.Clock = match
+		} else {
+			vCpuInfo.Clock = "-1"
 		}
-		vCpuInfo.Clock = targetClock
 
 	}
 	vmSpecInfo.VCpu = vCpuInfo
@@ -339,7 +341,7 @@ func extractVmSpec(instanceTypeInfo *cvm.InstanceTypeQuotaItem) irs.VMSpecInfo {
 			Count: "-1",
 			Model: "NA",
 			Mfr:   "NA",
-			Mem:   "0",
+			Mem:   "-1",
 		}
 		gpuInfo.Count = strconv.FormatInt(*instanceTypeInfo.Gpu, 10)
 


### PR DESCRIPTION
Invalid VCpu Clock : VCpu에서 "Clock" 정보 미제공 혹은 오표기  
"N/A", "", "NA" -> "-1"로 변경 ( GCP, Tencent )