### PR TITLE
[K8S:Kubeconfig] Add CSP native kubeconfig option for AWS/GCP

### DIFF
--- a/api-runtime/common-runtime/ClusterManager.go
+++ b/api-runtime/common-runtime/ClusterManager.go
@@ -901,7 +901,7 @@ func setResourcesNameId(connectionName string, info *cres.ClusterInfo) error {
 // (1) get IID:list
 // (2) get ClusterInfo:list
 // (3) set userIID, and ...
-func ListCluster(connectionName string, rsType string) ([]*cres.ClusterInfo, error) {
+func ListCluster(connectionName string, rsType string, kubeconfigType string) ([]*cres.ClusterInfo, error) {
 	cblog.Info("call ListCluster()")
 
 	// check empty and trim user inputs
@@ -984,6 +984,16 @@ func ListCluster(connectionName string, rsType string) ([]*cres.ClusterInfo, err
 			}
 		}
 
+		// Convert to CSP native kubeconfig if requested
+		if kubeconfigType == "native" && info.AccessInfo.Kubeconfig != "" {
+			nativeKubeconfig, err := convertToNativeKubeConfig(connectionName, &info)
+			if err != nil {
+				cblog.Warn("Failed to convert to native kubeconfig, using default: " + err.Error())
+			} else if nativeKubeconfig != "" {
+				info.AccessInfo.Kubeconfig = nativeKubeconfig
+			}
+		}
+
 		// set used Resources's userIID
 		err = setResourcesNameId(connectionName, &info)
 		if err != nil {
@@ -1000,7 +1010,7 @@ func ListCluster(connectionName string, rsType string) ([]*cres.ClusterInfo, err
 // (1) get IID(NameId)
 // (2) get resource(SystemId)
 // (3) set ResourceInfo(IID.NameId)
-func GetCluster(connectionName string, rsType string, clusterName string) (*cres.ClusterInfo, error) {
+func GetCluster(connectionName string, rsType string, clusterName string, kubeconfigType string) (*cres.ClusterInfo, error) {
 	cblog.Info("call GetCluster()")
 
 	// check empty and trim user inputs
@@ -1083,6 +1093,16 @@ func GetCluster(connectionName string, rsType string, clusterName string) (*cres
 		}
 		if strings.Contains(info.AccessInfo.Kubeconfig, "CLUSTER_NAME_PLACEHOLDER") {
 			info.AccessInfo.Kubeconfig = strings.ReplaceAll(info.AccessInfo.Kubeconfig, "CLUSTER_NAME_PLACEHOLDER", clusterName)
+		}
+	}
+
+	// Convert to CSP native kubeconfig if requested
+	if kubeconfigType == "native" && info.AccessInfo.Kubeconfig != "" {
+		nativeKubeconfig, err := convertToNativeKubeConfig(connectionName, &info)
+		if err != nil {
+			cblog.Warn("Failed to convert to native kubeconfig, using default: " + err.Error())
+		} else if nativeKubeconfig != "" {
+			info.AccessInfo.Kubeconfig = nativeKubeconfig
 		}
 	}
 
@@ -2006,4 +2026,116 @@ func CountClustersByConnection(connectionName string) (int64, error) {
 	}
 
 	return count, nil
+}
+
+// convertToNativeKubeConfig generates CSP native kubeconfig for AWS and GCP.
+// AWS: uses aws-iam-authenticator exec plugin
+// GCP: uses gke-gcloud-auth-plugin exec plugin
+// For other CSPs, returns empty string (no conversion needed, they already use static kubeconfig).
+func convertToNativeKubeConfig(connectionName string, info *cres.ClusterInfo) (string, error) {
+	providerName, err := ccm.GetProviderNameByConnectionName(connectionName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider name: %w", err)
+	}
+
+	providerName = strings.ToUpper(providerName)
+
+	switch providerName {
+	case "AWS":
+		return generateAWSNativeKubeConfig(info), nil
+	case "GCP":
+		return generateGCPNativeKubeConfig(info), nil
+	default:
+		// Other CSPs already use static kubeconfig, no conversion needed
+		return "", nil
+	}
+}
+
+// generateAWSNativeKubeConfig generates kubeconfig using aws-iam-authenticator exec plugin
+func generateAWSNativeKubeConfig(info *cres.ClusterInfo) string {
+	// Extract cluster name from IId
+	clusterName := info.IId.NameId
+	if info.IId.SystemId != "" {
+		clusterName = info.IId.SystemId
+	}
+
+	// Parse CA data and endpoint from existing kubeconfig or AccessInfo
+	endpoint := info.AccessInfo.Endpoint
+	caData := extractCADataFromKubeconfig(info.AccessInfo.Kubeconfig)
+
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority-data: %s
+  name: %s
+contexts:
+- context:
+    cluster: %s
+    user: aws-iam-user
+  name: %s
+current-context: %s
+users:
+- name: aws-iam-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      interactiveMode: Never
+      command: aws-iam-authenticator
+      args:
+      - token
+      - -i
+      - %s
+`, endpoint, caData, clusterName, clusterName, clusterName, clusterName, clusterName)
+}
+
+// generateGCPNativeKubeConfig generates kubeconfig using gke-gcloud-auth-plugin exec plugin
+func generateGCPNativeKubeConfig(info *cres.ClusterInfo) string {
+	// Extract cluster name from IId
+	clusterName := info.IId.NameId
+
+	// Parse CA data and endpoint from existing kubeconfig or AccessInfo
+	endpoint := info.AccessInfo.Endpoint
+	caData := extractCADataFromKubeconfig(info.AccessInfo.Kubeconfig)
+
+	// Ensure endpoint has https:// prefix
+	if !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "https://" + endpoint
+	}
+
+	return fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: %s
+    certificate-authority-data: %s
+  name: %s
+contexts:
+- context:
+    cluster: %s
+    user: gcp-gke-user
+  name: %s
+current-context: %s
+users:
+- name: gcp-gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following
+        https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin
+      provideClusterInfo: true
+`, endpoint, caData, clusterName, clusterName, clusterName, clusterName)
+}
+
+// extractCADataFromKubeconfig extracts certificate-authority-data from kubeconfig string
+func extractCADataFromKubeconfig(kubeconfig string) string {
+	for _, line := range strings.Split(kubeconfig, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "certificate-authority-data:") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "certificate-authority-data:"))
+		}
+	}
+	return ""
 }

