### PR TITLE
[Github:workflow] Align CI Go version and stabilize CD arm64 build

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -107,6 +107,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
+      - name: Docker prune
+        run: docker system prune -af
+
       - name: Build and publish
         id: docker_build
         uses: docker/build-push-action@v6
@@ -115,7 +118,7 @@ jobs:
           context: ./
           file: ./Dockerfile
           target: prod
-          platforms: linux/amd64,linux/arm # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
+          platforms: linux/amd64,linux/arm64 # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -123,3 +126,4 @@ jobs:
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Build source code
     strategy:
       matrix:
-        go-version: ["1.23"]
+        go-version: ["1.25"]
         os: [ubuntu-22.04]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
**[CD]**
* Improved CD Docker build stability by pruning unused Docker resources before build
* Updated CD build platforms to linux/amd64 and linux/arm64

**[CI]**
* Updated CI Go version from 1.23 to 1.25