### PR TITLE
[OpenStack] Implement FileSystemHandler for OpenStack

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
@@ -48,6 +48,7 @@ func (OpenStackDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.MyImageHandler = true
 	drvCapabilityInfo.NLBHandler = true
 	drvCapabilityInfo.ClusterHandler = false
+	drvCapabilityInfo.FileSystemHandler = true
 
 	drvCapabilityInfo.TagHandler = true
 	// ires.KEY, ires.DISK, ires.MYIMAGE, ires.CLUSTER: not supported
@@ -160,6 +161,13 @@ func clientCreator(connInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	}
 
 	iConn.ComputeClient, err = openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+		Region: connInfo.RegionInfo.Region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	iConn.SharedFileSystemClient, err = openstack.NewSharedFileSystemV2(provider, gophercloud.EndpointOpts{
 		Region: connInfo.RegionInfo.Region,
 	})
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -31,20 +31,16 @@ func init() {
 
 // OpenStackCloudConnection modified by powerkim, 2019.07.29
 type OpenStackCloudConnection struct {
-	CredentialInfo idrv.CredentialInfo
-	Region         idrv.RegionInfo
-	ComputeClient  *gophercloud.ServiceClient
-	ImageClient    *gophercloud.ServiceClient
-	NetworkClient  *gophercloud.ServiceClient
-	Volume2Client  *gophercloud.ServiceClient
-	Volume3Client  *gophercloud.ServiceClient
-	NLBClient      *gophercloud.ServiceClient
-	IdentityClient *gophercloud.ServiceClient
-}
-
-// CreateFileSystemHandler implements connect.CloudConnection.
-func (cloudConn *OpenStackCloudConnection) CreateFileSystemHandler() (irs.FileSystemHandler, error) {
-	panic("unimplemented")
+	CredentialInfo         idrv.CredentialInfo
+	Region                 idrv.RegionInfo
+	ComputeClient          *gophercloud.ServiceClient
+	ImageClient            *gophercloud.ServiceClient
+	NetworkClient          *gophercloud.ServiceClient
+	Volume2Client          *gophercloud.ServiceClient
+	Volume3Client          *gophercloud.ServiceClient
+	NLBClient              *gophercloud.ServiceClient
+	SharedFileSystemClient *gophercloud.ServiceClient
+	IdentityClient         *gophercloud.ServiceClient
 }
 
 func (cloudConn *OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
@@ -193,4 +189,17 @@ func (cloudConn *OpenStackCloudConnection) CreateTagHandler() (irs.TagHandler, e
 		NLBClient:      cloudConn.NLBClient,
 	}
 	return &tagHandler, nil
+}
+
+func (cloudConn *OpenStackCloudConnection) CreateFileSystemHandler() (irs.FileSystemHandler, error) {
+	cblogger.Info("OpenStack Driver: called CreateFileSystemHandler()!")
+
+	fileSystemHandler := osrs.OpenstackFileSystemHandler{
+		Region:                 cloudConn.Region,
+		CredentialInfo:         cloudConn.CredentialInfo,
+		SharedFileSystemClient: cloudConn.SharedFileSystemClient,
+		NetworkClient:          cloudConn.NetworkClient,
+		ComputeClient:          cloudConn.ComputeClient,
+	}
+	return &fileSystemHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/main/conf/config.yaml.sample
@@ -43,7 +43,7 @@ openstack:
       nameId: m1.small
       systemId:
     vpc:
-      nameId:  nlb-tester-vpc
+      nameId:  mcb-test-vpc
       systemId:
       ipv4CIDR: 180.0.0.0/16
       subnets:
@@ -86,3 +86,10 @@ openstack:
       tags:
         - key: vm-tag-key
           value: vm-tag-value
+    file:
+      IID:
+        nameId: mcb-test-file
+      vpcIID:
+        nameId: mcb-test-vpc
+      subnetIID:
+        nameId: mcb-test-vpc-subnet1

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/FileSystemHandler.go
@@ -1,0 +1,906 @@
+package resources
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
+	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharetypes"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type OpenstackFileSystemHandler struct {
+	Region                 idrv.RegionInfo
+	CredentialInfo         idrv.CredentialInfo
+	SharedFileSystemClient *gophercloud.ServiceClient
+	NetworkClient          *gophercloud.ServiceClient
+	ComputeClient          *gophercloud.ServiceClient
+}
+
+const (
+	DefaultShareType       = "cb-spider-share-type"
+	DefaultShareProtocol   = "NFS"
+	DefaultNFSVersion      = "4.1"
+	ShareNetworkNamePrefix = "cb-spider-share-network-"
+)
+
+type QuotaUsage struct {
+	TotalQuota   int64
+	UsedCapacity int64
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) getQuotaUsage() (*QuotaUsage, error) {
+	url := strings.TrimSuffix(filesystemHandler.SharedFileSystemClient.Endpoint, "/") + "/limits"
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("X-Auth-Token", filesystemHandler.SharedFileSystemClient.TokenID)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get shared filesystem quota: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	var limitsResp struct {
+		Limits struct {
+			Absolute struct {
+				MaxTotalShareGigabytes  int `json:"maxTotalShareGigabytes"`
+				TotalShareGigabytesUsed int `json:"totalShareGigabytesUsed"`
+			} `json:"absolute"`
+		} `json:"limits"`
+	}
+
+	err = json.Unmarshal(body, &limitsResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode quota response: %v", err)
+	}
+
+	listOpts := shares.ListOpts{}
+	allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list shares: %v", err)
+	}
+
+	shareList, err := shares.ExtractShares(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract shares: %v", err)
+	}
+
+	var usedCapacity int64
+	for _, share := range shareList {
+		usedCapacity += int64(share.Size)
+	}
+
+	return &QuotaUsage{
+		TotalQuota:   int64(limitsResp.Limits.Absolute.MaxTotalShareGigabytes),
+		UsedCapacity: int64(limitsResp.Limits.Absolute.TotalShareGigabytesUsed),
+	}, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) GetMetaInfo() (irs.FileSystemMetaInfo, error) {
+	availableCapacity := int64(0)
+
+	quotaUsage, err := filesystemHandler.getQuotaUsage()
+	if err != nil {
+		cblogger.Warnf("Failed to get quota usage %v", err)
+	} else {
+		totalQuota := quotaUsage.TotalQuota
+		usedCapacity := quotaUsage.UsedCapacity
+
+		if totalQuota > 0 {
+			remainingCapacity := totalQuota - usedCapacity
+			if remainingCapacity > 0 {
+				availableCapacity = remainingCapacity
+			}
+		}
+	}
+
+	metaInfo := irs.FileSystemMetaInfo{
+		SupportsFileSystemType: map[irs.FileSystemType]bool{
+			irs.FileSystemType("nfs"): true,
+		},
+
+		SupportsVPC: map[irs.RSType]bool{
+			irs.RSType("VPC"): true,
+		},
+
+		SupportsNFSVersion: []string{"4.1"},
+
+		SupportsCapacity: true,
+
+		CapacityGBOptions: map[string]irs.CapacityGBRange{
+			"Standard": {
+				Min: 1,
+				Max: availableCapacity,
+			},
+		},
+
+		PerformanceOptions: map[string][]string{},
+	}
+
+	return metaInfo, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(filesystemHandler.NetworkClient.IdentityEndpoint, call.FILESYSTEM, "FILESYSTEM", "ListIID()")
+	start := call.Start()
+
+	listOpts := shares.ListOpts{}
+	allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	shareList, err := shares.ExtractShares(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	var iidList []*irs.IID
+	for _, share := range shareList {
+		if filesystemHandler.Region.Zone != "" && share.AvailabilityZone != filesystemHandler.Region.Zone {
+			continue
+		}
+
+		iid := &irs.IID{
+			NameId:   share.Name,
+			SystemId: share.ID,
+		}
+		iidList = append(iidList, iid)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return iidList, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) findNetworkByName(name string) (string, error) {
+	listOpts := networks.ListOpts{
+		Name: name,
+	}
+	allPages, err := networks.List(filesystemHandler.NetworkClient, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	networkList, err := networks.ExtractNetworks(allPages)
+	if err != nil {
+		return "", err
+	}
+
+	if len(networkList) == 0 {
+		return "", fmt.Errorf("network with name %s not found", name)
+	}
+
+	return networkList[0].ID, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) findSubnetByName(name string) (string, error) {
+	listOpts := subnets.ListOpts{
+		Name: name,
+	}
+	allPages, err := subnets.List(filesystemHandler.NetworkClient, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	subnetList, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		return "", err
+	}
+
+	if len(subnetList) == 0 {
+		return "", fmt.Errorf("subnet with name %s not found", name)
+	}
+
+	return subnetList[0].ID, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) findSubnetsByNetwork(networkIID irs.IID) ([]irs.IID, error) {
+	var networkID string
+
+	if networkIID.SystemId != "" {
+		networkID = networkIID.SystemId
+	} else if networkIID.NameId != "" {
+		id, err := filesystemHandler.findNetworkByName(networkIID.NameId)
+		if err != nil {
+			return nil, err
+		}
+		networkID = id
+	}
+
+	listOpts := subnets.ListOpts{
+		NetworkID: networkID,
+	}
+	allPages, err := subnets.List(filesystemHandler.NetworkClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	subnetList, err := subnets.ExtractSubnets(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	var subnetIIDList []irs.IID
+	for _, subnet := range subnetList {
+		subnetIID := irs.IID{
+			NameId:   subnet.Name,
+			SystemId: subnet.ID,
+		}
+		subnetIIDList = append(subnetIIDList, subnetIID)
+	}
+
+	return subnetIIDList, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) getOrCreateShareNetwork(networkID, subnetID string) (string, error) {
+	listOpts := sharenetworks.ListOpts{
+		NeutronNetID:    networkID,
+		NeutronSubnetID: subnetID,
+	}
+
+	allPages, err := sharenetworks.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	shareNetworkList, err := sharenetworks.ExtractShareNetworks(allPages)
+	if err != nil {
+		return "", err
+	}
+
+	if len(shareNetworkList) > 0 {
+		return shareNetworkList[0].ID, nil
+	}
+
+	createOpts := sharenetworks.CreateOpts{
+		Name:            ShareNetworkNamePrefix + networkID + "-" + subnetID,
+		Description:     "Share network created by CB-Spider",
+		NeutronNetID:    networkID,
+		NeutronSubnetID: subnetID,
+	}
+
+	shareNetwork, err := sharenetworks.Create(filesystemHandler.SharedFileSystemClient, createOpts).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return shareNetwork.ID, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) getAvailableBackend() (string, error) {
+	url := strings.TrimSuffix(filesystemHandler.SharedFileSystemClient.Endpoint, "/") + "/scheduler-stats/pools"
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("X-Auth-Token", filesystemHandler.SharedFileSystemClient.TokenID)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	var poolsResp struct {
+		Pools []struct {
+			Name         string `json:"name"`
+			Host         string `json:"host"`
+			Capabilities struct {
+				ShareBackendName string `json:"share_backend_name"`
+			} `json:"capabilities"`
+		} `json:"pools"`
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &poolsResp)
+	if err != nil {
+		cblogger.Warnf("Failed to unmarshal pools response: %v", err)
+		return "", err
+	}
+
+	if len(poolsResp.Pools) > 0 {
+		pool := poolsResp.Pools[0]
+
+		if pool.Capabilities.ShareBackendName != "" {
+			return pool.Capabilities.ShareBackendName, nil
+		}
+
+		if strings.Contains(pool.Name, "#") {
+			parts := strings.Split(pool.Name, "#")
+			if len(parts) > 1 {
+				return parts[1], nil
+			}
+		}
+
+		if pool.Host != "" {
+			return "GENERIC", nil
+		}
+	}
+
+	return "GENERIC", nil // fallback
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) getOrCreateShareType() (string, error) {
+	listOpts := sharetypes.ListOpts{
+		IsPublic: "true",
+	}
+
+	allPages, err := sharetypes.List(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+	if err != nil {
+		return "", fmt.Errorf("failed to list share types: %v", err)
+	}
+
+	shareTypeList, err := sharetypes.ExtractShareTypes(allPages)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract share types: %v", err)
+	}
+
+	for _, shareType := range shareTypeList {
+		if shareType.Name == DefaultShareType {
+			return shareType.ID, nil
+		}
+	}
+
+	backendName, err := filesystemHandler.getAvailableBackend()
+	if err != nil {
+		backendName = "GENERIC" // fallback
+	}
+
+	requestBody := map[string]interface{}{
+		"share_type": map[string]interface{}{
+			"name":                           DefaultShareType,
+			"os-share-type-access:is_public": true,
+			"extra_specs": map[string]interface{}{
+				"share_backend_name":           backendName,
+				"driver_handles_share_servers": "True",
+				"snapshot_support":             "True",
+			},
+		},
+	}
+
+	var result sharetypes.CreateResult
+	resp, err := filesystemHandler.SharedFileSystemClient.Post(
+		filesystemHandler.SharedFileSystemClient.Endpoint+"/types",
+		requestBody,
+		&result.Body,
+		&gophercloud.RequestOpts{
+			OkCodes: []int{200, 202},
+		},
+	)
+	_, result.Header, result.Err = gophercloud.ParseResponse(resp, err)
+
+	if result.Err != nil {
+		return "", fmt.Errorf("failed to create share type: %v", result.Err)
+	}
+
+	shareType, err := result.Extract()
+	if err != nil {
+		return "", fmt.Errorf("failed to extract created share type: %v", err)
+	}
+
+	return shareType.ID, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) grantShareAccess(shareID string) error {
+	url := strings.TrimSuffix(filesystemHandler.SharedFileSystemClient.Endpoint, "/") + "/shares/" + shareID + "/action"
+
+	requestBody := map[string]interface{}{
+		"os-allow_access": map[string]interface{}{
+			"access_type":  "ip",
+			"access_to":    "0.0.0.0/0",
+			"access_level": "rw",
+		},
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	jsonData, _ := json.Marshal(requestBody)
+	req, err := http.NewRequest("POST", url, strings.NewReader(string(jsonData)))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("X-Auth-Token", filesystemHandler.SharedFileSystemClient.TokenID)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-OpenStack-Manila-API-Version", "2.1")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != 200 && resp.StatusCode != 202 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to grant access: %d %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) CreateFileSystem(reqInfo irs.FileSystemInfo) (irs.FileSystemInfo, error) {
+	hiscallInfo := GetCallLogScheme(filesystemHandler.NetworkClient.IdentityEndpoint, call.FILESYSTEM, filesystemHandler.Region.Region, "CreateFileSystem()")
+	start := call.Start()
+
+	if reqInfo.IId.NameId == "" {
+		err := fmt.Errorf("invalid request: NameId is required")
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, err
+	}
+
+	if !strings.EqualFold(reqInfo.NFSVersion, "4.1") {
+		err := fmt.Errorf("unsupported NFS version: %q", reqInfo.NFSVersion)
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, err
+	}
+
+	capacity := reqInfo.CapacityGB
+	if capacity <= 0 {
+		capacity = 1
+	}
+
+	var shareNetworkID string
+	if len(reqInfo.AccessSubnetList) > 0 {
+		subnetIID := reqInfo.AccessSubnetList[0]
+		var subnetID string
+
+		if subnetIID.SystemId != "" {
+			subnetID = subnetIID.SystemId
+		} else if subnetIID.NameId != "" {
+			id, err := filesystemHandler.findSubnetByName(subnetIID.NameId)
+			if err != nil {
+				LoggingError(hiscallInfo, err)
+				return irs.FileSystemInfo{}, fmt.Errorf("failed to find subnet: %v", err)
+			}
+			subnetID = id
+		}
+
+		subnet, err := subnets.Get(filesystemHandler.NetworkClient, subnetID).Extract()
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, fmt.Errorf("failed to get subnet info: %v", err)
+		}
+
+		shareNetworkID, err = filesystemHandler.getOrCreateShareNetwork(subnet.NetworkID, subnetID)
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, fmt.Errorf("failed to create share network: %v", err)
+		}
+	} else if reqInfo.VpcIID.NameId != "" || reqInfo.VpcIID.SystemId != "" {
+		err := fmt.Errorf("VPC is specified but no subnet provided. Please specify exactly one subnet from the VPC")
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, err
+	} else {
+		err := fmt.Errorf("either VPC with subnet or subnet must be specified")
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, err
+	}
+
+	shareTypeID, err := filesystemHandler.getOrCreateShareType()
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, fmt.Errorf("failed to get or create share type: %v", err)
+	}
+
+	createOpts := shares.CreateOpts{
+		Size:           int(capacity),
+		Name:           reqInfo.IId.NameId,
+		Description:    "FileSystem created by CB-Spider",
+		ShareProto:     DefaultShareProtocol,
+		ShareType:      shareTypeID,
+		ShareNetworkID: shareNetworkID,
+	}
+
+	if reqInfo.Zone != "" {
+		createOpts.AvailabilityZone = reqInfo.Zone
+	}
+
+	share, err := shares.Create(filesystemHandler.SharedFileSystemClient, createOpts).Extract()
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, fmt.Errorf("failed to create file share: %v", err)
+	}
+
+	for i := 0; i < 240; i++ {
+		currentShare, err := shares.Get(filesystemHandler.SharedFileSystemClient, share.ID).Extract()
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, fmt.Errorf("failed to check share status: %v", err)
+		}
+
+		if currentShare.Status == "available" {
+			break
+		} else if currentShare.Status == "error" {
+			return irs.FileSystemInfo{}, fmt.Errorf("share creation failed with error status")
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	err = filesystemHandler.grantShareAccess(share.ID)
+	if err != nil {
+		cblogger.Warnf("Failed to grant access rule: %v", err)
+	}
+
+	fileSystemInfo, err := filesystemHandler.GetFileSystem(irs.IID{
+		NameId:   share.Name,
+		SystemId: share.ID,
+	})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, fmt.Errorf("created but get failed: %v", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return fileSystemInfo, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) ListFileSystem() ([]*irs.FileSystemInfo, error) {
+	hiscallInfo := GetCallLogScheme(filesystemHandler.NetworkClient.IdentityEndpoint, call.FILESYSTEM, filesystemHandler.Region.Region, "ListFileSystem()")
+	start := call.Start()
+
+	listOpts := shares.ListOpts{}
+	allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	shareList, err := shares.ExtractShares(allPages)
+	if err != nil {
+		return nil, err
+	}
+
+	var list []*irs.FileSystemInfo
+	for _, share := range shareList {
+		if filesystemHandler.Region.Zone != "" && share.AvailabilityZone != filesystemHandler.Region.Zone {
+			continue
+		}
+
+		info, err := filesystemHandler.setterFileSystemInfo(&share)
+		if err != nil {
+			cblogger.Warnf("ListFileSystem: setter error for %s: %v", share.Name, err)
+			continue
+		}
+		list = append(list, info)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return list, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) GetFileSystem(iid irs.IID) (irs.FileSystemInfo, error) {
+	hiscallInfo := GetCallLogScheme(filesystemHandler.NetworkClient.IdentityEndpoint, call.FILESYSTEM, "FILESYSTEM", "GetFileSystem()")
+	start := call.Start()
+
+	var shareID string
+	if iid.SystemId != "" {
+		shareID = iid.SystemId
+	} else if iid.NameId != "" {
+		listOpts := shares.ListOpts{
+			Name: iid.NameId,
+		}
+		allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, fmt.Errorf("failed to list shares: %v", err)
+		}
+
+		shareList, err := shares.ExtractShares(allPages)
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, fmt.Errorf("failed to extract shares: %v", err)
+		}
+
+		if len(shareList) == 0 {
+			err := fmt.Errorf("file share with name %s not found", iid.NameId)
+			LoggingError(hiscallInfo, err)
+			return irs.FileSystemInfo{}, err
+		}
+
+		shareID = shareList[0].ID
+	} else {
+		err := fmt.Errorf("invalid IID: either NameId or SystemId is required")
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, err
+	}
+
+	share, err := shares.Get(filesystemHandler.SharedFileSystemClient, shareID).Extract()
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, fmt.Errorf("failed to get file share: %v", err)
+	}
+
+	info, err := filesystemHandler.setterFileSystemInfo(share)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.FileSystemInfo{}, fmt.Errorf("failed to parse file share info: %v", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return *info, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) findNetworkByID(networkID string) (*networks.Network, error) {
+	network, err := networks.Get(filesystemHandler.NetworkClient, networkID).Extract()
+	if err != nil {
+		return nil, err
+	}
+	return network, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) findSubnetByID(subnetID string) (*subnets.Subnet, error) {
+	subnet, err := subnets.Get(filesystemHandler.NetworkClient, subnetID).Extract()
+	if err != nil {
+		return nil, err
+	}
+	return subnet, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) setterFileSystemInfo(share *shares.Share) (*irs.FileSystemInfo, error) {
+	if share == nil {
+		return nil, fmt.Errorf("invalid Share input")
+	}
+
+	info := &irs.FileSystemInfo{
+		IId: irs.IID{
+			NameId:   share.Name,
+			SystemId: share.ID,
+		},
+		Region:           filesystemHandler.Region.Region,
+		Zone:             share.AvailabilityZone,
+		VpcIID:           irs.IID{},
+		AccessSubnetList: nil,
+		NFSVersion:       DefaultNFSVersion,
+		FileSystemType:   irs.FileSystemType("nfs"),
+		Encryption:       false,
+		CapacityGB:       int64(share.Size),
+		PerformanceInfo:  map[string]string{},
+		Status:           irs.FileSystemStatus("Unknown"),
+		CreatedTime:      share.CreatedAt,
+	}
+
+	switch share.Status {
+	case "available":
+		info.Status = irs.FileSystemAvailable
+	case "creating":
+		info.Status = irs.FileSystemCreating
+	case "deleting":
+		info.Status = irs.FileSystemDeleting
+	case "error":
+		info.Status = irs.FileSystemError
+	default:
+		info.Status = irs.FileSystemStatus(share.Status)
+	}
+
+	if share.ShareNetworkID != "" {
+		shareNetwork, err := sharenetworks.Get(filesystemHandler.SharedFileSystemClient, share.ShareNetworkID).Extract()
+		if err == nil {
+			if shareNetwork.NeutronNetID != "" {
+				network, err := filesystemHandler.findNetworkByID(shareNetwork.NeutronNetID)
+				if err == nil {
+					info.VpcIID = irs.IID{
+						NameId:   network.Name,
+						SystemId: network.ID,
+					}
+				}
+			}
+
+			if shareNetwork.NeutronSubnetID != "" {
+				subnet, err := filesystemHandler.findSubnetByID(shareNetwork.NeutronSubnetID)
+				if err == nil {
+					subnetIID := irs.IID{
+						NameId:   subnet.Name,
+						SystemId: subnet.ID,
+					}
+					info.AccessSubnetList = []irs.IID{subnetIID}
+				}
+			}
+		}
+	}
+
+	baseKVs := irs.StructToKeyValueList(share)
+	info.KeyValueList = baseKVs
+
+	return info, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) DeleteFileSystem(iid irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(filesystemHandler.NetworkClient.IdentityEndpoint, call.FILESYSTEM, "FILESYSTEM", "DeleteFileSystem()")
+	start := call.Start()
+
+	shareID := iid.SystemId
+	if shareID == "" && iid.NameId != "" {
+		listOpts := shares.ListOpts{
+			Name: iid.NameId,
+		}
+		allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return false, fmt.Errorf("failed to list shares: %v", err)
+		}
+
+		shareList, err := shares.ExtractShares(allPages)
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return false, fmt.Errorf("failed to extract shares: %v", err)
+		}
+
+		if len(shareList) == 0 {
+			err := fmt.Errorf("file share with name %s not found", iid.NameId)
+			LoggingError(hiscallInfo, err)
+			return false, err
+		}
+
+		shareID = shareList[0].ID
+	}
+
+	if shareID == "" {
+		err := fmt.Errorf("invalid IID: filesystem not found")
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+
+	filesystemInfo, err := filesystemHandler.GetFileSystem(irs.IID{SystemId: shareID})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+
+	err = shares.Delete(filesystemHandler.SharedFileSystemClient, shareID).ExtractErr()
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return false, fmt.Errorf("failed to delete file share: %v", err)
+	}
+
+	for i := 0; i < 120; i++ {
+		_, err := shares.Get(filesystemHandler.SharedFileSystemClient, shareID).Extract()
+		if err != nil {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+
+	accessSubnetList := filesystemInfo.AccessSubnetList
+	if len(accessSubnetList) == 0 {
+		cblogger.Warnf("subnet list is empty")
+	} else {
+		shareNetworkID, err := filesystemHandler.getOrCreateShareNetwork(filesystemInfo.VpcIID.SystemId, accessSubnetList[0].SystemId)
+		if err != nil {
+			cblogger.Warnf("failed to get share network: %v", err)
+		} else {
+			err = sharenetworks.Delete(filesystemHandler.SharedFileSystemClient, shareNetworkID).ExtractErr()
+			if err != nil {
+				cblogger.Warnf("failed to delete share network: %v", err)
+			}
+		}
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) AddAccessSubnet(fsIID irs.IID, subnetIID irs.IID) (irs.FileSystemInfo, error) {
+	return irs.FileSystemInfo{}, fmt.Errorf("AddAccessSubnet is not supported in OpenStack - use CreateFileSystem with subnet specification")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) RemoveAccessSubnet(fsIID irs.IID, subnetIID irs.IID) (bool, error) {
+	return false, fmt.Errorf("RemoveAccessSubnet is not supported in OpenStack - recreate filesystem with different subnet")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) ListAccessSubnet(fsIID irs.IID) ([]irs.IID, error) {
+	if fsIID.NameId == "" && fsIID.SystemId == "" {
+		return nil, fmt.Errorf("invalid filesystem IID: NameId or SystemId is required")
+	}
+
+	shareID := fsIID.SystemId
+	if shareID == "" {
+		listOpts := shares.ListOpts{
+			Name: fsIID.NameId,
+		}
+		allPages, err := shares.ListDetail(filesystemHandler.SharedFileSystemClient, listOpts).AllPages()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list shares: %v", err)
+		}
+
+		shareList, err := shares.ExtractShares(allPages)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract shares: %v", err)
+		}
+
+		if len(shareList) == 0 {
+			return nil, fmt.Errorf("filesystem not found")
+		}
+
+		shareID = shareList[0].ID
+	}
+
+	share, err := shares.Get(filesystemHandler.SharedFileSystemClient, shareID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get share: %v", err)
+	}
+
+	var subnetList []irs.IID
+	if share.ShareNetworkID != "" {
+		shareNetwork, err := sharenetworks.Get(filesystemHandler.SharedFileSystemClient, share.ShareNetworkID).Extract()
+		if err == nil && shareNetwork.NeutronSubnetID != "" {
+			subnet, err := filesystemHandler.findSubnetByID(shareNetwork.NeutronSubnetID)
+			if err == nil {
+				subnetIID := irs.IID{
+					NameId:   subnet.Name,
+					SystemId: subnet.ID,
+				}
+				subnetList = append(subnetList, subnetIID)
+			}
+		}
+	}
+
+	return subnetList, nil
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) ScheduleBackup(reqInfo irs.FileSystemBackupInfo) (irs.FileSystemBackupInfo, error) {
+	return irs.FileSystemBackupInfo{}, fmt.Errorf("backup scheduling is not supported in OpenStack Manila")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) OnDemandBackup(fsIID irs.IID) (irs.FileSystemBackupInfo, error) {
+	return irs.FileSystemBackupInfo{}, fmt.Errorf("on-demand backup is not supported in OpenStack Manila")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) ListBackup(fsIID irs.IID) ([]irs.FileSystemBackupInfo, error) {
+	return nil, fmt.Errorf("backup listing is not supported in OpenStack Manila")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) GetBackup(fsIID irs.IID, backupID string) (irs.FileSystemBackupInfo, error) {
+	return irs.FileSystemBackupInfo{}, fmt.Errorf("backup retrieval is not supported in OpenStack Manila")
+}
+
+func (filesystemHandler *OpenstackFileSystemHandler) DeleteBackup(fsIID irs.IID, backupID string) (bool, error) {
+	return false, fmt.Errorf("backup deletion is not supported in OpenStack Manila")
+}


### PR DESCRIPTION
## OpenStack
- Implement FileSystemHandler for OpenStack

### 제한 사항
- Region / Zone: manila-share 가 배포된 호스트가 포함된 Zone 만 설정 가능한 것으로 추정 (network 노드) / 이노그리드 OpenStack 환경으로 테스트 어려움
- VPC: 생성시 Network만 지정 불가능, 해당 Network의 1개 서브넷 필수 지정 필요
- Subnet: 1개의 서브넷만 지정 가능 하며, 라우터와 연결되어 있어야 함
- Access Control: IP 개별 및 CIDR 방식 설정 가능 하나, 1개의 서브넷만 지정할 수 있는 특성상 활용 불가능
- NFS Version: v4.X 만 동작 (Manila Service Image 따름 (master 브랜치 기준 OS: Ubuntu 22.04))
- Tag: Tag 기능은 없지만 Metadata 필드에 Key=Value 형식으로 설정 가능, CLI 상에서는 openstack share show {Share ID} 에서 properties 라는 필드로 확인 가능
- Manila 에서 Share Type 필요

### 제한 사항에 따른 조치 사항
- Access Control 관련하여서는 IP 개별 및 CIDR 방식 설정 가능 하나, 1개의 서브넷만 지정할 수 있는 특성상 활용 불가능 
  - 1개의 서브넷만 설정 가능한 특성상 연결대상에서는 모두 접근이 가능해야 하기 때문에 FileSystem 생성 후 0.0.0.0/0 허용하는 IP Rule을 추가하도록 함
  - AddAccessSubnet(), RemoveAccessSubnet() 함수 지원 불가 메세지로 에러 리턴
- Manila 에서 Share Type 필요
  - cb-spider-share-type 이름으로 없을 경우 생성
  - 다음 Extra Specs 지정하여 생성
    - driver_handles_share_servers=True
    - share_backend_name=GENERIC (사용할 수 있는 backend name을 먼저 조회하고 fallback 으로 GENERIC 사용)
    - snapshot_support=True