--- a/api-runtime/rest-runtime/ClusterRest.go
+++ b/api-runtime/rest-runtime/ClusterRest.go
@@ -227,6 +227,7 @@ type ClusterListResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param ConnectionName query string true "The name of the Connection to list Clusters for"
+// @Param KubeconfigType query string false "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based" Enums(native)
 // @Success 200 {object} ClusterListResponse "List of Clusters"
 // @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
 // @Failure 404 {object} SimpleMsg "Resource Not Found"
@@ -246,8 +247,10 @@ func ListCluster(c echo.Context) error {
 		req.ConnectionName = c.QueryParam("ConnectionName")
 	}
 
+	kubeconfigType := c.QueryParam("KubeconfigType") // "native" or "" (default: spider credential-based)
+
 	// Call common-runtime API
-	result, err := cmrt.ListCluster(req.ConnectionName, CLUSTER)
+	result, err := cmrt.ListCluster(req.ConnectionName, CLUSTER, kubeconfigType)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -319,6 +322,7 @@ func ListAllClusterInfo(c echo.Context) error { return listAllResourceInfo(c, cr
 // @Produce  json
 // @Param ConnectionName query string true "The name of the Connection to get a Cluster for"
 // @Param Name path string true "The name of the Cluster to retrieve"
+// @Param KubeconfigType query string false "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based" Enums(native)
 // @Success 200 {object} cres.ClusterInfo "Details of the Cluster"
 // @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
 // @Failure 404 {object} SimpleMsg "Resource Not Found"
@@ -339,9 +343,10 @@ func GetCluster(c echo.Context) error {
 	}
 
 	clusterName := c.Param("Name")
+	kubeconfigType := c.QueryParam("KubeconfigType") // "native" or "" (default: spider credential-based)
 
 	// Call common-runtime API
-	result, err := cmrt.GetCluster(req.ConnectionName, CLUSTER, clusterName)
+	result, err := cmrt.GetCluster(req.ConnectionName, CLUSTER, clusterName, kubeconfigType)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}

--- a/api-runtime/rest-runtime/admin-web/html/cluster.html
+++ b/api-runtime/rest-runtime/admin-web/html/cluster.html
@@ -673,7 +673,8 @@
                     {{if $cluster.Status}}
                         <a class="view-details-link" href="javascript:void(0);" onclick="showClusterDetailsOverlay('Access Info', {
                             endpoint: '{{$cluster.AccessInfo.Endpoint}}',
-                            kubeconfig: `{{$cluster.AccessInfo.Kubeconfig}}`
+                            kubeconfig: `{{$cluster.AccessInfo.Kubeconfig}}`,
+                            clusterName: '{{$cluster.IId.NameId}}'
                         })">View Details</a>
                     {{end}}
                 </td>
