### PR TITLE
fix(azure): default Public IP SKU to Standard (Basic retired)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/VMHandler.go
@@ -1335,13 +1335,17 @@ func CreatePublicIP(vmHandler *AzureVMHandler, vmReqInfo irs.VMReqInfo) (irs.IID
 	// PublicIP 이름 생성
 	publicIPName := generatePublicIPName(vmReqInfo.IId.NameId)
 
-	publicIPAddressSKUNameBasic := armnetwork.PublicIPAddressSKUNameBasic
+	// Use Standard SKU by default.
+	// Azure retired Basic SKU Public IP on Sep 30, 2025, and newer regions
+	// (e.g., Austria East) do not allow Basic Public IP creation at all.
+	// Ref: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance
+	publicIPAddressSKUNameStandard := armnetwork.PublicIPAddressSKUNameStandard
 	publicIPAddressVersion := armnetwork.IPVersionIPv4
 	publicIPAllocationMethod := armnetwork.IPAllocationMethodStatic
 	createOpts := armnetwork.PublicIPAddress{
 		Name: &publicIPName,
 		SKU: &armnetwork.PublicIPAddressSKU{
-			Name: &publicIPAddressSKUNameBasic,
+			Name: &publicIPAddressSKUNameStandard,
 		},
 		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
 			PublicIPAddressVersion:   &publicIPAddressVersion,
@@ -1354,22 +1358,11 @@ func CreatePublicIP(vmHandler *AzureVMHandler, vmReqInfo irs.VMReqInfo) (irs.IID
 		},
 	}
 
-	publicIPAddressSKUNameStandard := armnetwork.PublicIPAddressSKUNameStandard
-	// Setting zone if available
-	if vmHandler.Region.TargetZone != "" || vmHandler.Region.Zone != "" {
-		createOpts.SKU = &armnetwork.PublicIPAddressSKU{
-			Name: &publicIPAddressSKUNameStandard,
-		}
-		createOpts.Properties.PublicIPAllocationMethod = &publicIPAllocationMethod
-		if vmHandler.Region.TargetZone != "" {
-			createOpts.Zones = []*string{
-				toStrPtr(vmHandler.Region.TargetZone),
-			}
-		} else {
-			createOpts.Zones = []*string{
-				toStrPtr(vmHandler.Region.Zone),
-			}
-		}
+	// Attach zone if available (Standard SKU supports Availability Zones)
+	if vmHandler.Region.TargetZone != "" {
+		createOpts.Zones = []*string{toStrPtr(vmHandler.Region.TargetZone)}
+	} else if vmHandler.Region.Zone != "" {
+		createOpts.Zones = []*string{toStrPtr(vmHandler.Region.Zone)}
 	}
 
 	poller, err := vmHandler.PublicIPClient.BeginCreateOrUpdate(vmHandler.Ctx, vmHandler.Region.Region, publicIPName, createOpts, nil)


### PR DESCRIPTION

Azure VM provisioning in cb-spider has been **broken in newer Azure regions** (e.g., Austria East) and is at risk of breaking in all regions. 
The Azure driver hardcoded `Basic` SKU for Public IP, but **Microsoft retired Basic SKU Public IP on Sep 30, 2025**. 
New regions no longer allow Basic Public IP creation at all (quota = 0), and existing regions will follow.

Without this fix, any CB-TB MCI deployment that requests a Public IP on Azure fails with:

```
IPv4BasicSkuPublicIpCountLimitReached: Cannot create more than 0 IPv4 Basic SKU Public IP Addresses for this subscription in this region.
```

This is a **critical provisioning blocker**, 
not a cosmetic issue, users cannot create Azure VMs through CB-Spider in affected regions.

Ref: https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/public-ip-basic-upgrade-guidance

- Basic SKU is **EOL**, there is no reason to keep it as default.
- `NLBHandler` already uses Standard SKU; `VMHandler` was the outlier (inconsistent internal behavior).
- Standard SKU is a superset: supports Availability Zones, is required by new regions, and is Microsoft's recommended default.

## Change

- `VMHandler.go`: Public IP default SKU `Basic` → `Standard`.
- Simplified the Zone attach branch (Standard supports AZ unconditionally, so the "override to Standard only when zoned" branch is no longer needed).
- Preserved `Region.TargetZone` / `Region.Zone` propagation so VM ↔ Disk ↔ PublicIP zone alignment still works.

## Test: Done (by CB-TB)

- Built cleanly (`go build cloud-barista.` on the azure resources package).
- Zone-less region: OK (non-zonal Standard Public IP).
- Zoned region: OK (Public IP created in the same AZ as VM/Disk).
- Previously failing region (Austria East): unblocked.

---

## Note on maintenance / ownership / test coverage

Solving this was straightforward once diagnosed, but I want to flag a recurring pain point:

- I think CSP drivers lack clear ownership in perspective of sustainability. Issues like Basic SKU retirement were publicly announced by Microsoft more than a year in advance, yet the driver was left untouched until end-users hit hard failures in production. I understand CB-Spider is open source, but think about this is also critical issue for users.
- Same-pattern bugs keep recurring. Hardcoded SKUs / versions / API versions across drivers are a known class of bug, but we don't have a lint/audit step (or even a checklist) to catch them. It's not sustainable for me to keep patching these one by one. Each fix here is small, but the cumulative cost, diagnosing in and tracing through handler internals, verifying cross-resource side effects is high, and it's pulling time away from cb-tb work that is directly my responsibility.

Suggestions (not blocking this PR):

1. Designate a **driver owner** (or at least a "watcher") per CSP, responsible for tracking CSP deprecation feeds.
2. Revise driver code in perspective of easier and sustainable maintenance .