### PR TITLE
[Multi-Driver] Fix: VM, Disk, Cluster bug fixes and improvements across Azure, GCP, Alibaba, Tencent, IBM, OpenStack, NHN

### DIFF
--- a/api-runtime/rest-runtime/admin-web/html/cluster.html
+++ b/api-runtime/rest-runtime/admin-web/html/cluster.html
@@ -1377,8 +1377,11 @@
 
                 switch (providerName.toUpperCase()) {
                     case 'AZURE':
-                        versionInput.value = '1.30.3';
+                        versionInput.value = '1.35.0';
                         vmSpecInput.value = 'Standard_B2s';
+                        break;
+                    case 'IBM':
+                        versionInput.value = '1.32.13';
                         break;
                     case 'NHNCLOUD':
                         versionInput.value = 'v1.28.3';

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -556,8 +556,13 @@ func (ach *AlibabaClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqI
 	}
 	desiredSize := int64(nodeGroupReqInfo.DesiredNodeSize)
 
+	// Use the cluster's SecurityGroupId for the nodepool's worker nodes.
+	// Without this, Alibaba ACK auto-creates a separate SG for the nodepool that lacks
+	// the NodePort range (30000-32767), causing SLB health checks to fail (connection refused).
+	clusterSecurityGroupId := tea.StringValue(cluster.SecurityGroupId)
+
 	nodepoolId, err := aliCreateClusterNodePool(ach.CsClient, clusterId, name,
-		autoScalingEnable, maxInstances, minInstances, vswitchIds, instanceTypes, systemDiskCategory, systemDiskSize, keyPair, imageId, imageType, desiredSize)
+		autoScalingEnable, maxInstances, minInstances, vswitchIds, instanceTypes, systemDiskCategory, systemDiskSize, keyPair, imageId, imageType, desiredSize, clusterSecurityGroupId)
 	if err != nil {
 		err = fmt.Errorf("Failed to Add NodeGroup: %v", err)
 		cblogger.Error(err)
@@ -1496,7 +1501,7 @@ func extractRuntimeFromMetadata(metaData string) (string, string, error) {
 	return runtime, runtimeVersion, nil
 }
 
-func aliCreateClusterNodePool(csClient *cs2015.Client, clusterId, name string, autoScalingEnable bool, maxInstances, minInstances int64, vswitchIds, instanceTypes []string, systemDiskCategory string, systemDiskSize int64, keyPair, imageId, imageType string, desiredSize int64) (*string, error) {
+func aliCreateClusterNodePool(csClient *cs2015.Client, clusterId, name string, autoScalingEnable bool, maxInstances, minInstances int64, vswitchIds, instanceTypes []string, systemDiskCategory string, systemDiskSize int64, keyPair, imageId, imageType string, desiredSize int64, securityGroupId string) (*string, error) {
 	// Note: KubernetesConfig is optional - Alibaba automatically uses cluster's runtime if not specified
 	// The code below can be uncommented if you need to explicitly set runtime version
 
@@ -1536,6 +1541,10 @@ func aliCreateClusterNodePool(csClient *cs2015.Client, clusterId, name string, a
 			KeyPair:            tea.String(keyPair),
 			ImageId:            tea.String(imageId),
 			ImageType:          tea.String(imageType),
+			// SecurityGroupId must match the cluster's SG so that the worker nodes
+			// inherit the same SG rules (including NodePort range 30000-32767) needed
+			// by the SLB health checks. Without this, Alibaba auto-assigns a default SG.
+			SecurityGroupId: tea.String(securityGroupId),
 			//DesiredSize:        tea.Int64(desiredSize),
 		},
 		Management: &cs2015.CreateClusterNodePoolRequestManagement{
@@ -1914,7 +1923,7 @@ func validateAtCreateCluster(clusterInfo irs.ClusterInfo) error {
 		return fmt.Errorf("At least one Subnet must be specified")
 	}
 	if len(clusterInfo.Network.SecurityGroupIIDs) < 1 {
-		return fmt.Errorf("At least one Subnet must be specified")
+		return fmt.Errorf("At least one Security Group must be specified")
 	}
 	// CAUTION: Currently CB-Spider's Alibaba PMKS Drivers does not support to create a cluster with nodegroups
 	if len(clusterInfo.NodeGroupList) > 0 {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
@@ -1580,7 +1580,7 @@ func validateAtCreateCluster(clusterInfo irs.ClusterInfo) error {
 		return fmt.Errorf("At least one Subnet must be specified")
 	}
 	if len(clusterInfo.Network.SecurityGroupIIDs) < 1 {
-		return fmt.Errorf("At least one Subnet must be specified")
+		return fmt.Errorf("At least one Security Group must be specified")
 	}
 	if err := validateNodeGroup(clusterInfo.NodeGroupList); err != nil {
 		return err

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
@@ -2149,7 +2149,7 @@ func validateAtCreateCluster(clusterInfo irs.ClusterInfo, supportedK8sVersions [
 		return fmt.Errorf("At least one Subnet must be specified")
 	}
 	if len(clusterInfo.Network.SecurityGroupIIDs) < 1 {
-		return fmt.Errorf("At least one Subnet must be specified")
+		return fmt.Errorf("At least one Security Group must be specified")
 	}
 
 	// Check clusterInfo.Version

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
@@ -2239,7 +2239,7 @@ func validateAtCreateCluster(clusterInfo irs.ClusterInfo, supportedK8sVersions [
 		return fmt.Errorf("At least one Subnet must be specified")
 	}
 	if len(clusterInfo.Network.SecurityGroupIIDs) < 1 {
-		return fmt.Errorf("At least one Subnet must be specified")
+		return fmt.Errorf("At least one Security Group must be specified")
 	}
 
 	// Check clusterInfo.Version

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/DiskHandler.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	nhnsdk "github.com/cloud-barista/nhncloud-sdk-go"
@@ -83,10 +84,7 @@ func (diskHandler *NhnCloudDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (ir
 	}
 
 	if strings.EqualFold(diskReqInfo.Zone, "") {
-		newErr := fmt.Errorf("Invalid Zone Info!!")
-		cblogger.Error(newErr.Error())
-		LoggingError(callLogInfo, newErr)
-		return irs.DiskInfo{}, newErr
+		diskReqInfo.Zone = diskHandler.RegionInfo.Zone
 	}
 
 	reqDiskType := diskReqInfo.DiskType // 'default', 'General_HDD' or 'General_SSD'

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/VMHandler.go
@@ -30,8 +30,8 @@ import (
 	cdcom "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/common"
 	"github.com/gophercloud/gophercloud/v2"
 	volumes3 "github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumes"
-	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/keypairs"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/keypairs"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	layer3floatingips "github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
@@ -365,6 +365,12 @@ func (vmHandler *OpenStackVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (startvm i
 	}
 
 	serverInfo = vmHandler.mappingServerInfo(*serverResult)
+	// AssociatePublicIP succeeded but Nova's addresses field may not yet reflect
+	// the floating IP due to Neutron→Nova propagation delay. Fill it in directly.
+	if serverInfo.PublicIP == "" && publicIPStr != "" {
+		serverInfo.PublicIP = publicIPStr
+		serverInfo.AccessPoint = fmt.Sprintf("%s:%s", publicIPStr, "22")
+	}
 	password, err := getPassword(*serverResult)
 	if err == nil {
 		serverInfo.VMUserPasswd = password

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -601,6 +601,12 @@ func getClusterAccessInfo(access_key string, access_secret string, region_id str
 		accessInfo.Endpoint = *res.Response.ClusterExternalEndpoint
 	}
 
+	// If the endpoint is not a valid value (e.g. still a temporary message),
+	// do not expose the kubeconfig — it won't be externally accessible yet.
+	if !strings.Contains(accessInfo.Endpoint, ":") {
+		return accessInfo, nil
+	}
+
 	// (2) Kubeconfig
 	resKubeconfig, err := tencent.GetClusterKubeconfig(access_key, access_secret, region_id, cluster_id)
 	if err != nil {
@@ -963,7 +969,7 @@ func validateAtCreateCluster(clusterInfo irs.ClusterInfo) error {
 		return fmt.Errorf("At least one Subnet must be specified")
 	}
 	if len(clusterInfo.Network.SecurityGroupIIDs) < 1 {
-		return fmt.Errorf("At least one Subnet must be specified")
+		return fmt.Errorf("At least one Security Group must be specified")
 	}
 	// CAUTION: Currently CB-Spider's Tencent PMKS Drivers does not support to create a cluster with nodegroups
 	if len(clusterInfo.NodeGroupList) > 0 {

--- a/cloud-driver-libs/.cloud-init-ibm/cloud-init
+++ b/cloud-driver-libs/.cloud-init-ibm/cloud-init
@@ -1,12 +1,8 @@
-#cloud-config
-users:
-  - default
-  - name: {{username}}
-    groups: sudo
-    shell: /bin/bash
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-
-runcmd:
-  - cp -r /root/.ssh /home/{{username}}
-  - chown -R {{username}}:{{username}} /home/{{username}}/.ssh
-  - /bin/bash -c 'str=`cat /home/{{username}}/.ssh/authorized_keys`; delimiter=ssh-rsa; s=$str$delimiter; splitStr=(); while [[ $s ]]; do splitStr+=( "${s%%"$delimiter"*}" ); s=${s#*"$delimiter"}; done; echo $delimiter${splitStr[1]} > /home/{{username}}/.ssh/authorized_keys;'
+#!/bin/bash
+#### add Cloud-Barista user
+useradd -s /bin/bash cb-user -rm -G sudo;
+mkdir /home/cb-user/.ssh; 
+cp -r /root/.ssh/ /home/cb-user/;
+cp -r /home/ubuntu/.ssh/ /home/cb-user/;
+chown -R cb-user:cb-user /home/cb-user;
+echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;


### PR DESCRIPTION
## Summary
Bug fixes, consistency improvements, and version updates across multiple CSP drivers.
Bugs were identified during testing with SpiderWatch.

## Changes by Driver

### Azure
- AdminWeb: Update default Cluster Version: `1.30.3` → `1.35.0`

### GCP
- Fix incorrect error message in `validateAtCreateCluster`: `SecurityGroupIIDs` empty check was returning a Subnet error message instead of Security Group error message

### Alibaba
- Fix Kubeconfig format: remove unnecessary extra quotes (`'"sadf"'` → `"sadf"`)

### Tencent
- Fix Kubeconfig format: remove unnecessary extra quotes (`'"sadf"'` → `"sadf"`)
- Improve consistency: return `"Kubeconfig is not ready yet!"` when endpoint is not ready yet

### IBM
- VM: Replace cloud-init script with `cloud-driver-libs/.cloud-init-tencent/cloud-init` to fix SSH login failure on VM
- AdminWeb: Update default Cluster Version to `1.32.13`

### OpenStack
- Fix VM creation bug: `PublicIP` field was empty due to Nova propagation delay after `AssociatePublicIP()`
  - After `mappingServerInfo()`, if `PublicIP` is empty, fill it directly from the IP string already obtained by `AssociatePublicIP()`
  - Set `AccessPoint` with port 22 for Linux VMs accordingly

### NHN
- Fix `DiskHandler.CreateDisk`: instead of returning an error on empty Zone, fall back to `RegionInfo.Zone` as default