### PR TITLE
fix: [cluster] support imagename as imageid in nhncloud

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhncloud/resources/ClusterHandler.go
@@ -1566,6 +1566,7 @@ func (nch *NhnCloudClusterHandler) createNodeGroup(clusterId string, nodeGroupRe
 			return "", fmt.Errorf("failed to create a node group(%s) of cluster(id=%s): %v",
 				nodeGroupName, clusterId, err)
 		}
+		imageId = imageName
 	}
 
 	flavorId, err := nch.getFlavorIdByName(nodeGroupReqInfo.VMSpecName)


### PR DESCRIPTION
본 PR은 NHNCloud의 Cluster에 대해, image name에 image id를 입력한 경우 제대로 처리하지 못하는 버그를 수정합니다.