### PR TITLE
[Price] Change PriceInfo API from POST to GET and remove filterList

### DIFF
--- a/api-runtime/rest-runtime/PriceInfoRest.go
+++ b/api-runtime/rest-runtime/PriceInfoRest.go
@@ -63,12 +63,6 @@ func ListProductFamily(c echo.Context) error {
 	return c.JSON(http.StatusOK, &jsonResult)
 }
 
-// PriceInfoRequest represents the request body structure for the GetVMPriceInfo API.
-type PriceInfoRequest struct {
-	ConnectionName string          `json:"connectionName" validate:"required" description:"The name of the Connection to get Price Information for"`
-	FilterList     []cres.KeyValue `json:"filterList" description:"A list of filters to apply to the price information request"`
-}
-
 // PriceInfoResponse represents the response body structure for the GetVMPriceInfo API.
 type PriceInfoResponse struct {
 	cres.CloudPrice `json:",inline" description:"VM Price information details"`
@@ -77,22 +71,22 @@ type PriceInfoResponse struct {
 // getVMPriceInfo godoc
 // @ID get-vmprice-info
 // @Summary Get VM Price Information
-// @Description Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)] <br> * example body: {"connectionName":"aws-connection","FilterList":[{"Key":"instanceType","Value":"t2.micro"}]}
+// @Description Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]
 // @Tags [Cloud Metadata] VM Price Info
 // @Accept  json
 // @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to get Price Information for"
 // @Param RegionName path string true "The name of the Region to retrieve vm price information for"
 // @Param simple query bool false "Return simplified VM specification information (only VMSpecName). Default: false"
-// @Param PriceInfoRequest body PriceInfoRequest false "The request body containing additional filters for vm price information"
 // @Success 200 {object} PriceInfoResponse "VM Price Information Details"
 // @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
 // @Failure 404 {object} SimpleMsg "Resource Not Found"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
-// @Router /priceinfo/vm/{RegionName} [post]
+// @Router /priceinfo/vm/{RegionName} [get]
 func GetVMPriceInfo(c echo.Context) error {
 	cblog.Info("call GetVMPriceInfo()")
 
-	var req PriceInfoRequest
+	req := ConnectionRequest{}
 
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -114,7 +108,7 @@ func GetVMPriceInfo(c echo.Context) error {
 
 	// Call common-runtime API
 	// result, err := cmrt.GetPriceInfo(req.ConnectionName, c.Param("ProductFamily"), c.Param("RegionName"), req.FilterList, simpleVMSpecInfo)
-	result, err := cmrt.GetPriceInfo(req.ConnectionName, cres.RSTypeString(cres.VM), c.Param("RegionName"), req.FilterList, simpleVMSpecInfo)
+	result, err := cmrt.GetPriceInfo(req.ConnectionName, cres.RSTypeString(cres.VM), c.Param("RegionName"), nil, simpleVMSpecInfo)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Common.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Common.go
@@ -186,24 +186,10 @@ func getPriceInfoJsonString(connConfig string, resourceName string, productFamil
 		url += "&simple=true"
 	}
 
-	reqBody := struct {
-		ConnectionName string          `json:"ConnectionName"`
-		FilterList     []cres.KeyValue `json:"FilterList"`
-	}{
-		ConnectionName: connConfig,
-		FilterList:     filter,
-	}
-
-	jsonValue, err := json.Marshal(reqBody)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request body: %w", err)
-	}
-
-	request, err := http.NewRequest("GET", url, bytes.NewBuffer(jsonValue))
+	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}
-	request.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(request)

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-PriceInfo-TableList.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-PriceInfo-TableList.go
@@ -137,12 +137,6 @@ func PriceInfoTableList(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
-	var info struct {
-		FilterList []cres.KeyValue `json:"FilterList"`
-	}
-
-	json.Unmarshal([]byte(c.QueryParam("filterlist")), &info)
-
 	// Handle simplemode parameter
 	simpleMode := c.QueryParam("simplemode")
 	simpleVMSpecInfo := false
@@ -151,7 +145,7 @@ func PriceInfoTableList(c echo.Context) error {
 	}
 
 	var data cres.CloudPrice
-	err := getPriceInfoJsonString(connConfig, "priceinfo", c.Param("ProductFamily"), c.Param("RegionName"), info.FilterList, simpleVMSpecInfo, &data)
+	err := getPriceInfoJsonString(connConfig, "priceinfo", c.Param("ProductFamily"), c.Param("RegionName"), nil, simpleVMSpecInfo, &data)
 	if err != nil {
 		cblog.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())

--- a/api-runtime/rest-runtime/admin-web/html/priceinfo-request-template.html
+++ b/api-runtime/rest-runtime/admin-web/html/priceinfo-request-template.html
@@ -40,19 +40,6 @@
         .form-group select option {
             font-size: 14pt;
         }
-        textarea {
-            height: 200px; /* Adjust height as needed */
-        }
-
-        #filter {
-            font-family: 'Courier New', Courier, monospace;
-            font-size: 14px;
-            background-color: #f8f8f8; 
-            color: #333; 
-            white-space: pre; 
-            overflow: auto; 
-        }
-
         .fetch-btn {
             padding: 10px 20px;
             background-color: #f0f0f0;
@@ -64,46 +51,6 @@
         }
         .fetch-btn:hover {
             background-color: #e0e0e0;
-        }
-
-        .gen-tool-btn {
-            padding: 5px 10px;
-            background-color: #f0f0f0;
-            color: #333;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 14px;
-        }
-        .gen-tool-btn:hover {
-            background-color: #e0e0e0;
-        }
-
-        .button-textarea-group {
-            margin-bottom: 6px;
-        }
-
-        .gen-overlay {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(0, 0, 0, 0.7);
-            z-index: 1000;
-            display: none;
-        }
-        
-        .gen-overlay-content {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 90%;
-            height: 90%;
-            transform: translate(-50%, -50%);
-            background-color: white;
-            border: none;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
         }
 
         .fetch-overlay {
@@ -152,21 +99,8 @@
                     </select>                    
                 </div>
             </div>
-            <div class="form-group">
-                <div class="button-textarea-group">
-                    <label for="filter">Filter</label>
-                    <button type="button" class="gen-tool-btn" onclick="openGenOverlay()">Gen...</button>
-                    <button type="button" class="gen-tool-btn" onclick="clearFilter()">Clear</button>
-                </div>
-                <textarea id="filter" name="filter" spellcheck="false"></textarea>
-            </div>
             <button type="button" class="fetch-btn" onclick="OpenFetchOverlay()">Fetch</button>
         </form>
-    </div>
-
-    <!-- Gen Overlay -->
-    <div class="gen-overlay" id="genOverlay">
-        <iframe class="gen-overlay-content" id="genOverlayContent"></iframe>
     </div>
 
     <!-- Fetch Overlay -->
@@ -215,32 +149,16 @@
             });
         }
 
