### PR TITLE
Add STS authentication support to AWS driver

### DIFF
--- a/cloud-control-manager/CloudDriverHandler_common.go
+++ b/cloud-control-manager/CloudDriverHandler_common.go
@@ -164,6 +164,7 @@ func createConnectionInfo(cloudConnectName string, targetZoneName string) (idrv.
 		CredentialInfo: idrv.CredentialInfo{
 			ClientId:         getValue(crdInfo.KeyValueInfoList, "ClientId"),
 			ClientSecret:     getValue(crdInfo.KeyValueInfoList, "ClientSecret"),
+			StsToken:         getValue(crdInfo.KeyValueInfoList, "StsToken"),
 			TenantId:         getValue(crdInfo.KeyValueInfoList, "TenantId"),
 			SubscriptionId:   getValue(crdInfo.KeyValueInfoList, "SubscriptionId"),
 			IdentityEndpoint: getValue(crdInfo.KeyValueInfoList, "IdentityEndpoint"),
@@ -261,6 +262,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 				ClientEmail      string `json:"ClientEmail"`
 				ClientId         string `json:"ClientId"`
 				ClientSecret     string `json:"ClientSecret"`
+				StsToken         string `json:"StsToken"`
 				ClusterId        string `json:"ClusterId"`
 				ConnectionName   string `json:"ConnectionName"`
 				DomainName       string `json:"DomainName"`
@@ -300,6 +302,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 		CredentialInfo: idrv.CredentialInfo{
 			ClientId:         apiResponse.ConnectionInfo.CredentialInfo.ClientId,
 			ClientSecret:     apiResponse.ConnectionInfo.CredentialInfo.ClientSecret,
+			StsToken:         apiResponse.ConnectionInfo.CredentialInfo.StsToken,
 			ConnectionName:   apiResponse.ConnectionInfo.CredentialInfo.ConnectionName,
 			APIVersion:       apiResponse.ConnectionInfo.CredentialInfo.APIVersion,
 			ApiKey:           apiResponse.ConnectionInfo.CredentialInfo.ApiKey,
@@ -362,6 +365,7 @@ func GetCloudConnectionByDriverNameAndCredentialName(driverName string, credenti
 		CredentialInfo: idrv.CredentialInfo{
 			ClientId:         getValue(crdInfo.KeyValueInfoList, "ClientId"),
 			ClientSecret:     getValue(crdInfo.KeyValueInfoList, "ClientSecret"),
+			StsToken:         getValue(crdInfo.KeyValueInfoList, "StsToken"),
 			TenantId:         getValue(crdInfo.KeyValueInfoList, "TenantId"),
 			SubscriptionId:   getValue(crdInfo.KeyValueInfoList, "SubscriptionId"),
 			IdentityEndpoint: getValue(crdInfo.KeyValueInfoList, "IdentityEndpoint"),

--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -82,14 +82,14 @@ func (AwsDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 
 // 공통 AWS 세션 생성 함수
 func newAWSSession(connectionInfo idrv.ConnectionInfo, region string) (*session.Session, error) {
-	// cblog.Debug("Received connection information")
-	// cblog.Debug("============================================================================================")
-	// if connectionInfo.CredentialInfo.StsToken != "" {
-	// 	cblog.Debugf("Using SessionToken(For iam-manager - STS) for AWS API calls : [%s]", connectionInfo.CredentialInfo.StsToken)
-	// } else {
-	// 	cblog.Debugf("Using Normal AWS Session for AWS API calls [%s]", connectionInfo.CredentialInfo.ClientId)
-	// }
-	// cblog.Debug("============================================================================================")
+	cblog.Debug("Received connection information")
+	cblog.Debug("============================================================================================")
+	if connectionInfo.CredentialInfo.StsToken != "" {
+		cblog.Debugf("Using SessionToken(For iam-manager - STS) for AWS API calls : [%s]", connectionInfo.CredentialInfo.StsToken)
+	} else {
+		cblog.Debugf("Using Normal AWS Session for AWS API calls [%s]", connectionInfo.CredentialInfo.ClientId)
+	}
+	cblog.Debug("============================================================================================")
 
 	awsConfig := &aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(true),
@@ -97,8 +97,7 @@ func newAWSSession(connectionInfo idrv.ConnectionInfo, region string) (*session.
 		Credentials: credentials.NewStaticCredentials(
 			connectionInfo.CredentialInfo.ClientId,
 			connectionInfo.CredentialInfo.ClientSecret,
-			// connectionInfo.CredentialInfo.StsToken, // TS SessionToekn field in AWS
-			"",
+			connectionInfo.CredentialInfo.StsToken, // TS SessionToekn field in AWS
 		),
 	}
 	// return session.NewSession(awsConfig)

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -2190,8 +2190,9 @@ func getResourceHandler(handlerType string) (interface{}, error) {
 	config := readConfigFile()
 	connectionInfo := idrv.ConnectionInfo{
 		CredentialInfo: idrv.CredentialInfo{
-			ClientId:     config.Aws.AawsAccessKeyID,
+			ClientId:     config.Aws.AwsAccessKeyID,
 			ClientSecret: config.Aws.AwsSecretAccessKey,
+			StsToken:     config.Aws.AwsStsToken,
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
@@ -2251,8 +2252,9 @@ func setKeyPairHandler() (irs.KeyPairHandler, error) {
 	config := readConfigFile()
 	connectionInfo := idrv.ConnectionInfo{
 		CredentialInfo: idrv.CredentialInfo{
-			ClientId:     config.Aws.AawsAccessKeyID,
+			ClientId:     config.Aws.AwsAccessKeyID,
 			ClientSecret: config.Aws.AwsSecretAccessKey,
+			StsToken:     config.Aws.AwsStsToken,
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
@@ -2279,8 +2281,9 @@ func setVPCHandler() (irs.VPCHandler, error) {
 	config := readConfigFile()
 	connectionInfo := idrv.ConnectionInfo{
 		CredentialInfo: idrv.CredentialInfo{
-			ClientId:     config.Aws.AawsAccessKeyID,
+			ClientId:     config.Aws.AwsAccessKeyID,
 			ClientSecret: config.Aws.AwsSecretAccessKey,
+			StsToken:     config.Aws.AwsStsToken,
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region: config.Aws.Region,
@@ -2312,8 +2315,9 @@ func setVPCHandler() (irs.VPCHandler, error) {
 // SecurityGroupID : 생성할 VM에 적용할 보안그룹 ID (ex) sg-0df1c209ea1915e4b
 type Config struct {
 	Aws struct {
-		AawsAccessKeyID    string `yaml:"aws_access_key_id"`
+		AwsAccessKeyID     string `yaml:"aws_access_key_id"`
 		AwsSecretAccessKey string `yaml:"aws_secret_access_key"`
+		AwsStsToken        string `yaml:"aws_sts_token"`
 		Region             string `yaml:"region"`
 		Zone               string `yaml:"zone"`
 
@@ -2356,7 +2360,7 @@ func readConfigFile() Config {
 	}
 
 	cblogger.Info("Loaded ConfigFile...")
-	cblogger.Debug(config.Aws.AawsAccessKeyID, " ", config.Aws.Region)
+	cblogger.Debug(config.Aws.AwsAccessKeyID, " ", config.Aws.Region)
 	return config
 }
 
@@ -2369,10 +2373,10 @@ func main() {
 	//handleTag()
 	// handlePublicIP() // PublicIP 생성 후 conf
 
-	//handleVPC()
+	handleVPC()
 	//handleSecurity()
 	//handleKeyPair()
-	//handleVM()
+	handleVM()
 	//handleDisk()
 	//handleMyImage()
 	//handleNLB()

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/stsTest/GenStsInfo.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/stsTest/GenStsInfo.go
@@ -1,0 +1,89 @@
+/*
+You must grant the following policies to IAM users
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:GetSessionToken",
+      "Resource": "*"
+    }
+  ]
+}
+*/
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+func main() {
+	clientID := os.Getenv("CLIENT_ID")
+	clientSecret := os.Getenv("CLIENT_SECRET")
+
+	if clientID == "" || clientSecret == "" {
+		log.Fatal("Environment variables CLIENT_ID or CLIENT_SECRET are not set. Please set them first.")
+	}
+
+	region := promptRegionWithDefault("ap-northeast-2")
+
+	// Create a new AWS session with static credentials
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(region),
+		Credentials: credentials.NewStaticCredentials(clientID, clientSecret, ""),
+	})
+	if err != nil {
+		log.Fatalf("Failed to create AWS session: %v", err)
+	}
+
+	// Create STS client
+	stsSvc := sts.New(sess)
+
+	// Request session token (valid for 1 hour)
+	input := &sts.GetSessionTokenInput{
+		DurationSeconds: aws.Int64(3600),
+	}
+	result, err := stsSvc.GetSessionToken(input)
+	if err != nil {
+		log.Fatalf("Failed to get session token from STS: %v", err)
+	}
+
+	creds := result.Credentials
+	fmt.Println("STS session token acquired successfully!")
+	fmt.Printf("AccessKeyId: %s\n", *creds.AccessKeyId)
+	fmt.Printf("SecretAccessKey: %s\n", *creds.SecretAccessKey)
+	fmt.Printf("SessionToken: %s\n", *creds.SessionToken)
+	fmt.Printf("Expiration: %s\n", creds.Expiration.Format(time.RFC3339))
+
+	// Print reusable credential code snippet
+	fmt.Println("\nUse the following in your client code:")
+	fmt.Printf(`credentials.NewStaticCredentials(
+	"%s",
+	"%s",
+	"%s",
+)
+`, *creds.AccessKeyId, *creds.SecretAccessKey, *creds.SessionToken)
+}
+
+// Prompt user to input region, fallback to default if blank
+func promptRegionWithDefault(defaultRegion string) string {
+	fmt.Printf("Enter AWS region (default: %s): ", defaultRegion)
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	region := strings.TrimSpace(input)
+	if region == "" {
+		return defaultRegion
+	}
+	return region
+}

--- a/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
+++ b/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
@@ -54,6 +54,7 @@ type CredentialInfo struct {
 	// key-value pairs
 	ClientId         string // Azure Credential
 	ClientSecret     string // Azure Credential
+	StsToken         string // STS SessionToekn field in AWS, Alibaba
 	TenantId         string // Azure Credential
 	SubscriptionId   string // Azure Credential
 	IdentityEndpoint string // OpenStack Credential


### PR DESCRIPTION
Summary
Added STS (Security Token Service) authentication support to the AWS driver.

Details
- No impact on existing behavior: the previously unused Token field is now utilized for STS-based authentication.

- Explicitly added the CredentialInfo.StsToken field for STS support.

- Verified basic functionality using the main/Test_Resources.go test.

- Added main/stsTest/GenStsInfo.go for generating STS-based credential test data.

- Currently, the StsToken field is applied only to credential-related APIs. Additional updates to other relevant methods are still needed.