### PR TITLE
[Workflow/Perf] Optimize multi-platform Docker image build time

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -87,14 +87,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -109,9 +101,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Docker prune
-        run: docker system prune -af
-
       - name: Build and publish
         id: docker_build
         uses: docker/build-push-action@v6
@@ -123,8 +112,8 @@ jobs:
           platforms: linux/amd64,linux/arm64 # linux/arm/v7,linux/arm64,linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -48,7 +48,7 @@ jobs:
           go-version: ${{matrix.go-version}}
 
       - name: Install swag CLI
-        run: go install github.com/swaggo/swag/cmd/swag@v1.16.3
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.4
         
       - name: Build
         run: make
@@ -76,20 +76,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Cache Docker layers
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
-
       - name: Build image
         env:
           IMAGE_NAME: ${{ github.event.repository.name }}
         run: |
           docker buildx build --file Dockerfile --tag $IMAGE_NAME \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache \
+            --cache-from=type=gha \
+            --cache-to=type=gha,mode=max \
             --load .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@
 ## Stage 1 - Go Build
 ##############################################################
 
-FROM golang:1.25.0 AS builder
+# Note: --platform=$BUILDPLATFORM runs the builder natively on the host (e.g., amd64),
+# avoiding slow QEMU emulation. Cross-compilation is handled via TARGETOS/TARGETARCH.
+FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 ENV GO111MODULE=on
 
 # Install git for version information
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
-#RUN apk update && apk add --no-cache bash
-#RUN apt update
-
-#RUN apk add gcc
 
 ADD . /go/src/github.com/cloud-barista/cb-spider
 
@@ -24,7 +24,7 @@ WORKDIR api-runtime
 RUN VERSION=$(git describe --tags --abbrev=8 2>/dev/null | sed 's/-g.*//' || echo "unknown") && \
     COMMIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
     BUILD_TIME=$(date) && \
-    CGO_ENABLED=0 GOOS=linux go build -tags cb-spider \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags cb-spider \
     -ldflags="-X 'main.Version=${VERSION}' -X 'main.CommitSHA=${COMMIT_SHA}' -X 'main.BuildTime=${BUILD_TIME}'" \
     -o cb-spider -v
 


### PR DESCRIPTION
- Use --platform=$BUILDPLATFORM with Go cross-compilation to avoid slow QEMU emulation for arm64
- Switch Docker layer cache from type=local to type=gha with mode=max (CD and CI workflows)
- Remove redundant actions/cache steps and docker system prune step
- Bump swag CLI version from v1.16.3 to v1.16.4