### PR TITLE
feat(aws): add missing EKS AMI types (AL2023 NVIDIA/Neuron, Windows 2025)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
@@ -107,6 +107,9 @@ func getServerAddress() string {
 var eksAMITypes = []string{
 	"AL2023_x86_64_STANDARD",
 	"AL2023_ARM_64_STANDARD",
+	"AL2023_x86_64_NVIDIA",
+	"AL2023_ARM_64_NVIDIA",
+	"AL2023_x86_64_NEURON",
 	"BOTTLEROCKET_ARM_64",
 	"BOTTLEROCKET_x86_64",
 	"BOTTLEROCKET_ARM_64_NVIDIA",
@@ -115,6 +118,8 @@ var eksAMITypes = []string{
 	"WINDOWS_FULL_2019_x86_64",
 	"WINDOWS_CORE_2022_x86_64",
 	"WINDOWS_FULL_2022_x86_64",
+	"WINDOWS_CORE_2025_x86_64",
+	"WINDOWS_FULL_2025_x86_64",
 }
 
 // isValidEKSAMIType reports whether s is a known EKS AMI Type string.


### PR DESCRIPTION
- Add missing EKS AMI types to eksAMITypes
- Verified all added AMI types via cb-tumblebug integration test