### PR TITLE
Bypass checking logic for unsupported/incomplete resource types in the resource registration

### DIFF
--- a/api-runtime/rest-runtime/SecurityGroupRest.go
+++ b/api-runtime/rest-runtime/SecurityGroupRest.go
@@ -26,7 +26,7 @@ import (
 type SecurityGroupRegisterRequest struct {
 	ConnectionName string `json:"ConnectionName" validate:"required" example:"aws-connection"`
 	ReqInfo        struct {
-		VPCName string `json:"VPCName" validate:"required" example:"vpc-01"`
+		VPCName string `json:"VPCName" example:"vpc-01"` // Optional: some CSPs (e.g., Azure, Tencent, NHN) don't bind SG to VPC
 		Name    string `json:"Name" validate:"required" example:"sg-01"`
 		CSPId   string `json:"CSPId" validate:"required" example:"csp-sg-1234"`
 	} `json:"ReqInfo" validate:"required"`


### PR DESCRIPTION
This PR helps the registration feature of existing CSP resources in CB-Tumblebug.

- https://github.com/cloud-barista/cb-tumblebug/issues/2307
- https://github.com/cloud-barista/cb-tumblebug/issues/2308

by letting bypassing checking logic for unsupported/incomplete resource types (Keypair, SecurityGroup-(VPC))

Those issues in CB-TB cannot be resolved without this support from CB-SP.

I've tested this PR for creating VMs (and all related resources types) and registering Keypair, SecurityGroup-(VPC) individually.