### PR TITLE
fix(docker): resolve apt install failure caused by stale cache in sep…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,10 @@ RUN GOOS=linux go build -tags cb-spider -o cb-spider -v
 
 FROM ubuntu:22.04 AS prod
 
-RUN apt update
-
-RUN apt install -y ca-certificates curl
+# Note: Combine update and install in a single RUN to avoid stale package list from cached layers.
+# --no-install-recommends: Skip unnecessary recommended packages to reduce image size.
+# rm -rf /var/lib/apt/lists/*: Clean up apt cache (does not affect installed packages).
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 # use bash
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh


### PR DESCRIPTION
…arate layers

- Combine apt-get update and install to fix exit code 100 from stale cached layers
- Add --no-install-recommends flag to reduce image size
- Clean up apt cache with rm -rf /var/lib/apt/lists/*