### PR TITLE
[NCP] Apply 'RegionCode' parameter to KeyPairHandler

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
@@ -4,6 +4,7 @@
 // NCP VPC KeyPair Handler
 //
 // by ETRI, 2020.10.
+// Updated by ETRI, 2025.09.
 
 package resources
 
@@ -34,7 +35,8 @@ func (keyPairHandler *NcpVpcKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error
 	callLogInfo := GetCallLogScheme(keyPairHandler.RegionInfo.Zone, call.VMKEYPAIR, "ListKey()", "ListKey()")
 
 	keypairReq := vserver.GetLoginKeyListRequest{
-		KeyName: nil,
+		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
+		KeyName: 	nil,
 	}
 
 	callLogStart := call.Start()
@@ -81,7 +83,8 @@ func (keyPairHandler *NcpVpcKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPair
 	}
 
 	keypairReq := vserver.CreateLoginKeyRequest{
-		KeyName: ncloud.String(keyPairReqInfo.IId.NameId),
+		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
+		KeyName: 	ncloud.String(keyPairReqInfo.IId.NameId),
 	}
 
 	// Creates a new  keypair with the given name
@@ -145,9 +148,9 @@ func (keyPairHandler *NcpVpcKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPairI
 
 	// NCP VPC Key does not have SystemId, so the unique NameId value is also applied to the SystemId when create it.
 	keypairReq := vserver.GetLoginKeyListRequest{
-		KeyName: ncloud.String(keyNameId),
+		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
+		KeyName: 	ncloud.String(keyNameId),
 	}
-
 	callLogStart := call.Start()
 	result, err := keyPairHandler.VMClient.V2Api.GetLoginKeyList(&keypairReq)
 	if err != nil {
@@ -199,6 +202,7 @@ func (keyPairHandler *NcpVpcKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, err
 	}
 
 	keypairDelReq := vserver.DeleteLoginKeysRequest{
+		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
 		KeyNameList: []*string{
 			ncloud.String(keyIID.NameId),
 		},
@@ -257,7 +261,8 @@ func (keyPairHandler *NcpVpcKeyPairHandler) ListIID() ([]*irs.IID, error) {
 	callLogInfo := GetCallLogScheme(keyPairHandler.RegionInfo.Zone, call.VMKEYPAIR, "ListIID()", "ListIID()")
 
 	keypairReq := vserver.GetLoginKeyListRequest{
-		KeyName: nil,
+		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
+		KeyName: 	nil,
 	}
 
 	callLogStart := call.Start()

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/IBM/platform-services-go-sdk v0.30.0
 	github.com/Masterminds/semver/v3 v3.2.1
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.23
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27
 	github.com/alibabacloud-go/cs-20151215/v4 v4.5.8
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.6
 	github.com/alibabacloud-go/ecs-20140526/v4 v4.24.17

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,8 @@ github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.23 h1:IAN9TYKHLWrx0rgQ1e/RbiKstPqWB/rSQJSJ5UO+rcE=
 github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.23/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27 h1:lxXZjrSodJdg4IHGWGMFlWTLOHsD7lTZz6VD2XewX9c=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=


### PR DESCRIPTION
- Update NCP KeyPairHandler
  - Apply 'RegionCode' parameter
- Update go.mod and go.sum
  - Update ncloud-sdk-go version to v1.6.27
- Related issue : https://github.com/cloud-barista/cb-spider/issues/1526
- Related PR : https://github.com/NaverCloudPlatform/ncloud-sdk-go-v2/pull/84