### PR TITLE
[Priceinfo] Add vmspec info simple mode and fix multi-CSP issues

### DIFF
--- a/api-runtime/rest-runtime/PriceInfoRest.go
+++ b/api-runtime/rest-runtime/PriceInfoRest.go
@@ -28,7 +28,7 @@ type ProductFamilyListResponse struct {
 // @ID list-product-family
 // @Summary List Product Families
 // @Description Retrieve a list of Product Families associated with a specific connection and region. 🕷️ [[Concept Guide](https://github.com/cloud-barista/cb-spider/wiki/Price-Info-and-Cloud-Driver-API)], 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/RestAPI-Multi%E2%80%90Cloud-Price-Information-Guide)]
-// @Tags [Cloud Metadata] Price Info
+// @Tags [Cloud Metadata] VM Price Info
 // @Accept  json
 // @Produce  json
 // @Param ConnectionName query string true "The name of the Connection to list Product Families for"
@@ -78,7 +78,7 @@ type PriceInfoResponse struct {
 // @ID get-vmprice-info
 // @Summary Get VM Price Information
 // @Description Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)] <br> * example body: {"connectionName":"aws-connection","FilterList":[{"Key":"instanceType","Value":"t2.micro"}]}
-// @Tags [Cloud Metadata] Price Info
+// @Tags [Cloud Metadata] VM Price Info
 // @Accept  json
 // @Produce  json
 // @Param RegionName path string true "The name of the Region to retrieve vm price information for"

--- a/api-runtime/rest-runtime/admin-web/html/priceinfo-request-template.html
+++ b/api-runtime/rest-runtime/admin-web/html/priceinfo-request-template.html
@@ -144,6 +144,13 @@
                         {{end}}
                     </select>                    
                 </div>
+                <div class="form-group">
+                    <label for="simpleMode">VMSpec Display Mode</label>
+                    <select id="simpleMode" name="simpleMode">
+                        <option value="OFF">Detailed (Full VMSpecInfo)</option>
+                        <option value="ON">Simple (VMSpecName only)</option>
+                    </select>                    
+                </div>
             </div>
             <div class="form-group">
                 <div class="button-textarea-group">
@@ -227,12 +234,13 @@
             var region = document.getElementById('region').value;
             var connectionName = document.getElementById('connectionName').value;
             var filterList = document.getElementById('filter').value;
+            var simpleMode = document.getElementById('simpleMode').value;
 
             var fetchOverlayContent = document.getElementById('fetchOverlayContent');
             document.getElementById('fetchOverlay').style.display = 'block';
             fetchOverlayContent.src = 'about:blank'; // clear the iframe content
 
-            var url = `/spider/adminweb/priceinfotablelist/vm/${region}/${connectionName}?filterlist=${filterList}`;
+            var url = `/spider/adminweb/priceinfotablelist/vm/${region}/${connectionName}?filterlist=${filterList}&simplemode=${simpleMode}`;
 
             // logging the fetch URL
             var hostname = window.location.hostname;

--- a/api-runtime/rest-runtime/admin-web/html/priceinfo-tablelist-template.html
+++ b/api-runtime/rest-runtime/admin-web/html/priceinfo-tablelist-template.html
@@ -208,7 +208,13 @@
     {{ $fileName := .CachedFileName }}
 
     <div class="cloudHeader">
-        <h3>{{.Data.CloudName}}</h3>
+        <h3>{{.Data.CloudName}} 
+            {{if eq .SimpleMode "ON"}}
+                <span style="color: #0066cc; font-size: 14px;">[Simple Mode]</span>
+            {{else}}
+                <span style="color: #666; font-size: 14px;">[Detailed Mode]</span>
+            {{end}}
+        </h3>
         <button id="toggleButton-{{.Data.CloudName}}" onclick="toggleView('{{.Data.CloudName}}')">JSON View</button>
 
         <button onclick="conditionalDownload('{{.Data.CloudName}}', '{{$totalNum}}', '{{$fileName}}')">JSON Download</button>
@@ -238,6 +244,7 @@
             <td>
                 <ul>
                     {{if .ProductInfo.VMSpecInfo}}
+                        <!-- Detailed Mode: Full VMSpecInfo -->
                         <li><strong>VMSpec: {{.ProductInfo.VMSpecInfo.Name}}</strong></li>
                         <li>VCPU: {{.ProductInfo.VMSpecInfo.VCpu.Count}}</li>
                         <li>Memory(MiB): {{.ProductInfo.VMSpecInfo.MemSizeMiB}}</li>
@@ -249,6 +256,12 @@
                                 <li>GPU Total Memory(GB): {{.TotalMemSizeGB}}</li>
                             {{end}}
                         {{end}}
+                    {{else if .ProductInfo.VMSpecName}}
+                        <!-- Simple Mode: VMSpecName only -->
+                        <li><strong>VMSpec: {{.ProductInfo.VMSpecName}}</strong></li>
+                        <li><em>Simple mode - detailed specs not available</em></li>
+                    {{else}}
+                        <li><em>No VM specification information available</em></li>
                     {{end}}
                 </ul>
             </td>

--- a/api/docs.go
+++ b/api/docs.go
@@ -5510,7 +5510,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud Metadata] Price Info"
+                    "[Cloud Metadata] VM Price Info"
                 ],
                 "summary": "Get VM Price Information",
                 "operationId": "get-vmprice-info",
