### PR TITLE
Fix bug in Azure referencing wrong resourceGroup

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
@@ -129,7 +129,7 @@ func (diskHandler *AzureDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
 
 	var diskList []*armcompute.Disk
 
-	pager := diskHandler.DiskClient.NewListPager(nil)
+	pager := diskHandler.DiskClient.NewListByResourceGroupPager(diskHandler.Region.Region, nil)
 
 	for pager.More() {
 		page, err := pager.NextPage(diskHandler.Ctx)
@@ -394,7 +394,7 @@ func GetRawDisk(diskIID irs.IID, resourceGroup string, client *armcompute.DisksC
 	if diskIID.NameId == "" {
 		var diskList []*armcompute.Disk
 
-		pager := client.NewListPager(nil)
+		pager := client.NewListByResourceGroupPager(resourceGroup, nil)
 
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
@@ -415,13 +415,7 @@ func GetRawDisk(diskIID irs.IID, resourceGroup string, client *armcompute.DisksC
 		notExistVpcErr := errors.New(fmt.Sprintf("The Disk id %s not found", diskIID.SystemId))
 		return armcompute.Disk{}, notExistVpcErr
 	} else {
-		rg := resourceGroup
-		if diskIID.SystemId != "" {
-			if extractedRG, err := getResourceGroupById(diskIID.SystemId); err == nil {
-				rg = extractedRG
-			}
-		}
-		resp, err := client.Get(ctx, rg, diskIID.NameId, nil)
+		resp, err := client.Get(ctx, resourceGroup, diskIID.NameId, nil)
 		if err != nil {
 			return armcompute.Disk{}, err
 		}
@@ -541,7 +535,7 @@ func (diskHandler *AzureDiskHandler) validationDiskReq(diskReq irs.DiskInfo) err
 func CheckExistDisk(diskIID irs.IID, resourceGroup string, client *armcompute.DisksClient, ctx context.Context) (bool, error) {
 	var diskList []*armcompute.Disk
 
-	pager := client.NewListPager(nil)
+	pager := client.NewListByResourceGroupPager(resourceGroup, nil)
 
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
@@ -762,7 +756,7 @@ func (diskHandler *AzureDiskHandler) ListIID() ([]*irs.IID, error) {
 
 	var iidList []*irs.IID
 
-	pager := diskHandler.DiskClient.NewListPager(nil)
+	pager := diskHandler.DiskClient.NewListByResourceGroupPager(diskHandler.Region.Region, nil)
 
 	for pager.More() {
 		page, err := pager.NextPage(diskHandler.Ctx)

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
@@ -415,7 +415,13 @@ func GetRawDisk(diskIID irs.IID, resourceGroup string, client *armcompute.DisksC
 		notExistVpcErr := errors.New(fmt.Sprintf("The Disk id %s not found", diskIID.SystemId))
 		return armcompute.Disk{}, notExistVpcErr
 	} else {
-		resp, err := client.Get(ctx, resourceGroup, diskIID.NameId, nil)
+		rg := resourceGroup
+		if diskIID.SystemId != "" {
+			if extractedRG, err := getResourceGroupById(diskIID.SystemId); err == nil {
+				rg = extractedRG
+			}
+		}
+		resp, err := client.Get(ctx, rg, diskIID.NameId, nil)
 		if err != nil {
 			return armcompute.Disk{}, err
 		}


### PR DESCRIPTION
이 PR은, Azure의 disk list 확인시, 
지정한 리전으로 리스트 출력 범위를 한정하도록 만들어서, 

GET /spider/alldisk 및 잠재된 오류를 수정합니다.

---

CB-TB 로 Azure의 전체 리전에 대해, 리소스 등록 작업 수행시,
CB-Spider Azure 드라이버에서 Azure Resource Group을 잘 못 지정해서 처리하는 경우가 있습니다.

현재 Azure 드라이버에서 활용하는 ListDisk 결과(Azure 내부 disk 현황)가 
disk는 리전과 무관하게 전체 Disk 리스트를 리턴하고 있는 상태로 보입니다.

그래서 리전(커넥션)을 명시해서 GET /spider/alldisk 으로, OnlyCSPList 현황을 확인시, 

모든 리전(azure 커넥션)에 대해서, 
OnlyCSPList 에 동일한 data disk 리소스가, 중복되어 리턴되는 버그가 있습니다.

이 문제가 CB-TB의 기존 자원 등록 기능 구동 상, 불필요한 작업을 수행하게 만들고,
의미 없는 조회 오류들도 유발합니다.

```
cb-tumblebug                | 2:05PM DBG src/core/common/client/client.go:324 > Internal Call Start Method=POST URI=http://cb-spider:1024/spider/regdisk requestBody={"ConnectionName":"azure-brazilsouth","ReqInfo":{"CSPid":"/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/NORTHEUROPE/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg","CreatedTime":"0001-01-01T00:00:00Z","DiskSize":"0","DiskType":"","IId":{"NameId":"","SystemId":""},"KeyValueList":null,"Name":"tbd7svigg5ufjs73ff0q80","OwnerNode":{"NameId":"","SystemId":""},"Status":""}}
cb-spider                   | [CB-SPIDER].[ERROR]: 2026-05-05 14:05:57 DiskHandler.go:175, github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/azure/resources.(*AzureDiskHandler).GetDisk() - Failed to Get Disk. err = GET https://management.azure.com/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/brazilsouth/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   | RESPONSE 404: 404 Not Found
cb-spider                   | ERROR CODE: ResourceNotFound
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   | {
cb-spider                   |   "error": {
cb-spider                   |     "code": "ResourceNotFound",
cb-spider                   |     "message": "The Resource 'Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg' under resource group 'brazilsouth' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"
cb-spider                   |   }
cb-spider                   | }
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   |
cb-spider                   | [CB-SPIDER].[ERROR]: 2026-05-05 14:05:57 DiskManager.go:140, github.com/cloud-barista/cb-spider/api-runtime/common-runtime.RegisterDisk() - Failed to Get Disk. err = GET https://management.azure.com/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/brazilsouth/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   | RESPONSE 404: 404 Not Found
cb-spider                   | ERROR CODE: ResourceNotFound
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   | {
cb-spider                   |   "error": {
cb-spider                   |     "code": "ResourceNotFound",
cb-spider                   |     "message": "The Resource 'Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg' under resource group 'brazilsouth' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix"
cb-spider                   |   }
cb-spider                   | }
cb-spider                   | --------------------------------------------------------------------------------
cb-spider                   |
cb-tumblebug                | 2:05PM DBG src/core/common/client/client.go:512 > Internal Call Error Method=POST URI=http://cb-spider:1024/spider/regdisk latency=3510.261483 responseBody={"message":"Failed to Get Disk. err = GET https://management.azure.com/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/brazilsouth/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg\n--------------------------------------------------------------------------------\nRESPONSE 404: 404 Not Found\nERROR CODE: ResourceNotFound\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"ResourceNotFound\",\n    \"message\": \"The Resource 'Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg' under resource group 'brazilsouth' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix\"\n  }\n}\n--------------------------------------------------------------------------------\n"} status=500
cb-tumblebug                | 2:05PM ERR src/core/resource/datadisk.go:123 > error="Failed to Get Disk. err = GET https://management.azure.com/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/brazilsouth/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg -------------------------------------------------------------------------------- RESPONSE 404: 404 Not Found ERROR CODE: ResourceNotFound -------------------------------------------------------------------------------- { error: { code: ResourceNotFound, message: The Resource 'Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg' under resource group 'brazilsouth' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix } } -------------------------------------------------------------------------------- (from cb-spider:1024/spider/regdisk (500 Internal Server Error))"
cb-tumblebug                | 2:05PM ERR src/core/infra/utility.go:1326 > Failed to register dataDisk: azure-brazilsouth-subscriptions-a20fed83-96bd-4480-92a9-140b8e3b7c3a-resourcegroups-northeurope-providers-microsoft-compute-disks-spider-watch-d7svcths6pis738l9kgg error="Failed to Get Disk. err = GET https://management.azure.com/subscriptions/a20fed83-96bd-4480-92a9-140b8e3b7c3a/resourceGroups/brazilsouth/providers/Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg -------------------------------------------------------------------------------- RESPONSE 404: 404 Not Found ERROR CODE: ResourceNotFound -------------------------------------------------------------------------------- { error: { code: ResourceNotFound, message: The Resource 'Microsoft.Compute/disks/spider-watch-d7svcths6pis738l9kgg' under resource group 'brazilsouth' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix } } -------------------------------------------------------------------------------- (from cb-spider:1024/spider/regdisk (500 Internal Server Error))"
```

