### PR TITLE
[K8S] Support kubeconfig with dynamic token types

### DIFF
--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -431,6 +431,7 @@ func RunServer() {
 		{"GET", "/cluster", ListCluster},
 		{"GET", "/cluster/:Name", GetCluster},
 		{"DELETE", "/cluster/:Name", DeleteCluster},
+		{"GET", "/cluster/:Name/token", GetClusterToken},
 		//-- for NodeGroup
 		{"POST", "/cluster/:Name/nodegroup", AddNodeGroup},
 		{"DELETE", "/cluster/:Name/nodegroup/:NodeGroupName", RemoveNodeGroup},

--- a/api-runtime/rest-runtime/admin-web/html/cluster.html
+++ b/api-runtime/rest-runtime/admin-web/html/cluster.html
@@ -1894,10 +1894,38 @@
         }
 
         function copyKubeconfigToClipboard(button) {
-            const kubeconfigText = button.previousElementSibling.textContent; // Grab the kubeconfig value
+            let kubeconfigText = button.previousElementSibling.textContent; // Grab the kubeconfig value
+            
+            // Remove leading/trailing whitespace and normalize line breaks
+            kubeconfigText = kubeconfigText.trim();
+            
+            // Remove excessive leading whitespace from each line while preserving YAML structure
+            const lines = kubeconfigText.split('\n');
+            const cleanLines = [];
+            let minIndent = Infinity;
+            
+            // Find minimum indentation (excluding empty lines)
+            lines.forEach(line => {
+                if (line.trim()) {
+                    const leadingSpaces = line.match(/^\s*/)[0].length;
+                    minIndent = Math.min(minIndent, leadingSpaces);
+                }
+            });
+            
+            // Remove the minimum indentation from all lines
+            lines.forEach(line => {
+                if (line.trim()) {
+                    cleanLines.push(line.substring(minIndent));
+                } else {
+                    cleanLines.push('');
+                }
+            });
+            
+            const cleanKubeconfigText = cleanLines.join('\n').trim();
+            
             const tempInput = document.createElement('textarea'); // Use textarea to handle multi-line text
             document.body.appendChild(tempInput);
-            tempInput.value = kubeconfigText; // Set its value to the kubeconfig YAML text
+            tempInput.value = cleanKubeconfigText; // Set its value to the cleaned kubeconfig YAML text
             tempInput.select(); // Select the text
             document.execCommand('copy'); // Execute the copy command
             document.body.removeChild(tempInput); // Remove the temporary input element            

--- a/api/docs.go
+++ b/api/docs.go
@@ -1481,6 +1481,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/cluster/{Name}/token": {
+            "get": {
+                "description": "Get a temporary token for accessing EKS cluster (for kubectl exec auth)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cluster Management]"
+                ],
+                "summary": "Get Cluster Token",
+                "operationId": "get-cluster-token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Cluster to get token for",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to use",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Temporary token for cluster access",
+                        "schema": {
+                            "$ref": "#/definitions/spider.ClusterTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, missing required parameters",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/cluster/{Name}/upgrade": {
             "put": {
                 "description": "Upgrade a Cluster to a specified version.",
@@ -11578,6 +11636,31 @@ const docTemplate = `{
                             "example": "true"
                         }
                     }
+                }
+            }
+        },
+        "spider.ClusterTokenResponse": {
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "example": "client.authentication.k8s.io/v1"
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "ExecCredential"
+                },
+                "status": {
+                    "$ref": "#/definitions/spider.ClusterTokenStatus"
+                }
+            }
+        },
+        "spider.ClusterTokenStatus": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "example": "k8s-aws-v1.aHR0cHM6Ly9zdHMuYXA..."
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1478,6 +1478,64 @@
                 }
             }
         },
+        "/cluster/{Name}/token": {
+            "get": {
+                "description": "Get a temporary token for accessing EKS cluster (for kubectl exec auth)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Cluster Management]"
+                ],
+                "summary": "Get Cluster Token",
+                "operationId": "get-cluster-token",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Cluster to get token for",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to use",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Temporary token for cluster access",
+                        "schema": {
+                            "$ref": "#/definitions/spider.ClusterTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, missing required parameters",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/cluster/{Name}/upgrade": {
             "put": {
                 "description": "Upgrade a Cluster to a specified version.",
@@ -11575,6 +11633,31 @@
                             "example": "true"
                         }
                     }
+                }
+            }
+        },
+        "spider.ClusterTokenResponse": {
+            "type": "object",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "example": "client.authentication.k8s.io/v1"
+                },
+                "kind": {
+                    "type": "string",
+                    "example": "ExecCredential"
+                },
+                "status": {
+                    "$ref": "#/definitions/spider.ClusterTokenStatus"
+                }
+            }
+        },
+        "spider.ClusterTokenStatus": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "example": "k8s-aws-v1.aHR0cHM6Ly9zdHMuYXA..."
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1959,6 +1959,23 @@ definitions:
     - ConnectionName
     - ReqInfo
     type: object
+  spider.ClusterTokenResponse:
+    properties:
+      apiVersion:
+        example: client.authentication.k8s.io/v1
+        type: string
+      kind:
+        example: ExecCredential
+        type: string
+      status:
+        $ref: '#/definitions/spider.ClusterTokenStatus'
+    type: object
+  spider.ClusterTokenStatus:
+    properties:
+      token:
+        example: k8s-aws-v1.aHR0cHM6Ly9zdHMuYXA...
+        type: string
+    type: object
   spider.ClusterUpgradeRequest:
     properties:
       ConnectionName:
@@ -4265,6 +4282,46 @@ paths:
           schema:
             $ref: '#/definitions/spider.SimpleMsg'
       summary: Set Node Group Auto Scaling
+      tags:
+      - '[Cluster Management]'
+  /cluster/{Name}/token:
+    get:
+      consumes:
+      - application/json
+      description: Get a temporary token for accessing EKS cluster (for kubectl exec
+        auth)
+      operationId: get-cluster-token
+      parameters:
+      - description: The name of the Cluster to get token for
+        in: path
+        name: Name
+        required: true
+        type: string
+      - description: The name of the Connection to use
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Temporary token for cluster access
+          schema:
+            $ref: '#/definitions/spider.ClusterTokenResponse'
+        "400":
+          description: Bad Request, missing required parameters
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Get Cluster Token
       tags:
       - '[Cluster Management]'
   /cluster/{Name}/upgrade:

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -289,6 +289,12 @@ func (ach *AlibabaClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInf
 	return *clusterInfo, nil
 }
 
+// GenerateClusterToken generates a token for cluster authentication
+// Alibaba Cloud does not support dynamic token generation yet
+func (ach *AlibabaClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", fmt.Errorf("GenerateClusterToken is not supported for Alibaba Cloud clusters yet")
+}
+
 func (ach *AlibabaClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {
 	cblogger.Debug("Alibaba Cloud Driver: called DeleteCluster()")
 	hiscallInfo := GetCallLogScheme(ach.RegionInfo, call.CLUSTER, clusterIID.NameId, "DeleteCluster()")
@@ -821,7 +827,6 @@ func (ach *AlibabaClusterHandler) getClusterInfoWithoutNodeGroupList(regionId, c
 
 	clusterInfo.KeyValueList = irs.StructToKeyValueList(cluster)
 
-
 	return clusterInfo, nil
 }
 
@@ -970,7 +975,6 @@ func (ach *AlibabaClusterHandler) getNodeGroupInfo(clusterId, nodeGroupId string
 	// }
 
 	nodeGroupInfo.KeyValueList = irs.StructToKeyValueList(nodepool)
-
 
 	return nodeGroupInfo, err
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/sts"
 	cblogger "github.com/cloud-barista/cb-log"
 )
 
@@ -280,6 +281,16 @@ func getIamClient(connectionInfo idrv.ConnectionInfo) (*iam.IAM, error) {
 	return iam.New(sess), nil
 }
 
+// STS 처리를 위한 STS 클라이언트 획득
+func getStsClient(connectionInfo idrv.ConnectionInfo) (*sts.STS, error) {
+	sess, err := newAWSSession(connectionInfo, connectionInfo.RegionInfo.Region)
+	if err != nil {
+		cblog.Error("Could not create AWS session", err)
+		return nil, err
+	}
+	return sts.New(sess), nil
+}
+
 // AutoScaling 처리를 위한 autoScaling 클라이언트 획득
 func getAutoScalingClient(connectionInfo idrv.ConnectionInfo) (*autoscaling.AutoScaling, error) {
 
@@ -342,6 +353,7 @@ func (driver *AwsDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 	nlbClient, err := getNLBClient(connectionInfo)
 	eksClient, err := getEKSClient(connectionInfo)
 	iamClient, err := getIamClient(connectionInfo)
+	stsClient, err := getStsClient(connectionInfo)
 	pricingClient, err := getPricingClient(connectionInfo)
 	autoScalingClient, err := getAutoScalingClient(connectionInfo)
 	efsClient, err := getEFSClient(connectionInfo)
@@ -372,6 +384,7 @@ func (driver *AwsDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 
 		EKSClient:         eksClient,
 		IamClient:         iamClient,
+		StsClient:         stsClient,
 		AutoScalingClient: autoScalingClient,
 
 		RegionZoneClient: vmClient,

--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -281,7 +281,7 @@ func getIamClient(connectionInfo idrv.ConnectionInfo) (*iam.IAM, error) {
 	return iam.New(sess), nil
 }
 
-// STS 처리를 위한 STS 클라이언트 획득
+// Get STS client for STS processing
 func getStsClient(connectionInfo idrv.ConnectionInfo) (*sts.STS, error) {
 	sess, err := newAWSSession(connectionInfo, connectionInfo.RegionInfo.Region)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/eks"
@@ -62,6 +63,7 @@ type AwsCloudConnection struct {
 
 	EKSClient         *eks.EKS
 	IamClient         *iam.IAM
+	StsClient         *sts.STS
 	AutoScalingClient *autoscaling.AutoScaling
 
 	AnyCallClient *ec2.EC2
@@ -197,7 +199,7 @@ func (cloudConn *AwsCloudConnection) CreateClusterHandler() (irs.ClusterHandler,
 	if cloudConn.AutoScalingClient == nil {
 		cblogger.Info("cloudConn.AutoScalingClient is nil")
 	}
-	handler := ars.AwsClusterHandler{Region: cloudConn.Region, Client: cloudConn.EKSClient, EC2Client: cloudConn.VNetworkClient, Iam: cloudConn.IamClient, AutoScaling: cloudConn.AutoScalingClient, TagHandler: &tagHandler}
+	handler := ars.AwsClusterHandler{Region: cloudConn.Region, Client: cloudConn.EKSClient, EC2Client: cloudConn.VNetworkClient, Iam: cloudConn.IamClient, StsClient: cloudConn.StsClient, AutoScaling: cloudConn.AutoScalingClient, TagHandler: &tagHandler}
 	return &handler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"io"
 	"math"
 	"net"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
@@ -295,6 +296,13 @@ func (ac *AzureClusterHandler) GetCluster(clusterIID irs.IID) (info irs.ClusterI
 	LoggingInfo(hiscallInfo, start)
 	return info, nil
 }
+
+// GenerateClusterToken generates a token for cluster authentication
+// Azure AKS uses different authentication method, this is not supported yet
+func (ac *AzureClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", errors.New("GenerateClusterToken is not supported for Azure AKS clusters yet")
+}
+
 func (ac *AzureClusterHandler) DeleteCluster(clusterIID irs.IID) (deleteResult bool, delErr error) {
 	hiscallInfo := GetCallLogScheme(ac.Region, call.CLUSTER, clusterIID.NameId, "DeleteCluster()")
 	start := call.Start()

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
@@ -16,11 +20,8 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-version"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -457,6 +458,12 @@ func (ic *IbmClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInfo, er
 
 	LoggingInfo(hiscallInfo, start)
 	return irs.ClusterInfo{}, nil
+}
+
+// GenerateClusterToken generates a token for cluster authentication
+// IBM does not support dynamic token generation yet
+func (ic *IbmClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", fmt.Errorf("GenerateClusterToken is not supported for IBM clusters yet")
 }
 
 func (ic *IbmClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/ClusterHandler.go
@@ -207,6 +207,16 @@ func (clusterHandler *MockClusterHandler) GetCluster(iid irs.IID) (irs.ClusterIn
 	return irs.ClusterInfo{}, fmt.Errorf("%s Cluster does not exist!!", iid.NameId)
 }
 
+// GenerateClusterToken generates a token for cluster authentication
+// Mock implementation returns a fake token
+func (clusterHandler *MockClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	cblogger := cblog.GetLogger("CB-SPIDER")
+	cblogger.Info("Mock Driver: called GenerateClusterToken()!")
+
+	// Return a mock token for testing purposes
+	return "mock-token-k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5", nil
+}
+
 func (clusterHandler *MockClusterHandler) DeleteCluster(iid irs.IID) (bool, error) {
 	cblogger := cblog.GetLogger("CB-SPIDER")
 	cblogger.Info("Mock Driver: called DeleteCluster()!")

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
@@ -381,61 +381,61 @@ func (nvch *NcpVpcClusterHandler) addSubnetAndWait(vpcNo, subnetName, subnetRang
 func (nvch *NcpVpcClusterHandler) ListCluster() ([]*irs.ClusterInfo, error) {
 	return nil, nil
 	/*
-		if ClusterHandler == nil {
-			cblogger.Error("ClusterHandlerIs nil")
-			return nil, errors.New("ClusterHandler is nil")
+			if ClusterHandler == nil {
+				cblogger.Error("ClusterHandlerIs nil")
+				return nil, errors.New("ClusterHandler is nil")
 
-	   }
+		   }
 
-	   cblogger.Debug(ClusterHandler)
+		   cblogger.Debug(ClusterHandler)
 
-		if nvch.Client == nil {
-			cblogger.Error(" nvch.Client Is nil")
-			return nil, errors.New("ClusterHandler is nil")
-		}
+			if nvch.Client == nil {
+				cblogger.Error(" nvch.Client Is nil")
+				return nil, errors.New("ClusterHandler is nil")
+			}
 
-	   input := &vnks.ListClustersInput{}
-	   // logger for HisCall
-	   callogger := call.GetLogger("HISCALL")
+		   input := &vnks.ListClustersInput{}
+		   // logger for HisCall
+		   callogger := call.GetLogger("HISCALL")
 
-		callLogInfo := call.CLOUDLOGSCHEMA{
-			CloudOS:      call.AWS,
-			RegionZone:   nvch.Region.Zone,
-			ResourceType: call.CLUSTER,
-			ResourceName: "List()",
-			CloudOSAPI:   "ListClusters()",
-			ElapsedTime:  "",
-			ErrorMSG:     "",
-		}
+			callLogInfo := call.CLOUDLOGSCHEMA{
+				CloudOS:      call.AWS,
+				RegionZone:   nvch.Region.Zone,
+				ResourceType: call.CLUSTER,
+				ResourceName: "List()",
+				CloudOSAPI:   "ListClusters()",
+				ElapsedTime:  "",
+				ErrorMSG:     "",
+			}
 
-	   callLogStart := call.Start()
+		   callLogStart := call.Start()
 
-	   result, err := nvch.ClusterClient.ListClusters(input)
-	   callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+		   result, err := nvch.ClusterClient.ListClusters(input)
+		   callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 
-		if err != nil {
-			callLogInfo.ErrorMSG = err.Error()
-			callogger.Info(call.String(callLogInfo))
-			cblogger.Error(err.Error())
-			return nil, err
-		}
+			if err != nil {
+				callLogInfo.ErrorMSG = err.Error()
+				callogger.Info(call.String(callLogInfo))
+				cblogger.Error(err.Error())
+				return nil, err
+			}
 
-	   callogger.Info(call.String(callLogInfo))
+		   callogger.Info(call.String(callLogInfo))
 
-	   cblogger.Debug(result)
+		   cblogger.Debug(result)
 
-	   clusterList := []*irs.ClusterInfo{}
-	   for _, clusterName := range result.Clusters {
+		   clusterList := []*irs.ClusterInfo{}
+		   for _, clusterName := range result.Clusters {
 
-		clusterInfo, err := nvch.GetCluster(irs.IID{SystemId: *clusterName})
-		if err != nil {
-			cblogger.Error(err)
-			continue //	에러가 나면 일단 skip시킴.
-		}
-		clusterList = append(clusterList, &clusterInfo)
+			clusterInfo, err := nvch.GetCluster(irs.IID{SystemId: *clusterName})
+			if err != nil {
+				cblogger.Error(err)
+				continue //	에러가 나면 일단 skip시킴.
+			}
+			clusterList = append(clusterList, &clusterInfo)
 
-	   }
-	   return clusterList, nil
+		   }
+		   return clusterList, nil
 	*/
 }
 
@@ -594,6 +594,12 @@ func (nvch *NcpVpcClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInf
 	LoggingInfo(hiscallInfo, start)
 	cblogger.Debug(clusterInfo)
 	return clusterInfo, nil
+}
+
+// GenerateClusterToken generates a token for cluster authentication
+// NCP does not support dynamic token generation yet
+func (nvch *NcpVpcClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", fmt.Errorf("GenerateClusterToken is not supported for NCP clusters yet")
 }
 
 /*

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
@@ -271,6 +271,12 @@ func (nch *NhnCloudClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterIn
 	return *clusterInfo, nil
 }
 
+// GenerateClusterToken generates a token for cluster authentication
+// NHN Cloud does not support dynamic token generation yet
+func (nch *NhnCloudClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", fmt.Errorf("GenerateClusterToken is not supported for NHN Cloud clusters yet")
+}
+
 func (nch *NhnCloudClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -156,6 +156,12 @@ func (clusterHandler *TencentClusterHandler) GetCluster(clusterIID irs.IID) (irs
 	return *cluster_info, nil
 }
 
+// GenerateClusterToken generates a token for cluster authentication
+// Tencent Cloud does not support dynamic token generation yet
+func (clusterHandler *TencentClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+	return "", fmt.Errorf("GenerateClusterToken is not supported for Tencent Cloud clusters yet")
+}
+
 func (clusterHandler *TencentClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {
 	cblogger.Info("Tencent Cloud Driver: called DeleteCluster()")
 	callLogInfo := GetCallLogScheme(clusterHandler.RegionInfo, call.CLUSTER, clusterIID.NameId, "DeleteCluster()")
@@ -524,7 +530,6 @@ func getClusterInfo(access_key string, access_secret string, region_id string, c
 
 	clusterInfo.KeyValueList = irs.StructToKeyValueList(*res.Response.Clusters[0])
 
-
 	// NodeGroups
 	res2, err := tencent.ListNodeGroup(access_key, access_secret, region_id, cluster_id)
 	if err != nil {
@@ -764,7 +769,6 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 	// }
 
 	nodeGroupInfo.KeyValueList = irs.StructToKeyValueList(*res.Response.NodePool)
-
 
 	return nodeGroupInfo, err
 }

--- a/cloud-control-manager/cloud-driver/interfaces/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/ClusterHandler.go
@@ -113,6 +113,9 @@ type ClusterHandler interface {
 	GetCluster(clusterIID IID) (ClusterInfo, error)
 	DeleteCluster(clusterIID IID) (bool, error)
 
+	//------ Token Management
+	GenerateClusterToken(clusterIID IID) (string, error)
+
 	//------ NodeGroup Management
 	AddNodeGroup(clusterIID IID, nodeGroupReqInfo NodeGroupInfo) (NodeGroupInfo, error)
 	SetNodeGroupAutoScaling(clusterIID IID, nodeGroupIID IID, on bool) (bool, error)


### PR DESCRIPTION
- Updated GetCluster API to provide kubeconfig
- Added dynamic token type (AWS, GCP) and static token type (other CSPs)
- Added temporary token API for kubectl and related tools
- Verified with kubectl and OpenLens deployments

<br>

- kubconfig example for AWS
```
apiVersion: v1
kind: Config
clusters:
- cluster:
    server: https://7D23A46B1EFE6826611F2FD09D4813AC.gr7.ap-southeast-2.eks.amazonaws.com
    certificate-authority-data: **********************
  name: aws-sydney-cluster-0f5-d39o7061pc4tged15jv0
contexts:
- context:
    cluster: aws-sydney-cluster-0f5-d39o7061pc4tged15jv0
    user: aws-dynamic-token
  name: aws-sydney-cluster-0f5-d39o7061pc4tged15jv0
current-context: aws-sydney-cluster-0f5-d39o7061pc4tged15jv0
users:
- name: aws-dynamic-token
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      interactiveMode: Never
      command: curl
      args:
      - -s
      - "http://localhost:1024/spider/cluster/aws-sydney-cluster-0f5/token?ConnectionName=aws-config01"
```