### PR TITLE
chore: [nhncloud/cluster] apply default cluster's node root disk size

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ClusterHandler.go
@@ -1069,7 +1069,7 @@ func (nch *NhnCloudClusterHandler) getLabelsForNodeGroup(nodeGroupInfo *irs.Node
 	}
 
 	if strings.EqualFold(nodeGroupInfo.RootDiskSize, "") || strings.EqualFold(nodeGroupInfo.RootDiskSize, "default") {
-		nodeGroupInfo.RootDiskSize = DefaultDiskSize
+		nodeGroupInfo.RootDiskSize = DefaultNodeRootDiskSize
 	}
 	bootVolumeSize := nodeGroupInfo.RootDiskSize
 

--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/VMHandler.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cloud-barista/nhncloud-sdk-go/openstack/compute/v2/extensions/bootfromvolume"
 	"io"
 	"net/http"
 	"os"
@@ -25,6 +24,9 @@ import (
 	"strings"
 	"time"
 	_ "time/tzdata" // To prevent 'unknown time zone Asia/Seoul' error
+
+	"github.com/cloud-barista/nhncloud-sdk-go/openstack/compute/v2/extensions/bootfromvolume"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	nhnsdk "github.com/cloud-barista/nhncloud-sdk-go"
@@ -35,6 +37,7 @@ import (
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/compute/v2/flavors"
 	comimages "github.com/cloud-barista/nhncloud-sdk-go/openstack/compute/v2/images" // compute/v2/images
 	"github.com/cloud-barista/nhncloud-sdk-go/openstack/compute/v2/servers"
+
 	//	images "github.com/cloud-barista/nhncloud-sdk-go/openstack/imageservice/v2/images" // imageservice/v2/images : For Visibility parameter
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
@@ -49,6 +52,7 @@ const (
 	WinCloudInitFilePath    string = "/cloud-driver-libs/.cloud-init-nhncloud/cloud-init-windows"
 	DefaultDiskSize         string = "20"
 	DefaultWinRootDiskSize  string = "50"
+	DefaultNodeRootDiskSize string = "30"
 )
 
 type NhnCloudVMHandler struct {


### PR DESCRIPTION
NHNCloud의 클러스터 생성시 노드의 최소 루트디스크 크기가 20GB에서 30GB로 변경된 것으로 파악되었으며, 본 PR은 이를 반영합니다.
콘솔 상 VM의 루트디스크 크기는 여전히 20GB가 최소값으로 확인됩니다. @innodreamer 

![image](https://github.com/user-attachments/assets/8c7de32d-0287-42f8-af58-ecdc694d43fb)
