### PR TITLE
AWS: Add monitoring API

### DIFF
--- a/api-runtime/common-runtime/MonitoringManager.go
+++ b/api-runtime/common-runtime/MonitoringManager.go
@@ -159,7 +159,12 @@ func GetClusterNodeMetricData(connectionName string, clusterNameID string, nodeG
 	var nodeNameId string
 
 	for _, nodeGroup := range clusterInfo.NodeGroupList {
-		if nodeGroup.IId.NameId == nodeGroupDriverIID.NameId {
+		// Driver-level GetCluster may return NodeGroupInfo with only IId.SystemId
+		// populated (NameId left empty), since NameId/SystemId mapping is owned by
+		// common-runtime via NodeGroupIIDInfo. Match on either side so monitoring
+		// works regardless of which field the driver chose to populate.
+		if nodeGroup.IId.NameId == nodeGroupDriverIID.NameId ||
+			nodeGroup.IId.SystemId == nodeGroupDriverIID.SystemId {
 			if nodeNumberInt > len(nodeGroup.Nodes) {
 				errMsg := fmt.Sprintf("Node number %s is greater than the number of nodes (%d).", nodeNumber, len(nodeGroup.Nodes))
 				cblog.Error(errMsg)

--- a/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -11,7 +11,6 @@
 package connect
 
 import (
-	"errors"
 	cblog "github.com/cloud-barista/cb-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 
@@ -227,5 +226,22 @@ func (cloudConn *AwsCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfoHand
 }
 
 func (cloudConn *AwsCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
-	return nil, errors.New("GCP Cloud Driver: not implemented")
+	tagHandler := cloudConn.CreateAwsTagHandler()
+	clusterHandler := &ars.AwsClusterHandler{
+		Region:      cloudConn.Region,
+		Client:      cloudConn.EKSClient,
+		EC2Client:   cloudConn.VNetworkClient,
+		Iam:         cloudConn.IamClient,
+		StsClient:   cloudConn.StsClient,
+		AutoScaling: cloudConn.AutoScalingClient,
+		TagHandler:  &tagHandler,
+	}
+	handler := ars.AwsMonitoringHandler{
+		Region:         cloudConn.Region,
+		CredentialInfo: cloudConn.CredentialInfo,
+		CwClient:       cloudConn.CloudWatchClient,
+		VMClient:       cloudConn.VMClient,
+		ClusterHandler: clusterHandler,
+	}
+	return &handler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/Test_Resources.go
@@ -1862,7 +1862,7 @@ func handlePriceInfo() {
 				//result, err := handler.GetPriceInfo("AmazonEC2", "ap-northeast-2", filterList)
 
 				// AmazonEC2는 ServiceCode고정 -> ProductFamily : Compute Instance로 두고 테스트
-				result, err := handler.GetPriceInfo("Compute Instance", "us-west-1", filterList)
+				result, err := handler.GetPriceInfo("Compute Instance", "us-west-1", filterList, false)
 
 				if err != nil {
 					cblogger.Infof("GetPriceInfo Lookup Failed : ", err)

--- a/cloud-control-manager/cloud-driver/drivers/aws/main/test_monitoring/main.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/main/test_monitoring/main.go
@@ -1,0 +1,766 @@
+// AWS Monitoring end-to-end test.
+// Creates VPC -> SG -> KeyPair -> VM (and optionally EKS) using the AWS driver,
+// then exercises every MetricType from PR #1697 against both the VM and an EKS
+// cluster node, and tears everything down.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awscreds "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"gopkg.in/yaml.v2"
+
+	awsdrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	icon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/connect"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+const (
+	namePrefix  = "cb-mon-test"
+	region      = "ap-northeast-2"
+	zoneA       = "ap-northeast-2a"
+	zoneC       = "ap-northeast-2c"
+	vpcCIDR     = "10.42.0.0/16"
+	subnetACIDR = "10.42.1.0/24"
+	subnetCCIDR = "10.42.2.0/24"
+	vmSpec      = "t3.small"
+	eksVersion  = "1.30"
+	eksNodeSpec = "t3.medium"
+
+	// CloudWatch standard EC2 metrics post at 5-min granularity unless detailed
+	// monitoring is on. Wait long enough that GetMetricStatistics returns >=1
+	// datapoint for cpu/network. Disk metrics may still be empty on idle VMs.
+	metricSettleWait = 7 * time.Minute
+)
+
+type yamlConfig struct {
+	AWS struct {
+		AccessKey string `yaml:"aws_access_key_id"`
+		SecretKey string `yaml:"aws_secret_access_key"`
+		Region    string `yaml:"region"`
+	} `yaml:"aws"`
+}
+
+type testCtx struct {
+	cred       idrv.CredentialInfo
+	regionInfo idrv.RegionInfo
+	conn       icon.CloudConnection
+	al2AMI     string
+	eksAMI     string
+
+	vpcIID     irs.IID
+	subnetAIID irs.IID // captured from CreateVPC response (zoneA)
+	subnetCIID irs.IID // captured from CreateVPC response (zoneC)
+	sgIID      irs.IID
+	keyIID     irs.IID
+	vmIID      irs.IID
+
+	clusterIID   irs.IID
+	nodeGroupIID irs.IID
+	nodeIID      irs.IID
+
+	withCluster  bool
+	reuse        bool
+	skipTeardown bool
+}
+
+func main() {
+	configPath := flag.String("config", "config.yaml", "path to AWS test config yaml")
+	noCluster := flag.Bool("no-cluster", false, "skip EKS cluster creation/test")
+	reuse := flag.Bool("reuse", false, "reuse existing resources matching namePrefix (skip preflight cleanup, skip create where one exists)")
+	skipTeardown := flag.Bool("skip-teardown", false, "leave resources behind for inspection")
+	flag.Parse()
+
+	cfg := loadConfig(*configPath)
+	tc := &testCtx{
+		cred: idrv.CredentialInfo{
+			ClientId:     cfg.AWS.AccessKey,
+			ClientSecret: cfg.AWS.SecretKey,
+		},
+		regionInfo: idrv.RegionInfo{
+			Region: cfg.AWS.Region,
+			Zone:   zoneA,
+		},
+		withCluster:  !*noCluster,
+		reuse:        *reuse,
+		skipTeardown: *skipTeardown,
+	}
+
+	log.Printf("[start] region=%s cluster=%v", tc.regionInfo.Region, tc.withCluster)
+
+	mustResolveAMIs(tc)
+
+	driver := &awsdrv.AwsDriver{}
+	conn, err := driver.ConnectCloud(idrv.ConnectionInfo{
+		CredentialInfo: tc.cred,
+		RegionInfo:     tc.regionInfo,
+	})
+	if err != nil {
+		log.Panicf("ConnectCloud: %v", err)
+	}
+	tc.conn = conn
+
+	defer func() {
+		panicked := false
+		if r := recover(); r != nil {
+			panicked = true
+			log.Printf("[panic-recovered] %v", r)
+		}
+		if tc.skipTeardown {
+			log.Printf("[teardown] SKIPPED (--skip-teardown).")
+			return
+		}
+		if tc.reuse && panicked {
+			log.Printf("[teardown] SKIPPED in --reuse mode after panic — resources may pre-exist; clean up manually or re-run.")
+			return
+		}
+		teardown(tc)
+	}()
+
+	if tc.reuse {
+		adoptExisting(tc)
+	} else {
+		preflightCleanup(tc)
+	}
+	if tc.vpcIID.SystemId == "" {
+		createVPC(tc)
+	}
+	if tc.sgIID.SystemId == "" {
+		createSG(tc)
+	}
+	if tc.keyIID.SystemId == "" {
+		createKeyPair(tc)
+	}
+	if tc.vmIID.SystemId == "" {
+		createVM(tc)
+	}
+
+	if tc.withCluster {
+		createCluster(tc)
+	}
+
+	log.Printf("[wait] %s for CloudWatch metrics to populate...", metricSettleWait)
+	time.Sleep(metricSettleWait)
+
+	runVMMetricTests(tc)
+	if tc.withCluster {
+		runClusterNodeMetricTests(tc)
+	}
+
+	log.Printf("[done] tests finished. teardown will proceed via defer.")
+}
+
+// ---------------------------------------------------------------------------
+// Config + AMI resolution
+// ---------------------------------------------------------------------------
+
+func loadConfig(path string) yamlConfig {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Panicf("readConfig %q: %v", path, err)
+	}
+	var c yamlConfig
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		log.Panicf("yaml unmarshal: %v", err)
+	}
+	if c.AWS.AccessKey == "" || c.AWS.SecretKey == "" {
+		log.Panicf("config has empty credentials")
+	}
+	if c.AWS.Region == "" {
+		c.AWS.Region = region
+	}
+	return c
+}
+
+func mustResolveAMIs(tc *testCtx) {
+	sess, err := session.NewSession(&aws.Config{
+		Region:      aws.String(tc.regionInfo.Region),
+		Credentials: awscreds.NewStaticCredentials(tc.cred.ClientId, tc.cred.ClientSecret, ""),
+	})
+	if err != nil {
+		log.Panicf("aws session: %v", err)
+	}
+	svc := ssm.New(sess)
+
+	resolve := func(name string) string {
+		out, err := svc.GetParameter(&ssm.GetParameterInput{Name: aws.String(name)})
+		if err != nil {
+			log.Panicf("ssm get %s: %v", name, err)
+		}
+		return aws.StringValue(out.Parameter.Value)
+	}
+
+	tc.al2AMI = resolve("/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2")
+	tc.eksAMI = resolve(fmt.Sprintf("/aws/service/eks/optimized-ami/%s/amazon-linux-2/recommended/image_id", eksVersion))
+	log.Printf("[ami] AL2=%s  EKS-AL2-%s=%s", tc.al2AMI, eksVersion, tc.eksAMI)
+}
+
+// ---------------------------------------------------------------------------
+// Resource lifecycle
+// ---------------------------------------------------------------------------
+
+// adoptExisting fills tc with IIDs of any pre-existing resources whose NameId
+// matches our namePrefix conventions. Used in --reuse mode so we don't re-create
+// what's already there from a previous interrupted run.
+func adoptExisting(tc *testCtx) {
+	log.Printf("[reuse] adopting existing resources with prefix %q", namePrefix)
+	if h, err := tc.conn.CreateVPCHandler(); err == nil {
+		if list, _ := h.ListVPC(); list != nil {
+			for _, v := range list {
+				if v.IId.NameId == namePrefix+"-vpc" {
+					tc.vpcIID = v.IId
+					for _, s := range v.SubnetInfoList {
+						switch s.Zone {
+						case zoneA:
+							tc.subnetAIID = s.IId
+						case zoneC:
+							tc.subnetCIID = s.IId
+						}
+					}
+					log.Printf("[reuse] VPC %s subnetA=%s subnetC=%s",
+						v.IId.SystemId, tc.subnetAIID.SystemId, tc.subnetCIID.SystemId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateSecurityHandler(); err == nil {
+		if list, _ := h.ListSecurity(); list != nil {
+			for _, s := range list {
+				if s.IId.NameId == namePrefix+"-sg" {
+					tc.sgIID = s.IId
+					log.Printf("[reuse] SG %s", s.IId.SystemId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateKeyPairHandler(); err == nil {
+		if list, _ := h.ListKey(); list != nil {
+			for _, k := range list {
+				if k.IId.NameId == namePrefix+"-key" {
+					tc.keyIID = k.IId
+					log.Printf("[reuse] KeyPair %s", k.IId.SystemId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateVMHandler(); err == nil {
+		if list, _ := h.ListVM(); list != nil {
+			for _, v := range list {
+				if v.IId.NameId != namePrefix+"-vm" {
+					continue
+				}
+				// Skip terminated/shutting-down — the test needs a live VM that
+				// can produce CloudWatch metrics during the settle window.
+				st, _ := h.GetVMStatus(v.IId)
+				stStr := strings.ToLower(string(st))
+				if stStr == "terminated" || stStr == "terminating" || stStr == "shutting-down" {
+					log.Printf("[reuse] skipping VM %s (status=%s) — will recreate", v.IId.SystemId, stStr)
+					continue
+				}
+				tc.vmIID = v.IId
+				log.Printf("[reuse] VM %s status=%s", v.IId.SystemId, stStr)
+			}
+		}
+	}
+	if h, err := tc.conn.CreateClusterHandler(); err == nil {
+		// Direct GetCluster — ListCluster's per-item GetCluster sometimes errors
+		// on CREATING clusters (no nodegroup yet), filtering them out silently.
+		ci, err := h.GetCluster(irs.IID{SystemId: namePrefix + "-eks"})
+		if err == nil && ci.IId.SystemId != "" {
+			tc.clusterIID = ci.IId
+			log.Printf("[reuse] Cluster %s status=%s", ci.IId.SystemId, ci.Status)
+		}
+	}
+}
+
+// preflightCleanup deletes any stale resources from a previous failed run that
+// share our namePrefix, so the fresh run does not collide on names.
+func preflightCleanup(tc *testCtx) {
+	log.Printf("[pre ] sweeping stale resources with prefix %q", namePrefix)
+
+	if h, err := tc.conn.CreateClusterHandler(); err == nil {
+		if list, err := h.ListCluster(); err == nil {
+			for _, c := range list {
+				if strings.HasPrefix(c.IId.NameId, namePrefix) {
+					log.Printf("[pre ] DeleteCluster %s", c.IId.SystemId)
+					_, _ = h.DeleteCluster(c.IId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateVMHandler(); err == nil {
+		if list, err := h.ListVM(); err == nil {
+			for _, v := range list {
+				if strings.HasPrefix(v.IId.NameId, namePrefix) {
+					log.Printf("[pre ] TerminateVM %s", v.IId.SystemId)
+					_, _ = h.TerminateVM(v.IId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateKeyPairHandler(); err == nil {
+		if list, err := h.ListKey(); err == nil {
+			for _, k := range list {
+				if strings.HasPrefix(k.IId.NameId, namePrefix) {
+					log.Printf("[pre ] DeleteKey %s", k.IId.SystemId)
+					_, _ = h.DeleteKey(k.IId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateSecurityHandler(); err == nil {
+		if list, err := h.ListSecurity(); err == nil {
+			for _, s := range list {
+				if strings.HasPrefix(s.IId.NameId, namePrefix) {
+					log.Printf("[pre ] DeleteSecurity %s", s.IId.SystemId)
+					_, _ = h.DeleteSecurity(s.IId)
+				}
+			}
+		}
+	}
+	if h, err := tc.conn.CreateVPCHandler(); err == nil {
+		if list, err := h.ListVPC(); err == nil {
+			for _, v := range list {
+				if strings.HasPrefix(v.IId.NameId, namePrefix) {
+					log.Printf("[pre ] DeleteVPC %s", v.IId.SystemId)
+					_, _ = h.DeleteVPC(v.IId)
+				}
+			}
+		}
+	}
+}
+
+func createVPC(tc *testCtx) {
+	h, err := tc.conn.CreateVPCHandler()
+	if err != nil {
+		log.Panicf("VPCHandler: %v", err)
+	}
+	req := irs.VPCReqInfo{
+		IId:       irs.IID{NameId: namePrefix + "-vpc"},
+		IPv4_CIDR: vpcCIDR,
+		SubnetInfoList: []irs.SubnetInfo{
+			{IId: irs.IID{NameId: namePrefix + "-subnet-a"}, Zone: zoneA, IPv4_CIDR: subnetACIDR},
+			{IId: irs.IID{NameId: namePrefix + "-subnet-c"}, Zone: zoneC, IPv4_CIDR: subnetCCIDR},
+		},
+	}
+	info, err := h.CreateVPC(req)
+	if err != nil {
+		log.Panicf("CreateVPC: %v", err)
+	}
+	tc.vpcIID = info.IId
+	for _, s := range info.SubnetInfoList {
+		switch s.Zone {
+		case zoneA:
+			tc.subnetAIID = s.IId
+		case zoneC:
+			tc.subnetCIID = s.IId
+		}
+	}
+	log.Printf("[vpc ] created: %s (%s)  subnetA=%s subnetC=%s",
+		info.IId.NameId, info.IId.SystemId,
+		tc.subnetAIID.SystemId, tc.subnetCIID.SystemId)
+	if tc.subnetAIID.SystemId == "" || tc.subnetCIID.SystemId == "" {
+		log.Panicf("CreateVPC returned no SubnetInfoList SystemIds: %+v", info.SubnetInfoList)
+	}
+}
+
+func createSG(tc *testCtx) {
+	h, err := tc.conn.CreateSecurityHandler()
+	if err != nil {
+		log.Panicf("SecurityHandler: %v", err)
+	}
+	// AWS auto-attaches an outbound allow-all rule to every new SG, so we only
+	// add inbound. Adding outbound here would 409 with InvalidPermission.Duplicate.
+	rules := []irs.SecurityRuleInfo{
+		{Direction: "inbound", IPProtocol: "ALL", FromPort: "-1", ToPort: "-1", CIDR: "0.0.0.0/0"},
+	}
+	req := irs.SecurityReqInfo{
+		IId:           irs.IID{NameId: namePrefix + "-sg"},
+		VpcIID:        tc.vpcIID,
+		SecurityRules: &rules,
+	}
+	info, err := h.CreateSecurity(req)
+	if err != nil {
+		log.Panicf("CreateSecurity: %v", err)
+	}
+	tc.sgIID = info.IId
+	log.Printf("[sg  ] created: %s (%s)", info.IId.NameId, info.IId.SystemId)
+}
+
+func createKeyPair(tc *testCtx) {
+	h, err := tc.conn.CreateKeyPairHandler()
+	if err != nil {
+		log.Panicf("KeyPairHandler: %v", err)
+	}
+	req := irs.KeyPairReqInfo{IId: irs.IID{NameId: namePrefix + "-key"}}
+	info, err := h.CreateKey(req)
+	if err != nil {
+		log.Panicf("CreateKey: %v", err)
+	}
+	tc.keyIID = info.IId
+	log.Printf("[key ] created: %s (%s)", info.IId.NameId, info.IId.SystemId)
+}
+
+func createVM(tc *testCtx) {
+	h, err := tc.conn.CreateVMHandler()
+	if err != nil {
+		log.Panicf("VMHandler: %v", err)
+	}
+	req := irs.VMReqInfo{
+		IId:               irs.IID{NameId: namePrefix + "-vm"},
+		ImageType:         irs.PublicImage,
+		ImageIID:          irs.IID{SystemId: tc.al2AMI},
+		VpcIID:            tc.vpcIID,
+		SubnetIID:         tc.subnetAIID,
+		SecurityGroupIIDs: []irs.IID{tc.sgIID},
+		VMSpecName:        vmSpec,
+		KeyPairIID:        tc.keyIID,
+		RootDiskType:      "default",
+		RootDiskSize:      "default",
+	}
+	info, err := h.StartVM(req)
+	if err != nil {
+		log.Panicf("StartVM: %v", err)
+	}
+	tc.vmIID = info.IId
+	log.Printf("[vm  ] started: %s (%s)", info.IId.NameId, info.IId.SystemId)
+
+	// Wait until Running.
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		st, err := h.GetVMStatus(tc.vmIID)
+		if err == nil {
+			if strings.EqualFold(string(st), "running") {
+				log.Printf("[vm  ] Running confirmed")
+				return
+			}
+		}
+		time.Sleep(15 * time.Second)
+	}
+	log.Printf("[vm  ] WARN: did not confirm Running within 5m (continuing)")
+}
+
+func createCluster(tc *testCtx) {
+	h, err := tc.conn.CreateClusterHandler()
+	if err != nil {
+		log.Panicf("ClusterHandler: %v", err)
+	}
+	clusterName := namePrefix + "-eks"
+	nodeGroupName := namePrefix + "-ng"
+	if tc.clusterIID.SystemId == "" {
+		tc.clusterIID = irs.IID{NameId: clusterName}
+	}
+	if tc.nodeGroupIID.NameId == "" {
+		tc.nodeGroupIID = irs.IID{NameId: nodeGroupName}
+	}
+
+	// AWS driver's CreateCluster is async (returns once the EKS CreateCluster
+	// API accepts) and does NOT add NodeGroups. We need to:
+	//   1) call CreateCluster (no NodeGroupList — added separately below),
+	//   2) poll GetCluster until status=Active,
+	//   3) call AddNodeGroup,
+	//   4) poll GetCluster until the node has a SystemId.
+	t0 := time.Now()
+	if tc.clusterIID.SystemId == "" {
+		req := irs.ClusterInfo{
+			IId:     tc.clusterIID,
+			Version: eksVersion,
+			Network: irs.NetworkInfo{
+				VpcIID:            tc.vpcIID,
+				SubnetIIDs:        []irs.IID{tc.subnetAIID, tc.subnetCIID},
+				SecurityGroupIIDs: []irs.IID{tc.sgIID},
+			},
+		}
+		log.Printf("[eks ] CreateCluster (cluster-only, async)...")
+		info, err := h.CreateCluster(req)
+		if err != nil {
+			log.Panicf("CreateCluster: %v", err)
+		}
+		tc.clusterIID = info.IId
+		log.Printf("[eks ] CreateCluster returned in %s, status=%s — waiting until Active", time.Since(t0), info.Status)
+	} else {
+		log.Printf("[eks ] reusing existing cluster %s — waiting until Active", tc.clusterIID.SystemId)
+	}
+
+	waitCluster := func(target string, timeout time.Duration) irs.ClusterInfo {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			ci, err := h.GetCluster(tc.clusterIID)
+			if err == nil {
+				log.Printf("[eks ] cluster status=%s elapsed=%s",
+					ci.Status, time.Since(t0).Round(time.Second))
+				if strings.EqualFold(string(ci.Status), target) {
+					return ci
+				}
+			} else {
+				log.Printf("[eks ] GetCluster err (will retry): %v", err)
+			}
+			time.Sleep(30 * time.Second)
+		}
+		log.Panicf("[eks ] timed out waiting for cluster status=%s", target)
+		return irs.ClusterInfo{}
+	}
+	_ = waitCluster("Active", 25*time.Minute)
+	log.Printf("[eks ] cluster Active in %s", time.Since(t0).Round(time.Second))
+
+	// Skip AddNodeGroup if the cluster already has it (reuse case).
+	hasNG := false
+	if ci, err := h.GetCluster(tc.clusterIID); err == nil {
+		for _, ng := range ci.NodeGroupList {
+			if ng.IId.NameId == tc.nodeGroupIID.NameId || ng.IId.SystemId == tc.nodeGroupIID.NameId {
+				tc.nodeGroupIID = ng.IId
+				hasNG = true
+				log.Printf("[eks ] nodegroup %s already exists (status=%s nodes=%d)",
+					ng.IId.NameId, ng.Status, len(ng.Nodes))
+				break
+			}
+		}
+	}
+	if !hasNG {
+		ngReq := irs.NodeGroupInfo{
+			IId:             tc.nodeGroupIID,
+			ImageIID:        irs.IID{SystemId: tc.eksAMI},
+			VMSpecName:      eksNodeSpec,
+			RootDiskType:    "default",
+			RootDiskSize:    "default",
+			KeyPairIID:      tc.keyIID,
+			OnAutoScaling:   true,
+			DesiredNodeSize: 1,
+			MinNodeSize:     1,
+			MaxNodeSize:     2,
+		}
+		log.Printf("[eks ] AddNodeGroup %s...", nodeGroupName)
+		tNG := time.Now()
+		ngInfo, err := h.AddNodeGroup(tc.clusterIID, ngReq)
+		if err != nil {
+			log.Panicf("AddNodeGroup: %v", err)
+		}
+		tc.nodeGroupIID = ngInfo.IId
+		log.Printf("[eks ] AddNodeGroup returned in %s status=%s — waiting for node to appear", time.Since(tNG), ngInfo.Status)
+	}
+
+	// Poll GetCluster until our node group has a Node SystemId.
+	deadline := time.Now().Add(15 * time.Minute)
+	for time.Now().Before(deadline) {
+		ci, err := h.GetCluster(tc.clusterIID)
+		if err == nil {
+			for _, ng := range ci.NodeGroupList {
+				if ng.IId.NameId != tc.nodeGroupIID.NameId && ng.IId.SystemId != tc.nodeGroupIID.SystemId {
+					continue
+				}
+				if len(ng.Nodes) > 0 && ng.Nodes[0].SystemId != "" {
+					tc.nodeGroupIID = ng.IId
+					tc.nodeIID = ng.Nodes[0]
+					log.Printf("[eks ] node ready ng=%s node=%s ngStatus=%s",
+						ng.IId.NameId, ng.Nodes[0].SystemId, ng.Status)
+					return
+				}
+				log.Printf("[eks ] ng=%s status=%s nodes=%d (waiting...)",
+					ng.IId.NameId, ng.Status, len(ng.Nodes))
+			}
+		}
+		time.Sleep(30 * time.Second)
+	}
+	log.Panicf("[eks ] timed out waiting for node SystemId in nodegroup %s", tc.nodeGroupIID.NameId)
+}
+
+// ---------------------------------------------------------------------------
+// Monitoring tests
+// ---------------------------------------------------------------------------
+
+var allMetrics = []irs.MetricType{
+	irs.CPUUsage, irs.MemoryUsage,
+	irs.DiskRead, irs.DiskWrite, irs.DiskReadOps, irs.DiskWriteOps,
+	irs.NetworkIn, irs.NetworkOut,
+}
+
+type testResult struct {
+	metric  irs.MetricType
+	want    string // "data", "reject", or "either"
+	got     string // "data", "reject", "error", "empty"
+	points  int
+	errMsg  string
+	pass    bool
+	details string
+}
+
+func runVMMetricTests(tc *testCtx) {
+	h, err := tc.conn.CreateMonitoringHandler()
+	if err != nil {
+		log.Panicf("MonitoringHandler: %v", err)
+	}
+
+	log.Printf("============================================================")
+	log.Printf(" VM monitoring tests (vmIID=%s)", tc.vmIID.SystemId)
+	log.Printf("============================================================")
+	results := []testResult{}
+	for _, m := range allMetrics {
+		want := "data"
+		if m == irs.MemoryUsage {
+			want = "reject"
+		}
+		r := testOne(m, want, func() (irs.MetricData, error) {
+			return h.GetVMMetricData(irs.VMMonitoringReqInfo{
+				VMIID:      tc.vmIID,
+				MetricType: m,
+			})
+		})
+		results = append(results, r)
+	}
+	printSummary("VM", results)
+}
+
+func runClusterNodeMetricTests(tc *testCtx) {
+	if tc.nodeIID.SystemId == "" {
+		log.Printf("[skip] cluster-node tests: no node resolved")
+		return
+	}
+	h, err := tc.conn.CreateMonitoringHandler()
+	if err != nil {
+		log.Panicf("MonitoringHandler: %v", err)
+	}
+
+	log.Printf("============================================================")
+	log.Printf(" Cluster-node monitoring tests (cluster=%s ng=%s node=%s)",
+		tc.clusterIID.NameId, tc.nodeGroupIID.NameId, tc.nodeIID.SystemId)
+	log.Printf("============================================================")
+	results := []testResult{}
+	for _, m := range allMetrics {
+		want := "data"
+		if m == irs.MemoryUsage {
+			want = "reject"
+		}
+		r := testOne(m, want, func() (irs.MetricData, error) {
+			return h.GetClusterNodeMetricData(irs.ClusterNodeMonitoringReqInfo{
+				ClusterIID:  tc.clusterIID,
+				NodeGroupID: tc.nodeGroupIID,
+				NodeIID:     tc.nodeIID,
+				MetricType:  m,
+			})
+		})
+		results = append(results, r)
+	}
+	printSummary("ClusterNode", results)
+}
+
+func testOne(m irs.MetricType, want string, call func() (irs.MetricData, error)) testResult {
+	r := testResult{metric: m, want: want}
+	data, err := call()
+	if err != nil {
+		r.got = "error"
+		r.errMsg = err.Error()
+		if want == "reject" && strings.Contains(err.Error(), "is not supported") {
+			r.got = "reject"
+			r.pass = true
+		} else {
+			r.pass = false
+		}
+		return r
+	}
+	if len(data.TimestampValues) == 0 {
+		r.got = "empty"
+		r.pass = (want == "either")
+		return r
+	}
+	r.got = "data"
+	r.points = len(data.TimestampValues)
+	r.details = fmt.Sprintf("first=%v last=%v",
+		data.TimestampValues[0].Value, data.TimestampValues[len(data.TimestampValues)-1].Value)
+	r.pass = (want == "data" || want == "either")
+	return r
+}
+
+func printSummary(label string, results []testResult) {
+	pass, fail := 0, 0
+	for _, r := range results {
+		mark := "FAIL"
+		if r.pass {
+			mark = "PASS"
+			pass++
+		} else {
+			fail++
+		}
+		switch r.got {
+		case "data":
+			log.Printf(" %s  %-15s  want=%s got=data points=%d %s", mark, r.metric, r.want, r.points, r.details)
+		case "reject":
+			log.Printf(" %s  %-15s  want=%s got=reject  %q", mark, r.metric, r.want, r.errMsg)
+		case "error":
+			log.Printf(" %s  %-15s  want=%s got=error   %q", mark, r.metric, r.want, r.errMsg)
+		case "empty":
+			log.Printf(" %s  %-15s  want=%s got=empty (no datapoints)", mark, r.metric, r.want)
+		}
+	}
+	log.Printf("[%s summary] pass=%d fail=%d", label, pass, fail)
+}
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+func teardown(tc *testCtx) {
+	log.Printf("============================================================")
+	log.Printf(" Teardown")
+	log.Printf("============================================================")
+	if tc.withCluster && tc.clusterIID.SystemId != "" {
+		if h, err := tc.conn.CreateClusterHandler(); err == nil {
+			log.Printf("[eks ] DeleteCluster %s", tc.clusterIID.SystemId)
+			if _, err := h.DeleteCluster(tc.clusterIID); err != nil {
+				log.Printf("[eks ] DeleteCluster err: %v", err)
+			}
+		}
+	}
+	if tc.vmIID.SystemId != "" {
+		if h, err := tc.conn.CreateVMHandler(); err == nil {
+			log.Printf("[vm  ] TerminateVM %s", tc.vmIID.SystemId)
+			if _, err := h.TerminateVM(tc.vmIID); err != nil {
+				log.Printf("[vm  ] Terminate err: %v", err)
+			}
+			// Wait for full termination so SG/KeyPair deletion can succeed.
+			deadline := time.Now().Add(5 * time.Minute)
+			for time.Now().Before(deadline) {
+				st, err := h.GetVMStatus(tc.vmIID)
+				if err != nil || string(st) == "Terminated" || string(st) == "" {
+					break
+				}
+				time.Sleep(10 * time.Second)
+			}
+		}
+	}
+	if tc.keyIID.SystemId != "" {
+		if h, err := tc.conn.CreateKeyPairHandler(); err == nil {
+			log.Printf("[key ] DeleteKey %s", tc.keyIID.SystemId)
+			if _, err := h.DeleteKey(tc.keyIID); err != nil {
+				log.Printf("[key ] Delete err: %v", err)
+			}
+		}
+	}
+	if tc.sgIID.SystemId != "" {
+		if h, err := tc.conn.CreateSecurityHandler(); err == nil {
+			log.Printf("[sg  ] DeleteSecurity %s", tc.sgIID.SystemId)
+			if _, err := h.DeleteSecurity(tc.sgIID); err != nil {
+				log.Printf("[sg  ] Delete err: %v", err)
+			}
+		}
+	}
+	if tc.vpcIID.SystemId != "" {
+		if h, err := tc.conn.CreateVPCHandler(); err == nil {
+			log.Printf("[vpc ] DeleteVPC %s", tc.vpcIID.SystemId)
+			if _, err := h.DeleteVPC(tc.vpcIID); err != nil {
+				log.Printf("[vpc ] Delete err: %v", err)
+			}
+		}
+	}
+	log.Printf("[teardown] done")
+	_ = os.Stderr
+}

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/MonitoringHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/MonitoringHandler.go
@@ -1,0 +1,497 @@
+// AWS Driver of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// by CB-Spider Team, 2026.04.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type AwsMonitoringHandler struct {
+	Region         idrv.RegionInfo
+	CredentialInfo idrv.CredentialInfo
+	CwClient       *cloudwatch.CloudWatch
+	VMClient       *ec2.EC2
+	ClusterHandler *AwsClusterHandler
+}
+
+// awsMetricSpec describes how to query a single CloudWatch metric.
+// PerSecond divides the aggregated value by the period (seconds) to turn a
+// Sum-of-counts into a per-second rate.
+type awsMetricSpec struct {
+	Namespace  string
+	MetricName string
+	Statistic  string // "Average", "Sum"
+	PerSecond  bool
+	Unit       string // informational only; the common runtime rewrites the response unit
+}
+
+// monitoringQuery is the resolved per-request input for getMetricData.
+type monitoringQuery struct {
+	instanceID     string
+	instanceType   string // e.g. "t3.small" — drives instance-store vs EBS metric selection
+	instanceState  string
+	intervalMinute int
+	timeBeforeHour int
+}
+
+// ============================================================================
+// Metric Specs
+// ============================================================================
+
+var (
+	awsSpecCPU = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "CPUUtilization",
+		Statistic:  "Average",
+		Unit:       "Percent",
+	}
+	// Disk*: instance-store volume I/O (legacy/Xen-era and i3/m4d/c5d-style
+	// instances that ship with NVMe instance store). Reports 0 / not-published
+	// on EBS-only instances.
+	awsSpecDiskRead = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "DiskReadBytes",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+	awsSpecDiskWrite = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "DiskWriteBytes",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+	awsSpecDiskReadOps = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "DiskReadOps",
+		Statistic:  "Sum",
+		PerSecond:  true,
+		Unit:       "CountPerSecond",
+	}
+	awsSpecDiskWriteOps = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "DiskWriteOps",
+		Statistic:  "Sum",
+		PerSecond:  true,
+		Unit:       "CountPerSecond",
+	}
+	// EBS*: EBS volume I/O on Nitro instances (most current types: t3, t4g, m5,
+	// c5, c6i, …). Same statistic semantics as the Disk* group.
+	awsSpecEBSRead = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "EBSReadBytes",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+	awsSpecEBSWrite = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "EBSWriteBytes",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+	awsSpecEBSReadOps = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "EBSReadOps",
+		Statistic:  "Sum",
+		PerSecond:  true,
+		Unit:       "CountPerSecond",
+	}
+	awsSpecEBSWriteOps = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "EBSWriteOps",
+		Statistic:  "Sum",
+		PerSecond:  true,
+		Unit:       "CountPerSecond",
+	}
+	awsSpecNetworkIn = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "NetworkIn",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+	awsSpecNetworkOut = awsMetricSpec{
+		Namespace:  "AWS/EC2",
+		MetricName: "NetworkOut",
+		Statistic:  "Sum",
+		Unit:       "Bytes",
+	}
+)
+
+// ============================================================================
+// Handler Registry
+// ============================================================================
+
+// awsMetricHandler resolves a request to either a CloudWatch query or a
+// dedicated unsupported-metric error, picked by the per-MetricType registry.
+type awsMetricHandler func(*AwsMonitoringHandler, monitoringQuery) (irs.MetricData, error)
+
+// EKS nodes are standard EC2 instances, so the cluster-node path reuses the
+// same handlers (same AWS/EC2 metrics, InstanceId dimension).
+var awsMetricHandlers = map[irs.MetricType]awsMetricHandler{
+	irs.CPUUsage: awsDirect(irs.CPUUsage, awsSpecCPU),
+	irs.MemoryUsage: awsRejected(
+		"memory_usage is not supported for AWS VMs in API-based(agentless) monitoring.",
+	),
+	irs.DiskRead:     awsDiskDispatch(irs.DiskRead, awsSpecDiskRead, awsSpecEBSRead),
+	irs.DiskWrite:    awsDiskDispatch(irs.DiskWrite, awsSpecDiskWrite, awsSpecEBSWrite),
+	irs.DiskReadOps:  awsDiskDispatch(irs.DiskReadOps, awsSpecDiskReadOps, awsSpecEBSReadOps),
+	irs.DiskWriteOps: awsDiskDispatch(irs.DiskWriteOps, awsSpecDiskWriteOps, awsSpecEBSWriteOps),
+	irs.NetworkIn:    awsDirect(irs.NetworkIn, awsSpecNetworkIn),
+	irs.NetworkOut:   awsDirect(irs.NetworkOut, awsSpecNetworkOut),
+}
+
+func awsDirect(mt irs.MetricType, spec awsMetricSpec) awsMetricHandler {
+	return func(h *AwsMonitoringHandler, q monitoringQuery) (irs.MetricData, error) {
+		return h.getMetricData(mt, spec, q)
+	}
+}
+
+// awsRejected returns a handler that fails fast with a fixed reason. Used for
+// MetricTypes present in the common interface but intentionally unsupported on
+// EC2's API-based monitoring (e.g., memory_usage requires CloudWatch Agent).
+func awsRejected(reason string) awsMetricHandler {
+	return func(_ *AwsMonitoringHandler, _ monitoringQuery) (irs.MetricData, error) {
+		err := errors.New(reason)
+		cblogger.Error(err.Error())
+		return irs.MetricData{}, err
+	}
+}
+
+// awsDiskDispatch picks the right CloudWatch metric for a disk request based
+// on the instance type. EC2 publishes "Disk*" only for instance-store volumes
+// and "EBS*" only for EBS volumes — the two are mutually exclusive per
+// instance-type, so we dispatch on InstanceStorageSupported. Falls back to the
+// EBS spec when the type lookup fails (Nitro EBS-only is the current default).
+func awsDiskDispatch(mt irs.MetricType, instStoreSpec, ebsSpec awsMetricSpec) awsMetricHandler {
+	return func(h *AwsMonitoringHandler, q monitoringQuery) (irs.MetricData, error) {
+		spec := ebsSpec
+		if q.instanceType != "" {
+			hasIS, err := awsInstanceHasInstanceStore(h.VMClient, q.instanceType)
+			if err != nil {
+				cblogger.Errorf("failed to resolve instance-store support for %q (defaulting to EBS metrics): %v", q.instanceType, err)
+			} else if hasIS {
+				spec = instStoreSpec
+			}
+		}
+		return h.getMetricData(mt, spec, q)
+	}
+}
+
+// awsInstanceStoreCache memoizes DescribeInstanceTypes lookups. Instance type
+// catalog is stable per region, so a simple per-process map is enough.
+var awsInstanceStoreCache sync.Map // map[string]bool
+
+func awsInstanceHasInstanceStore(svc *ec2.EC2, instanceType string) (bool, error) {
+	if v, ok := awsInstanceStoreCache.Load(instanceType); ok {
+		cblogger.Debugf("[disk-dispatch] cache HIT instance_type=%s has_instance_store=%v", instanceType, v.(bool))
+		return v.(bool), nil
+	}
+	cblogger.Infof("[disk-dispatch] cache MISS instance_type=%s — calling DescribeInstanceTypes", instanceType)
+	out, err := svc.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{
+		InstanceTypes: []*string{aws.String(instanceType)},
+	})
+	if err != nil {
+		return false, err
+	}
+	if len(out.InstanceTypes) == 0 {
+		return false, fmt.Errorf("instance type not found: %s", instanceType)
+	}
+	has := aws.BoolValue(out.InstanceTypes[0].InstanceStorageSupported)
+	awsInstanceStoreCache.Store(instanceType, has)
+	cblogger.Infof("[disk-dispatch] cached instance_type=%s has_instance_store=%v", instanceType, has)
+	return has, nil
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+func (handler *AwsMonitoringHandler) GetVMMetricData(req irs.VMMonitoringReqInfo) (irs.MetricData, error) {
+	cblogger.Info("AWS Cloud Driver: called GetVMMetricData()")
+
+	if req.VMIID.NameId == "" && req.VMIID.SystemId == "" {
+		return irs.MetricData{}, errors.New("VMIID is empty")
+	}
+
+	intervalMinute, timeBeforeHour, err := awsParseAndValidateInterval(req.IntervalMinute, req.TimeBeforeHour)
+	if err != nil {
+		return irs.MetricData{}, err
+	}
+
+	instanceID, instanceType, instanceState, err := handler.resolveInstance(req.VMIID)
+	if err != nil {
+		return irs.MetricData{}, err
+	}
+
+	handle, ok := awsMetricHandlers[req.MetricType]
+	if !ok {
+		return irs.MetricData{}, fmt.Errorf("unsupported VM metric type: %s", req.MetricType)
+	}
+
+	q := monitoringQuery{
+		instanceID:     instanceID,
+		instanceType:   instanceType,
+		instanceState:  instanceState,
+		intervalMinute: intervalMinute,
+		timeBeforeHour: timeBeforeHour,
+	}
+	return handle(handler, q)
+}
+
+// GetClusterNodeMetricData fetches node-level metrics for an EKS node. EKS
+// nodes are standard EC2 instances, so queries reuse the same AWS/EC2 metrics
+// as VMs with the node's EC2 InstanceId.
+func (handler *AwsMonitoringHandler) GetClusterNodeMetricData(req irs.ClusterNodeMonitoringReqInfo) (irs.MetricData, error) {
+	cblogger.Info("AWS Cloud Driver: called GetClusterNodeMetricData()")
+
+	if req.ClusterIID.NameId == "" && req.ClusterIID.SystemId == "" {
+		return irs.MetricData{}, errors.New("ClusterIID is empty")
+	}
+
+	intervalMinute, timeBeforeHour, err := awsParseAndValidateInterval(req.IntervalMinute, req.TimeBeforeHour)
+	if err != nil {
+		return irs.MetricData{}, err
+	}
+
+	if handler.ClusterHandler == nil {
+		return irs.MetricData{}, errors.New("cluster handler is not configured")
+	}
+	cluster, err := handler.ClusterHandler.GetCluster(req.ClusterIID)
+	if err != nil {
+		return irs.MetricData{}, fmt.Errorf("failed to get cluster info: %w", err)
+	}
+
+	instanceID, err := findAwsClusterNodeInstanceID(cluster, req.NodeGroupID, req.NodeIID)
+	if err != nil {
+		return irs.MetricData{}, err
+	}
+
+	_, instanceType, instanceState, err := handler.resolveInstance(irs.IID{SystemId: instanceID})
+	if err != nil {
+		return irs.MetricData{}, err
+	}
+
+	handle, ok := awsMetricHandlers[req.MetricType]
+	if !ok {
+		return irs.MetricData{}, fmt.Errorf("unsupported cluster-node metric type: %s", req.MetricType)
+	}
+
+	q := monitoringQuery{
+		instanceID:     instanceID,
+		instanceType:   instanceType,
+		instanceState:  instanceState,
+		intervalMinute: intervalMinute,
+		timeBeforeHour: timeBeforeHour,
+	}
+	return handle(handler, q)
+}
+
+func findAwsClusterNodeInstanceID(cluster irs.ClusterInfo, nodeGroupID, nodeIID irs.IID) (string, error) {
+	for _, nodeGroup := range cluster.NodeGroupList {
+		if nodeGroup.IId.NameId != nodeGroupID.NameId &&
+			nodeGroup.IId.SystemId != nodeGroupID.SystemId {
+			continue
+		}
+		for _, node := range nodeGroup.Nodes {
+			if node.NameId != nodeIID.NameId && node.SystemId != nodeIID.SystemId {
+				continue
+			}
+			if node.SystemId != "" {
+				return node.SystemId, nil
+			}
+			return node.NameId, nil
+		}
+	}
+	return "", errors.New("node not found in the cluster")
+}
+
+// ============================================================================
+// Metric Execution
+// ============================================================================
+
+func (handler *AwsMonitoringHandler) getMetricData(
+	metricType irs.MetricType,
+	spec awsMetricSpec,
+	q monitoringQuery,
+) (irs.MetricData, error) {
+	endTime := time.Now().UTC()
+	startTime := endTime.Add(-time.Duration(q.timeBeforeHour) * time.Hour)
+	periodSec := int64(q.intervalMinute * 60)
+
+	input := &cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String(spec.Namespace),
+		MetricName: aws.String(spec.MetricName),
+		Dimensions: []*cloudwatch.Dimension{
+			{Name: aws.String("InstanceId"), Value: aws.String(q.instanceID)},
+		},
+		StartTime:  aws.Time(startTime),
+		EndTime:    aws.Time(endTime),
+		Period:     aws.Int64(periodSec),
+		Statistics: []*string{aws.String(spec.Statistic)},
+	}
+
+	resp, err := handler.CwClient.GetMetricStatistics(input)
+	if err != nil {
+		return irs.MetricData{}, fmt.Errorf("failed to get metric data: %w", err)
+	}
+
+	result := irs.MetricData{
+		MetricName:      spec.MetricName,
+		MetricUnit:      spec.Unit,
+		TimestampValues: []irs.TimestampValue{},
+	}
+
+	points := resp.Datapoints
+	sortDatapointsAsc(points)
+
+	for _, dp := range points {
+		v := pickDatapointValue(dp, spec.Statistic)
+		if v == nil {
+			continue
+		}
+		val := *v
+		if spec.PerSecond && periodSec > 0 {
+			val = val / float64(periodSec)
+		}
+		result.TimestampValues = append(result.TimestampValues, irs.TimestampValue{
+			Timestamp: dp.Timestamp.UTC(),
+			Value:     strconv.FormatFloat(val, 'f', -1, 64),
+		})
+	}
+
+	if len(result.TimestampValues) == 0 {
+		return irs.MetricData{}, awsDiagnoseEmptyMetric(metricType, q.instanceID, q.instanceState)
+	}
+	return result, nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// resolveInstance returns the EC2 instance id, type, and state. instanceType
+// is exposed so disk-metric dispatch can pick instance-store vs EBS metrics
+// without a second API call. NameId is not supported as an EC2 lookup key on
+// AWS; callers must provide SystemId.
+func (handler *AwsMonitoringHandler) resolveInstance(vmIID irs.IID) (id, instanceType, state string, err error) {
+	instanceID := vmIID.SystemId
+	if instanceID == "" {
+		instanceID = vmIID.NameId
+	}
+	if instanceID == "" {
+		return "", "", "", errors.New("instance id is empty")
+	}
+
+	out, err := handler.VMClient.DescribeInstances(&ec2.DescribeInstancesInput{
+		InstanceIds: []*string{aws.String(instanceID)},
+	})
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to describe instance %q: %w", instanceID, err)
+	}
+	for _, res := range out.Reservations {
+		for _, inst := range res.Instances {
+			st := ""
+			if inst.State != nil && inst.State.Name != nil {
+				st = *inst.State.Name
+			}
+			return aws.StringValue(inst.InstanceId),
+				aws.StringValue(inst.InstanceType),
+				st,
+				nil
+		}
+	}
+	return "", "", "", fmt.Errorf("instance %q not found", instanceID)
+}
+
+// awsParseAndValidateInterval mirrors the Azure handler: TimeBeforeHour*60
+// must be >= IntervalMinute. Empty strings default to "1". CloudWatch accepts
+// any positive period so we do not restrict the interval values themselves.
+func awsParseAndValidateInterval(intervalMinuteStr, timeBeforeHourStr string) (intervalMinute, timeBeforeHour int, err error) {
+	if intervalMinuteStr == "" {
+		intervalMinuteStr = "1"
+	}
+	if timeBeforeHourStr == "" {
+		timeBeforeHourStr = "1"
+	}
+
+	intervalMinute, err = strconv.Atoi(intervalMinuteStr)
+	if err != nil || intervalMinute <= 0 {
+		return 0, 0, errors.New("invalid value of IntervalMinute")
+	}
+	timeBeforeHour, err = strconv.Atoi(timeBeforeHourStr)
+	if err != nil || timeBeforeHour < 0 {
+		return 0, 0, errors.New("invalid value of TimeBeforeHour")
+	}
+	if timeBeforeHour*60 < intervalMinute {
+		return 0, 0, errors.New("IntervalMinute is too far in the past")
+	}
+	return intervalMinute, timeBeforeHour, nil
+}
+
+func pickDatapointValue(dp *cloudwatch.Datapoint, stat string) *float64 {
+	if dp == nil {
+		return nil
+	}
+	switch stat {
+	case "Sum":
+		return dp.Sum
+	case "Average":
+		return dp.Average
+	case "Minimum":
+		return dp.Minimum
+	case "Maximum":
+		return dp.Maximum
+	case "SampleCount":
+		return dp.SampleCount
+	default:
+		return dp.Average
+	}
+}
+
+func sortDatapointsAsc(points []*cloudwatch.Datapoint) {
+	for i := 1; i < len(points); i++ {
+		for j := i; j > 0; j-- {
+			if points[j-1].Timestamp == nil || points[j].Timestamp == nil {
+				break
+			}
+			if points[j-1].Timestamp.After(*points[j].Timestamp) {
+				points[j-1], points[j] = points[j], points[j-1]
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func awsDiagnoseEmptyMetric(metricType irs.MetricType, instanceID, state string) error {
+	if state != "" && state != "running" {
+		return fmt.Errorf(
+			"no %s data: instance %q is in %q state (must be running to emit metrics)",
+			metricType, instanceID, state)
+	}
+	return fmt.Errorf(
+		"no %s data for running instance %q in the requested window: "+
+			"the instance may have been started recently or detailed monitoring is off; "+
+			"try increasing TimeBeforeHour",
+		metricType, instanceID)
+}


### PR DESCRIPTION
# AWS Monitoring Test (cb-spider)

## Supports
- VM Monitoring
- Cluster Node Monitoring (EKS)

## Supported Metrics
에이전트 없이 아래 메트릭 수집 가능

| MetricType       | 데이터 소스                                                            |
|------------------|------------------------------------------------------------------------|
| cpu_usage        | CloudWatch `AWS/EC2:CPUUtilization`                                    |
| disk_read        | CloudWatch `AWS/EC2:EBSReadBytes` (Nitro) / `:DiskReadBytes` (instance store) |
| disk_write       | CloudWatch `AWS/EC2:EBSWriteBytes` (Nitro) / `:DiskWriteBytes` (instance store) |
| disk_read_ops    | CloudWatch `AWS/EC2:EBSReadOps` (Nitro) / `:DiskReadOps` (instance store) |
| disk_write_ops   | CloudWatch `AWS/EC2:EBSWriteOps` (Nitro) / `:DiskWriteOps` (instance store) |
| network_in       | CloudWatch `AWS/EC2:NetworkIn`                                         |
| network_out      | CloudWatch `AWS/EC2:NetworkOut`                                        |

총 7종, 모두 `AWS/EC2` 네임스페이스 기본 메트릭이라 **추가 에이전트 설치 없이 그대로 조회**됩니다.

### 디스크 메트릭 자동 dispatch

AWS는 EC2의 디스크 I/O를 두 그룹으로 분리해서 보고합니다:
- `Disk*Bytes`/`Disk*Ops` — **instance store** 볼륨 I/O (i3, m5d, c5d 등 NVMe instance store 인스턴스)
- `EBS*Bytes`/`EBS*Ops` — **EBS** 볼륨 I/O (t3, t4g, m5, c5, c6i 등 Nitro EBS-only 인스턴스)

두 그룹은 인스턴스 타입별로 상호 배타적이라 (instance store가 없는 타입에서 `Disk*`는 0/미보고), 드라이버는 호출 시점에 `DescribeInstanceTypes`의 `InstanceStorageSupported` 플래그를 보고 자동으로 어느 메트릭을 쿼리할지 결정합니다. 결과는 인스턴스 타입별로 process-level 캐시되어 두 번째 호출부터는 추가 API 호출 없이 동작합니다.

---

## 미지원 메트릭

### `memory_usage`
- AWS는 `memory_usage`를 미지원 처리합니다. 호출 시 다음과 같은 안내 에러를 반환합니다:
  ```
  memory_usage is not supported for AWS VMs in API-based(agentless) monitoring.
  ```

### 미지원으로 둔 이유
- EC2 하이퍼바이저는 **게스트 OS 내부 상태**(메모리, 프로세스, 파일시스템 사용률 등)를 관측하지 못합니다.
- 본 드라이버는 **인스턴스 내부에 에이전트를 주입·운영하는 책임을 지지 않는다**는 방침이므로, 에이전트가 있어야만 수집 가능한 메트릭은 일괄 미지원으로 둡니다.

### 참고 (CSP 비교)
| CSP   | 메모리 메트릭 수집 방식                                   |
|-------|-----------------------------------------------------------|
| AWS   | CloudWatch Agent 필요 → 본 드라이버 미지원                |
| Azure | 본 드라이버는 `Available Memory Bytes` + VM Size 총량으로 사용률 계산 (별도 에이전트 불필요) |
| GCP   | VM: Ops Agent 필요 → 본 드라이버 미지원 (GKE만 자동 수집, kubernetes.io 네임스페이스) |

---

## 테스트 환경
- CB-Spider 엔드포인트: `localhost:1024`
- ConnectionName: `aws-ap-northeast-2`
- Region: `ap-northeast-2`
- VM: `cb-mon-test-vm` (`t3.small`)
- Cluster: `cb-mon-test-eks` (Kubernetes 1.30)
- NodeGroup: `cb-mon-test-ng` (노드 1개, `t3.medium`)

---

# 모니터링 API 호출 방법

## 지원되는 메트릭 종류 (Metric Type)
- cpu_usage (Percent)
- disk_read (Bytes)
- disk_write (Bytes)
- disk_read_ops (CountPerSecond)
- disk_write_ops (CountPerSecond)
- network_in (Bytes)
- network_out (Bytes)

## 지원되는 Interval Minutes
- 1, 5, 15, 30, 60, 360, 720, 1440
- CloudWatch `GetMetricStatistics`는 임의 양의 period를 허용하지만, 드라이버에서 `TimeBeforeHour*60 >= IntervalMinute` 조건만 검증합니다.

## 기본 설정값
- 시간 범위: 현재 시간으로부터 1시간 전
- 간격 (IntervalMinute): 1분

## 반환되는 시간 Time Zone
- UTC (국내시간 +9시간)

## 공통 응답 구조
모든 CSP/리소스(VM·클러스터 노드)에 대해 MetricType별 `metricName`/`metricUnit`이 아래와 같이 고정됩니다 (공통 런타임이 드라이버 응답을 정규화).

| MetricType       | metricName               | metricUnit     |
|------------------|--------------------------|----------------|
| cpu_usage        | CPU Usage Percent        | Percent        |
| disk_read        | Disk Read Bytes          | Bytes          |
| disk_write       | Disk Write Bytes         | Bytes          |
| disk_read_ops    | Disk Read Operations/Sec | CountPerSecond |
| disk_write_ops   | Disk Write Operations/Sec| CountPerSecond |
| network_in       | Network In Bytes         | Bytes          |
| network_out      | Network Out Bytes        | Bytes          |

### `memory_usage` 호출 시 응답
드라이버에서 다음과 같은 에러를 반환하므로, REST API 응답은 일반 4xx 에러로 전달됩니다.
```
memory_usage is not supported for AWS VMs in API-based(agentless) monitoring.
```

---

## 1. VM 모니터링

- curl을 이용한 API 호출 방법 (기본값 사용)
```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/{VM 명}/{Metric Type} -H 'Content-Type: application/json' -d '{"ConnectionName": "(Connection 이름)"}'
```

- curl을 이용한 API 호출 방법 (시간 범위, 간격 설정)
```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/{VM 명}/{Metric Type} -H 'Content-Type: application/json' -d '{"ConnectionName": "(Connection 이름)", "TimeBeforeHour": "(현재 시간의 몇 시간 전부터 조회할지)", "IntervalMinute": "(분 단위 간격)"}'
```

### 1-1. cpu_usage

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/cpu_usage -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "CPU Usage Percent",
  "metricUnit": "Percent",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 1-2. memory_usage (미지원)

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/memory_usage -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}'
```
```
memory_usage is not supported for AWS VMs in API-based(agentless) monitoring.
```

### 1-3. disk_read

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/disk_read -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Read Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

> 디스크 부하가 없는 idle VM에서는 CloudWatch에 datapoint가 적재되지 않아 다음 진단 에러가 반환됩니다 (정상 동작):
> ```
> no disk_read data for running instance "<instance-id>" in the requested window:
> the instance may have been started recently or detailed monitoring is off;
> try increasing TimeBeforeHour
> ```

### 1-4. disk_write

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/disk_write -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Write Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 1-5. disk_read_ops

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/disk_read_ops -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Read Operations/Sec",
  "metricUnit": "CountPerSecond",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 1-6. disk_write_ops

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/disk_write_ops -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Write Operations/Sec",
  "metricUnit": "CountPerSecond",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 1-7. network_in

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/network_in -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Network In Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 1-8. network_out

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/vm/cb-mon-test-vm/network_out -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Network Out Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

---

## 2. K8S (Cluster Node) 모니터링

- 참고: cb-spider 기본값으로 EKS 클러스터를 생성한 경우 노드 갯수는 보통 1~2개입니다 (`DesiredNodeSize:2`, `MinNodeSize:1`, `MaxNodeSize:3`).
- 참고: AWS의 EKS 노드는 표준 EC2 인스턴스이므로 VM과 동일한 `AWS/EC2` 네임스페이스 메트릭을 그대로 재사용합니다 (`InstanceId` 차원).

- curl을 이용한 API 호출 방법 (기본값 사용)
```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/{K8S 클러스터 명}/{Node Group 명}/{노드 번호 (1~2)}/{Metric Type} -H 'Content-Type: application/json' -d '{"ConnectionName": "(Connection 이름)"}'
```

- curl을 이용한 API 호출 방법 (시간 범위, 간격 설정)
```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/{K8S 클러스터 명}/{Node Group 명}/{노드 번호 (1~2)}/{Metric Type} -H 'Content-Type: application/json' -d '{"ConnectionName": "(Connection 이름)", "TimeBeforeHour": "(현재 시간의 몇 시간 전부터 조회할지)", "IntervalMinute": "(분 단위 간격)"}'
```

### 2-1. cpu_usage

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/cpu_usage -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "CPU Usage Percent",
  "metricUnit": "Percent",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-2. memory_usage (미지원)

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/memory_usage -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}'
```
```
memory_usage is not supported for AWS VMs in API-based(agentless) monitoring.
```

### 2-3. disk_read

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/disk_read -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Read Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-4. disk_write

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/disk_write -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Write Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-5. disk_read_ops

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/disk_read_ops -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Read Operations/Sec",
  "metricUnit": "CountPerSecond",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-6. disk_write_ops

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/disk_write_ops -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Disk Write Operations/Sec",
  "metricUnit": "CountPerSecond",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-7. network_in

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/network_in -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Network In Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

### 2-8. network_out

```
curl -udefault:default -sX GET http://localhost:1024/spider/monitoring/clusternode/cb-mon-test-eks/cb-mon-test-ng/1/network_out -H 'Content-Type: application/json' -d '{"ConnectionName": "aws-ap-northeast-2"}' | jq
```
```json
{
  "metricName": "Network Out Bytes",
  "metricUnit": "Bytes",
  "timestampValues": [
    { "timestamp": "...", "value": "..." },
    { "timestamp": "...", "value": "..." }
  ]
}
```

---

## 동작 검증 요약

| 항목 | 결과 |
|---|---|
| VM `cpu_usage` | ✅ 정상 응답 |
| VM `memory_usage` 명시적 거부 | ✅ 의도된 에러 메시지 |
| VM `network_in` / `network_out` | ✅ 정상 응답 |
| VM `disk_*` 4종 | ✅ EBS dispatch → 정상 응답 |
| ClusterNode `cpu_usage` | ✅ 정상 응답 |
| ClusterNode `memory_usage` 명시적 거부 | ✅ 의도된 에러 메시지 |
| ClusterNode `network_in` / `network_out` | ✅ 정상 응답 |
| ClusterNode `disk_*` 4종 | ✅ EBS dispatch → 정상 응답 |
