### PR TITLE
fix(ncp): prevent nil pointer panic in calllogger

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
@@ -28,6 +28,7 @@ import (
 
 	// ncpcon "github.com/cloud-barista/ncp/ncp/connect"	// For local testing
 	ncpcon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ncp/connect"
+	ncprs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ncp/resources"
 )
 
 var cblogger *logrus.Logger
@@ -138,6 +139,9 @@ func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ic
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
 	// 3. create CloudConnection Instance of "connect/TDA_CloudConnection".
 	// 4. return CloudConnection Interface of TDA_CloudConnection.
+
+	// Initialize Logger
+	ncprs.InitLog()
 
 	vmClient, err := getVmClient(connectionInfo)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/CommonNcpVpcFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/CommonNcpVpcFunc.go
@@ -85,12 +85,18 @@ func String(n int32) string {
 }
 
 func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
+	if cblogger == nil || calllogger == nil {
+		InitLog()
+	}
 	cblogger.Error(err.Error())
 	hiscallInfo.ErrorMSG = err.Error()
 	calllogger.Error(call.String(hiscallInfo))
 }
 
 func LoggingInfo(hiscallInfo call.CLOUDLOGSCHEMA, start time.Time) {
+	if calllogger == nil {
+		InitLog()
+	}
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	calllogger.Info(call.String(hiscallInfo))
 }


### PR DESCRIPTION
# fix(ncp): prevent nil pointer panic in calllogger

## Problem

`LoggingInfo()` or `LoggingError()` causes panic when `calllogger` is nil in NCP driver.

**Root cause**: `InitLog()` was not called in `ConnectCloud()` (unlike AWS and other CSPs)

### Error Message
```
PANIC!! runtime error: invalid memory address or nil pointer dereference

github.com/sirupsen/logrus.(*Logger).Info(...)
github.com/cloud-barista/cb-spider/.../CommonNcpVpcFunc.go:95
    → calllogger.Info(call.String(hiscallInfo))
```

## Changes

| File | Change | Purpose |
|------|--------|---------|
| `CommonNcpVpcFunc.go` | Add nil check in `LoggingInfo/LoggingError` | Defensive coding |
| `NCPDriver.go` | Call `ncprs.InitLog()` in `ConnectCloud()` | Root cause fix |

### CommonNcpVpcFunc.go
```go
func LoggingError(hiscallInfo call.CLOUDLOGSCHEMA, err error) {
    if cblogger == nil || calllogger == nil {
        InitLog()
    }
    // ...
}

func LoggingInfo(hiscallInfo call.CLOUDLOGSCHEMA, start time.Time) {
    if calllogger == nil {
        InitLog()
    }
    // ...
}
```

### NCPDriver.go
```go
func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
    // Initialize Logger
    ncprs.InitLog()
    
    // ...
}
```

## Affected Functions

- `GetCluster()`
- `DeleteCluster()`
- All functions using `LoggingInfo()` or `LoggingError()`

## Related Issues

- Similar past issue: #572 (NCP nil pointer panic, 2022, closed)
