### PR TITLE
[Azure] Fix bugs in FileSystemHandler

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/Test_Resources.go
@@ -2233,7 +2233,7 @@ Loop:
 				fmt.Println("Finish AddAccessSubnet()")
 			case 6:
 				fmt.Println("Start RemoveAccessSubnet() ...")
-				if ok, err := fileSystemHandler.RemoveAccessSubnet(vpcIID, subnetIID); !ok {
+				if ok, err := fileSystemHandler.RemoveAccessSubnet(fileNameId, subnetIID); !ok {
 					fmt.Println(err)
 				}
 				fmt.Println("Finish RemoveAccessSubnet()")

--- a/cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/azure/main/conf/config.yaml.sample
@@ -76,3 +76,11 @@ azure:
       updateDiskSize: 78
       attachedVM:
         nameId:
+    file:
+      IID:
+        nameId: mcb-test-file
+      VpcIID:
+        nameId:  mcb-test-vpc
+      AccessSubnetIIDs:
+        - nameId: mcb-test-sub-1
+        - nameId: mcb-test-sub-2

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/FileSystemHandler.go
@@ -170,11 +170,22 @@ func (af *AzureFileSystemHandler) RemoveAccessSubnet(iid irs.IID, subnetIID irs.
 		return false, fmt.Errorf("no network rule set found for storage account")
 	}
 
+	rawFS, err := af.getRawFileSystem(saName, iid)
+	if err != nil {
+		cblogger.Errorf("Failed to get raw file system: %v", err)
+		return false, err
+	}
+	info, err := af.setterFileSystemInfo(&rawFS)
+	if err != nil {
+		cblogger.Errorf("Failed to get file system info: %v", err)
+		return false, err
+	}
+
 	if subnetIID.SystemId == "" {
 		subnetIID.SystemId = GetSubnetIdByName(
 			af.CredentialInfo,
 			rg,
-			iid.NameId,
+			info.VpcIID.NameId,
 			subnetIID.NameId,
 		)
 		cblogger.Infof("Constructed SystemId for removal: %s", subnetIID.SystemId)


### PR DESCRIPTION
### Azure
- Fix access subnet is not included in the test codes when creating the filesystem.
- Fix filesystem IID is not provided in RemoveAccessSubnet()