### PR TITLE
fix(openstack): URL-encode tag strings in TagHandler path

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/TagHandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
@@ -166,15 +167,22 @@ func handleAddTag(tagHandler *OpenStackTagHandler, resType irs.RSType, resIID ir
 		return err
 	}
 
+	// gophercloud's attributestags/computeTags Add/Delete embed the tag string
+	// into the URL path verbatim. A '/' in the value (e.g. CIDR "10.0.0.0/18")
+	// is then misread as an additional path segment by Neutron/Nova and the
+	// request 404s. Escape the tag for path-safe transport before the call.
+	// NLB tags are sent in the JSON body, so they keep the raw form.
+	encodedTag := url.PathEscape(tagString)
+
 	switch resType {
 	case irs.VM:
 		cc := tagHandler.ComputeClient
 		cc.Microversion = "2.52"
-		err = computeTags.Add(context.TODO(), cc, systemId, tagString).ExtractErr()
+		err = computeTags.Add(context.TODO(), cc, systemId, encodedTag).ExtractErr()
 	case irs.VPC:
-		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "networks", systemId, tagString).ExtractErr()
+		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "networks", systemId, encodedTag).ExtractErr()
 	case irs.SUBNET:
-		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "subnets", systemId, tagString).ExtractErr()
+		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "subnets", systemId, encodedTag).ExtractErr()
 	case irs.NLB:
 		if err := tagHandler.checkNLBClient(); err != nil {
 			return err
@@ -195,7 +203,7 @@ func handleAddTag(tagHandler *OpenStackTagHandler, resType irs.RSType, resIID ir
 			Tags: &tags,
 		}).Extract()
 	case irs.SG:
-		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "security-groups", systemId, tagString).ExtractErr()
+		err = networkTags.Add(context.TODO(), tagHandler.NetworkClient, "security-groups", systemId, encodedTag).ExtractErr()
 	default:
 		return errors.New(string(resType) + " is not supported Resource!!")
 	}
@@ -266,15 +274,19 @@ func handleRemoveTag(tagHandler *OpenStackTagHandler, resType irs.RSType, resIID
 		return err
 	}
 
+	// See handleAddTag for why path-escape is needed. NLB removal compares the
+	// raw form against tags fetched in the same raw form, so it stays unescaped.
+	encodedTag := url.PathEscape(tagString)
+
 	switch resType {
 	case irs.VM:
 		cc := tagHandler.ComputeClient
 		cc.Microversion = "2.52"
-		err = computeTags.Delete(context.TODO(), cc, systemId, tagString).ExtractErr()
+		err = computeTags.Delete(context.TODO(), cc, systemId, encodedTag).ExtractErr()
 	case irs.VPC:
-		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "networks", systemId, tagString).ExtractErr()
+		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "networks", systemId, encodedTag).ExtractErr()
 	case irs.SUBNET:
-		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "subnets", systemId, tagString).ExtractErr()
+		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "subnets", systemId, encodedTag).ExtractErr()
 	case irs.NLB:
 		if err := tagHandler.checkNLBClient(); err != nil {
 			return err
@@ -302,7 +314,7 @@ func handleRemoveTag(tagHandler *OpenStackTagHandler, resType irs.RSType, resIID
 			}).Extract()
 		}
 	case irs.SG:
-		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "security-groups", systemId, tagString).ExtractErr()
+		err = networkTags.Delete(context.TODO(), tagHandler.NetworkClient, "security-groups", systemId, encodedTag).ExtractErr()
 	default:
 		return errors.New(string(resType) + " is not supported Resource!!")
 	}


### PR DESCRIPTION
Fixes #1704

OpenStack Neutron / Nova의 태그 API는 태그 문자열을 URL 경로에 그대로 넣는 구조입니다 (`PUT/DELETE .../tags/{tag}`). 값에 `/`가 들어가면 (예: `sys.cidr=10.164.0.0/18`) 서버가 뒷부분을 추가 path segment로 해석해서 `404 NeutronError: HTTPNotFound`로 떨어집니다.

이 PR은 gophercloud의 `attributestags.Add/Delete` 와 `computeTags.Add/Delete` 호출 직전에 `url.PathEscape()`를 적용해서 `/` 가 `%2F` 로 인코딩된 채 전송되도록 합니다. 그러면 의도한 엔드포인트로 정상 도달.

NLB 태그는 JSON 요청 바디로 전송되고, 서버에서 받은 raw 형태와 그대로 비교되기 때문에 인코딩하지 않고 그대로 둡니다.

수정된 호출 위치 (총 8곳): VM / VPC / Subnet / SecurityGroup 각각 `Add` + `Delete`.
