### PR TITLE
fix: resolve version display in docker and optimize static build

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for version information
 
       # About billing for GitHub Packages
       # https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for version information
 
       # Cache Go modules
       - name: Cache Go modules
@@ -67,6 +69,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for version information
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,13 @@ ADD . /go/src/github.com/cloud-barista/cb-spider
 
 WORKDIR /go/src/github.com/cloud-barista/cb-spider
 
-#RUN ./build_all_driver_lib.sh
-
+# Note: Docker image provides static mode only (dynamic mode available in binary releases)
 WORKDIR api-runtime
 
 RUN VERSION=$(git describe --tags --abbrev=8 2>/dev/null | sed 's/-g.*//' || echo "unknown") && \
     COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
     BUILD_TIME=$(date) && \
-    GOOS=linux go build -tags cb-spider \
+    CGO_ENABLED=0 GOOS=linux go build -tags cb-spider \
     -ldflags="-X 'main.Version=${VERSION}' -X 'main.CommitSHA=${COMMIT_SHA}' -X 'main.BuildTime=${BUILD_TIME}'" \
     -o cb-spider -v
 
@@ -45,8 +44,7 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 WORKDIR /root/go/src/github.com/cloud-barista/cb-spider
 
-COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/cloud-driver-libs/ /root/go/src/github.com/cloud-barista/cb-spider/cloud-driver-libs/
-
+# Note: cloud-driver-libs not needed for static mode
 COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/conf/ /root/go/src/github.com/cloud-barista/cb-spider/conf/
 
 COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/api-runtime/cb-spider /root/go/src/github.com/cloud-barista/cb-spider/api-runtime/
@@ -57,10 +55,9 @@ COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/api-runtime/rest-
 
 COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/api/ /root/go/src/github.com/cloud-barista/cb-spider/api/
 
-#COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/setup.env /root/go/src/github.com/cloud-barista/cb-spider/
-#RUN /bin/bash -c "source /root/go/src/github.com/cloud-barista/cb-spider/setup.env"
 ENV CBSPIDER_ROOT=/root/go/src/github.com/cloud-barista/cb-spider
 ENV CBLOG_ROOT=/root/go/src/github.com/cloud-barista/cb-spider
+# Static mode only (dynamic mode available in binary releases)
 ENV PLUGIN_SW=OFF
 
 ENTRYPOINT [ "/root/go/src/github.com/cloud-barista/cb-spider/api-runtime/cb-spider" ]


### PR DESCRIPTION
* **CI/CD Workflow**

  * Updated `actions/checkout` to `fetch-depth: 0`
  * Ensures full Git history is available for versioning info during builds

* 현재 container version은 `static mode`만 제공하도록 정리함
  - 사유: arm64 platform dynamic mode build 시간이 약 40분 소요, 사용 빈도에 비해 소모적임
    - 사유: arm64 Platform build는 QEMU 에뮬레이션 환경에서 build됨(Github arm64 run 환경은 유료)
    - 이때, Driver Plugin을 위한 CGO 옵션 Go build는 시간이 오래 걸림
  - 현재 `dynamic mode`는 binary version에서만 제공함
    - dynamic mode docker image는 추후 사용 빈도가 높아지는 시점에 분리 배포 등을 고려
