### PR TITLE
[Dockerfile] Fix: Restore cloud-driver-libs in Docker image for static mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,8 @@ RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 WORKDIR /root/go/src/github.com/cloud-barista/cb-spider
 
-# Note: cloud-driver-libs not needed for static mode
+COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/cloud-driver-libs/ /root/go/src/github.com/cloud-barista/cb-spider/cloud-driver-libs/
+
 COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/conf/ /root/go/src/github.com/cloud-barista/cb-spider/conf/
 
 COPY --from=builder /go/src/github.com/cloud-barista/cb-spider/api-runtime/cb-spider /root/go/src/github.com/cloud-barista/cb-spider/api-runtime/


### PR DESCRIPTION
- Restore `cloud-driver-libs` COPY instruction that was previously removed from Dockerfile
- The directory contains runtime files required by static mode drivers