### PR TITLE
[S3] Support multi-key credentials and improve adminweb error handling

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
@@ -131,7 +131,7 @@ func fetchS3Buckets(connConfig string) ([]S3BucketInfo, error) {
 
 		// If we get HTML, it means the S3 API didn't recognize our request
 		if strings.Contains(bodyStr, "<html>") {
-			return nil, fmt.Errorf("S3 API endpoint not accessible with ConnectionName parameter. Response: %s", bodyStr[:min(len(bodyStr), 200)])
+			return nil, fmt.Errorf("S3 API endpoint not accessible with ConnectionName parameter. Try checking S3 routes configuration. Response: %s", bodyStr[:min(len(bodyStr), 200)])
 		}
 		return nil, fmt.Errorf("received non-XML response: %s", bodyStr[:min(len(bodyStr), 100)])
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
@@ -8,6 +8,7 @@
 package adminweb
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"html/template"
@@ -63,18 +64,23 @@ func S3Management(c echo.Context) error {
 	}
 
 	buckets, err := fetchS3Buckets(connConfig)
+	var errorMessage string
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		// Set error message but don't return error - show empty table with error message
+		errorMessage = err.Error()
+		buckets = []S3BucketInfo{} // Empty bucket list
 	}
 
 	data := struct {
 		ConnectionConfig string
 		RegionName       string
 		Buckets          []S3BucketInfo
+		ErrorMessage     string
 	}{
 		ConnectionConfig: connConfig,
 		RegionName:       regionName,
 		Buckets:          buckets,
+		ErrorMessage:     errorMessage,
 	}
 
 	templatePath := filepath.Join(os.Getenv("CBSPIDER_ROOT"), "/api-runtime/rest-runtime/admin-web/html/s3.html")
@@ -111,11 +117,44 @@ func fetchS3Buckets(connConfig string) ([]S3BucketInfo, error) {
 	// Check if response is XML (should start with <?xml or <ListAllMyBucketsResult)
 	bodyStr := string(body)
 	if !strings.HasPrefix(bodyStr, "<?xml") && !strings.HasPrefix(bodyStr, "<ListAllMyBucketsResult") {
+		// Check if it's a JSON error response first
+		if strings.HasPrefix(bodyStr, "{") && strings.Contains(bodyStr, "error") {
+			// Try to parse JSON error response
+			type JSONError struct {
+				Error string `json:"error"`
+			}
+			var jsonErr JSONError
+			if err := json.Unmarshal(body, &jsonErr); err == nil && jsonErr.Error != "" {
+				return nil, fmt.Errorf("%s", jsonErr.Error)
+			}
+		}
+
 		// If we get HTML, it means the S3 API didn't recognize our request
 		if strings.Contains(bodyStr, "<html>") {
-			return nil, fmt.Errorf("S3 API endpoint not accessible with ConnectionName parameter. Try checking S3 routes configuration. Response: %s", bodyStr[:min(len(bodyStr), 200)])
+			return nil, fmt.Errorf("S3 API endpoint not accessible with ConnectionName parameter. Response: %s", bodyStr[:min(len(bodyStr), 200)])
 		}
 		return nil, fmt.Errorf("received non-XML response: %s", bodyStr[:min(len(bodyStr), 100)])
+	}
+
+	// Check if it's an S3 Error XML response
+	if strings.Contains(bodyStr, "<Error>") {
+		// Parse S3 Error XML
+		type S3Error struct {
+			XMLName   xml.Name `xml:"Error"`
+			Code      string   `xml:"Code"`
+			Message   string   `xml:"Message"`
+			RequestId string   `xml:"RequestId"`
+		}
+
+		var s3Error S3Error
+		if err := xml.Unmarshal(body, &s3Error); err == nil {
+			if s3Error.Message != "" {
+				return nil, fmt.Errorf("S3 Error [%s]: %s", s3Error.Code, s3Error.Message)
+			} else if s3Error.Code != "" {
+				return nil, fmt.Errorf("S3 Error: %s", s3Error.Code)
+			}
+		}
+		return nil, fmt.Errorf("S3 Error response received but could not parse details")
 	}
 
 	// Parse S3 standard XML response

--- a/api-runtime/rest-runtime/admin-web/html/s3.html
+++ b/api-runtime/rest-runtime/admin-web/html/s3.html
@@ -176,6 +176,15 @@
             </div>
         </div>
 
+        {{if .ErrorMessage}}
+        <script>
+            // Show error popup when page loads
+            window.addEventListener('DOMContentLoaded', function() {
+                alert('⚠️ S3 Connection Error:\n\n{{.ErrorMessage}}');
+            });
+        </script>
+        {{end}}
+
         <table id="bucket-table">
             <thead>
                 <tr>


### PR DESCRIPTION
- Added multi-key credential support for GCP, IBM, NHN, KT S3 access
  - cf) [S3 Storage Guide](https://github.com/cloud-barista/cb-spider/wiki/S3-Storage-Guide/433f4a8e79947b526cd335c30c817387146ec51c) 
- Enhanced AdminWeb error handling with server error parsing