### PR TITLE
Fix Azure ARM client 60s CANCEL issue

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -12,6 +12,7 @@ package azure
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"time"
 
@@ -42,6 +43,25 @@ var cblog *logrus.Logger
 
 func init() {
 	cblog = cblogger.GetLogger("CLOUD-BARISTA")
+}
+
+// newArmClientOptions returns arm.ClientOptions with a fresh http.Transport per call.
+//
+// Azure ARM sends HTTP/2 GOAWAY frames periodically (~60s) to recycle connections.
+// When all SDK clients share http.DefaultTransport, a single GOAWAY simultaneously
+// cancels every in-flight stream across all concurrent VM operations. By giving each
+// ConnectCloud() call its own transport, each concurrent operation has an isolated
+// HTTP/2 connection — a GOAWAY on one connection only affects that one operation.
+func newArmClientOptions(extraPolicies ...policy.Policy) *arm.ClientOptions {
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: &http.Client{Transport: &http.Transport{}},
+		},
+	}
+	if len(extraPolicies) > 0 {
+		opts.ClientOptions.PerCallPolicies = extraPolicies
+	}
+	return opts
 }
 
 type AzureDriver struct{}
@@ -89,7 +109,7 @@ func getResourceGroupsClient(credential idrv.CredentialInfo) (context.Context, *
 	if err != nil {
 		return nil, nil, err
 	}
-	resourceGroupsClient, err := armresources.NewResourceGroupsClient(credential.SubscriptionId, cred, nil)
+	resourceGroupsClient, err := armresources.NewResourceGroupsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -325,7 +345,7 @@ func getSubscriptionClient(credential idrv.CredentialInfo) (context.Context, *ar
 		return nil, nil, err
 	}
 
-	subscriptionsClient, err := armsubscription.NewSubscriptionsClient(cred, nil)
+	subscriptionsClient, err := armsubscription.NewSubscriptionsClient(cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -340,19 +360,12 @@ func getVMClient(credential idrv.CredentialInfo) (context.Context, *armcompute.V
 		return nil, nil, err
 	}
 
-	var clientOptions *arm.ClientOptions
-
-	if os.Getenv("CALL_COUNT") != "" {
-		clientOptions = &arm.ClientOptions{
-			ClientOptions: azcore.ClientOptions{
-				PerCallPolicies: []policy.Policy{profile.NewCountingPolicy()},
-			},
+	vmClient, err := armcompute.NewVirtualMachinesClient(credential.SubscriptionId, cred, func() *arm.ClientOptions {
+		if os.Getenv("CALL_COUNT") != "" {
+			return newArmClientOptions(profile.NewCountingPolicy())
 		}
-	} else {
-		clientOptions = &arm.ClientOptions{}
-	}
-
-	vmClient, err := armcompute.NewVirtualMachinesClient(credential.SubscriptionId, cred, clientOptions)
+		return newArmClientOptions()
+	}())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -368,7 +381,7 @@ func getImageClient(credential idrv.CredentialInfo) (context.Context, *armcomput
 		return nil, nil, err
 	}
 
-	imageClient, err := armcompute.NewImagesClient(credential.SubscriptionId, cred, nil)
+	imageClient, err := armcompute.NewImagesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -383,7 +396,7 @@ func getPublicIPClient(credential idrv.CredentialInfo) (context.Context, *armnet
 		return nil, nil, err
 	}
 
-	publicIPClient, err := armnetwork.NewPublicIPAddressesClient(credential.SubscriptionId, cred, nil)
+	publicIPClient, err := armnetwork.NewPublicIPAddressesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -398,7 +411,7 @@ func getSecurityGroupClient(credential idrv.CredentialInfo) (context.Context, *a
 		return nil, nil, err
 	}
 
-	sgClient, err := armnetwork.NewSecurityGroupsClient(credential.SubscriptionId, cred, nil)
+	sgClient, err := armnetwork.NewSecurityGroupsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -413,7 +426,7 @@ func getSecurityGroupRuleClient(credential idrv.CredentialInfo) (context.Context
 		return nil, nil, err
 	}
 
-	sgClient, err := armnetwork.NewSecurityRulesClient(credential.SubscriptionId, cred, nil)
+	sgClient, err := armnetwork.NewSecurityRulesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -428,7 +441,7 @@ func getVNetworkClient(credential idrv.CredentialInfo) (context.Context, *armnet
 		return nil, nil, err
 	}
 
-	vNetClient, err := armnetwork.NewVirtualNetworksClient(credential.SubscriptionId, cred, nil)
+	vNetClient, err := armnetwork.NewVirtualNetworksClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -443,7 +456,7 @@ func getVNicClient(credential idrv.CredentialInfo) (context.Context, *armnetwork
 		return nil, nil, err
 	}
 
-	vNicClient, err := armnetwork.NewInterfacesClient(credential.SubscriptionId, cred, nil)
+	vNicClient, err := armnetwork.NewInterfacesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -458,7 +471,7 @@ func getIPConfigClient(credential idrv.CredentialInfo) (context.Context, *armnet
 		return nil, nil, err
 	}
 
-	ipConfigClient, err := armnetwork.NewInterfaceIPConfigurationsClient(credential.SubscriptionId, cred, nil)
+	ipConfigClient, err := armnetwork.NewInterfaceIPConfigurationsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -473,7 +486,7 @@ func getSubnetClient(credential idrv.CredentialInfo) (context.Context, *armnetwo
 		return nil, nil, err
 	}
 
-	subnetClient, err := armnetwork.NewSubnetsClient(credential.SubscriptionId, cred, nil)
+	subnetClient, err := armnetwork.NewSubnetsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -488,7 +501,7 @@ func getSshKeyClient(credential idrv.CredentialInfo) (context.Context, *armcompu
 		return nil, nil, err
 	}
 
-	sshClientClient, err := armcompute.NewSSHPublicKeysClient(credential.SubscriptionId, cred, nil)
+	sshClientClient, err := armcompute.NewSSHPublicKeysClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -503,7 +516,7 @@ func getVMImageClient(credential idrv.CredentialInfo) (context.Context, *armcomp
 		return nil, nil, err
 	}
 
-	vmImageClient, err := armcompute.NewVirtualMachineImagesClient(credential.SubscriptionId, cred, nil)
+	vmImageClient, err := armcompute.NewVirtualMachineImagesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -518,7 +531,7 @@ func getDiskClient(credential idrv.CredentialInfo) (context.Context, *armcompute
 		return nil, nil, err
 	}
 
-	diskClient, err := armcompute.NewDisksClient(credential.SubscriptionId, cred, nil)
+	diskClient, err := armcompute.NewDisksClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -533,7 +546,7 @@ func getVmSpecClient(credential idrv.CredentialInfo) (context.Context, *armcompu
 		return nil, nil, err
 	}
 
-	vmSpecClient, err := armcompute.NewVirtualMachineSizesClient(credential.SubscriptionId, cred, nil)
+	vmSpecClient, err := armcompute.NewVirtualMachineSizesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -548,7 +561,7 @@ func getNLBClient(credential idrv.CredentialInfo) (context.Context, *armnetwork.
 		return nil, nil, err
 	}
 
-	nlbClient, err := armnetwork.NewLoadBalancersClient(credential.SubscriptionId, cred, nil)
+	nlbClient, err := armnetwork.NewLoadBalancersClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -563,7 +576,7 @@ func getNLBBackendAddressPoolsClient(credential idrv.CredentialInfo) (context.Co
 		return nil, nil, err
 	}
 
-	nlbBackendAddressPoolsClient, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(credential.SubscriptionId, cred, nil)
+	nlbBackendAddressPoolsClient, err := armnetwork.NewLoadBalancerBackendAddressPoolsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -578,7 +591,7 @@ func getLoadBalancingRulesClient(credential idrv.CredentialInfo) (context.Contex
 		return nil, nil, err
 	}
 
-	nlbBackendAddressPoolsClient, err := armnetwork.NewLoadBalancerLoadBalancingRulesClient(credential.SubscriptionId, cred, nil)
+	nlbBackendAddressPoolsClient, err := armnetwork.NewLoadBalancerLoadBalancingRulesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -607,7 +620,7 @@ func getManagedClustersClient(credential idrv.CredentialInfo) (context.Context, 
 	if err != nil {
 		return nil, nil, err
 	}
-	managedClustersClient, err := armcontainerservice.NewManagedClustersClient(credential.SubscriptionId, cred, nil)
+	managedClustersClient, err := armcontainerservice.NewManagedClustersClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -621,7 +634,7 @@ func getAgentPoolsClient(credential idrv.CredentialInfo) (context.Context, *armc
 	if err != nil {
 		return nil, nil, err
 	}
-	agentPoolsClient, err := armcontainerservice.NewAgentPoolsClient(credential.SubscriptionId, cred, nil)
+	agentPoolsClient, err := armcontainerservice.NewAgentPoolsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -635,7 +648,7 @@ func getVirtualMachineScaleSetsClient(credential idrv.CredentialInfo) (context.C
 	if err != nil {
 		return nil, nil, err
 	}
-	virtualMachineScaleSetsClient, err := armcompute.NewVirtualMachineScaleSetsClient(credential.SubscriptionId, cred, nil)
+	virtualMachineScaleSetsClient, err := armcompute.NewVirtualMachineScaleSetsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -649,7 +662,7 @@ func getVirtualMachineScaleSetVMsClient(credential idrv.CredentialInfo) (context
 	if err != nil {
 		return nil, nil, err
 	}
-	virtualMachineScaleSetVMsClient, err := armcompute.NewVirtualMachineScaleSetVMsClient(credential.SubscriptionId, cred, nil)
+	virtualMachineScaleSetVMsClient, err := armcompute.NewVirtualMachineScaleSetVMsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -663,7 +676,7 @@ func getVirtualMachineRunCommandClient(credential idrv.CredentialInfo) (context.
 	if err != nil {
 		return nil, nil, err
 	}
-	virtualMachineRunCommandsClient, err := armcompute.NewVirtualMachineRunCommandsClient(credential.SubscriptionId, cred, nil)
+	virtualMachineRunCommandsClient, err := armcompute.NewVirtualMachineRunCommandsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -677,7 +690,7 @@ func getResourceSKUsClient(credential idrv.CredentialInfo) (context.Context, *ar
 	if err != nil {
 		return nil, nil, err
 	}
-	resourceSKUsClient, err := armcompute.NewResourceSKUsClient(credential.SubscriptionId, cred, nil)
+	resourceSKUsClient, err := armcompute.NewResourceSKUsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -691,7 +704,7 @@ func getTagsClient(credential idrv.CredentialInfo) (context.Context, *armresourc
 		return nil, nil, err
 	}
 
-	tagsClient, err := armresources.NewTagsClient(credential.SubscriptionId, cred, nil)
+	tagsClient, err := armresources.NewTagsClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -706,7 +719,7 @@ func getDnsZoneClient(credential idrv.CredentialInfo) (context.Context, *armdns.
 		return nil, nil, err
 	}
 
-	dnsZoneClient, err := armdns.NewZonesClient(credential.SubscriptionId, cred, nil)
+	dnsZoneClient, err := armdns.NewZonesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -721,7 +734,7 @@ func getFileShareClient(credential idrv.CredentialInfo) (context.Context, *armst
 		return nil, nil, err
 	}
 
-	fileShareClient, err := armstorage.NewFileSharesClient(credential.SubscriptionId, cred, &arm.ClientOptions{})
+	fileShareClient, err := armstorage.NewFileSharesClient(credential.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -735,7 +748,7 @@ func getAccountsClient(credInfo idrv.CredentialInfo) (context.Context, *armstora
 	if err != nil {
 		return nil, nil, err
 	}
-	client, err := armstorage.NewAccountsClient(credInfo.SubscriptionId, cred, &arm.ClientOptions{})
+	client, err := armstorage.NewAccountsClient(credInfo.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- ref: https://github.com/cloud-barista/cb-tumblebug/issues/2461


현재 CB-Tumblebug에서 Azure 단일 리전에 여러 VM을 병렬 생성하면, 
20개 수준의 요청도 안정적으로 처리되지 않고 일부 VM만 생성됩니다.

20개를 요청하면 13개 수준의 VM만 우연히 성공하며, 
나머지는 모두 정상적이지 않은 고아 자원(퍼블릭IP, Network Interface 등)을 남기면서 실패합니다. 
이렇게 고아가 생기면, Cloud-Barista로는 삭제가 불가한 자원들이 남고, 
결국 Azure 콘솔에 접속해서 정리해야 하는 상황이 발생합니다.


문제의 원인을 추적해보면,
현재 Azure 드라이버에, VM 프로비저닝 병렬 처리시, 심각한 오류가 숨겨져 있는 것으로 보입니다. (아마도..)

ConnectCloud()가 Spider 요청마다 호출되는데, 생성된 모든 클라이언트가 
http.DefaultTransport를 공유하는 형상인 것 같습니다.
Go의 HTTP/2 transport는 같은 호스트에 하나의 연결만 유지하므로, 
goroutine의 Azure API 호출이 모두 같은 연결 하나에 올라탑니다. 

VM 1개만 생성해도 PublicIP(~30s) + NIC(~30s) + VM(~60-120s) = 총 120-180s가 필요한데, 
60초마다 Azure가 연결을 재활용하면서, 동일한 HTTP/2 연결 위에서 60초 이상 걸리는 작업은 필연적으로 CANCEL을 당하게 되는 구조인 것 같습니다.

Azure가 CANCEL로 GOAWAY를 보내면 진행 중이던 병렬 VM 생성 작업이 전부 한꺼번에 죽는 구조로 보입니다.

---

이 PR은 각 Azure client 생성 시 독립적인 http.Transport를 사용하는 newArmClientOptions()를 적용하여, ResourceGroup, VNet, NIC, Public IP, VM client가 동일한 transport를 공유하지 않도록 조정합니다. 

getXxxClient() 함수마다 newArmClientOptions() 호출 
--> 각 client마다 별도 &http.Transport{}

vm_creation_1:
  getResourceGroupClient() → transport_A (60s clock 독립)
  getVNetClient()          → transport_B (60s clock 독립)
  getNICClient()           → transport_C (60s clock 독립)
  getPublicIPClient()      → transport_D (60s clock 독립)
  getVMClient()            → transport_E (60s clock 독립)


그 결과 병렬 VM 생성 시 하나의 HTTP/2 연결에 모든 요청이 몰리는 상황을 줄이고, 
25개 수준의 병렬 생성까지 동작하는 것을 확인하였습니다.