-        function setFilter(filterContent) {
-            document.getElementById('filter').value = filterContent;
-            closeGenOverlay();
-        }
-
-        function openGenOverlay() {
-            document.getElementById('genOverlay').style.display = 'block';
-            document.getElementById('genOverlayContent').src = '/spider/adminweb/html/priceinfo-filter-gen.html';
-        }
-
-        function closeGenOverlay() {
-            document.getElementById('genOverlay').style.display = 'none';
-            document.getElementById('genOverlayContent').src = '';
-        }
-
         function OpenFetchOverlay() {
             var region = document.getElementById('region').value;
             var connectionName = document.getElementById('connectionName').value;
-            var filterList = document.getElementById('filter').value;
             var simpleMode = document.getElementById('simpleMode').value;
 
             var fetchOverlayContent = document.getElementById('fetchOverlayContent');
             document.getElementById('fetchOverlay').style.display = 'block';
             fetchOverlayContent.src = 'about:blank'; // clear the iframe content
 
-            var url = `/spider/adminweb/priceinfotablelist/vm/${region}/${connectionName}?filterlist=${filterList}&simplemode=${simpleMode}`;
+            var url = `/spider/adminweb/priceinfotablelist/vm/${region}/${connectionName}?simplemode=${simpleMode}`;
 
             // logging the fetch URL
             var hostname = window.location.hostname;
@@ -248,8 +166,8 @@
 
             // make apiURL just to log curl command
             var apiURL = `/spider/priceinfo/vm/${encodeURIComponent(region)}?ConnectionName=${connectionName}`;
-            if (filterList) {
-                apiURL += ` -H 'Content-Type: application/json' -d '${filterList}'`
+            if (simpleMode === 'ON') {
+                apiURL += '&simple'
             }
             try {
                 parent.frames["log_frame"].Log("curl -sX GET http://" + `${hostname}` + ":" + `${port}`  + apiURL);
@@ -296,10 +214,6 @@
                                     // Do nothing if error occurs
                     }
                 });