@@ -1781,13 +1782,22 @@
 
                 const kubeconfigRow = document.createElement('tr');
                 kubeconfigRow.innerHTML = `
-                    <th>Kubeconfig (YAML)</th>
+                    <th>Kubeconfig (YAML)
+                        <div style="margin-top:8px;">
+                            <select id="kubeconfigTypeSelect" onchange="switchKubeconfigType(this, '${data.clusterName}')" style="font-size:11px; padding:2px 4px; border-radius:3px; border:1px solid #aaa;">
+                                <option value="default" selected>Spider Default</option>
+                                <option value="native">CSP Native</option>
+                            </select>
+                        </div>
+                    </th>
                     <td>
-                        <div style="max-height: 200px; overflow: auto; padding: 5px; border: 1px solid #ccc;">
+                        <div id="kubeconfigContent" style="max-height: 200px; overflow: auto; padding: 5px; border: 1px solid #ccc;">
                             <pre class="kubeconfig-yaml" style="white-space: pre-wrap; word-wrap: break-word;">${data.kubeconfig}</pre>
                         </div>
                         <button class="copy-icon-btn" onclick="copyKubeconfigToClipboard(this)">📋</button>
+                        <span id="kubeconfigLoading" style="display:none; color:#666; font-size:11px; margin-left:8px;">Loading...</span>
                     </td>`;
+                kubeconfigRow.querySelector('#kubeconfigTypeSelect').dataset.defaultKubeconfig = data.kubeconfig;
                 detailsTable.appendChild(kubeconfigRow);
             }
 
@@ -2006,8 +2016,46 @@
             overlay.style.display = 'none';
         }
 
