### PR TITLE
[IBM:RootDisk/Disk] Support root/data disk options and improve disk size selection UX

### DIFF
--- a/api-runtime/rest-runtime/admin-web/html/disk.html
+++ b/api-runtime/rest-runtime/admin-web/html/disk.html
@@ -699,8 +699,14 @@
         const diskName = document.getElementById('diskName').value;
         const diskZone = document.getElementById('diskZone').value;
         const diskType = document.getElementById('diskType').value;
-        const diskSize = document.getElementById('diskSize').value;
+        let diskSize = document.getElementById('diskSize').value;
         const diskCount = parseInt(document.getElementById('diskCount').value);
+
+        // If custom size is selected, use the value from the custom input field
+        if (diskSize === 'custom') {
+            const customInput = document.getElementById('customDiskSize');
+            diskSize = customInput ? customInput.value : '';
+        }
 
         if (!diskName || !diskZone || !diskType || !diskSize || diskCount < 1) {
             alert("All fields are required.");
@@ -1001,6 +1007,7 @@
                         window.diskSizes = metaInfo.DiskSize;
 
                         diskTypeSelect.addEventListener('change', updateSizeOptions);
+                        updateSizeOptions(); // initialize size options for the default type on load
                     })
                     .catch(error => {
                         console.error('Error fetching Disk Types:', error);
@@ -1024,15 +1031,48 @@
 
         diskSizeSelect.innerHTML = '<option value="default" selected>default</option>';
 
+        // Remove any previously created custom size input
+        const existingCustomInput = document.getElementById('customDiskSize');
+        if (existingCustomInput) {
+            existingCustomInput.remove();
+        }
+
         if (diskType === 'default') {
+            // Even with default type, allow custom size input
+            const customSizeOption = document.createElement('option');
+            customSizeOption.value = 'custom';
+            customSizeOption.textContent = 'Custom...';
+            diskSizeSelect.appendChild(customSizeOption);
+
+            const customSizeInput = document.createElement('input');
+            customSizeInput.type = 'number';
+            customSizeInput.id = 'customDiskSize';
+            customSizeInput.name = 'customDiskSize';
+            customSizeInput.placeholder = 'Size in GB';
+            customSizeInput.style.display = 'none';
+            diskSizeSelect.parentNode.appendChild(customSizeInput);
+
+            diskSizeSelect.addEventListener('change', function () {
+                if (diskSizeSelect.value === 'custom') {
+                    customSizeInput.style.display = 'inline-block';
+                } else {
+                    customSizeInput.style.display = 'none';
+                }
+            });
             return;
         }
 
         const sizeOption = window.diskSizes.find(size => size.startsWith(diskType));
         if (sizeOption) {
             const [type, minSize, maxSize, unit] = sizeOption.split('|');
-            const increment = 50;
 
+            // Add Custom option right after default for easy access
+            const customSizeOption = document.createElement('option');
+            customSizeOption.value = 'custom';
+            customSizeOption.textContent = `Custom (${minSize} - ${maxSize} ${unit})`;
+            diskSizeSelect.appendChild(customSizeOption);
+
+            const increment = 50;
             for (let i = parseInt(minSize); i <= parseInt(maxSize); i = (i === 1 ? 50 : i + increment)) {
                 const option = document.createElement('option');
                 option.value = i;
@@ -1046,11 +1086,6 @@
                 option.textContent = `${maxSize} ${unit}`;
                 diskSizeSelect.appendChild(option);
             }
-
-            const customSizeOption = document.createElement('option');
-            customSizeOption.value = 'custom';
-            customSizeOption.textContent = 'Custom...';
-            diskSizeSelect.appendChild(customSizeOption);
 
             const customSizeInput = document.createElement('input');
             customSizeInput.type = 'number';

--- a/api-runtime/rest-runtime/admin-web/html/vm.html
+++ b/api-runtime/rest-runtime/admin-web/html/vm.html
@@ -346,7 +346,7 @@ THE SOFTWARE.
         text-align: right;
         margin-right: 10px;
     }
-    .form-group input, .form-group textarea {
+    .form-group input, .form-group textarea, .form-group select {
         flex: 2;
     }
     .form-group button {
@@ -1635,7 +1635,9 @@ THE SOFTWARE.
                 <div class="form-group-container">
                     <div class="form-group">
                         <label for="rootDiskType">Root Disk Type:</label>
-                        <input type="text" id="rootDiskType" name="rootDiskType" value="default" required>
+                        <select id="rootDiskType" name="rootDiskType" required>
+                            <option value="default" selected>default</option>
+                        </select>
                     </div>
 
                     <div class="form-group">
@@ -2715,11 +2717,34 @@ THE SOFTWARE.
                     mockButtonsContainer.appendChild(button10);
                     mockButtonsContainer.appendChild(button50);
                 }
+                loadRootDiskTypes(currentProvider);
             })
             .catch(error => {
                 showError("Error loading connection configuration: " + error.message, "Connection Config Error");
             });
     });
