### PR TITLE
[AWS] Fix cb-user SSH login issue by updating cloud-init script

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/CommonAwsFunc.go
@@ -37,7 +37,7 @@ const CBDefaultCidrBlock string = "192.168.0.0/16"  // CB Default CidrBlock
 //const CBKeyPairPath string = "/meta_db/.ssh-aws/" // 이슈 #480에 의한 로컬 키 관리 제거
 
 const CBCloudInitWindowsFilePath string = "/cloud-driver-libs/.cloud-init-aws/cloud-init-windows" //Windows용 사용자 비번 설정을 위한 탬플릿
-const CBCloudInitFilePath string = "/cloud-driver-libs/.cloud-init-common/cloud-init"
+const CBCloudInitFilePath string = "/cloud-driver-libs/.cloud-init-aws/cloud-init-ubuntu"
 const CBDefaultVmUserName string = "cb-user" // default VM User Name
 
 const CUSTOM_ERR_CODE_TOOMANY string = "600"            //awserr.New("600", "n개 이상의 xxxx 정보가 존재합니다.", nil)

--- a/cloud-driver-libs/.cloud-init-aws/cloud-init-ubuntu
+++ b/cloud-driver-libs/.cloud-init-aws/cloud-init-ubuntu
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+USER="cb-user"
+HOME_DIR="/home/${USER}"
+SSH_DIR="${HOME_DIR}/.ssh"
+AUTH_KEYS="${SSH_DIR}/authorized_keys"
+IMDS="http://169.254.169.254"
+
+# 1) Create cb-user
+id -u "$USER" &>/dev/null || useradd -m -s /bin/bash -G sudo "$USER"
+
+# 2) Create .ssh directory and set permissions
+install -d -m 700 -o "$USER" -g "$USER" "$SSH_DIR"
+
+# 3) Retrieve IMDSv2 token
+TOKEN="$(curl -sS -X PUT "${IMDS}/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+
+# 4) Fetch public key (when a Key Pair is attached to the instance)
+#    Use -f so it fails immediately on error
+curl -sSf -H "X-aws-ec2-metadata-token: ${TOKEN}" \
+  "${IMDS}/latest/meta-data/public-keys/0/openssh-key" > "$AUTH_KEYS"
+
+# 5) Set permissions and ownership
+chmod 600 "$AUTH_KEYS"
+chown -R "$USER:$USER" "$HOME_DIR"
+
+# 6) Allow passwordless sudo (sudoers.d recommended)
+echo "${USER} ALL=(ALL:ALL) NOPASSWD: ALL" > "/etc/sudoers.d/${USER}"
+chmod 440 "/etc/sudoers.d/${USER}"
+

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/cloud-barista/cb-log v0.9.0 h1:pti3gxl85NyqaEiQDF8Dba4zniOy9+6XMy7Jzv
 github.com/cloud-barista/cb-log v0.9.0/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240826073400-9dd317d24d0a h1:7sm+NSqmjuktaERMdTayiqsKmfgmFLMBzHrpG85Z5do=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20240826073400-9dd317d24d0a/go.mod h1:ZIrUxItUvMIGZyX6Re7tUdcS3cwBIzBPcL+Pk/6lt/8=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20250910122903-6175e6cf0fc1 h1:t9R7KH27RjN2533/OWiQGNKanNATD04zg/6RfxPlk/M=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20250910122903-6175e6cf0fc1/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20250911153447-1314aa57e794 h1:yJfX0RpSmULJDmLKhJVGQaOz6MXSUmmF6X8LQaVHN9U=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20250911153447-1314aa57e794/go.mod h1:SDTNI+0ZyoEWhQKHASGwhS1a9kad+mxsXCKSfnpWnSA=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20250820130332-f0e139707117 h1:8DcfVIdNpwpRbjovtnelOtrwrxGVpwz9EuWrNPJBKss=


### PR DESCRIPTION
Key changes:

- Replaced the legacy metadata retrieval method (no longer supported by AWS).
- Switched to IMDSv2 (token-based) for fetching instance metadata.

Login test results:
- Passed: AWS, Azure, GCP, Alibaba, IBM, NCP, NHN, KT
- Not available test: Tencent, OpenStack