### PR TITLE
[AdminWeb] Set Dashboard to filter empty connections by default

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
@@ -152,6 +152,7 @@ func Dashboard(c echo.Context) error {
 		serverIP = "localhost"
 	}
 
+	// Default is false (filter empty connections), only true if explicitly set to "true"
 	showEmpty := c.QueryParam("showEmpty") == "true"
 
 	providers, err := fetchProviders()

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Frame.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Frame.go
@@ -118,7 +118,7 @@ func Top(c echo.Context) error {
                     <font size=1>$$TIME$$</font>
                     <br>
                     <!-- Dashboard Button -->
-                    <a href="dashboard?showEmpty=true" target="main_frame" id="menuDashboard" onclick="selectMenu('menuDashboard')">
+                    <a href="dashboard" target="main_frame" id="menuDashboard" onclick="selectMenu('menuDashboard')">
                         Dashboard
                     </a>
                 </td>

--- a/api-runtime/rest-runtime/admin-web/html/dashboard.html
+++ b/api-runtime/rest-runtime/admin-web/html/dashboard.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <title>CB-Spider Multi-Cloud Dashboard</title>
+<link rel="icon" type="image/png" href="/spider/adminweb/images/logo.png">
 <style>
     body {
         font-family: Arial, sans-serif;
@@ -200,8 +201,8 @@
         } else {
             url.searchParams.delete('showEmpty');
         }
-        window.history.pushState({}, '', url);
-        refreshDashboard();
+        // Update URL and reload to apply filter
+        window.location.href = url.href;
     }
 
     function setTopMenu(configName, provider, regionZone) {

--- a/api-runtime/rest-runtime/admin-web/html/left_menu.html
+++ b/api-runtime/rest-runtime/admin-web/html/left_menu.html
@@ -100,7 +100,7 @@
         function selectLeftMenu(menu) {
             changeSelectedImage(menu);
             const menuUrlMap = {
-                dashboard: "/spider/adminweb/dashboard?showEmpty=true",
+                dashboard: "/spider/adminweb/dashboard",
                 connection: "/spider/adminweb/connectionconfig"
             };
 

--- a/api-runtime/rest-runtime/admin-web/html/main.html
+++ b/api-runtime/rest-runtime/admin-web/html/main.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>CB-Spider Admin Web Tool</title>
+    <link rel="icon" type="image/png" href="/spider/adminweb/images/logo.png">
     <style>
         body, html {
             margin: 0;
@@ -269,10 +270,12 @@
         const menus = ['region-zone', 'price', 'vm-image', 'vm-specs'];
         menus.forEach(menu => {
             const imgElement = document.getElementById(menu + '-img');
-            if (menu === selectedMenu) {
-                imgElement.src = `/spider/adminweb/images/top-menu/${menu}_selected.png`;
-            } else {
-                imgElement.src = `/spider/adminweb/images/top-menu/${menu}.png`;
+            if (imgElement) {
+                if (menu === selectedMenu) {
+                    imgElement.src = `/spider/adminweb/images/top-menu/${menu}_selected.png`;
+                } else {
+                    imgElement.src = `/spider/adminweb/images/top-menu/${menu}.png`;
+                }
             }
         });
         parent.frames['left_menu'].postMessage({ type: 'deselectLeftMenu' }, '*');
@@ -292,7 +295,9 @@
             const menus = ['region-zone', 'price', 'vm-image', 'vm-specs'];
             menus.forEach(menu => {
                 const imgElement = document.getElementById(menu + '-img');
-                imgElement.src = `/spider/adminweb/images/top-menu/${menu}.png`;
+                if (imgElement) {
+                    imgElement.src = `/spider/adminweb/images/top-menu/${menu}.png`;
+                }
             });
         }
     });


### PR DESCRIPTION
* Dashboard page initial display behavior
* **[AS-IS]**
  * Shows resource counts for all connections (including empty ones)

* **[TO-BE]**
  * Shows resource counts only for connections with resources (empty connections are hidden by default)