+
+    function loadRootDiskTypes(providerName) {
+        const select = document.getElementById('rootDiskType');
+        fetch(`/spider/cloudos/metainfo/${providerName}`)
+            .then(response => response.json())
+            .then(metaInfo => {
+                const types = (metaInfo.RootDiskType || []).filter(t => t && t.trim() !== '');
+                // Remove existing options except 'default'
+                while (select.options.length > 1) {
+                    select.remove(1);
+                }
+                types.forEach(t => {
+                    const option = document.createElement('option');
+                    option.value = t;
+                    option.textContent = t;
+                    select.appendChild(option);
+                });
+            })
+            .catch(err => {
+                console.warn('Failed to load root disk types:', err);
+            });
+    }
 
     function createMultipleVMs(count) {
         const connConfigElement = document.getElementById('connConfig').value;
@@ -3587,7 +3612,7 @@ THE SOFTWARE.
         const rootDiskSizeField = document.getElementById('rootDiskSize');
         
         if (imageType === 'MyImage') {
-            rootDiskTypeField.value = '';
+            rootDiskTypeField.value = 'default';
             rootDiskSizeField.value = '';
             rootDiskTypeField.disabled = true;
             rootDiskSizeField.disabled = true;
@@ -3596,6 +3621,7 @@ THE SOFTWARE.
             rootDiskTypeField.value = 'default';
             rootDiskTypeField.disabled = false;
             rootDiskSizeField.disabled = false;
+            rootDiskSizeField.value = '';
             imageNameField.innerHTML = `
                 <input type="text" id="imageName" name="imageName" required style="background-color: #f7f7e6; flex: 1; border: 1px solid #767676; padding: 2px;" readonly>
                 <button type="button" onclick="showImageSelectionOverlay()" style="margin-left: 5px; min-width: 26px; height: 22px; padding: 0 4px; font-size: 12px; line-height: 1;">🔍</button>

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
@@ -5,14 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
-	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
-	"github.com/IBM/vpc-go-sdk/vpcv1"
-	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
-	cdcom "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/common"
-	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
-	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"io/ioutil"
 	"math/rand"
 	"net/url"
@@ -22,6 +14,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	cdcom "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/common"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
 type IbmVMHandler struct {
@@ -282,7 +283,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			UserData: &userData,
 		})
 	} else {
-		createInstanceOptions.SetInstancePrototype(&vpcv1.InstancePrototype{
+		instancePrototype := &vpcv1.InstancePrototype{
 			Name: &vmReqInfo.IId.NameId,
 			Image: &vpcv1.ImageIdentity{
 				ID: image.ID,
@@ -309,7 +310,38 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			},
 			UserData:          &userData,
 			VolumeAttachments: existingDataVolumeAttachments,
-		})
+		}
+
+		// Set boot volume profile and/or capacity if specified
+		rootDiskType := vmReqInfo.RootDiskType
+		rootDiskSize := vmReqInfo.RootDiskSize
+		if (rootDiskType != "" && strings.ToLower(rootDiskType) != "default") ||
+			(rootDiskSize != "" && strings.ToLower(rootDiskSize) != "default") {
+			bootVolume := &vpcv1.VolumePrototypeInstanceByImageContext{}
+
+			// Set profile
+			if rootDiskType != "" && strings.ToLower(rootDiskType) != "default" {
+				bootVolume.Profile = &vpcv1.VolumeProfileIdentityByName{
+					Name: core.StringPtr(strings.ToLower(rootDiskType)),
+				}
+			} else {
+				bootVolume.Profile = &vpcv1.VolumeProfileIdentityByName{
+					Name: core.StringPtr("general-purpose"),
+				}
+			}
+
+			// Set capacity
+			if rootDiskSize != "" && strings.ToLower(rootDiskSize) != "default" {
+				size, _ := strconv.ParseInt(rootDiskSize, 10, 64)
+				bootVolume.Capacity = core.Int64Ptr(size)
+			}
+
+			instancePrototype.BootVolumeAttachment = &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
+				Volume: bootVolume,
+			}
+		}
+
+		createInstanceOptions.SetInstancePrototype(instancePrototype)
 	}
 
 	createInstance, _, err := vmHandler.VpcService.CreateInstanceWithContext(vmHandler.Ctx, createInstanceOptions)
@@ -904,10 +936,6 @@ func checkVmIID(vmIID irs.IID) error {
 }
 
 func checkVMReqInfo(vmReqInfo irs.VMReqInfo) error {
-	err := notSupportRootDiskCustom(vmReqInfo)
-	if err != nil {
-		return err
-	}
 	if vmReqInfo.IId.NameId == "" {
 		return errors.New("invalid VM IID")
 	}
@@ -1319,6 +1347,10 @@ func (vmHandler *IbmVMHandler) setVmInfo(instance vpcv1.Instance) (irs.VMInfo, e
 	}
 
 	vmInfo.RootDiskType = "general-purpose"
+	rawBootVolume, getBootVolumeErr := getRawVolume(irs.IID{SystemId: *instance.BootVolumeAttachment.Volume.ID}, vmHandler.VpcService, vmHandler.Ctx)
+	if getBootVolumeErr == nil && rawBootVolume.Profile != nil && rawBootVolume.Profile.Name != nil {
+		vmInfo.RootDiskType = *rawBootVolume.Profile.Name
+	}
 
 	vmInfo.VMBootDisk = *instance.BootVolumeAttachment.Volume.ID
 	rawBootDisk, getRawBootDiskErr := getRawDisk(vmHandler.VpcService, vmHandler.Ctx, irs.IID{SystemId: vmInfo.VMBootDisk})
@@ -1381,16 +1413,6 @@ func (vmHandler *IbmVMHandler) checkFloatingIPName(floatingIPName string) (exist
 		}
 	}
 	return false, nil
-}
-
-func notSupportRootDiskCustom(vmReqInfo irs.VMReqInfo) error {
-	if vmReqInfo.RootDiskType != "" && strings.ToLower(vmReqInfo.RootDiskType) != "default" {
-		return errors.New("IBM-VPC_CANNOT_CHANGE_ROOTDISKTYPE")
-	}
-	if vmReqInfo.RootDiskSize != "" && strings.ToLower(vmReqInfo.RootDiskSize) != "default" {
-		return errors.New("IBM-VPC_CANNOT_CHANGE_ROOTDISKSIZE")
-	}
-	return nil
 }
 
 type vmInfoWithError struct {

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -72,6 +72,10 @@ IBM:
   region: Region / Zone
   credential: ApiKey
   credentialcsp: ApiKey
+  rootdisktype: general-purpose / sdp
+  rootdisksize: general-purpose|100|250|GB / sdp|100|250|GB
+  disktype: general-purpose / 5iops-tier / 10iops-tier / sdp
+  disksize: general-purpose|10|16000|GB / 5iops-tier|10|9600|GB / 10iops-tier|10|4800|GB / sdp|1|32000|GB
   # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
   idmaxlength: 63 / 63 / 63 / 63 / 63 / 63 / 63 / 63 / 32 / 63
   defaultregiontoquery: us-south / us-south-1


### PR DESCRIPTION

- Remove IBM driver-side root disk validation and let CSP-side validation handle root disk type and size checks.
- Add IBM data disk metadata in cloudos_meta with supported disk types and size ranges.
- Improve AdminWeb root disk configuration and disk configuration UI.

<br>

**[Test Env.]**
- Region/Zone: us-south/us-south-1

**[RootDisk settings Test Results]**

| type | size | result |
|---|---|---|
| default | default (=> general-purpose, 100G) | pass |
| default | 150 | pass |
| general-purpose | default | pass |
| general-purpose | 150 | pass |
| sdp | default | pass |
| sdp | 150 | pass |

**[DataDisk creation Test Results]**

| type | size | result |
|---|---|---|
| default | default (=> general-purpose, 50G) | pass |
| default | 150 | pass |
| general-purpose | default | pass |
| general-purpose | 150 | pass |
| 5iops-tier | default | pass |
| 5iops-tier | 150 | pass |
| 10iops-tier | default | pass |
| 10iops-tier | 150 | pass |
| sdp | default | pass |
| sdp | 150 | pass |