@@ -5569,7 +5569,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud Metadata] Price Info"
+                    "[Cloud Metadata] VM Price Info"
                 ],
                 "summary": "List Product Families",
                 "operationId": "list-product-family",
@@ -10260,8 +10260,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "CSPProductInfo",
-                "ProductId",
-                "VMSpecInfo"
+                "ProductId"
             ],
             "properties": {
                 "CSPProductInfo": {
@@ -10278,12 +10277,17 @@ const docTemplate = `{
                     "example": "prod-123"
                 },
                 "VMSpecInfo": {
-                    "description": "Information about the VM spec",
+                    "description": "Information about the VM spec (used in detailed mode, default mode)",
                     "allOf": [
                         {
                             "$ref": "#/definitions/spider.VMSpecInfo"
                         }
                     ]
+                },
+                "VMSpecName": {
+                    "description": "Name of the VM spec (used in simple mode)",
+                    "type": "string",
+                    "example": "t2.micro"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5507,7 +5507,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud Metadata] Price Info"
+                    "[Cloud Metadata] VM Price Info"
                 ],
                 "summary": "Get VM Price Information",
                 "operationId": "get-vmprice-info",
@@ -5566,7 +5566,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud Metadata] Price Info"
+                    "[Cloud Metadata] VM Price Info"
                 ],
                 "summary": "List Product Families",
                 "operationId": "list-product-family",
@@ -10257,8 +10257,7 @@
             "type": "object",
             "required": [
                 "CSPProductInfo",
-                "ProductId",
-                "VMSpecInfo"
+                "ProductId"
             ],
             "properties": {
                 "CSPProductInfo": {
@@ -10275,12 +10274,17 @@
                     "example": "prod-123"
                 },
                 "VMSpecInfo": {
-                    "description": "Information about the VM spec",
+                    "description": "Information about the VM spec (used in detailed mode, default mode)",
                     "allOf": [
                         {
                             "$ref": "#/definitions/spider.VMSpecInfo"
                         }
                     ]
+                },
+                "VMSpecName": {
+                    "description": "Name of the VM spec (used in simple mode)",
+                    "type": "string",
+                    "example": "t2.micro"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1025,11 +1025,15 @@ definitions:
       VMSpecInfo:
         allOf:
         - $ref: '#/definitions/spider.VMSpecInfo'
-        description: Information about the VM spec
+        description: Information about the VM spec (used in detailed mode, default
+          mode)
+      VMSpecName:
+        description: Name of the VM spec (used in simple mode)
+        example: t2.micro
+        type: string
     required:
     - CSPProductInfo
     - ProductId
-    - VMSpecInfo
     type: object
   spider.RSType:
     enum:
@@ -7041,7 +7045,7 @@ paths:
             $ref: '#/definitions/spider.SimpleMsg'
       summary: Get VM Price Information
       tags:
-      - '[Cloud Metadata] Price Info'
+      - '[Cloud Metadata] VM Price Info'
   /productfamily/{RegionName}:
     get:
       consumes:
@@ -7082,7 +7086,7 @@ paths:
             $ref: '#/definitions/spider.SimpleMsg'
       summary: List Product Families
       tags:
-      - '[Cloud Metadata] Price Info'
+      - '[Cloud Metadata] VM Price Info'
   /readyz:
     get:
       consumes:

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/PriceInfoHandler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -246,8 +247,9 @@ func (priceInfoHandler *AzurePriceInfoHandler) GetPriceInfo(productFamily string
 	}
 
 	var skuList []*armcompute.ResourceSKU
+	simpleMode := strings.ToUpper(os.Getenv("VMSPECINFO_SIMPLE_MODE_IN_PRICEINFO")) == "ON"
 
-	if strings.ToLower(productFamily) == "compute" {
+	if strings.ToLower(productFamily) == "compute" && !simpleMode {
 		pager := priceInfoHandler.ResourceSkusClient.NewListPager(&armcompute.ResourceSKUsClientListOptions{})
 
 		for pager.More() {
@@ -289,77 +291,87 @@ func (priceInfoHandler *AzurePriceInfoHandler) GetPriceInfo(productFamily string
 			continue
 		}
 
-		productInfo := irs.ProductInfo{
-			ProductId: value[0].SkuID,
-			VMSpecInfo: irs.VMSpecInfo{
-				Name: "NA",
-				VCpu: irs.VCpuInfo{
-					Count:    "-1",
-					ClockGHz: "-1",
+		var productInfo irs.ProductInfo
+
+		// Simple 모드일 때는 VMSpecName만 설정
+		if simpleMode {
+			productInfo = irs.ProductInfo{
+				ProductId:      value[0].SkuID,
+				VMSpecName:     value[0].ArmSkuName,
+				Description:    value[0].ProductName,
+				CSPProductInfo: value[0],
+			}
+		} else {
+			// Non-simple 모드일 때는 VMSpecInfo를 기본값으로 초기화 (SKU capability에서 설정됨)
+			productInfo = irs.ProductInfo{
+				ProductId: value[0].SkuID,
+				VMSpecInfo: &irs.VMSpecInfo{
+					Region:     "",
+					Name:       value[0].ArmSkuName,
+					VCpu:       irs.VCpuInfo{Count: "-1", ClockGHz: "-1"},
+					MemSizeMiB: "-1",
+					DiskSizeGB: "-1",
 				},
-				MemSizeMiB: "-1",
-				DiskSizeGB: "-1",
-			},
-			Description:    value[0].ProductName,
-			CSPProductInfo: value[0],
+				Description:    value[0].ProductName,
+				CSPProductInfo: value[0],
+			}
 		}
 
 		foundMatchingSku := false
 		if strings.ToLower(productFamily) == "compute" {
-			gpuInfo := parseGpuInfo(value[0].ArmSkuName)
-			if gpuInfo != nil {
-				if productInfo.VMSpecInfo.Gpu == nil {
-					productInfo.VMSpecInfo.Gpu = make([]irs.GpuInfo, 0)
+			if simpleMode {
+				// Simple mode에서는 SKU 처리를 건너뛰고 Name만 유지
+				foundMatchingSku = true
+			} else {
+				gpuInfo := parseGpuInfo(value[0].ArmSkuName)
+				if gpuInfo != nil {
+					if productInfo.VMSpecInfo.Gpu == nil {
+						productInfo.VMSpecInfo.Gpu = make([]irs.GpuInfo, 0)
+					}
+					productInfo.VMSpecInfo.Gpu = append(productInfo.VMSpecInfo.Gpu, *gpuInfo)
 				}
-				productInfo.VMSpecInfo.Gpu = append(productInfo.VMSpecInfo.Gpu, *gpuInfo)
-			}
 
-			for _, sku := range skuList {
-				if value[0].ArmSkuName == *sku.Name {
-					foundMatchingSku = true
+				for _, sku := range skuList {
+					if value[0].ArmSkuName == *sku.Name {
+						foundMatchingSku = true
 
-					for _, capability := range sku.Capabilities {
-						if capability.Name == nil || capability.Value == nil {
-							continue
-						}
+						for _, capability := range sku.Capabilities {
+							if capability.Name == nil || capability.Value == nil {
+								continue
+							}
 
-						name := *capability.Name
-						value := *capability.Value
+							name := *capability.Name
+							value := *capability.Value
 
-						switch name {
-						case "OSVhdSizeMB":
-							productInfo.VMSpecInfo.DiskSizeGB, _ = irs.ConvertMiBToGB(value)
-						case "vCPUs":
-							productInfo.VMSpecInfo.VCpu.Count = value
-							productInfo.VMSpecInfo.VCpu.ClockGHz = "-1"
-						case "MemoryGB":
-							productInfo.VMSpecInfo.MemSizeMiB, _ = irs.ConvertGiBToMiB(value)
-						case "GPUs":
-							if gpuInfo == nil {
-								productInfo.VMSpecInfo.Gpu = []irs.GpuInfo{
-									{
-										Count:          value,
-										MemSizeGB:      "-1",
-										TotalMemSizeGB: "-1",
-										Mfr:            "NA",
-										Model:          "NA",
-									},
+							switch name {
+							case "OSVhdSizeMB":
+								productInfo.VMSpecInfo.DiskSizeGB, _ = irs.ConvertMiBToGB(value)
+							case "vCPUs":
+								productInfo.VMSpecInfo.VCpu.Count = value
+								productInfo.VMSpecInfo.VCpu.ClockGHz = "-1"
+							case "MemoryGB":
+								productInfo.VMSpecInfo.MemSizeMiB, _ = irs.ConvertGiBToMiB(value)
+							case "GPUs":
+								if gpuInfo == nil {
+									productInfo.VMSpecInfo.Gpu = []irs.GpuInfo{
+										{
+											Count:          value,
+											MemSizeGB:      "-1",
+											TotalMemSizeGB: "-1",
+											Mfr:            "NA",
+											Model:          "NA",
+										},
+									}
 								}
 							}
 						}
+						break
 					}
-					break
 				}
-			}
 
-			if !foundMatchingSku {
-				continue
-			}
-
-			if value[0].ArmSkuName == "" {
-				productInfo.VMSpecInfo.Name = "NA"
-			} else {
-				productInfo.VMSpecInfo.Name = value[0].ArmSkuName
+				if !foundMatchingSku {
+					continue
+				}
 			}
 		}
 

--- a/cloud-control-manager/cloud-driver/interfaces/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/PriceInfoHandler.go
@@ -34,10 +34,11 @@ type Price struct {
 
 // ProductInfo represents the product details.
 type ProductInfo struct {
-	ProductId      string      `json:"ProductId" validate:"required" example:"prod-123"`                           // ID of the product
-	VMSpecInfo     VMSpecInfo  `json:"VMSpecInfo" validate:"required" description:"Information about the VM spec"` // Information about the VM spec
-	Description    string      `json:"Description,omitempty" example:"General purpose instance"`                   // Description of the product
-	CSPProductInfo interface{} `json:"CSPProductInfo" validate:"required" description:"Additional product info"`   // Additional product information specific to CSP
+	ProductId      string      `json:"ProductId" validate:"required" example:"prod-123"`                                      // ID of the product
+	VMSpecName     string      `json:"VMSpecName,omitempty" validate:"omitempty" example:"t2.micro"`                          // Name of the VM spec (used in simple mode)
+	VMSpecInfo     *VMSpecInfo `json:"VMSpecInfo,omitempty" validate:"omitempty" description:"Information about the VM spec"` // Information about the VM spec (used in detailed mode, default mode)
+	Description    string      `json:"Description,omitempty" example:"General purpose instance"`                              // Description of the product
+	CSPProductInfo interface{} `json:"CSPProductInfo" validate:"required" description:"Additional product info"`              // Additional product information specific to CSP
 }
 
 // PriceInfo represents the pricing details for a product.

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20250911153447-1314aa57e794
 	github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20250820130332-f0e139707117
 	github.com/go-openapi/strfmt v0.23.0
+	github.com/goccy/go-json v0.10.5
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/itchyny/gojq v0.12.17
@@ -106,7 +107,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/validator/v10 v10.24.0 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/itchyny/timefmt-go v0.1.6 // indirect

--- a/setup.env
+++ b/setup.env
@@ -23,6 +23,9 @@ export PLUGIN_SW=OFF
 # default: ON
 export ID_TRANSFORM_MODE=ON
 
+# default: OFF
+export VMSPECINFO_SIMPLE_MODE_IN_PRICEINFO=OFF
+
 # root path of cb-log
 export CBLOG_ROOT=$CBSPIDER_ROOT
 


### PR DESCRIPTION
* Common: Added Simple Mode (providing VMSpecName) ([#1547](https://github.com/cloud-barista/cb-spider/issues/1547))
  * [VMSpec Info Simple Mode Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide#4-vmspec-info-simple-mode-%ED%99%9C%EC%9A%A9-%EA%B0%80%EC%9D%B4%EB%93%9C)
  * **Effect on Azure: 723MB => 99MB, 19sec => 5sec (see Guide for details)**
* AWS: Fixed GPU count conversion error (Float → Int)
* Alibaba: Fixed SystemDisk.Category error log ([#1566](https://github.com/cloud-barista/cb-spider/issues/1566))
* IBM: Added retry logic for DNS timeout
* NCP: Improved VMSpecName extraction rules ([#1535](https://github.com/cloud-barista/cb-spider/issues/1535))
* NCP: Enhanced and validated price information