### PR TITLE
fix(azure): Remove forced Zone override to respect user config (for GPU provisioning)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"


### PR DESCRIPTION
## Problem
When creating Azure GPU VMs (e.g., NC40ads), provisioning failed with OverconstrainedZonalAllocationRequest error. 

This occurred because the driver forcibly set Zone to "1" when the user intentionally left Zone empty to allow Azure's flexible zone allocation.

It is not ideal for resource provisioning and it cannot be avoided by a system utilizing CB-Spider.
This follows the Single Responsibility Principle (SRP) in perspective of CB-Tumblebug, 
and this also simplifies debugging. (it is hard to guess internal changes from outside)


```
// Previous problematic code
if connectionInfo.RegionInfo.Zone == "" || !zoneFound {
    iConn.Region.Zone = "1"  // Forced Zone="1" regardless of user intent
}
```

- User Intent: When users set Zone="" in Connection config, they expect Azure to automatically select an available zone.
- Separation of Concerns: CB-Spider should pass user configuration as-is. Zone validation and selection is CB-Tumblebug's responsibility.


## My suggestion

Remove the Zone override logic entirely. 
The driver now passes connectionInfo.RegionInfo directly to AzureCloudConnection, respecting user's original configuration.

## Testing
Verified by CB-TB, with Azure a GPU VM provisioning.