-        }
-
-        function clearFilter() {
-            document.getElementById('filter').value = ''; 
         }
 
         function closeFetchOverlay() {

--- a/api/docs.go
+++ b/api/docs.go
@@ -5595,8 +5595,8 @@ const docTemplate = `{
             }
         },
         "/priceinfo/vm/{RegionName}": {
-            "post": {
-                "description": "Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)] \u003cbr\u003e * example body: {\"connectionName\":\"aws-connection\",\"FilterList\":[{\"Key\":\"instanceType\",\"Value\":\"t2.micro\"}]}",
+            "get": {
+                "description": "Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]",
                 "consumes": [
                     "application/json"
                 ],
@@ -5611,6 +5611,13 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "The name of the Connection to get Price Information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "The name of the Region to retrieve vm price information for",
                         "name": "RegionName",
                         "in": "path",
@@ -5621,14 +5628,6 @@ const docTemplate = `{
                         "description": "Return simplified VM specification information (only VMSpecName). Default: false",
                         "name": "simple",
                         "in": "query"
-                    },
-                    {
-                        "description": "The request body containing additional filters for vm price information",
-                        "name": "PriceInfoRequest",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/spider.PriceInfoRequest"
-                        }
                     }
                 ],
                 "responses": {
@@ -13731,23 +13730,6 @@ const docTemplate = `{
                 },
                 "ID": {
                     "type": "string"
-                }
-            }
-        },
-        "spider.PriceInfoRequest": {
-            "type": "object",
-            "required": [
-                "connectionName"
-            ],
-            "properties": {
-                "connectionName": {
-                    "type": "string"
-                },
-                "filterList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/spider.KeyValue"
-                    }
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -5592,8 +5592,8 @@
             }
         },
         "/priceinfo/vm/{RegionName}": {
-            "post": {
-                "description": "Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)] \u003cbr\u003e * example body: {\"connectionName\":\"aws-connection\",\"FilterList\":[{\"Key\":\"instanceType\",\"Value\":\"t2.micro\"}]}",
+            "get": {
+                "description": "Retrieve VM Price Information for a specific connection and region. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]",
                 "consumes": [
                     "application/json"
                 ],
@@ -5608,6 +5608,13 @@
                 "parameters": [
                     {
                         "type": "string",
+                        "description": "The name of the Connection to get Price Information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
                         "description": "The name of the Region to retrieve vm price information for",
                         "name": "RegionName",
                         "in": "path",
@@ -5618,14 +5625,6 @@
                         "description": "Return simplified VM specification information (only VMSpecName). Default: false",
                         "name": "simple",
                         "in": "query"
-                    },
-                    {
-                        "description": "The request body containing additional filters for vm price information",
-                        "name": "PriceInfoRequest",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/spider.PriceInfoRequest"
-                        }
                     }
                 ],
                 "responses": {
@@ -13728,23 +13727,6 @@
                 },
                 "ID": {
                     "type": "string"
-                }
-            }
-        },
-        "spider.PriceInfoRequest": {
-            "type": "object",
-            "required": [
-                "connectionName"
-            ],
-            "properties": {
-                "connectionName": {
-                    "type": "string"
-                },
-                "filterList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/spider.KeyValue"
-                    }
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2731,17 +2731,6 @@ definitions:
       ID:
         type: string
     type: object
-  spider.PriceInfoRequest:
-    properties:
-      connectionName:
-        type: string
-      filterList:
-        items:
-          $ref: '#/definitions/spider.KeyValue'
-        type: array
-    required:
-    - connectionName
-    type: object
   spider.PriceInfoResponse:
     properties:
       CloudName:
@@ -7228,14 +7217,18 @@ paths:
       tags:
       - '[Cloud Metadata] Region/Zone'
   /priceinfo/vm/{RegionName}:
-    post:
+    get:
       consumes:
       - application/json
       description: "Retrieve VM Price Information for a specific connection and region.
-        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]
-        <br> * example body: {\"connectionName\":\"aws-connection\",\"FilterList\":[{\"Key\":\"instanceType\",\"Value\":\"t2.micro\"}]}"
+        \U0001F577️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide)]"
       operationId: get-vmprice-info
       parameters:
+      - description: The name of the Connection to get Price Information for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
       - description: The name of the Region to retrieve vm price information for
         in: path
         name: RegionName
@@ -7246,11 +7239,6 @@ paths:
         in: query
         name: simple
         type: boolean
-      - description: The request body containing additional filters for vm price information
-        in: body
-        name: PriceInfoRequest
-        schema:
-          $ref: '#/definitions/spider.PriceInfoRequest'
       produces:
       - application/json
       responses:


### PR DESCRIPTION
- #### API Changed (@seokho-son @yunkon-kim )
  - Get VM Price Info: Filter 인자 제거
  - POST Method => GET Method

- **[AS-IS]**
  - POST /priceinfo/vm/{RegionName} with filterList in request body
  - Complex filter processing increases CSP API call overhead

- **[TO-BE]**
  - GET /priceinfo/vm/{RegionName}?ConnectionName={name}
  - Simplified API without filterList parameter
  - Updated Swagger docs and AdminWeb UI
  - cf) https://github.com/cloud-barista/cb-spider/wiki/VM-Price-Info-Guide