### PR TITLE
[AWS:PMKS] enable aws-ebs-csi-driver and eks-pod-identity-agent by default

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonHandler.go
@@ -145,6 +145,24 @@ func DescribeAvailableDiskDeviceList(svc *ec2.EC2, vmIID irs.IID) ([]string, err
 	return availableDevices, nil
 }
 
+func ModifyInstanceMetadataOptionsHttpPutResponseHopLimit(svc *ec2.EC2, instanceId string, httpPutResponseHopLimit int) error {
+	modifyInstanceMetadataOptionsInput := &ec2.ModifyInstanceMetadataOptionsInput{
+		InstanceId:              aws.String(instanceId),
+		HttpPutResponseHopLimit: aws.Int64(int64(httpPutResponseHopLimit)),
+	}
+
+	modifyInstanceMetadataOptionsOutput, err := svc.ModifyInstanceMetadataOptions(modifyInstanceMetadataOptionsInput)
+	if err != nil {
+		return err
+	}
+
+	if aws.StringValue(modifyInstanceMetadataOptionsOutput.InstanceId) != instanceId {
+		return fmt.Errorf("invalid InstanceId")
+	}
+
+	return nil
+}
+
 // ---------------- Instance Area end ---------------//
 
 // ---------------- VOLUME Area begin -----------------//


### PR DESCRIPTION
본 PR은 타 CSP와 달리 볼륨을 사용할 수 없는 상황을 개선하기 위한 것으로,
클러스터 생성시 addon인 aws-ebs-csi-driver와 eks-pod-identity-agent를 설치하고, 노드그룹 생성시 내부적으로 생성되는 노드에 대한 metadata option 중 http-put-response-hop-limit 값을 2로 변경합니다.
더불어 IAMRole 설정이나 OIDC 설정 등은 불필요한 것으로 파악되어 관련 코드를 제거합니다.

fix #1487 