+        function switchKubeconfigType(selectEl, clusterName) {
+            const kubeconfigType = selectEl.value;
+            const kubeconfigContent = document.getElementById('kubeconfigContent');
+            const loadingSpan = document.getElementById('kubeconfigLoading');
+
+            if (kubeconfigType === 'default') {
+                // Restore default Spider kubeconfig
+                const defaultKubeconfig = selectEl.dataset.defaultKubeconfig;
+                kubeconfigContent.innerHTML = `<pre class="kubeconfig-yaml" style="white-space: pre-wrap; word-wrap: break-word;">${defaultKubeconfig}</pre>`;
+                return;
+            }
+
+            // Fetch CSP Native kubeconfig via API
+            loadingSpan.style.display = 'inline';
+            const connConfig = "{{.ConnectionConfig}}";
+            fetchWithProgress(`/spider/cluster/${clusterName}?ConnectionName=${connConfig}&KubeconfigType=native`, {
+                method: 'GET',
+                headers: { 'Content-Type': 'application/json' }
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(error => { throw new Error(error.message || 'Failed to fetch'); });
+                }
+                return response.json();
+            })
+            .then(clusterInfo => {
+                loadingSpan.style.display = 'none';
+                const nativeKubeconfig = clusterInfo.AccessInfo?.Kubeconfig || 'Native kubeconfig not available for this CSP.';
+                kubeconfigContent.innerHTML = `<pre class="kubeconfig-yaml" style="white-space: pre-wrap; word-wrap: break-word;">${nativeKubeconfig}</pre>`;
+            })
+            .catch(error => {
+                loadingSpan.style.display = 'none';
+                kubeconfigContent.innerHTML = `<pre class="kubeconfig-yaml" style="white-space: pre-wrap; word-wrap: break-word; color:red;">Error: ${error.message}</pre>`;
+            });
+        }
+
         function copyKubeconfigToClipboard(button) {
-            let kubeconfigText = button.previousElementSibling.textContent; // Grab the kubeconfig value
+            // Find the kubeconfig pre element within the kubeconfigContent div
+            const kubeconfigDiv = button.closest('td').querySelector('#kubeconfigContent');
+            let kubeconfigText = kubeconfigDiv ? kubeconfigDiv.textContent : button.previousElementSibling.textContent;
             
             // Remove leading/trailing whitespace and normalize line breaks
             kubeconfigText = kubeconfigText.trim();

--- a/api/docs.go
+++ b/api/docs.go
@@ -1017,6 +1017,15 @@ const docTemplate = `{
                         "name": "ConnectionName",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "native"
+                        ],
+                        "type": "string",
+                        "description": "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based",
+                        "name": "KubeconfigType",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1126,6 +1135,15 @@ const docTemplate = `{
                         "name": "Name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "native"
+                        ],
+                        "type": "string",
+                        "description": "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based",
+                        "name": "KubeconfigType",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -11145,13 +11163,11 @@ const docTemplate = `{
                 },
                 "avgCreationTime": {
                     "description": "Average VM creation time in seconds",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "creationCount": {
                     "description": "Number of successful VM creations",
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "csp": {
                     "type": "string"
@@ -12943,18 +12959,6 @@ const docTemplate = `{
                 "Suspending": "from running to suspended",
                 "Terminating": "from running, suspended to terminated"
             },
-            "x-enum-descriptions": [
-                "from launch to running",
-                "",
-                "from running to suspended",
-                "",
-                "from suspended to running",
-                "from running to running",
-                "from running, suspended to terminated",
-                "",
-                "VM does not exist",
-                ""
-            ],
             "x-enum-varnames": [
                 "Creating",
                 "Running",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1014,6 +1014,15 @@
                         "name": "ConnectionName",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "native"
+                        ],
+                        "type": "string",
+                        "description": "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based",
+                        "name": "KubeconfigType",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1123,6 +1132,15 @@
                         "name": "Name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "native"
+                        ],
+                        "type": "string",
+                        "description": "Kubeconfig type: 'native' for CSP native plugin (aws-iam-authenticator, gke-gcloud-auth-plugin), default is CB-Spider credential-based",
+                        "name": "KubeconfigType",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -11142,13 +11160,11 @@
                 },
                 "avgCreationTime": {
                     "description": "Average VM creation time in seconds",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "creationCount": {
                     "description": "Number of successful VM creations",
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "csp": {
                     "type": "string"
@@ -12940,18 +12956,6 @@
                 "Suspending": "from running to suspended",
                 "Terminating": "from running, suspended to terminated"
             },
-            "x-enum-descriptions": [
-                "from launch to running",
-                "",
-                "from running to suspended",
-                "",
-                "from suspended to running",
-                "from running to running",
-                "from running, suspended to terminated",
-                "",
-                "VM does not exist",
-                ""
-            ],
             "x-enum-varnames": [
                 "Creating",
                 "Running",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -202,11 +202,9 @@ definitions:
         type: string
       avgCreationTime:
         description: Average VM creation time in seconds
-        format: float64
         type: number
       creationCount:
         description: Number of successful VM creations
-        format: int64
         type: integer
       csp:
         type: string
@@ -1491,17 +1489,6 @@ definitions:
       Resuming: from suspended to running
       Suspending: from running to suspended
       Terminating: from running, suspended to terminated
-    x-enum-descriptions:
-    - from launch to running
-    - ""
-    - from running to suspended
-    - ""
-    - from suspended to running
-    - from running to running
-    - from running, suspended to terminated
-    - ""
-    - VM does not exist
-    - ""
     x-enum-varnames:
     - Creating
     - Running
@@ -4172,6 +4159,13 @@ paths:
         name: ConnectionName
         required: true
         type: string
+      - description: 'Kubeconfig type: ''native'' for CSP native plugin (aws-iam-authenticator,
+          gke-gcloud-auth-plugin), default is CB-Spider credential-based'
+        enum:
+        - native
+        in: query
+        name: KubeconfigType
+        type: string
       produces:
       - application/json
       responses:
@@ -4294,6 +4288,13 @@ paths:
         in: path
         name: Name
         required: true
+        type: string
+      - description: 'Kubeconfig type: ''native'' for CSP native plugin (aws-iam-authenticator,
+          gke-gcloud-auth-plugin), default is CB-Spider credential-based'
+        enum:
+        - native
+        in: query
+        name: KubeconfigType
         type: string
       produces:
       - application/json

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
@@ -843,6 +843,8 @@ users:
 }
 
 // getDynamicKubeConfig generates kubeconfig with exec-based dynamic token
