### PR TITLE
[NCP VPC] Update to support KVM-based storage

### DIFF
--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -100,7 +100,7 @@ NCPVPC:
   rootdisktype: SSD / HDD
   rootdisksize: SSD|50|100|GB / HDD|50|100|GB
   disktype: SSD / HDD
-  disksize: SSD|10|2000|GB / HDD|10|2000|GB
+  disksize: SSD|100|16380|GB / HDD|100|16380|GB
   # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
   idmaxlength: 30 / 30 / 30 / 30 / 30 / 30 / 30 / 30 / 20
 


### PR DESCRIPTION
- Update NCP VPC DiskHandler
  - Update to support KVM-based storage
- Update cloudos_meta.yaml
  - Update Init Storage Size for KVM-based storage

- Related issue : https://github.com/cloud-barista/cb-spider/issues/1507