+// Credentials are read from ~/.cb-spider/.spider-credential file at kubectl execution time
+// The credentials file should contain: SPIDER_USERNAME=<username> and SPIDER_PASSWORD=<password>
 func (ClusterHandler *AwsClusterHandler) getDynamicKubeConfig(clusterDesc *eks.DescribeClusterOutput) string {
 
 	cluster := clusterDesc.Cluster
@@ -850,11 +852,8 @@ func (ClusterHandler *AwsClusterHandler) getDynamicKubeConfig(clusterDesc *eks.D
 	// Get Spider server address from environment variable
 	serverAddr := getServerAddress()
 
-	// Get Spider API credentials from environment variables
-	apiUsername := os.Getenv("SPIDER_USERNAME")
-	apiPassword := os.Getenv("SPIDER_PASSWORD")
-
-	// Generate kubeconfig content with exec-based dynamic token using cluster NameId instead of SystemId
+	// Generate kubeconfig content with exec-based dynamic token
+	// Credentials are sourced from ~/.cb-spider/.spider-credential at runtime (not embedded in kubeconfig)
 	kubeconfigContent := fmt.Sprintf(`apiVersion: v1
 kind: Config
 clusters:
@@ -874,13 +873,11 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1
       interactiveMode: Never
-      command: curl
+      command: sh
       args:
-      - -s
-      - -u
-      - "%s:%s"
-      - "http://%s/spider/cluster/CLUSTER_NAME_PLACEHOLDER/token?ConnectionName=CONNECTION_NAME_PLACEHOLDER"
-`, *cluster.Endpoint, *cluster.CertificateAuthority.Data, *cluster.Name, *cluster.Name, *cluster.Name, *cluster.Name, apiUsername, apiPassword, serverAddr)
+      - -c
+      - ". ~/.cb-spider/.spider-credential && curl -s -u \"$SPIDER_USERNAME:$SPIDER_PASSWORD\" \"http://%s/spider/cluster/CLUSTER_NAME_PLACEHOLDER/token?ConnectionName=CONNECTION_NAME_PLACEHOLDER\""
+`, *cluster.Endpoint, *cluster.CertificateAuthority.Data, *cluster.Name, *cluster.Name, *cluster.Name, *cluster.Name, serverAddr)
 
 	return kubeconfigContent
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
@@ -1448,17 +1448,16 @@ users:
 }
 
 // getDynamicKubeConfig generates kubeconfig with exec-based dynamic token
+// Credentials are read from ~/.cb-spider/.spider-credential file at kubectl execution time
+// The credentials file should contain: SPIDER_USERNAME=<username> and SPIDER_PASSWORD=<password>
 func getDynamicKubeConfig(cluster *container.Cluster) string {
 	configName := fmt.Sprintf("gke_%s_%s", cluster.Location, cluster.Name)
 
 	// Get Spider server address from environment variable
 	serverAddr := getServerAddress()
 
-	// Get Spider API credentials from environment variables
-	apiUsername := os.Getenv("SPIDER_USERNAME")
-	apiPassword := os.Getenv("SPIDER_PASSWORD")
-
 	// Generate kubeconfig content with exec-based dynamic token
+	// Credentials are sourced from ~/.cb-spider/.spider-credential at runtime (not embedded in kubeconfig)
 	kubeconfigContent := fmt.Sprintf(`apiVersion: v1
 kind: Config
 clusters:
@@ -1478,13 +1477,11 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1
       interactiveMode: Never
-      command: curl
+      command: sh
       args:
-      - -s
-      - -u
-      - "%s:%s"
-      - "http://%s/spider/cluster/CLUSTER_NAME_PLACEHOLDER/token?ConnectionName=CONNECTION_NAME_PLACEHOLDER"
-`, cluster.Endpoint, cluster.MasterAuth.ClusterCaCertificate, configName, configName, configName, configName, apiUsername, apiPassword, serverAddr)
+      - -c
+      - ". ~/.cb-spider/.spider-credential && curl -s -u \"$SPIDER_USERNAME:$SPIDER_PASSWORD\" \"http://%s/spider/cluster/CLUSTER_NAME_PLACEHOLDER/token?ConnectionName=CONNECTION_NAME_PLACEHOLDER\""
+`, cluster.Endpoint, cluster.MasterAuth.ClusterCaCertificate, configName, configName, configName, configName, serverAddr)
 
 	return kubeconfigContent
 }


### PR DESCRIPTION
- Add KubeconfigType query parameter to Cluster Get/List APIs for CSP-native kubeconfig 
  - (AWS: aws-iam-authenticator, GCP: gke-gcloud-auth-plugin)
- Implement native kubeconfig generation helpers 
  - (convertToNativeKubeConfig, generateAWSNativeKubeConfig, generateGCPNativeKubeConfig)
- Add kubeconfig type dropdown 
  - (Spider Default / CSP Native) to AdminWeb cluster details overlay
- Update Swagger/OpenAPI docs with KubeconfigType parameter
- For more details, see the [Guide to Using kubectl with CB-Spider Kubeconfig](https://github.com/cloud-barista/cb-spider/wiki/Guide-to-Using-kubectl-with-CB%E2%80%90Spider-Kubeconfig).