### PR TITLE
[RDBMS] Add Initial Multi-Cloud RDBMS Support with partial CSP validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,3 +47,5 @@
 - Local: `make`.  
 - Container: official image.  
 - Config: `setup.env`, `conf/*.conf`.
+- Run: `cd bin; ./start.sh`
+- Stop: `cd bin; ./stop.sh`

--- a/api-runtime/common-runtime/CommonManager.go
+++ b/api-runtime/common-runtime/CommonManager.go
@@ -45,6 +45,7 @@ const (
 	CLUSTER    string = string(cres.CLUSTER)
 	NODEGROUP  string = string(cres.NODEGROUP)
 	FILESYSTEM string = string(cres.FILESYSTEM)
+	RDBMS      string = string(cres.RDBMS)
 )
 
 func RSTypeString(rsType string) string {
@@ -61,6 +62,7 @@ var diskSPLock = splock.New()
 var myImageSPLock = splock.New()
 var clusterSPLock = splock.New()
 var fsSPLock = splock.New()
+var rdbmsSPLock = splock.New()
 
 // ====================================================================
 // Common column name and struct for GORM
@@ -316,6 +318,9 @@ func UnregisterResource(connectionName string, rsType string, nameId string) (bo
 	case FILESYSTEM:
 		fsSPLock.Lock(connectionName, nameId)
 		defer fsSPLock.Unlock(connectionName, nameId)
+	case RDBMS:
+		rdbmsSPLock.Lock(connectionName, nameId)
+		defer rdbmsSPLock.Unlock(connectionName, nameId)
 	default:
 		return false, fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -684,6 +689,55 @@ func UnregisterResource(connectionName string, rsType string, nameId string) (bo
 			}
 		}
 
+	case RDBMS:
+		var iidInfoList []*RDBMSIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			err = getAuthIIDInfoList(connectionName, &iidInfoList)
+			if err != nil {
+				cblog.Error(err)
+				return false, err
+			}
+			_, err := getAuthIIDInfo(&iidInfoList, nameId)
+			if err != nil {
+				if strings.Contains(err.Error(), "not found") {
+					return false, fmt.Errorf("The %s '%s' does not exist!", RSTypeString(rsType), nameId)
+				} else {
+					cblog.Error(err)
+					return false, err
+				}
+			}
+			for _, OneIIdInfo := range iidInfoList {
+				if OneIIdInfo.NameId == nameId {
+					_, err2 := infostore.DeleteByConditions(OneIIdInfo, NAME_ID_COLUMN, nameId, OWNER_VPC_NAME_COLUMN, OneIIdInfo.OwnerVPCName)
+					if err2 != nil {
+						cblog.Error(err2)
+						return false, err2
+					}
+					return true, nil
+				}
+			}
+		} else {
+			err := infostore.ListByConditions(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, nameId)
+			if err != nil {
+				cblog.Error(err)
+				return false, err
+			}
+			if len(iidInfoList) <= 0 {
+				return false, fmt.Errorf("The %s '%s' does not exist!", RSTypeString(rsType), nameId)
+			}
+			for _, OneIIdInfo := range iidInfoList {
+				if OneIIdInfo.NameId == nameId {
+					_, err2 := infostore.DeleteBy3Conditions(OneIIdInfo, CONNECTION_NAME_COLUMN, connectionName,
+						NAME_ID_COLUMN, nameId, OWNER_VPC_NAME_COLUMN, OneIIdInfo.OwnerVPCName)
+					if err2 != nil {
+						cblog.Error(err2)
+						return false, err2
+					}
+					return true, nil
+				}
+			}
+		}
+
 	default:
 		return false, fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -730,6 +784,8 @@ func ListAllResource(connectionName string, rsType string) (AllResourceList, err
 		handler, err = cldConn.CreateMyImageHandler()
 	case CLUSTER:
 		handler, err = cldConn.CreateClusterHandler()
+	case RDBMS:
+		handler, err = cldConn.CreateRDBMSHandler()
 	default:
 		return AllResourceList{}, fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -821,6 +877,17 @@ func ListAllResource(connectionName string, rsType string) (AllResourceList, err
 		}
 	case CLUSTER:
 		var iidInfoList []*ClusterIIDInfo
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		if err != nil {
+			cblog.Error(err)
+			return AllResourceList{}, err
+		}
+		for _, info := range iidInfoList {
+			iid := makeUserIID(info.NameId, info.SystemId)
+			iidList = append(iidList, &iid)
+		}
+	case RDBMS:
+		var iidInfoList []*RDBMSIIDInfo
 		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
 		if err != nil {
 			cblog.Error(err)
@@ -924,6 +991,17 @@ func ListAllResource(connectionName string, rsType string) (AllResourceList, err
 		}
 	case CLUSTER:
 		infoList, err := handler.(cres.ClusterHandler).ListCluster()
+		if err != nil {
+			cblog.Error(err)
+			return AllResourceList{}, err
+		}
+		if infoList != nil {
+			for _, info := range infoList {
+				iidCSPList = append(iidCSPList, &info.IId)
+			}
+		}
+	case RDBMS:
+		infoList, err := handler.(cres.RDBMSHandler).ListRDBMS()
 		if err != nil {
 			cblog.Error(err)
 			return AllResourceList{}, err
@@ -1041,6 +1119,8 @@ func ListAllResourceInfo(connectionName string, rsType cres.RSType) (AllResource
 		handler, err = cldConn.CreateMyImageHandler()
 	case cres.CLUSTER:
 		handler, err = cldConn.CreateClusterHandler()
+	case cres.RDBMS:
+		handler, err = cldConn.CreateRDBMSHandler()
 	default:
 		return AllResourceInfoList{}, fmt.Errorf("%s is not a supported resource type", rsType)
 	}
@@ -1126,6 +1206,12 @@ func fetchIIDList(connectionName string, rsType cres.RSType, iidList *[]*cres.II
 		for _, info := range iidInfoList {
 			*iidList = append(*iidList, &cres.IID{NameId: info.NameId, SystemId: info.SystemId})
 		}
+	case cres.RDBMS:
+		var iidInfoList []*RDBMSIIDInfo
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		for _, info := range iidInfoList {
+			*iidList = append(*iidList, &cres.IID{NameId: info.NameId, SystemId: info.SystemId})
+		}
 	default:
 		return fmt.Errorf("%s is not a supported resource type", rsType)
 	}
@@ -1158,6 +1244,9 @@ func fetchResourceInfoList(handler interface{}, rsType cres.RSType) ([]interface
 		return convertToInterfaceSlice(infoList), err
 	case cres.CLUSTER:
 		infoList, err := handler.(cres.ClusterHandler).ListCluster()
+		return convertToInterfaceSlice(infoList), err
+	case cres.RDBMS:
+		infoList, err := handler.(cres.RDBMSHandler).ListRDBMS()
 		return convertToInterfaceSlice(infoList), err
 	default:
 		return nil, fmt.Errorf("%s is not a supported resource type", rsType)
@@ -1218,6 +1307,8 @@ func resourceInfoMatchesIID(info interface{}, driverSystemId string) bool {
 		return v.IId.SystemId == driverSystemId
 	case *cres.ClusterInfo:
 		return v.IId.SystemId == driverSystemId
+	case *cres.RDBMSInfo:
+		return v.IId.SystemId == driverSystemId
 	default:
 		return false
 	}
@@ -1256,6 +1347,10 @@ func resourceInfoInMappedList(rsType cres.RSType, info interface{}, mappedList [
 			}
 		case cres.CLUSTER:
 			if mapped, ok := mappedInfo.(*cres.ClusterInfo); ok && mapped.IId.SystemId == info.(*cres.ClusterInfo).IId.SystemId {
+				return true
+			}
+		case cres.RDBMS:
+			if mapped, ok := mappedInfo.(*cres.RDBMSInfo); ok && mapped.IId.SystemId == info.(*cres.RDBMSInfo).IId.SystemId {
 				return true
 			}
 		default:
@@ -1359,6 +1454,8 @@ func DeleteCSPResource(connectionName string, rsType string, systemID string) (b
 		handler, err = cldConn.CreateMyImageHandler()
 	case CLUSTER:
 		handler, err = cldConn.CreateClusterHandler()
+	case RDBMS:
+		handler, err = cldConn.CreateRDBMSHandler()
 	default:
 		return false, "", fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -1417,6 +1514,12 @@ func DeleteCSPResource(connectionName string, rsType string, systemID string) (b
 		}
 	case CLUSTER:
 		result, err = handler.(cres.ClusterHandler).DeleteCluster(iid)
+		if err != nil {
+			cblog.Error(err)
+			return false, "", err
+		}
+	case RDBMS:
+		result, err = handler.(cres.RDBMSHandler).DeleteRDBMS(iid)
 		if err != nil {
 			cblog.Error(err)
 			return false, "", err
@@ -1560,6 +1663,8 @@ func GetCSPResourceInfo(connectionName string, rsType string, systemID string) (
 		handler, err = cldConn.CreateMyImageHandler()
 	case CLUSTER:
 		handler, err = cldConn.CreateClusterHandler()
+	case RDBMS:
+		handler, err = cldConn.CreateRDBMSHandler()
 	default:
 		return nil, fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -1624,6 +1729,13 @@ func GetCSPResourceInfo(connectionName string, rsType string, systemID string) (
 		jsonResult, _ = json.Marshal(result)
 	case CLUSTER:
 		result, err := handler.(cres.ClusterHandler).GetCluster(iid)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		jsonResult, _ = json.Marshal(result)
+	case RDBMS:
+		result, err := handler.(cres.RDBMSHandler).GetRDBMS(iid)
 		if err != nil {
 			cblog.Error(err)
 			return nil, err
@@ -1736,6 +1848,16 @@ func GetCSPResourceName(connectionName string, rsType string, nameID string) (st
 		}
 		// (2) get DriverNameId and return it
 		return makeDriverIID(iid.NameId, iid.SystemId).NameId, nil
+	case RDBMS:
+		// (1) get IID(NameId)
+		var iid RDBMSIIDInfo
+		err = infostore.GetByConditions(&iid, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, nameID)
+		if err != nil {
+			cblog.Error(err)
+			return "", err
+		}
+		// (2) get DriverNameId and return it
+		return makeDriverIID(iid.NameId, iid.SystemId).NameId, nil
 	default:
 		return "", fmt.Errorf(rsType + " is not supported Resource!!")
 	}
@@ -1775,7 +1897,7 @@ func Destroy(connectionName string) (DestroyedInfo, error) {
 
 	// Define resource type groups
 	resourceTypeGroups := [][]string{
-		{CLUSTER, MYIMAGE, NLB},
+		{CLUSTER, MYIMAGE, NLB, RDBMS},
 		{VM},
 		{DISK},
 		{KEY, SG},
@@ -1886,6 +2008,8 @@ func deleteAllResourcesInResType(connectionName string, rsType string) (*Deleted
 				_, err = DeleteMyImage(connectionName, MYIMAGE, nameId, "false")
 			case CLUSTER:
 				_, err = DeleteCluster(connectionName, CLUSTER, nameId, "false")
+			case RDBMS:
+				_, err = DeleteRDBMS(connectionName, RDBMS, nameId, "false")
 			default:
 				err = fmt.Errorf("%s is not supported Resource!!", rsType)
 			}
@@ -1938,6 +2062,9 @@ func ListResourceName(connectionName, rsType string) ([]string, error) {
 		info = &v
 	case CLUSTER:
 		v := ClusterIIDInfo{}
+		info = &v
+	case RDBMS:
+		v := RDBMSIIDInfo{}
 		info = &v
 	default:
 		return nil, fmt.Errorf("%s is not a supported Resource!!", rsType)
@@ -2140,6 +2267,28 @@ func getAuthIIDInfoList(connectionName string, iidInfoList interface{}) error {
 				}
 			}
 		}
+	case *[]*RDBMSIIDInfo:
+		tmpIIDInfoList := []*RDBMSIIDInfo{}
+		handler, err := cldConn.CreateRDBMSHandler()
+		// Fetch granted ID list from CSP
+		iidList, err := handler.ListIID()
+		if err != nil {
+			cblog.Error(err)
+			return fmt.Errorf("failed to list IIDs from CSP: %v", err)
+		}
+		err = infostore.List(&tmpIIDInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return fmt.Errorf("failed to list from MetaDB: %v", err)
+		}
+
+		for _, tmp := range tmpIIDInfoList {
+			for _, iid := range iidList {
+				if iid.SystemId == getDriverSystemId(cres.IID{NameId: tmp.NameId, SystemId: tmp.SystemId}) {
+					*v = append(*v, tmp)
+				}
+			}
+		}
 	default:
 		return fmt.Errorf("unsupported type for iidInfoList")
 	}
@@ -2197,6 +2346,12 @@ func isNameIdExists(iidInfoList interface{}, nameId string) (bool, error) {
 			}
 		}
 	case *[]*ClusterIIDInfo:
+		for _, iidInfo := range *v {
+			if iidInfo.NameId == nameId {
+				return true, nil // NameId exists
+			}
+		}
+	case *[]*RDBMSIIDInfo:
 		for _, iidInfo := range *v {
 			if iidInfo.NameId == nameId {
 				return true, nil // NameId exists
@@ -2272,6 +2427,13 @@ func getAuthIIDInfo(iidInfoList interface{}, nameId string) (interface{}, error)
 			}
 		}
 		return nil, fmt.Errorf("Cluster '%s' does not exist", nameId)
+	case *[]*RDBMSIIDInfo:
+		for _, iidInfo := range *v {
+			if iidInfo.NameId == nameId {
+				return iidInfo, nil // Return matching RDBMSIIDInfo
+			}
+		}
+		return nil, fmt.Errorf("RDBMS '%s' does not exist", nameId)
 	default:
 		return nil, fmt.Errorf("unsupported type for iidInfoList")
 	}
@@ -2340,6 +2502,13 @@ func getAuthIIDInfoBySystemIdContain(iidInfoList interface{}, systemId string) (
 			}
 		}
 		return nil, fmt.Errorf("Cluster with SystemId containing '%s' not found", systemId)
+	case *[]*RDBMSIIDInfo:
+		for _, iidInfo := range *v {
+			if strings.Contains(iidInfo.SystemId, systemId) {
+				return iidInfo, nil // Return matching RDBMSIIDInfo
+			}
+		}
+		return nil, fmt.Errorf("RDBMS with SystemId containing '%s' not found", systemId)
 	default:
 		return nil, fmt.Errorf("unsupported type for iidInfoList")
 	}

--- a/api-runtime/common-runtime/RDBMSManager.go
+++ b/api-runtime/common-runtime/RDBMSManager.go
@@ -1,0 +1,871 @@
+// Cloud Control Manager's Rest Runtime of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// by CB-Spider Team, April 2026.
+
+package commonruntime
+
+import (
+	"fmt"
+	"os"
+
+	ccm "github.com/cloud-barista/cb-spider/cloud-control-manager"
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	iidm "github.com/cloud-barista/cb-spider/cloud-control-manager/iid-manager"
+	infostore "github.com/cloud-barista/cb-spider/info-store"
+)
+
+// ====================================================================
+// type for GORM
+
+type RDBMSIIDInfo VPCDependentIIDInfo
+
+func (RDBMSIIDInfo) TableName() string {
+	return "rdbms_iid_infos"
+}
+
+//====================================================================
+
+func init() {
+	db, err := infostore.Open()
+	if err != nil {
+		cblog.Error(err)
+		return
+	}
+	db.AutoMigrate(&RDBMSIIDInfo{})
+	infostore.Close(db)
+}
+
+//================ RDBMS Handler
+
+// GetRDBMSOwnerVPC returns the owner VPC of a given RDBMS CSP ID
+func GetRDBMSOwnerVPC(connectionName string, cspID string) (ownerVPC cres.IID, err error) {
+	cblog.Info("call GetRDBMSOwnerVPC()")
+
+	connectionName, err = EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+
+	cspID, err = EmptyCheckAndTrim("cspID", cspID)
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+
+	var iidInfoList []*RDBMSIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return cres.IID{}, err
+		}
+	} else {
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		if err != nil {
+			cblog.Error(err)
+			return cres.IID{}, err
+		}
+	}
+	var isExist bool = false
+	var nameId string
+	for _, OneIIdInfo := range iidInfoList {
+		saveSystemId := getMSShortID(getDriverSystemId(cres.IID{NameId: OneIIdInfo.NameId, SystemId: OneIIdInfo.SystemId}))
+		if saveSystemId == cspID {
+			nameId = OneIIdInfo.NameId
+			isExist = true
+			break
+		}
+	}
+	if isExist {
+		var iidInfo RDBMSIIDInfo
+		err = infostore.GetByConditions(&iidInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, nameId)
+		if err != nil {
+			cblog.Error(err)
+			return cres.IID{}, err
+		}
+		ownerVPCName := iidInfo.OwnerVPCName
+		var vpcIIDInfo VPCIIDInfo
+		err = infostore.GetByConditions(&vpcIIDInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, ownerVPCName)
+		if err != nil {
+			cblog.Error(err)
+			return cres.IID{}, err
+		}
+		return getUserIID(cres.IID{NameId: vpcIIDInfo.NameId, SystemId: vpcIIDInfo.SystemId}), nil
+	}
+
+	// if not found in metadb, get from CSP
+	info, err := handler.GetRDBMS(cres.IID{NameId: getMSShortID(cspID), SystemId: cspID})
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+
+	// find VPC by SystemId
+	var vpcIIDInfo VPCIIDInfo
+	err = infostore.GetByContain(&vpcIIDInfo, CONNECTION_NAME_COLUMN, connectionName, SYSTEM_ID_COLUMN, info.VpcIID.SystemId)
+	if err != nil {
+		cblog.Error(err)
+		return cres.IID{}, err
+	}
+	return getUserIID(cres.IID{NameId: vpcIIDInfo.NameId, SystemId: vpcIIDInfo.SystemId}), nil
+}
+
+// GetRDBMSMetaInfo returns CSP's RDBMS meta information
+func GetRDBMSMetaInfo(connectionName string) (*cres.RDBMSMetaInfo, error) {
+	cblog.Info("call GetRDBMSMetaInfo()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	info, err := handler.GetMetaInfo()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// (1) check existence(UserID)
+// (2) get resource info(CSP-ID)
+// (3) create spiderIID: {UserID, SP-XID:CSP-ID}
+// (4) insert spiderIID
+func RegisterRDBMS(connectionName string, vpcUserID string, userIID cres.IID) (*cres.RDBMSInfo, error) {
+	cblog.Info("call RegisterRDBMS()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	vpcUserID, err = EmptyCheckAndTrim("vpcUserID", vpcUserID)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	emptyPermissionList := []string{}
+	err = ValidateStruct(userIID, emptyPermissionList)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	rsType := RDBMS
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	vpcSPLock.RLock(connectionName, vpcUserID)
+	defer vpcSPLock.RUnlock(connectionName, vpcUserID)
+	rdbmsSPLock.Lock(connectionName, userIID.NameId)
+	defer rdbmsSPLock.Unlock(connectionName, userIID.NameId)
+
+	// (0) check VPC existence(VPC UserID)
+	var bool_ret bool
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		var iidInfoList []*VPCIIDInfo
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		bool_ret, err = isNameIdExists(&iidInfoList, vpcUserID)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		bool_ret, err = infostore.HasByConditions(&VPCIIDInfo{}, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, vpcUserID)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+	if !bool_ret {
+		err := fmt.Errorf("%s '%s' does not exist in connection '%s'", RSTypeString(VPC), vpcUserID, connectionName)
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (1) check existence(UserID)
+	var isExist bool
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		isExist, err = infostore.HasByCondition(&RDBMSIIDInfo{}, NAME_ID_COLUMN, userIID.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		isExist, err = infostore.HasByConditions(&RDBMSIIDInfo{}, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, userIID.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+
+	if isExist {
+		err := fmt.Errorf("%s '%s' already exists in connection '%s'", RSTypeString(rsType), userIID.NameId, connectionName)
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (2) get resource info(CSP-ID)
+	getInfo, err := handler.GetRDBMS(cres.IID{NameId: getMSShortID(userIID.SystemId), SystemId: userIID.SystemId})
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (3) create spiderIID: {UserID, SP-XID:CSP-ID}
+	systemId := getMSShortID(getInfo.IId.SystemId)
+	spiderIId := cres.IID{NameId: userIID.NameId, SystemId: systemId + ":" + getInfo.IId.SystemId}
+
+	// (4) insert spiderIID
+	err = infostore.Insert(&RDBMSIIDInfo{ConnectionName: connectionName, NameId: spiderIId.NameId, SystemId: spiderIId.SystemId,
+		OwnerVPCName: vpcUserID})
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// set up RDBMS User IID for return info
+	getInfo.IId = userIID
+
+	// set up VPC UserIID for return info
+	var iidInfo VPCIIDInfo
+	err = infostore.GetByConditions(&iidInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, vpcUserID)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+	getInfo.VpcIID = getUserIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+
+	return &getInfo, nil
+}
+
+// (1) check exist(NameID)
+// (2) generate SP-XID and create reqIID, driverIID
+// (3) create Resource
+// (4) create spiderIID: {reqNameID, "driverNameID:driverSystemID"}
+// (5) insert spiderIID
+// (6) create userIID
+func CreateRDBMS(connectionName string, rsType string, reqInfo cres.RDBMSInfo, IDTransformMode string) (*cres.RDBMSInfo, error) {
+	cblog.Info("call CreateRDBMS()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	vpcSPLock.RLock(connectionName, reqInfo.VpcIID.NameId)
+	defer vpcSPLock.RUnlock(connectionName, reqInfo.VpcIID.NameId)
+
+	//+++++++++++++++++++++++++++++++++++++++++++
+	// set VPC's SystemId
+	var vpcIIDInfo VPCIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		var iidInfoList []*VPCIIDInfo
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, reqInfo.VpcIID.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		vpcIIDInfo = *castedIIDInfo.(*VPCIIDInfo)
+	} else {
+		err = infostore.GetByConditions(&vpcIIDInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, reqInfo.VpcIID.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+	reqInfo.VpcIID = getDriverIID(cres.IID{NameId: vpcIIDInfo.NameId, SystemId: vpcIIDInfo.SystemId})
+	//+++++++++++++++++++++++++++++++++++++++++++
+
+	// SubnetIIDs translation
+	for idx, subnetIID := range reqInfo.SubnetIIDs {
+		var subnetIIdInfo SubnetIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			var iidInfoList []*VPCIIDInfo
+			err = getAuthIIDInfoList(connectionName, &iidInfoList)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, vpcIIDInfo.NameId)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			vpcInfo := *castedIIDInfo.(*VPCIIDInfo)
+			err = infostore.GetBy3Conditions(&subnetIIdInfo, CONNECTION_NAME_COLUMN, vpcInfo.ConnectionName, NAME_ID_COLUMN, subnetIID.NameId, OWNER_VPC_NAME_COLUMN, vpcInfo.NameId)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+		} else {
+			err = infostore.GetBy3Conditions(&subnetIIdInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, subnetIID.NameId, OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+		}
+		reqInfo.SubnetIIDs[idx] = getDriverIID(cres.IID{NameId: subnetIIdInfo.NameId, SystemId: subnetIIdInfo.SystemId})
+	}
+	//+++++++++++++++++++++++++++++++++++++++++++
+
+	// SecurityGroupIIDs translation
+	for idx, sgIID := range reqInfo.SecurityGroupIIDs {
+		sgSPLock.RLock(connectionName, sgIID.NameId)
+		defer sgSPLock.RUnlock(connectionName, sgIID.NameId)
+		var sgIIdInfo SGIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			var iidInfoList []*SGIIDInfo
+			err := getAuthIIDInfoList(connectionName, &iidInfoList)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, sgIID.NameId)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			sgIIdInfo = *castedIIDInfo.(*SGIIDInfo)
+		} else {
+			err = infostore.GetByConditions(&sgIIdInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, sgIID.NameId)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+		}
+		reqInfo.SecurityGroupIIDs[idx] = getDriverIID(cres.IID{NameId: sgIIdInfo.NameId, SystemId: sgIIdInfo.SystemId})
+	}
+	//+++++++++++++++++++++++++++++++++++++++++++
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	rdbmsSPLock.Lock(connectionName, reqInfo.IId.NameId)
+	defer rdbmsSPLock.Unlock(connectionName, reqInfo.IId.NameId)
+
+	// (1) check exist(NameID)
+	var iidInfoList []*RDBMSIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		err = infostore.ListByConditions(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName, OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		err = infostore.ListByConditions(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName, OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+	var isExist bool = false
+	for _, OneIIdInfo := range iidInfoList {
+		if OneIIdInfo.NameId == reqInfo.IId.NameId {
+			isExist = true
+		}
+	}
+
+	if isExist {
+		err := fmt.Errorf("%s '%s' already exists in connection '%s'", RSTypeString(rsType), reqInfo.IId.NameId, connectionName)
+		cblog.Error(err)
+		return nil, err
+	}
+
+	spUUID := ""
+	if GetID_MGMT(IDTransformMode) == "ON" {
+		// (2) generate SP-XID and create reqIID, driverIID
+		spUUID, err = iidm.New(connectionName, rsType, reqInfo.IId.NameId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		spUUID = reqInfo.IId.NameId
+	}
+
+	// reqIID
+	reqIId := cres.IID{NameId: reqInfo.IId.NameId, SystemId: spUUID}
+	// driverIID
+	driverIId := cres.IID{NameId: spUUID, SystemId: ""}
+	reqInfo.IId = driverIId
+
+	// (3) create Resource
+	info, err := handler.CreateRDBMS(reqInfo)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// set VPC NameId
+	info.VpcIID.NameId = vpcIIDInfo.NameId
+
+	// (4) create spiderIID: {reqNameID, "driverNameID:driverSystemID"}
+	spiderIId := cres.IID{NameId: reqIId.NameId, SystemId: spUUID + ":" + info.IId.SystemId}
+
+	// (5) insert spiderIID
+	iidInfo := RDBMSIIDInfo{ConnectionName: connectionName, NameId: spiderIId.NameId, SystemId: spiderIId.SystemId,
+		OwnerVPCName: vpcIIDInfo.NameId}
+	err = infostore.Insert(&iidInfo)
+	if err != nil {
+		cblog.Error(err)
+		// rollback
+		_, err2 := handler.DeleteRDBMS(info.IId)
+		if err2 != nil {
+			cblog.Error(err2)
+			return nil, fmt.Errorf(err.Error() + ", " + err2.Error())
+		}
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (6) create userIID: {reqNameID, driverSystemID}
+	info.IId = getUserIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+
+	// set SubnetIIDs UserIID
+	setRDBMSSubnetUserIID(connectionName, vpcIIDInfo, &info)
+	// set SecurityGroupIIDs UserIID
+	setRDBMSSGUserIID(connectionName, vpcIIDInfo, &info)
+
+	return &info, nil
+}
+
+// setRDBMSSubnetUserIID sets SubnetIIDs to user-friendly names from metadb
+func setRDBMSSubnetUserIID(connectionName string, vpcIIDInfo VPCIIDInfo, info *cres.RDBMSInfo) {
+	for idx, subnetIID := range info.SubnetIIDs {
+		var subnetIIdInfo SubnetIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			err := infostore.GetByConditionsAndContain(&subnetIIdInfo, CONNECTION_NAME_COLUMN, vpcIIDInfo.ConnectionName,
+				OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId, SYSTEM_ID_COLUMN, subnetIID.SystemId)
+			if err != nil {
+				cblog.Info(err)
+				continue
+			}
+		} else {
+			err := infostore.GetByConditionsAndContain(&subnetIIdInfo, CONNECTION_NAME_COLUMN, connectionName,
+				OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId, SYSTEM_ID_COLUMN, subnetIID.SystemId)
+			if err != nil {
+				cblog.Info(err)
+				continue
+			}
+		}
+		info.SubnetIIDs[idx].NameId = subnetIIdInfo.NameId
+	}
+}
+
+// setRDBMSSGUserIID sets SecurityGroupIIDs to user-friendly names from metadb
+func setRDBMSSGUserIID(connectionName string, vpcIIDInfo VPCIIDInfo, info *cres.RDBMSInfo) {
+	for idx, sgIID := range info.SecurityGroupIIDs {
+		var sgIIdInfo SGIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			var iidInfoList []*SGIIDInfo
+			err := getAuthIIDInfoList(connectionName, &iidInfoList)
+			if err != nil {
+				cblog.Info(err)
+				continue
+			}
+			castedIIDInfo, err := getAuthIIDInfoBySystemIdContain(&iidInfoList, sgIID.SystemId)
+			if err != nil {
+				cblog.Info(err)
+				continue
+			}
+			sgIIdInfo = *castedIIDInfo.(*SGIIDInfo)
+		} else {
+			err := infostore.GetByConditionsAndContain(&sgIIdInfo, CONNECTION_NAME_COLUMN, connectionName,
+				OWNER_VPC_NAME_COLUMN, vpcIIDInfo.NameId, SYSTEM_ID_COLUMN, sgIID.SystemId)
+			if err != nil {
+				cblog.Info(err)
+				continue
+			}
+		}
+		info.SecurityGroupIIDs[idx].NameId = sgIIdInfo.NameId
+	}
+}
+
+// (1) get IID:list
+// (2) get RDBMSInfo:list
+// (3) set userIID, and ...
+func ListRDBMS(connectionName string, rsType string) ([]*cres.RDBMSInfo, error) {
+	cblog.Info("call ListRDBMS()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (1) get IID:list
+	var iidInfoList []*RDBMSIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+
+	var infoList []*cres.RDBMSInfo
+	if iidInfoList == nil || len(iidInfoList) <= 0 {
+		infoList = []*cres.RDBMSInfo{}
+		return infoList, nil
+	}
+
+	// (2) Get RDBMSInfo-list with IID-list
+	infoList2 := []*cres.RDBMSInfo{}
+	for _, iidInfo := range iidInfoList {
+
+		rdbmsSPLock.RLock(connectionName, iidInfo.NameId)
+
+		// get resource(SystemId)
+		info, err := handler.GetRDBMS(getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId}))
+		if err != nil {
+			rdbmsSPLock.RUnlock(connectionName, iidInfo.NameId)
+			if checkNotFoundError(err) {
+				cblog.Error(err)
+				info = cres.RDBMSInfo{IId: cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId}}
+				infoList2 = append(infoList2, &info)
+				continue
+			}
+			cblog.Error(err)
+			return nil, err
+		}
+		rdbmsSPLock.RUnlock(connectionName, iidInfo.NameId)
+
+		// (3) set ResourceInfo(IID.NameId)
+		info.IId = getUserIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+
+		// set VPC UserIID
+		var vpcIIDInfo VPCIIDInfo
+		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+			var iidInfoList []*VPCIIDInfo
+			err = getAuthIIDInfoList(connectionName, &iidInfoList)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, iidInfo.OwnerVPCName)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+			vpcIIDInfo = *castedIIDInfo.(*VPCIIDInfo)
+		} else {
+			err = infostore.GetByConditions(&vpcIIDInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, iidInfo.OwnerVPCName)
+			if err != nil {
+				cblog.Error(err)
+				return nil, err
+			}
+		}
+		info.VpcIID = getUserIID(cres.IID{NameId: vpcIIDInfo.NameId, SystemId: vpcIIDInfo.SystemId})
+
+		// set SubnetIIDs UserIID
+		setRDBMSSubnetUserIID(connectionName, vpcIIDInfo, &info)
+		// set SecurityGroupIIDs UserIID
+		setRDBMSSGUserIID(connectionName, vpcIIDInfo, &info)
+
+		infoList2 = append(infoList2, &info)
+	}
+
+	return infoList2, nil
+}
+
+// (1) get IID(NameId)
+// (2) get resource(SystemId)
+// (3) set ResourceInfo(IID.NameId)
+func GetRDBMS(connectionName string, rsType string, nameID string) (*cres.RDBMSInfo, error) {
+	cblog.Info("call GetRDBMS()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	nameID, err = EmptyCheckAndTrim("nameID", nameID)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	rdbmsSPLock.RLock(connectionName, nameID)
+	defer rdbmsSPLock.RUnlock(connectionName, nameID)
+
+	// (1) get IID(NameId)
+	var iidInfoList []*RDBMSIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	} else {
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+
+	var iidInfo *RDBMSIIDInfo
+	var bool_ret = false
+	for _, OneIIdInfo := range iidInfoList {
+		if OneIIdInfo.NameId == nameID {
+			iidInfo = OneIIdInfo
+			bool_ret = true
+			break
+		}
+	}
+	if !bool_ret {
+		err := fmt.Errorf("%s '%s' does not exist in connection '%s'", RSTypeString(rsType), nameID, connectionName)
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (2) get resource(SystemId)
+	info, err := handler.GetRDBMS(getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId}))
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// (3) set ResourceInfo(IID.NameId)
+	info.IId = getUserIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+
+	// set VPC UserIID
+	var vpcIIDInfo VPCIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		var iidInfoList []*VPCIIDInfo
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, iidInfo.OwnerVPCName)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		vpcIIDInfo = *castedIIDInfo.(*VPCIIDInfo)
+	} else {
+		err = infostore.GetByConditions(&vpcIIDInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, iidInfo.OwnerVPCName)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+	}
+	info.VpcIID = getUserIID(cres.IID{NameId: vpcIIDInfo.NameId, SystemId: vpcIIDInfo.SystemId})
+
+	// set SubnetIIDs UserIID
+	setRDBMSSubnetUserIID(connectionName, vpcIIDInfo, &info)
+	// set SecurityGroupIIDs UserIID
+	setRDBMSSGUserIID(connectionName, vpcIIDInfo, &info)
+
+	return &info, nil
+}
+
+func DeleteRDBMS(connectionName string, rsType string, nameID string, force string) (bool, error) {
+	cblog.Info("call DeleteRDBMS()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	nameID, err = EmptyCheckAndTrim("nameID", nameID)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	cldConn, err := ccm.GetCloudConnection(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	handler, err := cldConn.CreateRDBMSHandler()
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	rdbmsSPLock.Lock(connectionName, nameID)
+	defer rdbmsSPLock.Unlock(connectionName, nameID)
+
+	// (1) get spiderIID for creating driverIID
+	var iidInfoList []*RDBMSIIDInfo
+	if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+		err = getAuthIIDInfoList(connectionName, &iidInfoList)
+		if err != nil {
+			cblog.Error(err)
+			return false, err
+		}
+	} else {
+		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
+		if err != nil {
+			cblog.Error(err)
+			return false, err
+		}
+	}
+
+	var iidInfo *RDBMSIIDInfo
+	var bool_ret = false
+	for _, OneIIdInfo := range iidInfoList {
+		if OneIIdInfo.NameId == nameID {
+			iidInfo = OneIIdInfo
+			bool_ret = true
+			break
+		}
+	}
+	if !bool_ret {
+		err := fmt.Errorf("%s '%s' does not exist in connection '%s'", RSTypeString(rsType), nameID, connectionName)
+		cblog.Error(err)
+		return false, err
+	}
+
+	// (2) delete Resource(SystemId)
+	driverIId := getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+	result := false
+
+	result, err = handler.(cres.RDBMSHandler).DeleteRDBMS(driverIId)
+	if err != nil {
+		cblog.Error(err)
+		if checkNotFoundError(err) {
+			force = "true"
+		} else if force != "true" {
+			return false, err
+		}
+	}
+
+	if force != "true" {
+		if !result {
+			return result, nil
+		}
+	}
+
+	// (3) delete IID
+	_, err = infostore.DeleteByConditions(&RDBMSIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName, NAME_ID_COLUMN, nameID)
+	if err != nil {
+		cblog.Error(err)
+		if force != "true" {
+			return false, err
+		}
+	}
+
+	return result, nil
+}
+
+func CountAllRDBMS() (int64, error) {
+	var info RDBMSIIDInfo
+	count, err := infostore.CountAllNameIDs(&info)
+	if err != nil {
+		cblog.Error(err)
+		return count, err
+	}
+
+	return count, nil
+}
+
+func CountRDBMSByConnection(connectionName string) (int64, error) {
+	var info RDBMSIIDInfo
+	count, err := infostore.CountNameIDsByConnection(&info, connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return count, err
+	}
+
+	return count, nil
+}

--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -522,6 +522,28 @@ func getRoutes() []route {
 		//----------Destory All Resources in a Connection
 		{"DELETE", "/destroy", Destroy},
 
+		//----------RDBMS Handler
+		{"GET", "/getrdbmsowner", GetRDBMSOwnerVPC},
+		{"POST", "/getrdbmsowner", GetRDBMSOwnerVPC},
+		{"POST", "/regrdbms", RegisterRDBMS},
+		{"DELETE", "/regrdbms/:Name", UnregisterRDBMS},
+
+		{"POST", "/rdbms", CreateRDBMS},
+		{"GET", "/rdbms", ListRDBMS},
+		{"GET", "/rdbms/:Name", GetRDBMS},
+		{"DELETE", "/rdbms/:Name", DeleteRDBMS},
+
+		//-- for meta info
+		{"GET", "/rdbmsmetainfo", GetRDBMSMetaInfo},
+
+		//-- for management
+		{"GET", "/allrdbms", ListAllRDBMS},
+		{"GET", "/allrdbmsinfo", ListAllRDBMSInfo},
+		{"DELETE", "/csprdbms/:Id", DeleteCSPRDBMS},
+		//-- for dashboard
+		{"GET", "/countrdbms", CountAllRDBMS},
+		{"GET", "/countrdbms/:ConnectionName", CountRDBMSByConnection},
+
 		//----------checking TCP and UDP ports for NLB
 		{"GET", "/check/tcp", CheckTCPPort},
 		{"GET", "/check/udp", CheckUDPPort},
@@ -656,6 +678,21 @@ func getRoutes() []route {
 			{"GET", "/adminweb/s3/:ConnectConfig", aw.S3Management},
 
 			{"GET", "/adminweb/filesystem/:ConnectConfig", aw.FileSystemManagement},
+
+			{"GET", "/adminweb/rdbms/:ConnectConfig", aw.RDBMSManagement},
+
+			//-- RDBMS SQL Proxy (for AdminWeb DB management)
+			{"POST", "/adminweb/rdbms/:Name/sql/connect", aw.RDBMSTestConnection},
+			{"POST", "/adminweb/rdbms/:Name/sql/databases", aw.RDBMSListDatabases},
+			{"POST", "/adminweb/rdbms/:Name/sql/databases/create", aw.RDBMSCreateDatabase},
+			{"POST", "/adminweb/rdbms/:Name/sql/databases/:DBName/drop", aw.RDBMSDropDatabase},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables", aw.RDBMSListTables},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/create", aw.RDBMSCreateTable},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/:TableName/describe", aw.RDBMSDescribeTable},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/:TableName/drop", aw.RDBMSDropTable},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/:TableName/rows", aw.RDBMSListRows},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/:TableName/rows/insert", aw.RDBMSInsertRow},
+			{"POST", "/adminweb/rdbms/:Name/sql/tables/:TableName/rows/delete", aw.RDBMSDeleteRow},
 
 			//----------SSH WebTerminal Handler
 			{"GET", "/adminweb/sshwebterminal/ws", aw.HandleWebSocket}, //----------WebMon Handler

--- a/api-runtime/rest-runtime/CommonRest.go
+++ b/api-runtime/rest-runtime/CommonRest.go
@@ -38,6 +38,7 @@ const (
 	MYIMAGE   string = string(cres.MYIMAGE)
 	CLUSTER   string = string(cres.CLUSTER)
 	NODEGROUP string = string(cres.NODEGROUP)
+	RDBMS     string = string(cres.RDBMS)
 )
 
 //================ Common Request & Response

--- a/api-runtime/rest-runtime/RDBMSRest.go
+++ b/api-runtime/rest-runtime/RDBMSRest.go
@@ -1,0 +1,513 @@
+// Cloud Control Manager's Rest Runtime of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// by CB-Spider Team, April 2026.
+
+package restruntime
+
+import (
+	cmrt "github.com/cloud-barista/cb-spider/api-runtime/common-runtime"
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+
+	// REST API (echo)
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"strconv"
+)
+
+//================ RDBMS Handler
+
+// RDBMSRegisterRequest represents the request body for registering an RDBMS.
+type RDBMSRegisterRequest struct {
+	ConnectionName string `json:"ConnectionName" validate:"required" example:"aws-connection"`
+	ReqInfo        struct {
+		VPCName string `json:"VPCName" validate:"required" example:"vpc-01"`
+		Name    string `json:"Name" validate:"required" example:"rdbms-01"`
+		CSPId   string `json:"CSPId" validate:"required" example:"csp-rdbms-1234"`
+	} `json:"ReqInfo" validate:"required"`
+}
+
+// registerRDBMS godoc
+// @ID register-rdbms
+// @Summary Register RDBMS
+// @Description Register a new RDBMS with the specified name and CSP ID.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param RDBMSRegisterRequest body restruntime.RDBMSRegisterRequest true "Request body for registering an RDBMS"
+// @Success 200 {object} cres.RDBMSInfo "Details of the registered RDBMS"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /regrdbms [post]
+func RegisterRDBMS(c echo.Context) error {
+	cblog.Info("call RegisterRDBMS()")
+
+	req := RDBMSRegisterRequest{}
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// create UserIID
+	userIId := cres.IID{req.ReqInfo.Name, req.ReqInfo.CSPId}
+
+	// Call common-runtime API
+	result, err := cmrt.RegisterRDBMS(req.ConnectionName, req.ReqInfo.VPCName, userIId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// unregisterRDBMS godoc
+// @ID unregister-rdbms
+// @Summary Unregister RDBMS
+// @Description Unregister an RDBMS with the specified name.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionRequest body restruntime.ConnectionRequest true "Request body for unregistering an RDBMS"
+// @Param Name path string true "The name of the RDBMS to unregister"
+// @Success 200 {object} BooleanInfo "Result of the unregister operation"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /regrdbms/{Name} [delete]
+func UnregisterRDBMS(c echo.Context) error {
+	cblog.Info("call UnregisterRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// Call common-runtime API
+	result, err := cmrt.UnregisterResource(req.ConnectionName, RDBMS, c.Param("Name"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resultInfo := BooleanInfo{
+		Result: strconv.FormatBool(result),
+	}
+
+	return c.JSON(http.StatusOK, &resultInfo)
+}
+
+// RDBMSCreateRequest represents the request body for creating an RDBMS.
+type RDBMSCreateRequest struct {
+	ConnectionName  string `json:"ConnectionName" validate:"required" example:"aws-connection"`
+	IDTransformMode string `json:"IDTransformMode,omitempty" validate:"omitempty" example:"ON"` // ON: transform CSP ID, OFF: no-transform CSP ID
+	ReqInfo         struct {
+		Name    string `json:"Name" validate:"required" example:"rdbms-01"`
+		VPCName string `json:"VPCName" validate:"required" example:"vpc-01"`
+
+		DBEngine        string `json:"DBEngine" validate:"required" example:"mysql"`
+		DBEngineVersion string `json:"DBEngineVersion" validate:"required" example:"8.0"`
+		DBInstanceSpec  string `json:"DBInstanceSpec" validate:"required" example:"db.t3.medium"`
+		StorageSize     string `json:"StorageSize" validate:"required" example:"100"` // in GB
+
+		StorageType string `json:"StorageType,omitempty" validate:"omitempty" example:"gp2"`
+		Port        string `json:"Port,omitempty" validate:"omitempty" example:"3306"`
+
+		SubnetNames        []string `json:"SubnetNames,omitempty" validate:"omitempty" example:"subnet-01"`
+		SecurityGroupNames []string `json:"SecurityGroupNames,omitempty" validate:"omitempty" example:"sg-01"`
+
+		MasterUserName     string `json:"MasterUserName" validate:"required" example:"admin"`
+		MasterUserPassword string `json:"MasterUserPassword" validate:"required" example:"password123!"`
+		DatabaseName       string `json:"DatabaseName,omitempty" validate:"omitempty" example:"mydb"`
+
+		HighAvailability    bool   `json:"HighAvailability,omitempty" default:"false"`
+		BackupRetentionDays int    `json:"BackupRetentionDays,omitempty" example:"7"`
+		BackupTime          string `json:"BackupTime,omitempty" validate:"omitempty" example:"03:00"`
+
+		PublicAccess       bool `json:"PublicAccess,omitempty" default:"false"`
+		Encryption         bool `json:"Encryption,omitempty" default:"false"`
+		DeletionProtection bool `json:"DeletionProtection,omitempty" default:"false"`
+
+		TagList []cres.KeyValue `json:"TagList,omitempty" validate:"omitempty"`
+	} `json:"ReqInfo" validate:"required"`
+}
+
+// createRDBMS godoc
+// @ID create-rdbms
+// @Summary Create RDBMS
+// @Description Create a new Relational Database (RDBMS) with the specified configuration.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param RDBMSCreateRequest body restruntime.RDBMSCreateRequest true "Request body for creating an RDBMS"
+// @Success 200 {object} cres.RDBMSInfo "Details of the created RDBMS"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /rdbms [post]
+func CreateRDBMS(c echo.Context) error {
+	cblog.Info("call CreateRDBMS()")
+
+	req := RDBMSCreateRequest{}
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// Build SubnetIIDs from names
+	subnetIIDs := []cres.IID{}
+	for _, name := range req.ReqInfo.SubnetNames {
+		subnetIIDs = append(subnetIIDs, cres.IID{NameId: name, SystemId: ""})
+	}
+
+	// Build SecurityGroupIIDs from names
+	sgIIDs := []cres.IID{}
+	for _, name := range req.ReqInfo.SecurityGroupNames {
+		sgIIDs = append(sgIIDs, cres.IID{NameId: name, SystemId: ""})
+	}
+
+	// Rest RegInfo => Driver ReqInfo
+	reqInfo := cres.RDBMSInfo{
+		IId:    cres.IID{NameId: req.ReqInfo.Name, SystemId: req.ReqInfo.Name},
+		VpcIID: cres.IID{NameId: req.ReqInfo.VPCName, SystemId: ""},
+
+		DBEngine:        req.ReqInfo.DBEngine,
+		DBEngineVersion: req.ReqInfo.DBEngineVersion,
+		DBInstanceSpec:  req.ReqInfo.DBInstanceSpec,
+		StorageType:     req.ReqInfo.StorageType,
+		StorageSize:     req.ReqInfo.StorageSize,
+		Port:            req.ReqInfo.Port,
+
+		SubnetIIDs:        subnetIIDs,
+		SecurityGroupIIDs: sgIIDs,
+
+		MasterUserName:     req.ReqInfo.MasterUserName,
+		MasterUserPassword: req.ReqInfo.MasterUserPassword,
+		DatabaseName:       req.ReqInfo.DatabaseName,
+
+		HighAvailability:    req.ReqInfo.HighAvailability,
+		BackupRetentionDays: req.ReqInfo.BackupRetentionDays,
+		BackupTime:          req.ReqInfo.BackupTime,
+
+		PublicAccess:       req.ReqInfo.PublicAccess,
+		Encryption:         req.ReqInfo.Encryption,
+		DeletionProtection: req.ReqInfo.DeletionProtection,
+
+		TagList: req.ReqInfo.TagList,
+	}
+
+	// Call common-runtime API
+	result, err := cmrt.CreateRDBMS(req.ConnectionName, RDBMS, reqInfo, req.IDTransformMode)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// RDBMSListResponse represents the response body for listing RDBMS instances.
+type RDBMSListResponse struct {
+	Result []*cres.RDBMSInfo `json:"rdbms" validate:"required" description:"A list of RDBMS information"`
+}
+
+// listRDBMS godoc
+// @ID list-rdbms
+// @Summary List RDBMS
+// @Description Retrieve a list of RDBMS instances associated with a specific connection.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to list RDBMS for"
+// @Success 200 {object} RDBMSListResponse "List of RDBMS instances"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /rdbms [get]
+func ListRDBMS(c echo.Context) error {
+	cblog.Info("call ListRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// To support for Get-Query Param Type API
+	if req.ConnectionName == "" {
+		req.ConnectionName = c.QueryParam("ConnectionName")
+	}
+
+	// Call common-runtime API
+	result, err := cmrt.ListRDBMS(req.ConnectionName, RDBMS)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	jsonResult := RDBMSListResponse{
+		Result: result,
+	}
+
+	return c.JSON(http.StatusOK, &jsonResult)
+}
+
+// listAllRDBMS godoc
+// @ID list-all-rdbms
+// @Summary List All RDBMS in a Connection
+// @Description Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to list RDBMS for"
+// @Success 200 {object} AllResourceListResponse "List of all RDBMS instances within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /allrdbms [get]
+func ListAllRDBMS(c echo.Context) error {
+	cblog.Info("call ListAllRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// To support for Get-Query Param Type API
+	if req.ConnectionName == "" {
+		req.ConnectionName = c.QueryParam("ConnectionName")
+	}
+
+	// Call common-runtime API
+	allResourceList, err := cmrt.ListAllResource(req.ConnectionName, RDBMS)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, &allResourceList)
+}
+
+// listAllRDBMSInfo godoc
+// @ID list-all-rdbms-info
+// @Summary List All RDBMS Info
+// @Description Retrieve a list of all RDBMS information associated with all connections.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} AllResourceListResponse "List of all RDBMS information across all connections"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /allrdbmsinfo [get]
+func ListAllRDBMSInfo(c echo.Context) error { return listAllResourceInfo(c, cres.RDBMS) }
+
+// getRDBMS godoc
+// @ID get-rdbms
+// @Summary Get RDBMS
+// @Description Retrieve details of a specific RDBMS instance.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to get an RDBMS for"
+// @Param Name path string true "The name of the RDBMS to retrieve"
+// @Success 200 {object} cres.RDBMSInfo "Details of the RDBMS"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /rdbms/{Name} [get]
+func GetRDBMS(c echo.Context) error {
+	cblog.Info("call GetRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// To support for Get-Query Param Type API
+	if req.ConnectionName == "" {
+		req.ConnectionName = c.QueryParam("ConnectionName")
+	}
+
+	// Call common-runtime API
+	result, err := cmrt.GetRDBMS(req.ConnectionName, RDBMS, c.Param("Name"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// deleteRDBMS godoc
+// @ID delete-rdbms
+// @Summary Delete RDBMS
+// @Description Delete a specified RDBMS instance.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionRequest body restruntime.ConnectionRequest true "Request body for deleting an RDBMS"
+// @Param Name path string true "The name of the RDBMS to delete"
+// @Param force query string false "Force delete the RDBMS. ex) true or false(default: false)"
+// @Success 200 {object} BooleanInfo "Result of the delete operation"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /rdbms/{Name} [delete]
+func DeleteRDBMS(c echo.Context) error {
+	cblog.Info("call DeleteRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// Call common-runtime API
+	result, err := cmrt.DeleteRDBMS(req.ConnectionName, RDBMS, c.Param("Name"), c.QueryParam("force"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resultInfo := BooleanInfo{
+		Result: strconv.FormatBool(result),
+	}
+
+	return c.JSON(http.StatusOK, &resultInfo)
+}
+
+// deleteCSPRDBMS godoc
+// @ID delete-csp-rdbms
+// @Summary Delete CSP RDBMS
+// @Description Delete a specified CSP RDBMS.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionRequest body restruntime.ConnectionRequest true "Request body for deleting a CSP RDBMS"
+// @Param Id path string true "The CSP RDBMS ID to delete"
+// @Success 200 {object} BooleanInfo "Result of the delete operation"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /csprdbms/{Id} [delete]
+func DeleteCSPRDBMS(c echo.Context) error {
+	cblog.Info("call DeleteCSPRDBMS()")
+
+	var req ConnectionRequest
+
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	// Call common-runtime API
+	result, _, err := cmrt.DeleteCSPResource(req.ConnectionName, RDBMS, c.Param("Id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resultInfo := BooleanInfo{
+		Result: strconv.FormatBool(result),
+	}
+
+	return c.JSON(http.StatusOK, &resultInfo)
+}
+
+// getRDBMSMetaInfo godoc
+// @ID get-rdbms-metainfo
+// @Summary Get RDBMS Meta Information
+// @Description Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options).
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection"
+// @Success 200 {object} cres.RDBMSMetaInfo "RDBMS MetaInfo for the CSP"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /rdbmsmetainfo [get]
+func GetRDBMSMetaInfo(c echo.Context) error {
+	cblog.Info("call GetRDBMSMetaInfo()")
+
+	connectionName := c.QueryParam("ConnectionName")
+
+	// Call common-runtime API
+	result, err := cmrt.GetRDBMSMetaInfo(connectionName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// getRDBMSOwnerVPC godoc
+// @ID get-rdbms-owner-vpc
+// @Summary Get RDBMS Owner VPC
+// @Description Retrieve the Owner VPC of a given RDBMS CSP ID.
+// @Tags [RDBMS Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection"
+// @Param CSPId query string true "The CSP RDBMS ID"
+// @Success 200 {object} cres.IID "Owner VPC IID"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /getrdbmsowner [get]
+func GetRDBMSOwnerVPC(c echo.Context) error {
+	cblog.Info("call GetRDBMSOwnerVPC()")
+
+	connectionName := c.QueryParam("ConnectionName")
+	cspId := c.QueryParam("CSPId")
+
+	// Call common-runtime API
+	result, err := cmrt.GetRDBMSOwnerVPC(connectionName, cspId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// countAllRDBMS godoc
+// @ID count-all-rdbms
+// @Summary Count All RDBMS
+// @Description Get the total number of RDBMS instances across all connections.
+// @Tags [RDBMS Management]
+// @Produce  json
+// @Success 200 {object} CountResponse "Total count of RDBMS instances"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /countrdbms [get]
+func CountAllRDBMS(c echo.Context) error {
+	count, err := cmrt.CountAllRDBMS()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	jsonResult := CountResponse{
+		Count: int(count),
+	}
+
+	return c.JSON(http.StatusOK, jsonResult)
+}
+
+// countRDBMSByConnection godoc
+// @ID count-rdbms-by-connection
+// @Summary Count RDBMS by Connection
+// @Description Get the total number of RDBMS instances for a specific connection.
+// @Tags [RDBMS Management]
+// @Produce  json
+// @Param ConnectionName path string true "The name of the Connection"
+// @Success 200 {object} CountResponse "Total count of RDBMS instances for the connection"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /countrdbms/{ConnectionName} [get]
+func CountRDBMSByConnection(c echo.Context) error {
+	count, err := cmrt.CountRDBMSByConnection(c.Param("ConnectionName"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	jsonResult := CountResponse{
+		Count: int(count),
+	}
+
+	return c.JSON(http.StatusOK, jsonResult)
+}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
@@ -35,6 +35,7 @@ type ResourceCounts struct {
 	Clusters             int    `json:"clusters"`
 	MyImages             int    `json:"myImages"`
 	S3Buckets            int    `json:"s3Buckets"`
+	RDBMSInstances       int    `json:"rdbmsInstances"`
 }
 
 // DashboardData aggregates the data for rendering the dashboard
@@ -58,7 +59,8 @@ func filterEmptyConnections(resourceCounts map[string][]ResourceCounts) map[stri
 		for _, count := range counts {
 			if count.VPCs > 0 || count.Subnets > 0 || count.SecurityGroups > 0 || count.VMs > 0 ||
 				count.KeyPairs > 0 || count.Disks > 0 || count.NetworkLoadBalancers > 0 ||
-				count.Clusters > 0 || count.MyImages > 0 || count.S3Buckets > 0 {
+				count.Clusters > 0 || count.MyImages > 0 || count.S3Buckets > 0 ||
+				count.RDBMSInstances > 0 {
 				nonEmptyCounts = append(nonEmptyCounts, count)
 			}
 		}
@@ -85,7 +87,7 @@ func fetchResourceCounts(config ConnectionConfig, provider string, wg *sync.Wait
 	counts.RegionName = config.RegionName
 
 	baseURL := "http://localhost:1024/spider"
-	resources := []string{"vpc", "subnet", "securitygroup", "vm", "keypair", "disk", "nlb", "cluster", "myimage", "s3"}
+	resources := []string{"vpc", "subnet", "securitygroup", "vm", "keypair", "disk", "nlb", "cluster", "myimage", "s3", "rdbms"}
 
 	for _, resource := range resources {
 		url := fmt.Sprintf("%s/count%s/%s", baseURL, resource, config.ConfigName)
@@ -127,6 +129,8 @@ func fetchResourceCounts(config ConnectionConfig, provider string, wg *sync.Wait
 			counts.MyImages = response.Count
 		case "s3":
 			counts.S3Buckets = response.Count
+		case "rdbms":
+			counts.RDBMSInstances = response.Count
 		}
 	}
 	countsChan <- struct {

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
@@ -1,0 +1,836 @@
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// by CB-Spider Team, June 2025.
+
+package adminweb
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	cr "github.com/cloud-barista/cb-spider/api-runtime/common-runtime"
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/labstack/echo/v4"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+// validIdentifier checks that a SQL identifier (table/column name) contains only safe characters.
+var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+func isValidIdentifier(name string) bool {
+	return validIdentifier.MatchString(name) && len(name) <= 128
+}
+
+// fetchRDBMSInfo retrieves RDBMS info via the internal REST API.
+func fetchRDBMSInfo(connConfig, rdbmsName string) (*cres.RDBMSInfo, error) {
+	url := "http://localhost" + cr.ServerPort + "/spider/rdbms/" + rdbmsName
+
+	var reqBody struct {
+		ConnectionName string `json:"ConnectionName"`
+	}
+	reqBody.ConnectionName = connConfig
+
+	jsonValue, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	request, err := http.NewRequest("GET", url, strings.NewReader(string(jsonValue)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	setBasicAuthIfConfigured(request)
+
+	client := http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RDBMS info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch RDBMS info: HTTP %d", resp.StatusCode)
+	}
+
+	var info cres.RDBMSInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("failed to decode RDBMS info: %w", err)
+	}
+	return &info, nil
+}
+
+// openDBConnection creates a database/sql connection to the RDBMS instance.
+// dbNameOverride, if non-empty, takes precedence over info.DatabaseName.
+func openDBConnection(info *cres.RDBMSInfo, password, dbNameOverride string) (*sql.DB, string, error) {
+	engine := strings.ToLower(info.DBEngine)
+	endpoint := info.Endpoint
+	port := info.Port
+	user := info.MasterUserName
+	dbName := info.DatabaseName
+	if dbNameOverride != "" {
+		dbName = dbNameOverride
+	}
+	// Treat "NA" as no database specified (some drivers return "NA" as placeholder)
+	if strings.EqualFold(dbName, "NA") {
+		dbName = ""
+	}
+
+	if endpoint == "" {
+		status := string(info.Status)
+		if status != "" && status != "Available" {
+			return nil, "", fmt.Errorf("RDBMS is not available yet (Status: %s). Please wait until it becomes Available", status)
+		}
+		return nil, "", fmt.Errorf("RDBMS endpoint is empty. The instance may still be provisioning")
+	}
+
+	// Strip port from endpoint if it already contains one (e.g., "host.rds.amazonaws.com:3306")
+	host := endpoint
+	if idx := strings.LastIndex(endpoint, ":"); idx > 0 {
+		hostPart := endpoint[:idx]
+		portPart := endpoint[idx+1:]
+		// Check if the part after ':' looks like a port number
+		if _, err := fmt.Sscanf(portPart, "%d", new(int)); err == nil {
+			host = hostPart
+			if port == "" {
+				port = portPart
+			}
+		}
+	}
+
+	var driverName, dsn string
+
+	switch {
+	case engine == "mysql" || engine == "mariadb":
+		driverName = "mysql"
+		if port == "" {
+			port = "3306"
+		}
+		// Base DSN: user:password@tcp(host:port)/dbname?parseTime=true&timeout=30s
+		dsn = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true&timeout=30s",
+			user, password, host, port, dbName)
+		// Enable TLS for cloud providers that require secure transport (e.g., Azure Flexible Server).
+		// Other providers (e.g., AWS RDS) work without TLS, avoiding unnecessary handshake overhead.
+		if strings.Contains(strings.ToLower(host), ".azure.") {
+			dsn += "&tls=skip-verify"
+		}
+
+	case engine == "postgresql" || engine == "postgres":
+		driverName = "postgres"
+		if port == "" {
+			port = "5432"
+		}
+		pgDB := dbName
+		if pgDB == "" {
+			pgDB = "postgres" // default database for PostgreSQL
+		}
+		dsn = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=require connect_timeout=30",
+			host, port, user, password, pgDB)
+
+	default:
+		return nil, "", fmt.Errorf("unsupported DB engine: %s", engine)
+	}
+
+	db, err := sql.Open(driverName, dsn)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to open DB connection: %w", err)
+	}
+
+	db.SetConnMaxLifetime(30 * time.Second)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, "", fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	return db, driverName, nil
+}
+
+// --- Request/Response structures ---
+
+type rdbmsQueryRequest struct {
+	ConnectionName string `json:"ConnectionName"`
+	Password       string `json:"Password"`
+	DatabaseName   string `json:"DatabaseName,omitempty"`
+}
+
+type createTableRequest struct {
+	ConnectionName string       `json:"ConnectionName"`
+	Password       string       `json:"Password"`
+	DatabaseName   string       `json:"DatabaseName,omitempty"`
+	TableName      string       `json:"TableName"`
+	Columns        []columnInfo `json:"Columns"`
+}
+
+type columnInfo struct {
+	Name       string `json:"Name"`
+	Type       string `json:"Type"`
+	PrimaryKey bool   `json:"PrimaryKey,omitempty"`
+	NotNull    bool   `json:"NotNull,omitempty"`
+}
+
+type insertRowRequest struct {
+	ConnectionName string            `json:"ConnectionName"`
+	Password       string            `json:"Password"`
+	DatabaseName   string            `json:"DatabaseName,omitempty"`
+	Values         map[string]string `json:"Values"`
+}
+
+type deleteRowRequest struct {
+	ConnectionName string            `json:"ConnectionName"`
+	Password       string            `json:"Password"`
+	DatabaseName   string            `json:"DatabaseName,omitempty"`
+	Where          map[string]string `json:"Where"`
+}
+
+// --- Handlers ---
+
+// RDBMSTestConnection tests connectivity to an RDBMS instance.
+func RDBMSTestConnection(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, _, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "connected"})
+}
+
+// RDBMSListDatabases lists all databases on the RDBMS instance.
+func RDBMSListDatabases(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	// Connect without specifying a database
+	db, driverName, err := openDBConnection(info, req.Password, "")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	var query string
+	switch driverName {
+	case "mysql":
+		query = "SHOW DATABASES"
+	case "postgres":
+		query = "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname"
+	}
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to list databases: %v", err)})
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to scan database name: %v", err)})
+		}
+		databases = append(databases, name)
+	}
+	if databases == nil {
+		databases = []string{}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{"databases": databases})
+}
+
+// RDBMSCreateDatabase creates a new database on the RDBMS instance.
+func RDBMSCreateDatabase(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+
+	var req struct {
+		ConnectionName string `json:"ConnectionName"`
+		Password       string `json:"Password"`
+		DatabaseName   string `json:"DatabaseName"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" || req.DatabaseName == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName, Password, and DatabaseName are required"})
+	}
+	if !isValidIdentifier(req.DatabaseName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid database name. Use only letters, numbers, and underscores."})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, "")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	var query string
+	switch driverName {
+	case "mysql":
+		query = fmt.Sprintf("CREATE DATABASE `%s`", req.DatabaseName)
+	case "postgres":
+		query = fmt.Sprintf(`CREATE DATABASE "%s"`, req.DatabaseName)
+	}
+
+	if _, err := db.Exec(query); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to create database: %v", err)})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "created", "database": req.DatabaseName})
+}
+
+// RDBMSDropDatabase drops a database on the RDBMS instance.
+func RDBMSDropDatabase(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	dbName := c.Param("DBName")
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+	if !isValidIdentifier(dbName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid database name"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, "")
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	var query string
+	switch driverName {
+	case "mysql":
+		query = fmt.Sprintf("DROP DATABASE `%s`", dbName)
+	case "postgres":
+		query = fmt.Sprintf(`DROP DATABASE "%s"`, dbName)
+	}
+
+	if _, err := db.Exec(query); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to drop database: %v", err)})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "dropped", "database": dbName})
+}
+
+// RDBMSListTables lists all tables in the database.
+func RDBMSListTables(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	var query string
+	switch driverName {
+	case "mysql":
+		query = "SHOW TABLES"
+	case "postgres":
+		query = "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+	}
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to list tables: %v", err)})
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to scan table name: %v", err)})
+		}
+		tables = append(tables, name)
+	}
+	if tables == nil {
+		tables = []string{}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{"tables": tables})
+}
+
+// RDBMSDescribeTable returns column information for a table.
+func RDBMSDescribeTable(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	tableName := c.Param("TableName")
+
+	if !isValidIdentifier(tableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name"})
+	}
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	type colDescription struct {
+		Name     string `json:"Name"`
+		Type     string `json:"Type"`
+		Nullable string `json:"Nullable"`
+		Key      string `json:"Key"`
+		Default  string `json:"Default"`
+	}
+
+	var columns []colDescription
+
+	switch driverName {
+	case "mysql":
+		rows, err := db.Query("DESCRIBE `" + tableName + "`")
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to describe table: %v", err)})
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var field, colType, null, key string
+			var defVal, extra sql.NullString
+			if err := rows.Scan(&field, &colType, &null, &key, &defVal, &extra); err != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to scan column info: %v", err)})
+			}
+			def := ""
+			if defVal.Valid {
+				def = defVal.String
+			}
+			columns = append(columns, colDescription{Name: field, Type: colType, Nullable: null, Key: key, Default: def})
+		}
+
+	case "postgres":
+		rows, err := db.Query(`
+			SELECT column_name, data_type, is_nullable,
+				CASE WHEN pk.column_name IS NOT NULL THEN 'PRI' ELSE '' END AS key,
+				COALESCE(column_default, '') AS column_default
+			FROM information_schema.columns c
+			LEFT JOIN (
+				SELECT ku.column_name
+				FROM information_schema.table_constraints tc
+				JOIN information_schema.key_column_usage ku ON tc.constraint_name = ku.constraint_name
+				WHERE tc.constraint_type = 'PRIMARY KEY' AND tc.table_name = $1
+			) pk ON c.column_name = pk.column_name
+			WHERE c.table_name = $1 AND c.table_schema = 'public'
+			ORDER BY c.ordinal_position`, tableName)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to describe table: %v", err)})
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var name, colType, nullable, key, def string
+			if err := rows.Scan(&name, &colType, &nullable, &key, &def); err != nil {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to scan column info: %v", err)})
+			}
+			columns = append(columns, colDescription{Name: name, Type: colType, Nullable: nullable, Key: key, Default: def})
+		}
+	}
+
+	if columns == nil {
+		columns = []colDescription{}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{"columns": columns})
+}
+
+// RDBMSListRows returns rows from a table (with LIMIT).
+func RDBMSListRows(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	tableName := c.Param("TableName")
+
+	if !isValidIdentifier(tableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name"})
+	}
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	var query string
+	switch driverName {
+	case "mysql":
+		query = "SELECT * FROM `" + tableName + "` LIMIT 200"
+	case "postgres":
+		query = `SELECT * FROM "` + tableName + `" LIMIT 200`
+	}
+
+	rows, err := db.Query(query)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to query rows: %v", err)})
+	}
+	defer rows.Close()
+
+	colNames, err := rows.Columns()
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to get column names: %v", err)})
+	}
+
+	var result []map[string]interface{}
+	for rows.Next() {
+		values := make([]interface{}, len(colNames))
+		valuePtrs := make([]interface{}, len(colNames))
+		for i := range values {
+			valuePtrs[i] = &values[i]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to scan row: %v", err)})
+		}
+
+		row := make(map[string]interface{})
+		for i, col := range colNames {
+			val := values[i]
+			switch v := val.(type) {
+			case []byte:
+				row[col] = string(v)
+			case nil:
+				row[col] = nil
+			default:
+				row[col] = v
+			}
+		}
+		result = append(result, row)
+	}
+
+	if result == nil {
+		result = []map[string]interface{}{}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"columns": colNames,
+		"rows":    result,
+		"count":   len(result),
+	})
+}
+
+// RDBMSCreateTable creates a new table.
+func RDBMSCreateTable(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+
+	var req createTableRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+	if !isValidIdentifier(req.TableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name (use alphanumeric and underscore only)"})
+	}
+	if len(req.Columns) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "At least one column is required"})
+	}
+
+	// Validate column names
+	for _, col := range req.Columns {
+		if !isValidIdentifier(col.Name) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("Invalid column name: %s", col.Name)})
+		}
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	// Build CREATE TABLE statement
+	var colDefs []string
+	var pkCols []string
+	for _, col := range req.Columns {
+		def := quoteIdentifier(driverName, col.Name) + " " + col.Type
+		if col.NotNull {
+			def += " NOT NULL"
+		}
+		colDefs = append(colDefs, def)
+		if col.PrimaryKey {
+			pkCols = append(pkCols, quoteIdentifier(driverName, col.Name))
+		}
+	}
+	if len(pkCols) > 0 {
+		colDefs = append(colDefs, "PRIMARY KEY ("+strings.Join(pkCols, ", ")+")")
+	}
+
+	ddl := "CREATE TABLE " + quoteIdentifier(driverName, req.TableName) + " (\n" + strings.Join(colDefs, ",\n") + "\n)"
+
+	if _, err := db.Exec(ddl); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to create table: %v", err)})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "created", "table": req.TableName})
+}
+
+// RDBMSDropTable drops a table.
+func RDBMSDropTable(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	tableName := c.Param("TableName")
+
+	if !isValidIdentifier(tableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name"})
+	}
+
+	var req rdbmsQueryRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	ddl := "DROP TABLE " + quoteIdentifier(driverName, tableName)
+	if _, err := db.Exec(ddl); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to drop table: %v", err)})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "dropped", "table": tableName})
+}
+
+// RDBMSInsertRow inserts a row into a table.
+func RDBMSInsertRow(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	tableName := c.Param("TableName")
+
+	if !isValidIdentifier(tableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name"})
+	}
+
+	var req insertRowRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+	if len(req.Values) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Values are required"})
+	}
+
+	// Validate column names
+	for col := range req.Values {
+		if !isValidIdentifier(col) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("Invalid column name: %s", col)})
+		}
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	// Build INSERT statement with parameterized values
+	var cols []string
+	var placeholders []string
+	var args []interface{}
+	i := 1
+	for col, val := range req.Values {
+		cols = append(cols, quoteIdentifier(driverName, col))
+		if driverName == "postgres" {
+			placeholders = append(placeholders, fmt.Sprintf("$%d", i))
+		} else {
+			placeholders = append(placeholders, "?")
+		}
+		args = append(args, val)
+		i++
+	}
+
+	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)",
+		quoteIdentifier(driverName, tableName),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "))
+
+	if _, err := db.Exec(query, args...); err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to insert row: %v", err)})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "inserted"})
+}
+
+// RDBMSDeleteRow deletes rows from a table matching WHERE conditions.
+func RDBMSDeleteRow(c echo.Context) error {
+	rdbmsName := c.Param("Name")
+	tableName := c.Param("TableName")
+
+	if !isValidIdentifier(tableName) {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid table name"})
+	}
+
+	var req deleteRowRequest
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+	}
+	if req.ConnectionName == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "ConnectionName and Password are required"})
+	}
+	if len(req.Where) == 0 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "WHERE conditions are required"})
+	}
+
+	// Validate column names
+	for col := range req.Where {
+		if !isValidIdentifier(col) {
+			return c.JSON(http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("Invalid column name: %s", col)})
+		}
+	}
+
+	info, err := fetchRDBMSInfo(req.ConnectionName, rdbmsName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	db, driverName, err := openDBConnection(info, req.Password, req.DatabaseName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	defer db.Close()
+
+	// Build DELETE statement with parameterized WHERE
+	var conditions []string
+	var args []interface{}
+	i := 1
+	for col, val := range req.Where {
+		if driverName == "postgres" {
+			conditions = append(conditions, fmt.Sprintf("%s = $%d", quoteIdentifier(driverName, col), i))
+		} else {
+			conditions = append(conditions, quoteIdentifier(driverName, col)+" = ?")
+		}
+		args = append(args, val)
+		i++
+	}
+
+	query := fmt.Sprintf("DELETE FROM %s WHERE %s",
+		quoteIdentifier(driverName, tableName),
+		strings.Join(conditions, " AND "))
+
+	result, err := db.Exec(query, args...)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("Failed to delete rows: %v", err)})
+	}
+
+	affected, _ := result.RowsAffected()
+	return c.JSON(http.StatusOK, map[string]interface{}{"status": "deleted", "affected": affected})
+}
+
+// quoteIdentifier quotes a SQL identifier based on the driver.
+func quoteIdentifier(driverName, name string) string {
+	switch driverName {
+	case "mysql":
+		return "`" + name + "`"
+	case "postgres":
+		return `"` + name + `"`
+	default:
+		return `"` + name + `"`
+	}
+}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS.go
@@ -1,0 +1,130 @@
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// by CB-Spider Team, April 2026.
+
+package adminweb
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	"github.com/labstack/echo/v4"
+)
+
+// Function to fetch RDBMSs
+func fetchRDBMSs(connConfig string) ([]*cres.RDBMSInfo, error) {
+	resBody, err := getResourceList_with_Connection_JsonByte(connConfig, "rdbms")
+	if err != nil {
+		return nil, fmt.Errorf("error fetching RDBMSs: %v", err)
+	}
+
+	var info struct {
+		ResultList []*cres.RDBMSInfo `json:"rdbms"`
+	}
+	if err := json.Unmarshal(resBody, &info); err != nil {
+		return nil, fmt.Errorf("error decoding RDBMSs: %v", err)
+	}
+
+	return info.ResultList, nil
+}
+
+// Handler function to render the RDBMS management page
+func RDBMSManagement(c echo.Context) error {
+	connConfig := c.Param("ConnectConfig")
+	if connConfig == "region not set" {
+		htmlStr := `
+			<html>
+			<head>
+			    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+				<style>
+				th {
+				  border: 1px solid lightgray;
+				}
+				td {
+				  border: 1px solid lightgray;
+				  border-radius: 4px;
+				}
+				</style>
+			    <script type="text/javascript">
+				alert(connConfig)
+			    </script>
+			</head>
+			<body>
+				<br>
+				<br>
+				<label style="font-size:24px;color:#606262;">&nbsp;&nbsp;&nbsp;Please select a Connection Configuration! (MENU: 2.CONNECTION)</label>	
+			</body>
+		`
+
+		return c.HTML(http.StatusOK, htmlStr)
+	}
+
+	providerName, err := getProviderName(connConfig)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	regionName, err := getRegionName(connConfig)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	region, zone, err := getRegionZone(regionName)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	// Fetch RDBMSs
+	rdbmss, err := fetchRDBMSs(connConfig)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	data := struct {
+		ConnectionConfig string
+		ProviderName     string
+		RegionName       string
+		Region           string
+		Zone             string
+		RDBMSs           []*cres.RDBMSInfo
+		APIUsername      string
+		APIPassword      string
+	}{
+		ConnectionConfig: connConfig,
+		ProviderName:     providerName,
+		RegionName:       regionName,
+		Region:           region,
+		Zone:             zone,
+		RDBMSs:           rdbmss,
+		APIUsername:      os.Getenv("SPIDER_USERNAME"),
+		APIPassword:      os.Getenv("SPIDER_PASSWORD"),
+	}
+
+	templatePath := filepath.Join(os.Getenv("CBSPIDER_ROOT"), "/api-runtime/rest-runtime/admin-web/html/rdbms.html")
+	tmpl, err := template.New("rdbms.html").Funcs(template.FuncMap{
+		"inc": func(i int) int {
+			return i + 1
+		},
+		"trim": func(s string) string {
+			return strings.TrimSpace(s)
+		},
+	}).ParseFiles(templatePath)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Error loading template: " + err.Error()})
+	}
+
+	c.Response().WriteHeader(http.StatusOK)
+	if err := tmpl.Execute(c.Response().Writer, data); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	return nil
+}

--- a/api-runtime/rest-runtime/admin-web/html/dashboard.html
+++ b/api-runtime/rest-runtime/admin-web/html/dashboard.html
@@ -283,6 +283,7 @@
                 <th>NLBs</th>
                 <th>Clusters</th>
                 <th>S3 Buckets</th>
+                <th>RDBMS</th>
             </tr>
             {{if index $.ResourceCounts $provider}}
                 {{range $count := index $.ResourceCounts $provider}}
@@ -300,11 +301,12 @@
                     <td class="{{if gt $count.NetworkLoadBalancers 0}}highlight{{end}}"><a href="#" onclick="openOverlay('http://{{$.ServerIP}}/spider/adminweb/nlb/{{$count.ConnectionName}}'); return false;">{{$count.NetworkLoadBalancers}}</a></td>
                     <td class="{{if gt $count.Clusters 0}}highlight-clusters{{end}}"><a href="#" onclick="openOverlay('http://{{$.ServerIP}}/spider/adminweb/cluster/{{$count.ConnectionName}}'); return false;">{{$count.Clusters}}</a></td>
                     <td class="{{if gt $count.S3Buckets 0}}highlight{{end}}"><a href="#" onclick="openOverlay('http://{{$.ServerIP}}/spider/adminweb/s3/{{$count.ConnectionName}}'); return false;">{{$count.S3Buckets}}</a></td>
+                    <td class="{{if gt $count.RDBMSInstances 0}}highlight{{end}}"><a href="#" onclick="openOverlay('http://{{$.ServerIP}}/spider/adminweb/rdbms/{{$count.ConnectionName}}'); return false;">{{$count.RDBMSInstances}}</a></td>
                 </tr>
                 {{end}}
             {{else}}
             <tr>
-                <td colspan="10">No connections found for {{$provider}}</td>
+                <td colspan="12">No connections found for {{$provider}}</td>
             </tr>
             {{end}}
         </table>

--- a/api-runtime/rest-runtime/admin-web/html/left_menu.html
+++ b/api-runtime/rest-runtime/admin-web/html/left_menu.html
@@ -73,7 +73,8 @@
                 nlb: "/spider/adminweb/nlb",
                 cluster: "/spider/adminweb/cluster",
                 s3: "/spider/adminweb/s3",
-                filesystem: "/spider/adminweb/filesystem"
+                filesystem: "/spider/adminweb/filesystem",
+                rdbms: "/spider/adminweb/rdbms"
             };
 
             const targetUrl = `${menuUrlMap[menu]}/${encodeURIComponent(connectionName)}`;
@@ -133,7 +134,7 @@
         }
 
         function changeSelectedImage(selectedMenu) {
-            const menus = ['dashboard', 'connection', 'vpc', 'securitygroup', 'keypair', 'vm', 'disk', 'myimage', 'nlb', 'cluster', 's3', 'filesystem'];
+            const menus = ['dashboard', 'connection', 'vpc', 'securitygroup', 'keypair', 'vm', 'disk', 'myimage', 'nlb', 'cluster', 's3', 'filesystem', 'rdbms'];
             menus.forEach(menu => {
                 const imgElement = document.getElementById(menu + '-img');
                 if (imgElement) {
@@ -148,7 +149,7 @@
 
         window.addEventListener('message', function(event) {
             if (event.data.type === 'deselectLeftMenu') {
-                const menus = ['dashboard', 'connection', 'vpc', 'securitygroup', 'keypair', 'vm', 'disk', 'myimage', 'nlb', 'cluster', 's3', 'filesystem'];
+                const menus = ['dashboard', 'connection', 'vpc', 'securitygroup', 'keypair', 'vm', 'disk', 'myimage', 'nlb', 'cluster', 's3', 'filesystem', 'rdbms'];
                 menus.forEach(menu => {
                     const imgElement = document.getElementById(menu + '-img');
                     if (imgElement) {
@@ -216,6 +217,10 @@
         <img id="filesystem-img" src="./images/left-menu/filesystem.png" alt="FileSystem Icon" onerror="this.src='./images/left-menu/disk.png'">
         <div class="menu-text">FS (WIP)</div>
     </div>
-    <div class="divider"></div> <!-- Divider after FileSystem -->
+    <div class="menu-item" onclick="checkConnectionAndRedirect('rdbms', event)">
+        <img id="rdbms-img" src="./images/left-menu/rdbms.png" alt="RDBMS Icon" onerror="this.src='./images/left-menu/disk.png'">
+        <div class="menu-text">RDB (WIP)</div>
+    </div>
+    <div class="divider"></div> <!-- Divider after RDBMS -->
 </body>
 </html>

--- a/api-runtime/rest-runtime/admin-web/html/rdbms.html
+++ b/api-runtime/rest-runtime/admin-web/html/rdbms.html
@@ -1,0 +1,2715 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>RDBMS Management</title>
+<style>
+    body {
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+    }
+    .header-container {
+        display: flex;
+        align-items: flex-end;
+    }
+    .header-container img {
+        margin-right: 10px;
+        height: 28px;
+    }
+    .header-container h1 {
+        font-size: 16px;
+        margin: 0;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: fixed;
+        margin-bottom: 0;
+    }
+    th, td {
+        border: 1px solid black;
+        padding: 6px;
+        position: relative;
+    }
+    th {
+        background-color: #f2f2f2;
+        font-size: 14px;
+        text-align: center;
+    }
+    td {
+        text-align: left;
+    }
+    .column-num {
+        width: 4%;
+        text-align: center;
+    }
+
+    .inner-table {
+        width: 100%;
+        table-layout: fixed;
+    }
+    .inner-table th {
+        width: 40%;
+        font-weight: normal;
+        font-size: 12px;
+        padding: 4px 8px;
+        text-align: right;
+    }
+    .inner-table td {
+        width: 60%;
+        font-size: 12px;
+        padding: 4px 8px;
+        text-align: center;
+    }
+
+    .inner-table tr:nth-child(-n+2) td:nth-child(2) {
+        background-color: #e0f7fa;
+        color: #00796b;
+        font-weight: bold;
+        border: 1px solid #004d40;
+    }
+
+    /* Loading spinner */
+    .loading-overlay {
+        display: none;
+        position: fixed;
+        top: 46px;
+        left: 0;
+        width: 100%;
+        height: calc(100% - 46px);
+        background: rgba(255,255,255,0.7);
+        z-index: 2000;
+        justify-content: center;
+        align-items: center;
+        flex-direction: column;
+    }
+    .loading-overlay.active {
+        display: flex;
+    }
+    .spinner {
+        width: 40px;
+        height: 40px;
+        border: 4px solid #ccc;
+        border-top: 4px solid #333;
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin {
+        0%   { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+    .loading-text {
+        margin-top: 12px;
+        font-size: 14px;
+        color: #555;
+    }
+
+    .center-align {
+        text-align: center;
+    }
+    .overlay {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0,0,0,0.5);
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+    }
+    .overlay-content {
+        background-color: white;
+        padding: 20px;
+        border-radius: 5px;
+        text-align: left;
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+        position: relative;
+        max-height: 90vh;
+        overflow-y: auto;
+    }
+    .overlay-close-btn {
+        background-color: #f0f0f0;
+        color: #d9534f;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+    }
+    .overlay-close-btn:hover {
+        background-color: #e0e0e0;
+    }
+    .fixed-header {
+        position: fixed;
+        top: 0;
+        width: 97%;
+        background-color: white;
+        z-index: 1000;
+        display: flex;
+        justify-content: space-between;
+        padding: 10px 20px;
+        align-items: center;
+        box-shadow: 0 4px 6px -6px #222;
+    }
+    .fixed-action-buttons {
+        display: flex;
+        align-items: center;
+    }
+    .fixed-action-buttons button {
+        margin-left: 10px;
+    }
+    #searchInput {
+        width: 190px;
+        font-family: Arial, sans-serif;
+        padding-right: 2.5cm;
+    }
+    #clearSearch {
+        position: absolute;
+        right: 0.1cm;
+        top: 50%;
+        transform: translateY(-50%);
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
+        font-family: Arial, sans-serif;
+    }
+    .searchContainer {
+        position: relative;
+        display: flex;
+        align-items: center;
+        padding-left: 0.5cm;
+    }
+    .searchContainer button {
+        position: absolute;
+        right: 0.5cm;
+        top: 50%;
+        transform: translateY(-50%);
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
+        font-family: Arial, sans-serif;
+    }
+
+    .add-button {
+        font-size: 14px;
+        font-weight: bold;
+        margin-left: 1px;
+        margin-right: 5px;
+        margin-bottom: 10px;
+    }
+    .content {
+        margin-top: 70px;
+    }
+    .highlight {
+        background-color: #fffab6;
+    }
+    .checkbox-cell {
+        width: 4%;
+        text-align: center;
+    }
+
+    .rdbms-name, .rdbms-status, .rdbms-vpc, .rdbms-engine, .rdbms-spec, .rdbms-network, .rdbms-auth, .rdbms-options, .tags, .misc {
+        text-align: center;
+    }
+    .rdbms-name {
+        width: 11%;
+        text-align: left;
+        font-size: 13px;
+        font-weight: bold;
+    }
+    .rdbms-status {
+        width: 5%;
+        text-align: center;
+    }
+    .rdbms-vpc {
+        width: 10%;
+    }
+    .rdbms-engine {
+        width: 12%;
+        vertical-align: top;
+    }
+    .rdbms-spec {
+        width: 13%;
+        vertical-align: top;
+    }
+    .rdbms-network {
+        width: 14%;
+        vertical-align: top;
+    }
+    .rdbms-auth {
+        width: 10%;
+        vertical-align: top;
+    }
+    .rdbms-options {
+        width: 12%;
+        vertical-align: top;
+    }
+    .tags {
+        width: 8%;
+    }
+    .misc {
+        width: 8%;
+    }
+
+    .tag-container {
+        display: inline-block;
+        background-color: #e1e1e1;
+        border-radius: 3px;
+        padding: 2px 5px;
+        margin: 2px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: pointer;
+        max-width: calc(100% - 2ch);
+    }
+    .tag-container:hover {
+        background-color: #c1e1c1;
+    }
+
+    .add-btn-container {
+        margin-top: 5px;
+        text-align: left;
+    }
+    .add-btn-container .add-btn {
+        background-color: transparent;
+        font-size: 14px;
+        border: none;
+        color: blue;
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    .misc-content {
+        max-height: 2.5em;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .more-btn {
+        display: none;
+        background-color: transparent;
+        border: none;
+        color: blue;
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    .misc-cell {
+        position: relative;
+    }
+
+    .misc-cell .more-btn {
+        position: absolute;
+        right: 5px;
+        bottom: 5px;
+    }
+
+    .overlay-dark-background {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.7);
+        z-index: 1999;
+        display: none;
+    }
+
+    .misc-overlay {
+        display: none;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        width: 50%;
+        height: 50%;
+        transform: translate(-50%, -50%);
+        background-color: white;
+        border: 1px solid black;
+        padding: 20px;
+        z-index: 2000;
+        overflow-y: auto;
+        user-select: text;
+    }
+
+    .misc-overlay .overlay-close-btn {
+        background-color: #f0f0f0;
+        color: #d9534f;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+    }
+    .misc-overlay .overlay-close-btn:hover {
+        background-color: #e0e0e0;
+    }
+
+    .misc-overlay-content {
+        font-size: 14px;
+        width: 700px;
+        position: relative;
+        padding-top: 30px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+    }
+
+    .tag-overlay {
+        display: none;
+        position: absolute;
+        background-color: white;
+        border: 1px solid black;
+        padding: 20px;
+        z-index: 1001;
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        max-width: 300px;
+        word-wrap: break-word;
+    }
+
+    .tag-overlay .overlay-close-btn {
+        background-color: #f0f0f0;
+        color: #d9534f;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+    }
+    .tag-overlay .overlay-close-btn:hover {
+        background-color: #e0e0e0;
+    }
+
+    .tag-overlay-content {
+        position: relative;
+        padding: 20px;
+        border-radius: 5px;
+        background-color: white;
+        text-align: left;
+        font-family: Arial, sans-serif;
+        font-size: 12px;
+    }
+
+    .tag-overlay-input-group {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+    }
+
+    .tag-overlay-input-group label {
+        flex: 1;
+        text-align: right;
+        margin-right: 10px;
+    }
+
+    .tag-overlay-input-group input {
+        flex: 2;
+    }
+
+    .tag-overlay-button-group {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 20px;
+    }
+
+    .add-tag-overlay-content {
+        background-color: white;
+        padding: 20px;
+        border-radius: 5px;
+        text-align: left;
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        max-width: 300px;
+        word-wrap: break-word;
+        position: relative;
+    }
+
+    .add-tag-overlay-content .tag-overlay-input-group {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+    }
+
+    .add-tag-overlay-content .tag-overlay-input-group:first-of-type {
+        margin-top: 30px;
+    }
+
+    .add-tag-overlay-content .tag-overlay-input-group label {
+        flex: 1;
+        text-align: right;
+        margin-right: 10px;
+    }
+
+    .add-tag-overlay-content .tag-overlay-input-group input {
+        flex: 2;
+    }
+
+    .add-tag-overlay-content .tag-overlay-button-group {
+        display: flex;
+        justify-content: space-between;
+        margin-top: 20px;
+    }
+
+    .rdbms-system-id {
+        display: block;
+        font-size: 12px;
+        font-weight: normal;
+        color: #666;
+        max-width: 200px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        cursor: pointer;
+    }
+
+    .system-id-overlay {
+        display: none;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 50%;
+        max-width: 600px;
+        background-color: white;
+        border: 1px solid black;
+        padding: 20px;
+        z-index: 2000;
+        border-radius: 5px;
+    }
+
+    .system-id-overlay-content {
+        position: relative;
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        word-wrap: break-word;
+    }
+
+    .system-id-overlay .overlay-close-btn {
+        background-color: #f0f0f0;
+        color: #d9534f;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+    }
+    .system-id-overlay .overlay-close-btn:hover {
+        background-color: #e0e0e0;
+    }
+
+    .copy-btn {
+        background: none;
+        border: none;
+        font-size: 16px;
+        cursor: pointer;
+        margin-left: 10px;
+    }
+
+    .rdbms-name .rdbms-created-time {
+        display: block;
+        font-size: 12px;
+        font-weight: normal;
+        color: #666;
+    }
+
+    .form-group {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+    }
+    .form-group label {
+        flex: 1;
+        text-align: right;
+        margin-right: 10px;
+    }
+    .form-group input, .form-group textarea, .form-group select {
+        flex: 2;
+    }
+    .form-group .tag-inputs {
+        display: flex;
+        flex: 2;
+        margin-left: 10px;
+    }
+    .form-group .tag-inputs input {
+        flex: 1;
+        margin-right: 5px;
+    }
+    .form-group button {
+        margin-left: 10px;
+    }
+
+    .form-group-tags {
+        display: flex;
+        align-items: center;
+        margin-bottom: 10px;
+    }
+    .info-group {
+        border: 1px solid #ccc;
+        padding: 10px;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        background-color: #f9f9f9;
+    }
+    .info-group legend {
+        font-size: 14px;
+        font-weight: bold;
+        color: #333;
+    }
+    .info-group .form-group:last-child,
+    .info-group .form-group-tags:last-child {
+        margin-bottom: 0;
+    }
+    .form-group-tags label {
+        flex: 1;
+        text-align: right;
+        margin-left: 6px;
+        margin-right: 2px;
+    }
+    .form-group-tags input {
+        flex: 2;
+    }
+
+    .tag-input-group {
+        display: flex;
+        align-items: center;
+        flex: 2;
+    }
+    .tag-input-group input {
+        width: 60px;
+        flex: 0.5;
+        margin-right: 5px;
+    }
+    .tag-input-group button {
+        margin-left: 5px;
+    }
+    .rdbms-tag-key {
+        margin-left: 10px;
+    }
+
+    #rdbms-tag-container {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .header-with-progress {
+        display: flex;
+        align-items: center;
+        margin-bottom: 0px;
+    }
+    .progress-bar-container {
+        width: 600px;
+        margin-left: 10px;
+        margin-bottom: 10px;
+        height: 22px;
+        background-color: #f0f5ff;
+        border-radius: 4px;
+        overflow: hidden;
+        display: none;
+        position: relative;
+        z-index: 2000;
+    }
+    .progress-bar {
+        width: 0;
+        height: 100%;
+        background-color: #cce6ff;
+        border-radius: 4px;
+        transition: width 3s ease;
+    }
+    #timeDisplay {
+        position: absolute;
+        top: 50%;
+        right: 10px;
+        transform: translateY(-50%);
+        font-size: 14px;
+        color: #333;
+        z-index: 30;
+    }
+
+    /* Error Modal Styling */
+    #errorModal {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.7);
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+    }
+
+    #errorModal .overlay-content {
+        background-color: white;
+        padding: 20px;
+        border-radius: 5px;
+        text-align: left;
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        max-width: 500px;
+        width: 80%;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+    }
+
+    #errorModal button {
+        margin-top: 15px;
+        padding: 5px 10px;
+        cursor: pointer;
+    }
+
+    .status-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 3px;
+        font-size: 11px;
+        font-weight: bold;
+    }
+    .status-available {
+        background-color: #d4edda;
+        color: #155724;
+    }
+    .status-creating {
+        background-color: #fff3cd;
+        color: #856404;
+    }
+    .status-deleting {
+        background-color: #f8d7da;
+        color: #721c24;
+    }
+    .status-stopped {
+        background-color: #e2e3e5;
+        color: #383d41;
+    }
+    .status-error {
+        background-color: #f8d7da;
+        color: #721c24;
+    }
+
+    .checkbox-wrapper {
+        display: block;
+        margin-right: 0px;
+    }
+
+    .checkbox-wrapper input[type="checkbox"] {
+        margin-right: 5px;
+    }
+
+    .spinner {
+        border: 4px solid #f3f3f3;
+        border-top: 4px solid #3498db;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        animation: spin 1s linear infinite;
+        margin: 0 auto;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+
+    /* DB Detail Panel Styles */
+    #db-panel {
+        margin-top: 20px;
+        margin-left: 20px;
+        margin-right: 20px;
+    }
+    .db-panel-header {
+        margin-bottom: 10px;
+    }
+    .db-panel-header h2 {
+        margin: 0;
+        font-size: 15px;
+    }
+    .db-connect-section {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 15px;
+        padding: 10px;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+    }
+    .db-connect-section label {
+        font-weight: bold;
+        font-size: 13px;
+    }
+    .db-connect-section input {
+        padding: 4px 8px;
+        border: 1px solid #ccc;
+        border-radius: 3px;
+        font-size: 12px;
+    }
+    .db-connect-section button {
+        padding: 4px 12px;
+        font-size: 12px;
+        font-weight: bold;
+        cursor: pointer;
+    }
+    .db-connect-status {
+        font-size: 12px;
+        margin-left: 10px;
+    }
+    .db-connect-status.connected {
+        color: #155724;
+    }
+    .db-connect-status.error {
+        color: #721c24;
+    }
+    #db-table-panel, #db-row-panel {
+        margin-top: 10px;
+    }
+    #db-table-list, #db-row-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+    }
+    #db-table-list th, #db-table-list td,
+    #db-row-table th, #db-row-table td {
+        border: 1px solid #ccc;
+        padding: 5px 8px;
+        text-align: left;
+    }
+    #db-table-list th, #db-row-table th {
+        background-color: #e8e8e8;
+        font-size: 13px;
+        text-align: center;
+    }
+    #db-table-list tr:hover {
+        background-color: #f0f8ff;
+        cursor: pointer;
+    }
+    .selected-rdbms > td {
+        background-color: #e3f2fd !important;
+    }
+    .db-table-actions, .db-row-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        margin-bottom: 8px;
+    }
+    .db-breadcrumb {
+        font-size: 14px;
+        margin-bottom: 10px;
+    }
+    .db-breadcrumb span {
+        cursor: pointer;
+    }
+
+</style>
+</head>
+<body>
+    <div class="fixed-header">
+        <div class="header-container">
+            <img src="/spider/adminweb/images/left-menu/rdbms.png" alt="RDBMS Icon" onerror="this.src='/spider/adminweb/images/left-menu/disk.png'">
+            <h1>RDBMS Management</h1>
+            <div class="searchContainer">
+                <input type="text" id="searchInput" onkeyup="searchKeyword()" placeholder="Search Keyword...">
+                <button id="clearSearch" onclick="clearSearchInput()">X</button>
+            </div>
+        </div>
+        <div class="fixed-action-buttons">
+            <input type="checkbox" onclick="toggleSelectAll(this)">
+            <button onclick="deleteSelectedRDBMSs()">Delete</button>
+        </div>
+    </div>
+
+    <div class="content">
+        <div class="header-with-progress">
+            <button class="add-button" onclick="showOverlay()">+ RDBMS</button>
+            <div class="progress-bar-container" id="progressBarContainer">
+                <div class="progress-bar" id="progressBar"></div>
+                <span id="timeDisplay"></span>
+            </div>
+        </div>
+        <table id="rdbms-table">
+            <tr>
+                <th class="column-num">#</th>
+                <th class="rdbms-name" style="text-align: center;">Name</th>
+                <th class="rdbms-status" style="text-align: center;">Status</th>
+                <th class="rdbms-vpc">VPC</th>
+                <th class="rdbms-engine">Engine</th>
+                <th class="rdbms-spec">Instance</th>
+                <th class="rdbms-network">Network</th>
+                <th class="rdbms-auth">Auth</th>
+                <th class="rdbms-options">Options</th>
+                <th class="tags">Tags</th>
+                <th class="misc">Misc</th>
+                <th class="checkbox-cell"><input type="checkbox" onclick="toggleSelectAll(this)"></th>
+            </tr>
+            {{range $index, $rdbms := .RDBMSs}}
+            <tr id="rdbms-row-{{$index}}">
+                <td class="column-num" onclick="showDBPanel('{{$rdbms.IId.NameId}}')" style="cursor: pointer;">{{$index | inc}}</td>
+                <td class="rdbms-name" onclick="showDBPanel('{{$rdbms.IId.NameId}}')" style="cursor: pointer;">
+                    {{$rdbms.IId.NameId}}
+                    <span class="rdbms-system-id" onclick="showSystemIdOverlay('{{$rdbms.IId.SystemId}}')">&nbsp;• {{$rdbms.IId.SystemId}}</span>
+                    <span class="rdbms-created-time" data-time="{{ $rdbms.CreatedTime }}"></span>
+                </td>
+                <td class="rdbms-status">
+                    <span class="status-badge
+                        {{- if eq (printf "%s" $rdbms.Status) "Available"}} status-available
+                        {{- else if eq (printf "%s" $rdbms.Status) "Creating"}} status-creating
+                        {{- else if eq (printf "%s" $rdbms.Status) "Deleting"}} status-deleting
+                        {{- else if eq (printf "%s" $rdbms.Status) "Stopped"}} status-stopped
+                        {{- else if eq (printf "%s" $rdbms.Status) "Error"}} status-error
+                        {{- end}}">{{$rdbms.Status}}</span>
+                </td>
+                <td class="rdbms-vpc" style="text-align: left; font-size: 13px; font-weight: bold;">
+                    {{if $rdbms.VpcIID.NameId}}
+                        {{$rdbms.VpcIID.NameId}}
+                        <span class="rdbms-system-id" onclick="showSystemIdOverlay('{{$rdbms.VpcIID.SystemId}}')">&nbsp;• {{$rdbms.VpcIID.SystemId}}</span>
+                    {{end}}
+                </td>
+
+                <!-- Engine -->
+                <td class="rdbms-engine">
+                    <table class="inner-table">
+                        <tr>
+                            <th>Engine</th>
+                            <td>{{$rdbms.DBEngine}}</td>
+                        </tr>
+                        <tr>
+                            <th>Version</th>
+                            <td>{{$rdbms.DBEngineVersion}}</td>
+                        </tr>
+                        <tr>
+                            <th>Endpoint</th>
+                            <td style="font-size: 11px; word-break: break-all;">{{$rdbms.Endpoint}}</td>
+                        </tr>
+                        <tr>
+                            <th>Port</th>
+                            <td>{{$rdbms.Port}}</td>
+                        </tr>
+                    </table>
+                </td>
+
+                <!-- Instance -->
+                <td class="rdbms-spec">
+                    <table class="inner-table">
+                        <tr>
+                            <th>Spec</th>
+                            <td>{{$rdbms.DBInstanceSpec}}</td>
+                        </tr>
+                        <tr>
+                            <th>Type</th>
+                            <td>{{$rdbms.DBInstanceType}}</td>
+                        </tr>
+                        <tr>
+                            <th>Storage</th>
+                            <td>{{$rdbms.StorageSize}} GB</td>
+                        </tr>
+                        <tr>
+                            <th>StorageType</th>
+                            <td>{{$rdbms.StorageType}}</td>
+                        </tr>
+                    </table>
+                </td>
+
+                <!-- Network -->
+                <td class="rdbms-network">
+                    <table class="inner-table">
+                        <tr>
+                            <th>Subnets</th>
+                            <td style="font-size: 11px;">
+                                {{range $subnet := $rdbms.SubnetIIDs}}
+                                    <div>{{$subnet.NameId}}</div>
+                                {{end}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>SGs</th>
+                            <td style="font-size: 11px;">
+                                {{range $sg := $rdbms.SecurityGroupIIDs}}
+                                    <div>{{$sg.NameId}}</div>
+                                {{end}}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th>Public</th>
+                            <td>{{if $rdbms.PublicAccess}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                    </table>
+                </td>
+
+                <!-- Auth -->
+                <td class="rdbms-auth">
+                    <table class="inner-table">
+                        <tr>
+                            <th>User</th>
+                            <td>{{$rdbms.MasterUserName}}</td>
+                        </tr>
+                    </table>
+                </td>
+
+                <!-- Options -->
+                <td class="rdbms-options">
+                    <table class="inner-table">
+                        <tr>
+                            <th>HA</th>
+                            <td>{{if $rdbms.HighAvailability}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                        <tr>
+                            <th>Encrypt</th>
+                            <td>{{if $rdbms.Encryption}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                        <tr>
+                            <th>Backup</th>
+                            <td>{{$rdbms.BackupRetentionDays}}d / {{$rdbms.BackupTime}}</td>
+                        </tr>
+                        <tr>
+                            <th>DelProtect</th>
+                            <td>{{if $rdbms.DeletionProtection}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                    </table>
+                </td>
+
+                <td class="tags" style="text-align: left;">
+                    {{range $tag := $rdbms.TagList}}
+                    <div class="tag-container" onclick="showTagOverlay(event, '{{$tag.Key}}: {{$tag.Value}}', 'RDBMS', '{{$rdbms.IId.NameId}}')">{{$tag.Key}}: {{$tag.Value}}</div>
+                    {{end}}
+                    <div class="add-btn-container">
+                        <button class="add-btn" onclick="showAddTagOverlay('{{$rdbms.IId.NameId}}')">+</button>
+                    </div>
+                </td>
+
+                <td class="misc misc-cell">
+                    <div class="misc-content">{{range $kv := $rdbms.KeyValueList}}{{$kv.Key}} : {{$kv.Value}}<br>{{end}}</div>
+                    <button class="more-btn" onclick="showMiscOverlay(this)">more...</button>
+                </td>
+                <td class="checkbox-cell center-align">
+                    <input type="checkbox" name="deleteCheckbox" value="{{$rdbms.IId.NameId}}">
+                </td>
+            </tr>
+            {{end}}
+            {{if not .RDBMSs}}
+            <tr>
+                <td colspan="11" class="center-align">No RDBMSs found for this connection.</td>
+            </tr>
+            {{end}}
+        </table>
+
+        <!-- DB Detail Panel (like S3 Object Panel) -->
+        <div id="db-panel" style="display:none; border-top: 2px solid #ccc; margin-top: 20px; padding-top: 20px;">
+            <div class="db-panel-header">
+                <h2 id="db-panel-title"></h2>
+            </div>
+
+            <!-- Connection Section -->
+            <div class="db-connect-section">
+                <label>Password:</label>
+                <input type="password" id="dbPassword" placeholder="Master user password" style="width: 200px;">
+                <button onclick="connectToDB()">Connect</button>
+                <button onclick="disconnectDB()">Disconnect</button>
+                <span id="dbConnectStatus" class="db-connect-status"></span>
+            </div>
+
+            <!-- Database List Panel -->
+            <div id="db-database-panel" style="display:none;">
+                <div class="db-breadcrumb" id="db-database-breadcrumb"></div>
+                <div class="db-table-actions">
+                    <button class="add-button" onclick="showCreateDatabaseOverlay()">+ Database</button>
+                    <span style="font-size: 12px; color: #666;" id="db-database-count"></span>
+                </div>
+                <table id="db-database-list">
+                    <thead>
+                        <tr>
+                            <th style="width: 5%;">#</th>
+                            <th>Database Name</th>
+                            <th style="width: 15%;">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="db-database-list-body">
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Table List Panel -->
+            <div id="db-table-panel" style="display:none;">
+                <div class="db-breadcrumb" id="db-breadcrumb"></div>
+                <div class="db-table-actions">
+                    <button class="add-button" onclick="showCreateTableOverlay()">+ Table</button>
+                    <span style="font-size: 12px; color: #666;" id="db-table-count"></span>
+                </div>
+                <table id="db-table-list">
+                    <thead>
+                        <tr>
+                            <th style="width: 5%;">#</th>
+                            <th>Table Name</th>
+                            <th style="width: 15%;">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="db-table-list-body">
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Row List Panel -->
+            <div id="db-row-panel" style="display:none; margin-top: 15px; border-top: 1px solid #ddd; padding-top: 15px;">
+                <div class="db-breadcrumb" id="db-row-breadcrumb"></div>
+                <div class="db-row-actions">
+                    <button class="add-button" onclick="showInsertRowOverlay()">+ Row</button>
+                    <span style="font-size: 12px; color: #666;" id="db-row-count"></span>
+                </div>
+                <div style="overflow-x: auto;">
+                    <table id="db-row-table">
+                        <thead id="db-row-table-head">
+                        </thead>
+                        <tbody id="db-row-table-body">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- Overlay: Create Database -->
+    <div id="createDatabaseOverlay" class="overlay">
+        <div class="overlay-content" style="width: 400px;">
+            <button type="button" class="overlay-close-btn" onclick="hideCreateDatabaseOverlay()">X</button>
+            <h2>Create Database</h2>
+            <form id="createDatabaseForm" onsubmit="event.preventDefault(); createDatabase();">
+                <div class="form-group">
+                    <label for="newDatabaseName">Database Name:</label>
+                    <input type="text" id="newDatabaseName" required placeholder="e.g., mydb" style="width: 65%;" pattern="[a-zA-Z_][a-zA-Z0-9_]*" title="Letters, numbers, underscores only. Must start with a letter or underscore.">
+                </div>
+                <div class="form-group" style="display: flex; justify-content: center; margin-top: 20px;">
+                    <button type="submit">Create Database</button>
+                    <button type="button" onclick="hideCreateDatabaseOverlay()" style="margin-left: 10px;">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Overlay: Create Table -->
+    <div id="createTableOverlay" class="overlay">
+        <div class="overlay-content" style="width: 520px;">
+            <button type="button" class="overlay-close-btn" onclick="hideCreateTableOverlay()">X</button>
+            <h2>Create Table</h2>
+            <form id="createTableForm" onsubmit="event.preventDefault(); createTable();">
+                <div class="form-group">
+                    <label for="newTableName">Table Name:</label>
+                    <input type="text" id="newTableName" required placeholder="e.g., users" style="width: 65%;">
+                </div>
+                <fieldset class="info-group">
+                    <legend>Columns:</legend>
+                    <div id="createTableColumns">
+                        <div class="form-group create-table-col">
+                            <input type="text" placeholder="Column Name" class="col-name" style="width: 25%;" required>
+                            <select class="col-type" style="width: 25%;">
+                                <option value="INT">INT</option>
+                                <option value="BIGINT">BIGINT</option>
+                                <option value="VARCHAR(255)" selected>VARCHAR(255)</option>
+                                <option value="TEXT">TEXT</option>
+                                <option value="BOOLEAN">BOOLEAN</option>
+                                <option value="DATE">DATE</option>
+                                <option value="DATETIME">DATETIME</option>
+                                <option value="TIMESTAMP">TIMESTAMP</option>
+                                <option value="FLOAT">FLOAT</option>
+                                <option value="DOUBLE">DOUBLE</option>
+                                <option value="DECIMAL(10,2)">DECIMAL(10,2)</option>
+                            </select>
+                            <label style="font-size: 11px;"><input type="checkbox" class="col-pk"> PK</label>
+                            <label style="font-size: 11px;"><input type="checkbox" class="col-notnull"> NOT NULL</label>
+                            <button type="button" onclick="this.parentElement.remove()">-</button>
+                        </div>
+                    </div>
+                    <button type="button" onclick="addColumnField()">+ Column</button>
+                </fieldset>
+                <div class="form-group" style="display: flex; justify-content: center; margin-top: 20px;">
+                    <button type="submit">Create Table</button>
+                    <button type="button" onclick="hideCreateTableOverlay()" style="margin-left: 10px;">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Overlay: Insert Row -->
+    <div id="insertRowOverlay" class="overlay">
+        <div class="overlay-content" style="width: 520px;">
+            <button type="button" class="overlay-close-btn" onclick="hideInsertRowOverlay()">X</button>
+            <h2>Insert Row</h2>
+            <form id="insertRowForm" onsubmit="event.preventDefault(); insertRow();">
+                <div id="insertRowFields"></div>
+                <div class="form-group" style="display: flex; justify-content: center; margin-top: 20px;">
+                    <button type="submit">Insert</button>
+                    <button type="button" onclick="hideInsertRowOverlay()" style="margin-left: 10px;">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Overlay: Add New RDBMS -->
+    <div id="overlay" class="overlay">
+        <div class="overlay-content" style="width: 520px;">
+            <button type="button" class="overlay-close-btn" onclick="hideOverlay()">X</button>
+            <h2>Add New RDBMS</h2>
+            <form id="addRDBMSForm" onsubmit="event.preventDefault(); postRDBMS();">
+                <input type="hidden" id="connConfig" value="{{.ConnectionConfig}}">
+
+                <!-- RDBMS Basic Info -->
+                <fieldset class="info-group">
+                    <legend>Basic Info:</legend>
+                    <div class="form-group">
+                        <label for="rdbmsName">Name:</label>
+                        <input type="text" id="rdbmsName" name="rdbmsName" required style="width: 65%; color: #3366CC; font-weight: bold;">
+                    </div>
+                    <div class="form-group">
+                        <label for="vpcName">VPC Name:</label>
+                        <select id="vpcName" name="vpcName" required style="width: 65%;"></select>
+                    </div>
+                </fieldset>
+
+                <!-- DB Engine -->
+                <fieldset class="info-group">
+                    <legend>DB Engine:</legend>
+                    <div class="form-group">
+                        <label for="dbEngine">Engine:</label>
+                        <select id="dbEngine" name="dbEngine" required style="background-color: #E6E6FA; width: 65%;">
+                            <option value="mysql">mysql</option>
+                            <option value="mariadb">mariadb</option>
+                            <option value="postgresql">postgresql</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="dbEngineVersion">Version:</label>
+                        <input type="text" id="dbEngineVersion" name="dbEngineVersion" required placeholder="e.g., 8.0" style="background-color: #F5F5DC; width: 65%;">
+                    </div>
+                </fieldset>
+
+                <!-- Instance Spec -->
+                <fieldset class="info-group">
+                    <legend>Instance Spec:</legend>
+                    <div class="form-group">
+                        <label for="dbInstanceSpec">Instance Spec:</label>
+                        <input type="text" id="dbInstanceSpec" name="dbInstanceSpec" required placeholder="e.g., db.t3.medium" style="width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="storageSize">Storage (GB):</label>
+                        <input type="number" id="storageSize" name="storageSize" required min="1" value="20" style="background-color: #F5F5DC; width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="storageType">Storage Type:</label>
+                        <input type="text" id="storageType" name="storageType" placeholder="e.g., gp2 (optional)" style="width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="port">Port:</label>
+                        <input type="text" id="port" name="port" placeholder="e.g., 3306 (optional)" style="width: 65%;">
+                    </div>
+                </fieldset>
+
+                <!-- Network -->
+                <fieldset class="info-group">
+                    <legend>Network:</legend>
+                    <div class="form-group">
+                        <label for="subnetNames">Subnet Names:</label>
+                        <input type="text" id="subnetNames" name="subnetNames" placeholder="comma-separated (optional)" style="width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="sgNames">SG Names:</label>
+                        <input type="text" id="sgNames" name="sgNames" placeholder="comma-separated (optional)" style="width: 65%;">
+                    </div>
+                </fieldset>
+
+                <!-- Authentication -->
+                <fieldset class="info-group">
+                    <legend>Authentication:</legend>
+                    <div class="form-group">
+                        <label for="masterUserName">Master User:</label>
+                        <input type="text" id="masterUserName" name="masterUserName" required placeholder="e.g., admin" style="width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="masterUserPassword">Password:</label>
+                        <input type="password" id="masterUserPassword" name="masterUserPassword" required placeholder="Master password" style="width: 65%;">
+                    </div>
+                    <div class="form-group">
+                        <label for="databaseName">DB Name:</label>
+                        <input type="text" id="databaseName" name="databaseName" placeholder="Initial DB name (optional)" style="width: 65%;">
+                    </div>
+                </fieldset>
+
+                <!-- Advanced Options -->
+                <fieldset class="info-group">
+                    <legend>Advanced Options:</legend>
+                    <div class="form-group">
+                        <label for="highAvailability">HA:</label>
+                        <select id="highAvailability" name="highAvailability" style="background-color: #E6E6FA; width: 65%;">
+                            <option value="false">No</option>
+                            <option value="true">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="publicAccess">Public Access:</label>
+                        <select id="publicAccess" name="publicAccess" style="background-color: #E6E6FA; width: 65%;">
+                            <option value="false">No</option>
+                            <option value="true">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="encryption">Encryption:</label>
+                        <select id="encryption" name="encryption" style="background-color: #E6E6FA; width: 65%;">
+                            <option value="false">No</option>
+                            <option value="true">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="deletionProtection">Del. Protection:</label>
+                        <select id="deletionProtection" name="deletionProtection" style="background-color: #E6E6FA; width: 65%;">
+                            <option value="false">No</option>
+                            <option value="true">Yes</option>
+                        </select>
+                    </div>
+                    <div class="form-group-tags">
+                        <label for="backupRetentionDays">Backup Days:</label>
+                        <input type="number" id="backupRetentionDays" name="backupRetentionDays" value="0" min="0" style="width: 43px;">
+
+                        <label for="backupTime">Backup Time:</label>
+                        <input type="text" id="backupTime" name="backupTime" placeholder="HH:MM" style="width: 43px;">
+                    </div>
+                </fieldset>
+
+                <!-- Tags -->
+                <div class="form-group">
+                    <label for="rdbms-tag-container">Tags:</label>
+                    <div id="rdbms-tag-container"></div>
+                    <button type="button" onclick="addRDBMSTagField()">+</button>
+                </div>
+                <div class="form-group" style="display: flex; justify-content: center; align-items: center; margin-top: 20px;">
+                    <button type="submit">Add RDBMS</button>
+                    <button type="button" onclick="hideOverlay('overlay')" style="margin-left: 10px;">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div id="tag-overlay" class="tag-overlay">
+        <div class="tag-overlay-content"></div>
+    </div>
+
+    <!-- Add Tag Overlay -->
+    <div id="add-tag-overlay" class="overlay">
+        <div class="add-tag-overlay-content overlay-content"></div>
+    </div>
+
+    <!-- Error Modal -->
+    <div id="errorModal" class="overlay">
+        <div class="overlay-content">
+            <button type="button" class="overlay-close-btn" onclick="closeErrorModal()">X</button>
+            <h2 id="errorTitle">Error</h2>
+            <p id="errorMessage"></p>
+            <button onclick="closeErrorModal()">Close</button>
+        </div>
+    </div>
+
+    <div id="system-id-overlay" class="system-id-overlay">
+        <div class="system-id-overlay-content">
+            <button class="overlay-close-btn" onclick="closeSystemIdOverlay()">X</button>
+            <h2>System ID (Managed by CSP)</h2>
+            <p id="fullSystemId"></p>
+            <button class="copy-btn" onclick="copySystemId()">&#x1F4CB;</button>
+        </div>
+    </div>
+
+</body>
+
+<script>
+    // Basic Auth credentials from server
+    const SPIDER_USERNAME = '{{.APIUsername}}';
+    const SPIDER_PASSWORD = '{{.APIPassword}}';
+
+    // Helper function to create fetch options with Basic Auth if credentials are set
+    function createFetchOptions(options = {}) {
+        const fetchOptions = { ...options };
+
+        if (SPIDER_USERNAME && SPIDER_PASSWORD) {
+            const credentials = btoa(SPIDER_USERNAME + ':' + SPIDER_PASSWORD);
+            fetchOptions.headers = {
+                ...fetchOptions.headers,
+                'Authorization': 'Basic ' + credentials
+            };
+        }
+
+        return fetchOptions;
+    }
+
+    // Override fetch to automatically include Basic Auth
+    const originalFetch = window.fetch;
+    window.fetch = function(url, options) {
+        if (url.startsWith('/spider/') || url.startsWith('http://' + location.host + '/spider/')) {
+            options = createFetchOptions(options);
+        }
+        return originalFetch(url, options);
+    };
+
+    function searchKeyword() {
+        let input = document.getElementById('searchInput');
+        let filter = input.value.toUpperCase().trim();
+
+        if (!filter) {
+            clearSearchInput();
+            return;
+        }
+
+        let table = document.getElementById('rdbms-table');
+        let tr = table.getElementsByTagName('tr');
+
+        for (let i = 1; i < tr.length; i++) {
+            let tds = tr[i].getElementsByTagName('td');
+            let rowVisible = false;
+
+            for (let j = 0; j < tds.length; j++) {
+                let td = tds[j];
+                if (td) {
+                    let txtValue = td.textContent || td.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                        td.classList.add('highlight');
+                        rowVisible = true;
+                    } else {
+                        td.classList.remove('highlight');
+                    }
+                }
+            }
+        }
+    }
+
+    function clearSearchInput() {
+        let input = document.getElementById('searchInput');
+        input.value = '';
+
+        let table = document.getElementById('rdbms-table');
+        let tr = table.getElementsByTagName('tr');
+
+        for (let i = 1; i < tr.length; i++) {
+            tr[i].style.display = '';
+            let tds = tr[i].getElementsByTagName('td');
+            for (let j = 0; j < tds.length; j++) {
+                tds[j].classList.remove('highlight');
+            }
+        }
+    }
+
+    function fetchWithProgress(url, options) {
+        showProgressBar();
+
+        const startTime = Date.now();
+        const timerInterval = 500;
+        let timerId = setInterval(() => {
+            const elapsedTime = (Date.now() - startTime) / 1000;
+            const timeDisplay = document.getElementById('timeDisplay');
+            timeDisplay.textContent = `${(Math.floor(elapsedTime * 2) / 2).toFixed(1)}s`;
+        }, timerInterval);
+
+        return fetch(url, options)
+            .then(response => {
+                clearInterval(timerId);
+                hideProgressBar();
+                return response;
+            })
+            .catch(error => {
+                clearInterval(timerId);
+                hideProgressBar();
+                throw error;
+            });
+    }
+
+    function showProgressBar() {
+        const progressBarContainer = document.getElementById('progressBarContainer');
+        const progressBar = document.getElementById('progressBar');
+        progressBar.style.width = '0%';
+        progressBarContainer.style.display = 'block';
+
+        setTimeout(() => {
+            progressBar.style.width = '100%';
+        }, 100);
+    }
+
+    function hideProgressBar() {
+        const progressBarContainer = document.getElementById('progressBarContainer');
+        setTimeout(() => {
+            progressBarContainer.style.display = 'none';
+            document.getElementById('timeDisplay').textContent = '';
+        }, 500);
+    }
+
+    function deleteSelectedRDBMSs() {
+        const connConfig = document.getElementById('connConfig').value;
+        const checkboxes = document.querySelectorAll('input[name="deleteCheckbox"]:checked');
+        if (checkboxes.length === 0) {
+            alert("Please select RDBMSs to delete.");
+            return;
+        }
+
+        if (!confirm("Are you sure you want to delete the selected RDBMSs?")) {
+            return;
+        }
+
+        const deletePromises = Array.from(checkboxes).map(checkbox => {
+            const rdbmsName = checkbox.value;
+            const data = {
+                ConnectionName: connConfig
+            };
+
+            return fetchWithProgress(`/spider/rdbms/${encodeURIComponent(rdbmsName)}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(data)
+            }).then(response => {
+                if (!response.ok) {
+                    return response.json().then(error => {
+                        throw new Error(error.message);
+                    });
+                }
+                return response.json();
+            });
+        });
+
+        Promise.all(deletePromises)
+            .then(() => location.reload())
+            .catch(error => {
+                alert("Error deleting RDBMSs: " + error.message);
+            });
+    }
+
+    function toggleSelectAll(source) {
+        const checkboxes = document.querySelectorAll('input[name="deleteCheckbox"]');
+        for (const checkbox of checkboxes) {
+            checkbox.checked = source.checked;
+        }
+    }
+
+    function validateForm() {
+        const rdbmsName = document.getElementById('rdbmsName').value.trim();
+        const vpcName = document.getElementById('vpcName').value.trim();
+        const dbEngine = document.getElementById('dbEngine').value.trim();
+        const dbEngineVersion = document.getElementById('dbEngineVersion').value.trim();
+        const dbInstanceSpec = document.getElementById('dbInstanceSpec').value.trim();
+        const storageSize = document.getElementById('storageSize').value.trim();
+        const masterUserName = document.getElementById('masterUserName').value.trim();
+        const masterUserPassword = document.getElementById('masterUserPassword').value.trim();
+
+        if (!rdbmsName || !vpcName || !dbEngine || !dbEngineVersion || !dbInstanceSpec || !storageSize || !masterUserName || !masterUserPassword) {
+            alert("Please fill in all required fields.");
+            return false;
+        }
+
+        return true;
+    }
+
+    function postRDBMS() {
+        if (!validateForm()) {
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+        const rdbmsName = String(document.getElementById('rdbmsName').value);
+        const vpcName = document.getElementById('vpcName').value;
+        const dbEngine = document.getElementById('dbEngine').value;
+        const dbEngineVersion = document.getElementById('dbEngineVersion').value;
+        const dbInstanceSpec = document.getElementById('dbInstanceSpec').value;
+        const storageSize = document.getElementById('storageSize').value;
+        const storageType = document.getElementById('storageType').value.trim();
+        const port = document.getElementById('port').value.trim();
+
+        const subnetNamesRaw = document.getElementById('subnetNames').value.trim();
+        const subnetNames = subnetNamesRaw ? subnetNamesRaw.split(',').map(s => s.trim()).filter(s => s) : [];
+
+        const sgNamesRaw = document.getElementById('sgNames').value.trim();
+        const sgNames = sgNamesRaw ? sgNamesRaw.split(',').map(s => s.trim()).filter(s => s) : [];
+
+        const masterUserName = document.getElementById('masterUserName').value;
+        const masterUserPassword = document.getElementById('masterUserPassword').value;
+        const databaseName = document.getElementById('databaseName').value.trim();
+
+        const highAvailability = document.getElementById('highAvailability').value === 'true';
+        const publicAccess = document.getElementById('publicAccess').value === 'true';
+        const encryption = document.getElementById('encryption').value === 'true';
+        const deletionProtection = document.getElementById('deletionProtection').value === 'true';
+        const backupRetentionDays = parseInt(document.getElementById('backupRetentionDays').value) || 0;
+        const backupTime = document.getElementById('backupTime').value.trim();
+
+        const tags = Array.from(document.querySelectorAll('.rdbms-tag-input')).map(tagInput => ({
+            Key: tagInput.querySelector('.rdbms-tag-key').value,
+            Value: tagInput.querySelector('.rdbms-tag-value').value
+        }));
+
+        const data = {
+            ConnectionName: connConfig,
+            ReqInfo: {
+                Name: rdbmsName,
+                VPCName: vpcName,
+                DBEngine: dbEngine,
+                DBEngineVersion: dbEngineVersion,
+                DBInstanceSpec: dbInstanceSpec,
+                StorageSize: storageSize,
+                StorageType: storageType || undefined,
+                Port: port || undefined,
+                SubnetNames: subnetNames.length > 0 ? subnetNames : undefined,
+                SecurityGroupNames: sgNames.length > 0 ? sgNames : undefined,
+                MasterUserName: masterUserName,
+                MasterUserPassword: masterUserPassword,
+                DatabaseName: databaseName || undefined,
+                HighAvailability: highAvailability,
+                PublicAccess: publicAccess,
+                Encryption: encryption,
+                DeletionProtection: deletionProtection,
+                BackupRetentionDays: backupRetentionDays,
+                BackupTime: backupTime || undefined,
+                TagList: tags.length > 0 ? tags : undefined
+            }
+        };
+
+        fetchWithProgress('/spider/rdbms', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        }).then(response => {
+            if (!response.ok) {
+                return response.json().then(error => {
+                    throw new Error(error.message);
+                });
+            }
+            return response.json();
+        }).then(() => {
+            location.reload();
+        }).catch(error => {
+            showErrorModal("RDBMS Creation Error", `Error creating RDBMS: ${error.message}`);
+        });
+    }
+
+    function showErrorModal(title, message) {
+        document.getElementById('errorTitle').textContent = title;
+        document.getElementById('errorMessage').textContent = message;
+        document.getElementById('errorModal').style.display = 'flex';
+        document.addEventListener('keydown', handleEscErrorModal);
+    }
+
+    function handleEscErrorModal(event) {
+        if (event.key === 'Escape') {
+            closeErrorModal();
+        }
+    }
+
+    function closeErrorModal() {
+        document.getElementById('errorModal').style.display = 'none';
+        document.removeEventListener('keydown', handleEscErrorModal);
+    }
+
+    function showOverlay() {
+        loadVPCs().then(() => {
+            const region = '{{.RegionName}}';
+            const rdbmsNameInput = document.getElementById('rdbmsName');
+            rdbmsNameInput.value = `${region}-rdbms-${Math.random().toString(36).substring(2, 5)}`;
+
+            document.getElementById('overlay').style.display = 'flex';
+            document.addEventListener('keydown', handleEsc);
+        }).catch(error => {
+            console.error('Error loading VPCs:', error);
+        });
+    }
+
+    function clearFormFields() {
+        const region = '{{.RegionName}}';
+        document.getElementById('rdbmsName').value = `${region}-rdbms-${Math.random().toString(36).substring(2, 5)}`;
+        document.getElementById('dbEngine').value = 'mysql';
+        document.getElementById('dbEngineVersion').value = '';
+        document.getElementById('dbInstanceSpec').value = '';
+        document.getElementById('storageSize').value = '20';
+        document.getElementById('storageType').value = '';
+        document.getElementById('port').value = '';
+        document.getElementById('subnetNames').value = '';
+        document.getElementById('sgNames').value = '';
+        document.getElementById('masterUserName').value = '';
+        document.getElementById('masterUserPassword').value = '';
+        document.getElementById('databaseName').value = '';
+        document.getElementById('highAvailability').value = 'false';
+        document.getElementById('publicAccess').value = 'false';
+        document.getElementById('encryption').value = 'false';
+        document.getElementById('deletionProtection').value = 'false';
+        document.getElementById('backupRetentionDays').value = '0';
+        document.getElementById('backupTime').value = '';
+        document.querySelectorAll('.rdbms-tag-input').forEach(tagInput => tagInput.remove());
+    }
+
+    function hideOverlay(pos) {
+        const overlayId = pos || 'overlay';
+        document.getElementById(overlayId).style.display = 'none';
+        document.removeEventListener('keydown', handleEsc);
+        clearFormFields();
+    }
+
+    function handleEsc(event) {
+        if (event.key === "Escape") {
+            hideOverlay();
+        }
+    }
+
+    function loadVPCs() {
+        const connConfig = document.getElementById('connConfig').value;
+        const url = `/spider/vpc?ConnectionName=${encodeURIComponent(connConfig)}`;
+
+        return fetchWithProgress(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            const vpcSelect = document.getElementById('vpcName');
+            vpcSelect.innerHTML = '';
+            if (data.vpc && data.vpc.length > 0) {
+                data.vpc.forEach((vpc, index) => {
+                    const option = document.createElement('option');
+                    option.value = vpc.IId.NameId;
+                    option.text = `${vpc.IId.NameId} (${vpc.IPv4_CIDR})`;
+                    vpcSelect.appendChild(option);
+                    if (index === 0) {
+                        vpcSelect.value = vpc.IId.NameId;
+                    }
+                });
+            } else {
+                const option = document.createElement('option');
+                option.value = "";
+                option.text = "No VPCs. Create one.";
+                vpcSelect.appendChild(option);
+                vpcSelect.disabled = true;
+            }
+        })
+        .catch(error => {
+            console.error('Error loading VPCs:', error);
+            throw error;
+        });
+    }
+
+    function addRDBMSTagField() {
+        const tagContainer = document.getElementById('rdbms-tag-container');
+        const tagInput = document.createElement('div');
+        tagInput.className = 'rdbms-tag-input tag-input-group';
+        tagInput.innerHTML = `
+            <input type="text" class="rdbms-tag-key" placeholder="Key" required>
+            <input type="text" class="rdbms-tag-value" placeholder="Value" required>
+            <button type="button" onclick="removeTagField(this)">-</button>
+        `;
+        tagContainer.appendChild(tagInput);
+    }
+
+    function removeTagField(button) {
+        button.parentElement.remove();
+    }
+
+    function showMiscOverlay(button) {
+        const miscContent = button.previousElementSibling.innerHTML;
+        const overlayDarkBackground = document.createElement('div');
+        overlayDarkBackground.className = 'overlay-dark-background';
+        document.body.appendChild(overlayDarkBackground);
+
+        const overlay = document.createElement('div');
+        overlay.className = 'misc-overlay';
+        overlay.innerHTML = `
+            <button class="overlay-close-btn" onclick="this.parentElement.remove(); document.querySelector('.overlay-dark-background').remove();">X</button>
+            <div class="misc-overlay-content" tabindex="0">${miscContent}</div>
+        `;
+
+        document.body.appendChild(overlay);
+        overlayDarkBackground.style.display = 'block';
+        overlay.style.display = 'block';
+
+        const overlayContent = overlay.querySelector('.misc-overlay-content');
+        overlayContent.focus();
+
+        function closeMiscOverlay() {
+            if (overlay) overlay.remove();
+            if (overlayDarkBackground) overlayDarkBackground.remove();
+            document.removeEventListener('keydown', handleEscKey);
+            overlayDarkBackground.removeEventListener('click', handleClickOutside);
+        }
+
+        function handleEscKey(event) {
+            if (event.key === 'Escape') {
+                closeMiscOverlay();
+            }
+        }
+
+        function handleClickOutside(event) {
+            if (event.target === overlayDarkBackground) {
+                closeMiscOverlay();
+            }
+        }
+
+        document.addEventListener('keydown', handleEscKey);
+        overlayDarkBackground.addEventListener('click', handleClickOutside);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const miscCells = document.querySelectorAll('.misc-cell');
+
+        miscCells.forEach(cell => {
+            const content = cell.querySelector('.misc-content');
+            const button = cell.querySelector('.more-btn');
+
+            if (content.scrollHeight > content.clientHeight) {
+                button.style.display = 'inline-block';
+            } else {
+                button.style.display = 'none';
+            }
+        });
+    });
+
+    function showTagOverlay(event, tag, resourceType, resourceName) {
+        event.stopPropagation();
+        const tagOverlay = document.getElementById('tag-overlay');
+        const tagOverlayContent = document.querySelector('.tag-overlay-content');
+        tagOverlayContent.innerHTML = `
+            <button class="overlay-close-btn" onclick="closeTagOverlay()">X</button>
+            <p>${tag}</p>
+            <div class="button-group">
+                <button onclick="deleteTag('${tag}', '${resourceType}', '${resourceName}')">Delete</button>
+                <button onclick="closeTagOverlay()">Cancel</button>
+            </div>
+        `;
+        tagOverlay.style.display = 'block';
+        tagOverlay.style.top = `${event.clientY}px`;
+        tagOverlay.style.left = `${event.clientX}px`;
+        document.addEventListener('click', handleClickOutsideOverlay);
+        document.addEventListener('keydown', handleEscTagOverlay);
+    }
+
+    function deleteTag(tag, resourceType, resourceName) {
+        const connConfig = document.getElementById('connConfig').value;
+        const [tagKey, tagValue] = tag.split(': ');
+
+        const data = {
+            ConnectionName: connConfig,
+            ReqInfo: {
+                ResourceType: resourceType.trim(),
+                ResourceName: resourceName.trim()
+            }
+        };
+
+        fetchWithProgress(`/spider/tag/${tagKey.trim()}`, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        }).then(response => {
+            if (!response.ok) {
+                return response.json().then(error => {
+                    throw new Error(error.message);
+                });
+            }
+            return response.json();
+        }).then(() => {
+            closeTagOverlay();
+            location.reload();
+        }).catch(error => {
+            showErrorModal("Tag Deletion Error", "Error deleting tag from " + resourceName + ": " + error.message);
+        });
+    }
+
+    function closeTagOverlay() {
+        const tagOverlay = document.getElementById('tag-overlay');
+        tagOverlay.style.display = 'none';
+        document.removeEventListener('click', handleClickOutsideOverlay);
+        document.removeEventListener('keydown', handleEscTagOverlay);
+    }
+
+    function handleEscTagOverlay(event) {
+        if (event.key === "Escape") {
+            closeTagOverlay();
+        }
+    }
+
+    function handleClickOutsideOverlay(event) {
+        const tagOverlay = document.getElementById('tag-overlay');
+        if (!tagOverlay.contains(event.target)) {
+            closeTagOverlay();
+        }
+    }
+
+    function showAddTagOverlay(rdbmsName) {
+        const addTagOverlay = document.getElementById('add-tag-overlay');
+        const addTagOverlayContent = document.querySelector('.add-tag-overlay-content');
+        addTagOverlayContent.innerHTML = `
+            <button type="button" class="overlay-close-btn" onclick="closeAddTagOverlay()">X</button>
+            <div class="tag-overlay-input-group">
+                <label for="tagOverlayTagKey">Tag Key:</label>
+                <input type="text" id="tagOverlayTagKey" name="tagKey" required>
+            </div>
+            <div class="tag-overlay-input-group">
+                <label for="tagOverlayTagValue">Tag Value:</label>
+                <input type="text" id="tagOverlayTagValue" name="tagValue" required>
+            </div>
+            <div class="tag-overlay-button-group">
+                <button onclick="addTag('${rdbmsName}')">Add</button>
+                <button onclick="closeAddTagOverlay()">Cancel</button>
+            </div>
+        `;
+        addTagOverlay.style.display = 'flex';
+        document.addEventListener('keydown', handleEscAddTagOverlay);
+    }
+
+    function closeAddTagOverlay() {
+        const addTagOverlay = document.getElementById('add-tag-overlay');
+        addTagOverlay.style.display = 'none';
+        document.removeEventListener('keydown', handleEscAddTagOverlay);
+    }
+
+    function handleEscAddTagOverlay(event) {
+        if (event.key === "Escape") {
+            closeAddTagOverlay();
+        }
+    }
+
+    function addTag(rdbmsName) {
+        const tagKey = document.getElementById('tagOverlayTagKey').value;
+        const tagValue = document.getElementById('tagOverlayTagValue').value;
+        const connConfig = document.getElementById('connConfig').value;
+        if (!tagKey) {
+            alert("Please enter Tag Key.");
+            return;
+        }
+
+        const data = {
+            ConnectionName: connConfig,
+            ReqInfo: {
+                ResourceType: 'RDBMS',
+                ResourceName: rdbmsName,
+                Tag: { Key: tagKey, Value: tagValue }
+            }
+        };
+        fetchWithProgress('/spider/tag', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        }).then(response => {
+            if (!response.ok) {
+                return response.json().then(error => {
+                    throw new Error(error.message);
+                });
+            }
+            return response.json();
+        }).then(() => {
+            closeAddTagOverlay();
+            location.reload();
+        }).catch(error => {
+            showErrorModal("Tag Addition Error", "Error adding tag to RDBMS '" + rdbmsName + "': " + error.message);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        const timeElements = document.querySelectorAll('.rdbms-created-time');
+
+        timeElements.forEach(function(element) {
+            const originalTime = element.getAttribute('data-time');
+            if (originalTime) {
+                const formattedTime = formatTime(originalTime);
+                element.innerHTML = '&nbsp;• ' + formattedTime;
+            }
+        });
+
+        function formatTime(originalTime) {
+            const parts = originalTime.split(" ");
+            if (parts.length >= 4) {
+                const date = parts[0];
+                const time = parts[1].slice(0, 5);
+                const timezone = parts[3];
+                return `${date} ${time} ${timezone}`;
+            }
+            return originalTime;
+        }
+    });
+
+    function showSystemIdOverlay(systemId) {
+        const overlay = document.getElementById('system-id-overlay');
+        const fullSystemIdElement = document.getElementById('fullSystemId');
+        fullSystemIdElement.textContent = systemId;
+
+        overlay.style.display = 'block';
+        document.addEventListener('keydown', handleEscSystemIdOverlay);
+    }
+
+    function closeSystemIdOverlay() {
+        const overlay = document.getElementById('system-id-overlay');
+        overlay.style.display = 'none';
+        document.removeEventListener('keydown', handleEscSystemIdOverlay);
+    }
+
+    function handleEscSystemIdOverlay(event) {
+        if (event.key === "Escape") {
+            closeSystemIdOverlay();
+        }
+    }
+
+    function copySystemId() {
+        const fullSystemIdElement = document.getElementById('fullSystemId');
+        const range = document.createRange();
+        range.selectNode(fullSystemIdElement);
+        const selection = window.getSelection();
+
+        selection.removeAllRanges();
+        selection.addRange(range);
+
+        try {
+            document.execCommand('copy');
+            closeSystemIdOverlay();
+        } catch (err) {
+            console.error('Error copying SystemId: ', err);
+        }
+
+        selection.removeAllRanges();
+    }
+
+    // ==================== DB Detail Panel ====================
+    let currentRDBMS = null;
+    let currentDBPassword = null;
+    let currentDBName = null;
+    let currentTable = null;
+    let currentTableColumns = [];
+
+    function showDBPanel(rdbmsName) {
+        currentRDBMS = rdbmsName;
+        currentDBPassword = null;
+        currentDBName = null;
+        currentTable = null;
+        currentTableColumns = [];
+
+        // Clear previous selection
+        document.querySelectorAll('tr.selected-rdbms').forEach(el => el.classList.remove('selected-rdbms'));
+
+        // Highlight selected row
+        const table = document.getElementById('rdbms-table');
+        const rows = table.getElementsByTagName('tr');
+        for (let i = 1; i < rows.length; i++) {
+            const nameCell = rows[i].querySelector('.rdbms-name');
+            if (nameCell && nameCell.textContent.trim().startsWith(rdbmsName)) {
+                rows[i].classList.add('selected-rdbms');
+                break;
+            }
+        }
+
+        // Show panel
+        const panel = document.getElementById('db-panel');
+        panel.style.display = 'block';
+
+        // Update title
+        document.getElementById('db-panel-title').innerHTML =
+            '<span style="background: #e3f2fd; color: #1976d2; padding: 4px 10px; border-radius: 4px;">🗄️ ' + rdbmsName + '</span>';
+
+        // Reset state
+        document.getElementById('dbPassword').value = '';
+        document.getElementById('dbConnectStatus').textContent = '';
+        document.getElementById('dbConnectStatus').className = 'db-connect-status';
+        document.getElementById('db-database-panel').style.display = 'none';
+        document.getElementById('db-table-panel').style.display = 'none';
+        document.getElementById('db-row-panel').style.display = 'none';
+
+        // Scroll to panel
+        panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        // Auto-focus password input
+        setTimeout(function() { document.getElementById('dbPassword').focus(); }, 100);
+    }
+
+    function hideDBPanel() {
+        document.getElementById('db-panel').style.display = 'none';
+        document.querySelectorAll('tr.selected-rdbms').forEach(el => el.classList.remove('selected-rdbms'));
+        currentRDBMS = null;
+        currentDBPassword = null;
+        currentTable = null;
+    }
+
+    function connectToDB() {
+        const password = document.getElementById('dbPassword').value;
+        if (!password) {
+            alert('Please enter the database password.');
+            return;
+        }
+        if (!currentRDBMS) {
+            alert('No RDBMS selected.');
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+        const statusEl = document.getElementById('dbConnectStatus');
+        statusEl.textContent = 'Connecting...';
+        statusEl.className = 'db-connect-status';
+
+        showLoading();
+        // Connect without specifying a database to test connectivity
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/connect`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ConnectionName: connConfig, Password: password, DatabaseName: '' })
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                statusEl.textContent = '✗ ' + data.error;
+                statusEl.className = 'db-connect-status error';
+                return;
+            }
+            currentDBPassword = password;
+            currentDBName = null;
+            statusEl.textContent = '✓ Connected — Select a database below';
+            statusEl.className = 'db-connect-status connected';
+
+            // Show database list panel
+            document.getElementById('db-database-panel').style.display = 'block';
+            document.getElementById('db-table-panel').style.display = 'none';
+            document.getElementById('db-row-panel').style.display = 'none';
+            loadDatabases();
+        })
+        .catch(error => {
+            hideLoading();
+            statusEl.textContent = '✗ ' + error.message;
+            statusEl.className = 'db-connect-status error';
+        });
+    }
+
+    function disconnectDB() {
+        currentDBPassword = null;
+        currentDBName = null;
+        currentTable = null;
+        document.getElementById('dbConnectStatus').textContent = 'Disconnected';
+        document.getElementById('dbConnectStatus').className = 'db-connect-status';
+        document.getElementById('db-database-panel').style.display = 'none';
+        document.getElementById('db-table-panel').style.display = 'none';
+        document.getElementById('db-row-panel').style.display = 'none';
+    }
+
+    function loadDatabases() {
+        const connConfig = document.getElementById('connConfig').value;
+
+        document.getElementById('db-database-breadcrumb').innerHTML =
+            `<span style="background: #e3f2fd; color: #1976d2; padding: 3px 8px; border-radius: 4px; font-weight: bold;">🗄️ ${escapeHtml(currentRDBMS)}</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="font-weight: bold;">Databases</span>`;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/databases`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ConnectionName: connConfig, Password: currentDBPassword, DatabaseName: '' })
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Database List Error', data.error);
+                return;
+            }
+
+            const databases = data.databases || [];
+            document.getElementById('db-database-count').textContent = `${databases.length} database(s)`;
+            const body = document.getElementById('db-database-list-body');
+            body.innerHTML = '';
+
+            if (databases.length === 0) {
+                body.innerHTML = '<tr><td colspan="3" style="text-align: center;">No databases found.</td></tr>';
+                return;
+            }
+
+            databases.forEach((db, idx) => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td style="text-align: center;">${idx + 1}</td>
+                    <td style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="selectDatabase('${escapeHtml(db)}')">${escapeHtml(db)}</td>
+                    <td style="text-align: center;">
+                        <button onclick="dropDatabase('${escapeHtml(db)}')" style="color: red; font-size: 11px;">Drop</button>
+                    </td>
+                `;
+                body.appendChild(tr);
+            });
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Database List Error', error.message);
+        });
+    }
+
+    function selectDatabase(dbName) {
+        currentDBName = dbName;
+        currentTable = null;
+
+        // Update connection status
+        document.getElementById('dbConnectStatus').textContent = '✓ Connected (' + dbName + ')';
+
+        // Show table panel, hide row panel
+        document.getElementById('db-table-panel').style.display = 'block';
+        document.getElementById('db-row-panel').style.display = 'none';
+        loadTables();
+    }
+
+    function backToDatabases() {
+        currentDBName = null;
+        currentTable = null;
+        document.getElementById('dbConnectStatus').textContent = '✓ Connected — Select a database below';
+        document.getElementById('db-table-panel').style.display = 'none';
+        document.getElementById('db-row-panel').style.display = 'none';
+        loadDatabases();
+    }
+
+    // --- Create / Drop Database ---
+    function showCreateDatabaseOverlay() {
+        document.getElementById('newDatabaseName').value = '';
+        document.getElementById('createDatabaseOverlay').style.display = 'flex';
+        setTimeout(function() { document.getElementById('newDatabaseName').focus(); }, 100);
+    }
+
+    function hideCreateDatabaseOverlay() {
+        document.getElementById('createDatabaseOverlay').style.display = 'none';
+    }
+
+    function createDatabase() {
+        const dbName = document.getElementById('newDatabaseName').value.trim();
+        if (!dbName) {
+            alert('Please enter a database name.');
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/databases/create`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ConnectionName: connConfig, Password: currentDBPassword, DatabaseName: dbName })
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Create Database Error', data.error);
+                return;
+            }
+            hideCreateDatabaseOverlay();
+            loadDatabases();
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Create Database Error', error.message);
+        });
+    }
+
+    function dropDatabase(dbName) {
+        if (!confirm(`Are you sure you want to DROP database "${dbName}"? This will delete all tables and data. This cannot be undone.`)) {
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/databases/${encodeURIComponent(dbName)}/drop`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ConnectionName: connConfig, Password: currentDBPassword })
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Drop Database Error', data.error);
+                return;
+            }
+            // If the dropped database was the current one, reset to database list
+            if (currentDBName === dbName) {
+                currentDBName = null;
+                currentTable = null;
+                document.getElementById('dbConnectStatus').textContent = '✓ Connected — Select a database below';
+                document.getElementById('db-table-panel').style.display = 'none';
+                document.getElementById('db-row-panel').style.display = 'none';
+            }
+            loadDatabases();
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Drop Database Error', error.message);
+        });
+    }
+
+    function loadTables() {
+        const connConfig = document.getElementById('connConfig').value;
+
+        updateBreadcrumb();
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody())
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Table List Error', data.error);
+                return;
+            }
+
+            const tables = data.tables || [];
+            document.getElementById('db-table-count').textContent = `${tables.length} table(s)`;
+            const body = document.getElementById('db-table-list-body');
+            body.innerHTML = '';
+
+            if (tables.length === 0) {
+                body.innerHTML = '<tr><td colspan="3" style="text-align: center;">No tables found.</td></tr>';
+                return;
+            }
+
+            tables.forEach((t, idx) => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td style="text-align: center;">${idx + 1}</td>
+                    <td style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="selectTable('${escapeHtml(t)}')">${escapeHtml(t)}</td>
+                    <td style="text-align: center;">
+                        <button onclick="dropTable('${escapeHtml(t)}')" style="color: red; font-size: 11px;">Drop</button>
+                    </td>
+                `;
+                body.appendChild(tr);
+            });
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Table List Error', error.message);
+        });
+    }
+
+    function selectTable(tableName) {
+        currentTable = tableName;
+        document.getElementById('db-row-panel').style.display = 'block';
+
+        updateRowBreadcrumb();
+        loadRows(tableName);
+    }
+
+    function loadRows(tableName) {
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/${encodeURIComponent(tableName)}/rows`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody())
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Row List Error', data.error);
+                return;
+            }
+
+            const columns = data.columns || [];
+            const rows = data.rows || [];
+            currentTableColumns = columns;
+
+            document.getElementById('db-row-count').textContent = `${data.count} row(s) (max 200)`;
+
+            // Build header
+            const thead = document.getElementById('db-row-table-head');
+            let headerHtml = '<tr><th style="width: 4%;">#</th>';
+            columns.forEach(col => {
+                headerHtml += `<th>${escapeHtml(col)}</th>`;
+            });
+            headerHtml += '<th style="width: 6%;">Actions</th></tr>';
+            thead.innerHTML = headerHtml;
+
+            // Build rows
+            const tbody = document.getElementById('db-row-table-body');
+            tbody.innerHTML = '';
+
+            if (rows.length === 0) {
+                tbody.innerHTML = `<tr><td colspan="${columns.length + 2}" style="text-align: center;">No rows found.</td></tr>`;
+                return;
+            }
+
+            rows.forEach((row, idx) => {
+                const tr = document.createElement('tr');
+                let html = `<td style="text-align: center;">${idx + 1}</td>`;
+                columns.forEach(col => {
+                    const val = row[col];
+                    const display = val === null ? '<em style="color: #999;">NULL</em>' : escapeHtml(String(val));
+                    html += `<td>${display}</td>`;
+                });
+
+                // Build where clause from row data for delete
+                const whereData = {};
+                columns.forEach(col => {
+                    if (row[col] !== null) {
+                        whereData[col] = String(row[col]);
+                    }
+                });
+                const whereStr = btoa(JSON.stringify(whereData));
+
+                html += `<td style="text-align: center;"><button onclick="deleteRow('${whereStr}')" style="color: red; font-size: 11px;">Del</button></td>`;
+                tr.innerHTML = html;
+                tbody.appendChild(tr);
+            });
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Row List Error', error.message);
+        });
+    }
+
+    function updateBreadcrumb() {
+        document.getElementById('db-breadcrumb').innerHTML =
+            `<span style="background: #e3f2fd; color: #1976d2; padding: 3px 8px; border-radius: 4px; font-weight: bold; cursor: pointer;" onclick="backToDatabases()">🗄️ ${escapeHtml(currentRDBMS)}</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="backToDatabases()">Databases</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="font-weight: bold;">📁 ${escapeHtml(currentDBName)}</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="font-weight: bold;">Tables</span>`;
+    }
+
+    function updateRowBreadcrumb() {
+        document.getElementById('db-row-breadcrumb').innerHTML =
+            `<span style="background: #e3f2fd; color: #1976d2; padding: 3px 8px; border-radius: 4px; font-weight: bold; cursor: pointer;" onclick="backToDatabases()">🗄️ ${escapeHtml(currentRDBMS)}</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="backToDatabases()">Databases</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="backToTables()">📁 ${escapeHtml(currentDBName)}</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="cursor: pointer; color: #0066cc; font-weight: bold;" onclick="backToTables()">Tables</span>` +
+            `<span style="color: #666; margin: 0 5px;">/</span>` +
+            `<span style="font-weight: bold;">📋 ${escapeHtml(currentTable)}</span>`;
+    }
+
+    function backToTables() {
+        currentTable = null;
+        document.getElementById('db-row-panel').style.display = 'none';
+        loadTables();
+    }
+
+    // --- Create Table ---
+    function showCreateTableOverlay() {
+        document.getElementById('newTableName').value = '';
+        const colContainer = document.getElementById('createTableColumns');
+        colContainer.innerHTML = '';
+        addColumnField();
+        document.getElementById('createTableOverlay').style.display = 'flex';
+        setTimeout(function() { document.getElementById('newTableName').focus(); }, 100);
+    }
+
+    function hideCreateTableOverlay() {
+        document.getElementById('createTableOverlay').style.display = 'none';
+    }
+
+    function addColumnField() {
+        const container = document.getElementById('createTableColumns');
+        const div = document.createElement('div');
+        div.className = 'form-group create-table-col';
+        div.innerHTML = `
+            <input type="text" placeholder="Column Name" class="col-name" style="width: 25%;" required>
+            <select class="col-type" style="width: 25%;">
+                <option value="INT">INT</option>
+                <option value="BIGINT">BIGINT</option>
+                <option value="VARCHAR(255)" selected>VARCHAR(255)</option>
+                <option value="TEXT">TEXT</option>
+                <option value="BOOLEAN">BOOLEAN</option>
+                <option value="DATE">DATE</option>
+                <option value="DATETIME">DATETIME</option>
+                <option value="TIMESTAMP">TIMESTAMP</option>
+                <option value="FLOAT">FLOAT</option>
+                <option value="DOUBLE">DOUBLE</option>
+                <option value="DECIMAL(10,2)">DECIMAL(10,2)</option>
+            </select>
+            <label style="font-size: 11px;"><input type="checkbox" class="col-pk"> PK</label>
+            <label style="font-size: 11px;"><input type="checkbox" class="col-notnull"> NOT NULL</label>
+            <button type="button" onclick="this.parentElement.remove()">-</button>
+        `;
+        container.appendChild(div);
+    }
+
+    function createTable() {
+        const tableName = document.getElementById('newTableName').value.trim();
+        if (!tableName) {
+            alert('Please enter a table name.');
+            return;
+        }
+
+        const colDivs = document.querySelectorAll('.create-table-col');
+        const columns = [];
+        for (const div of colDivs) {
+            const name = div.querySelector('.col-name').value.trim();
+            const type = div.querySelector('.col-type').value;
+            const pk = div.querySelector('.col-pk').checked;
+            const notnull = div.querySelector('.col-notnull').checked;
+            if (!name) {
+                alert('Please fill in all column names.');
+                return;
+            }
+            columns.push({ Name: name, Type: type, PrimaryKey: pk, NotNull: notnull });
+        }
+
+        if (columns.length === 0) {
+            alert('At least one column is required.');
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/create`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody({ TableName: tableName, Columns: columns }))
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Create Table Error', data.error);
+                return;
+            }
+            hideCreateTableOverlay();
+            loadTables();
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Create Table Error', error.message);
+        });
+    }
+
+    function dropTable(tableName) {
+        if (!confirm(`Are you sure you want to DROP table "${tableName}"? This cannot be undone.`)) {
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/${encodeURIComponent(tableName)}/drop`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody())
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Drop Table Error', data.error);
+                return;
+            }
+            // If the dropped table was the current one, hide row panel
+            if (currentTable === tableName) {
+                currentTable = null;
+                document.getElementById('db-row-panel').style.display = 'none';
+            }
+            loadTables();
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Drop Table Error', error.message);
+        });
+    }
+
+    // --- Insert/Delete Row ---
+    function showInsertRowOverlay() {
+        if (!currentTable || currentTableColumns.length === 0) {
+            // Need to describe table first to get columns
+            const connConfig = document.getElementById('connConfig').value;
+            fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/${encodeURIComponent(currentTable)}/describe`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(dbRequestBody())
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.error) {
+                    showErrorModal('Describe Table Error', data.error);
+                    return;
+                }
+                buildInsertForm(data.columns || []);
+                document.getElementById('insertRowOverlay').style.display = 'flex';
+                setTimeout(function() { var f = document.querySelector('.insert-row-value'); if (f) f.focus(); }, 100);
+            })
+            .catch(error => {
+                showErrorModal('Describe Table Error', error.message);
+            });
+        } else {
+            // Use columns from the row data
+            buildInsertFormFromColumnNames(currentTableColumns);
+            document.getElementById('insertRowOverlay').style.display = 'flex';
+            setTimeout(function() { var f = document.querySelector('.insert-row-value'); if (f) f.focus(); }, 100);
+        }
+    }
+
+    function buildInsertForm(columns) {
+        const container = document.getElementById('insertRowFields');
+        container.innerHTML = `<p style="font-weight: bold; margin-bottom: 10px;">Table: ${escapeHtml(currentTable)}</p>`;
+        columns.forEach(col => {
+            const div = document.createElement('div');
+            div.className = 'form-group';
+            div.innerHTML = `
+                <label title="${escapeHtml(col.Type)} ${col.Nullable === 'YES' ? '(nullable)' : '(NOT NULL)'} ${col.Key === 'PRI' ? '[PK]' : ''}">${escapeHtml(col.Name)}:</label>
+                <input type="text" class="insert-row-value" data-column="${escapeHtml(col.Name)}" placeholder="${escapeHtml(col.Type)}" style="width: 65%;">
+            `;
+            container.appendChild(div);
+        });
+    }
+
+    function buildInsertFormFromColumnNames(columns) {
+        const container = document.getElementById('insertRowFields');
+        container.innerHTML = `<p style="font-weight: bold; margin-bottom: 10px;">Table: ${escapeHtml(currentTable)}</p>`;
+        columns.forEach(col => {
+            const div = document.createElement('div');
+            div.className = 'form-group';
+            div.innerHTML = `
+                <label>${escapeHtml(col)}:</label>
+                <input type="text" class="insert-row-value" data-column="${escapeHtml(col)}" style="width: 65%;">
+            `;
+            container.appendChild(div);
+        });
+    }
+
+    function hideInsertRowOverlay() {
+        document.getElementById('insertRowOverlay').style.display = 'none';
+    }
+
+    function insertRow() {
+        const inputs = document.querySelectorAll('.insert-row-value');
+        const values = {};
+        let hasValue = false;
+        inputs.forEach(input => {
+            const col = input.getAttribute('data-column');
+            const val = input.value;
+            if (val !== '') {
+                values[col] = val;
+                hasValue = true;
+            }
+        });
+
+        if (!hasValue) {
+            alert('Please enter at least one value.');
+            return;
+        }
+
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/${encodeURIComponent(currentTable)}/rows/insert`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody({ Values: values }))
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Insert Row Error', data.error);
+                return;
+            }
+            hideInsertRowOverlay();
+            loadRows(currentTable);
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Insert Row Error', error.message);
+        });
+    }
+
+    function deleteRow(whereBase64) {
+        if (!confirm('Are you sure you want to delete this row?')) {
+            return;
+        }
+
+        const whereData = JSON.parse(atob(whereBase64));
+        const connConfig = document.getElementById('connConfig').value;
+
+        showLoading();
+        fetch(`/spider/adminweb/rdbms/${encodeURIComponent(currentRDBMS)}/sql/tables/${encodeURIComponent(currentTable)}/rows/delete`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(dbRequestBody({ Where: whereData }))
+        })
+        .then(response => response.json())
+        .then(data => {
+            hideLoading();
+            if (data.error) {
+                showErrorModal('Delete Row Error', data.error);
+                return;
+            }
+            loadRows(currentTable);
+        })
+        .catch(error => {
+            hideLoading();
+            showErrorModal('Delete Row Error', error.message);
+        });
+    }
+
+    function escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    // Helper to build common request body with connection info
+    function dbRequestBody(extra = {}) {
+        const connConfig = document.getElementById('connConfig').value;
+        return Object.assign({ ConnectionName: connConfig, Password: currentDBPassword, DatabaseName: currentDBName || '' }, extra);
+    }
+
+    // --- Loading Spinner ---
+    function showLoading() {
+        document.getElementById('loadingOverlay').classList.add('active');
+    }
+    function hideLoading() {
+        document.getElementById('loadingOverlay').classList.remove('active');
+    }
+
+    // --- Auto-select first RDBMS on page load ---
+    document.addEventListener('DOMContentLoaded', function() {
+        var firstRow = document.querySelector('#rdbms-table tr[id^="rdbms-row-"]');
+        if (firstRow) {
+            var nameCell = firstRow.querySelector('.rdbms-name');
+            if (nameCell) {
+                var rdbmsName = nameCell.textContent.trim().split('\n')[0].trim();
+                if (rdbmsName) {
+                    showDBPanel(rdbmsName);
+                }
+            }
+        }
+    });
+
+    // --- Enter key on password triggers Connect ---
+    document.addEventListener('DOMContentLoaded', function() {
+        var pwField = document.getElementById('dbPassword');
+        if (pwField) {
+            pwField.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    connectToDB();
+                }
+            });
+        }
+    });
+
+</script>
+
+<!-- Loading Overlay -->
+<div id="loadingOverlay" class="loading-overlay">
+    <div class="spinner"></div>
+    <span class="loading-text">Loading...</span>
+</div>
+
+</html>

--- a/api/docs.go
+++ b/api/docs.go
@@ -491,6 +491,87 @@ const docTemplate = `{
                 }
             }
         },
+        "/allrdbms": {
+            "get": {
+                "description": "Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List All RDBMS in a Connection",
+                "operationId": "list-all-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of all RDBMS instances within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both.",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/allrdbmsinfo": {
+            "get": {
+                "description": "Retrieve a list of all RDBMS information associated with all connections.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List All RDBMS Info",
+                "operationId": "list-all-rdbms-info",
+                "responses": {
+                    "200": {
+                        "description": "List of all RDBMS information across all connections",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/allsecuritygroup": {
             "get": {
                 "description": "Retrieve a comprehensive list of all Security Groups associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
@@ -2216,6 +2297,69 @@ const docTemplate = `{
                 }
             }
         },
+        "/countrdbms": {
+            "get": {
+                "description": "Get the total number of RDBMS instances across all connections.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Count All RDBMS",
+                "operationId": "count-all-rdbms",
+                "responses": {
+                    "200": {
+                        "description": "Total count of RDBMS instances",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/countrdbms/{ConnectionName}": {
+            "get": {
+                "description": "Get the total number of RDBMS instances for a specific connection.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Count RDBMS by Connection",
+                "operationId": "count-rdbms-by-connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Total count of RDBMS instances for the connection",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/counts3/{ConnectionName}": {
             "get": {
                 "description": "Get the total number of S3 buckets for a specific connection.",
@@ -2933,6 +3077,66 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "The CSP NLB ID to delete",
+                        "name": "Id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/csprdbms/{Id}": {
+            "delete": {
+                "description": "Delete a specified CSP RDBMS.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Delete CSP RDBMS",
+                "operationId": "delete-csp-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting a CSP RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP RDBMS ID to delete",
                         "name": "Id",
                         "in": "path",
                         "required": true
@@ -4267,6 +4471,58 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/getrdbmsowner": {
+            "get": {
+                "description": "Retrieve the Owner VPC of a given RDBMS CSP ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS Owner VPC",
+                "operationId": "get-rdbms-owner-vpc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP RDBMS ID",
+                        "name": "CSPId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Owner VPC IID",
+                        "schema": {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
                         "schema": {
                             "$ref": "#/definitions/spider.SimpleMsg"
                         }
@@ -6338,6 +6594,275 @@ const docTemplate = `{
                 }
             }
         },
+        "/rdbms": {
+            "get": {
+                "description": "Retrieve a list of RDBMS instances associated with a specific connection.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List RDBMS",
+                "operationId": "list-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of RDBMS instances",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new Relational Database (RDBMS) with the specified configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Create RDBMS",
+                "operationId": "create-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for creating an RDBMS",
+                        "name": "RDBMSCreateRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the created RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/rdbms/{Name}": {
+            "get": {
+                "description": "Retrieve details of a specific RDBMS instance.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS",
+                "operationId": "get-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to get an RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to retrieve",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a specified RDBMS instance.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Delete RDBMS",
+                "operationId": "delete-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting an RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to delete",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Force delete the RDBMS. ex) true or false(default: false)",
+                        "name": "force",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/rdbmsmetainfo": {
+            "get": {
+                "description": "Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS Meta Information",
+                "operationId": "get-rdbms-metainfo",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RDBMS MetaInfo for the CSP",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSMetaInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/readyz": {
             "get": {
                 "description": "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]",
@@ -7171,6 +7696,119 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "The name of the NLB to unregister",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the unregister operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regrdbms": {
+            "post": {
+                "description": "Register a new RDBMS with the specified name and CSP ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Register RDBMS",
+                "operationId": "register-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for registering an RDBMS",
+                        "name": "RDBMSRegisterRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSRegisterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the registered RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regrdbms/{Name}": {
+            "delete": {
+                "description": "Unregister an RDBMS with the specified name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Unregister RDBMS",
+                "operationId": "unregister-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for unregistering an RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to unregister",
                         "name": "Name",
                         "in": "path",
                         "required": true
@@ -11236,13 +11874,11 @@ const docTemplate = `{
                 },
                 "avgCreationTime": {
                     "description": "Average VM creation time in seconds",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "creationCount": {
                     "description": "Number of successful VM creations",
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "csp": {
                     "type": "string"
@@ -12548,6 +13184,235 @@ const docTemplate = `{
                 }
             }
         },
+        "spider.RDBMSInfo": {
+            "description": "Relational Database (RDBMS) Information",
+            "type": "object",
+            "required": [
+                "DBEngine",
+                "DBEngineVersion",
+                "DBInstanceSpec",
+                "IId",
+                "MasterUserName",
+                "Status",
+                "StorageSize",
+                "VpcIID"
+            ],
+            "properties": {
+                "BackupRetentionDays": {
+                    "description": "Backup",
+                    "type": "integer",
+                    "example": 7
+                },
+                "BackupTime": {
+                    "description": "Preferred backup time (HH:MM in UTC)",
+                    "type": "string",
+                    "example": "03:00"
+                },
+                "CreatedTime": {
+                    "type": "string"
+                },
+                "DBEngine": {
+                    "description": "DB Engine",
+                    "type": "string",
+                    "example": "mysql"
+                },
+                "DBEngineVersion": {
+                    "description": "e.g., \"8.0\", \"10.6\", \"15\"",
+                    "type": "string",
+                    "example": "8.0"
+                },
+                "DBInstanceSpec": {
+                    "description": "Instance Spec",
+                    "type": "string",
+                    "example": "db.t3.medium"
+                },
+                "DBInstanceType": {
+                    "description": "Primary | ReadReplica (for response)",
+                    "type": "string",
+                    "example": "Primary"
+                },
+                "DatabaseName": {
+                    "description": "Database",
+                    "type": "string",
+                    "example": "mydb"
+                },
+                "DeletionProtection": {
+                    "description": "Protection",
+                    "type": "boolean",
+                    "default": false
+                },
+                "Encryption": {
+                    "description": "Encryption",
+                    "type": "boolean",
+                    "default": false
+                },
+                "Endpoint": {
+                    "description": "Connection endpoint (for response)",
+                    "type": "string"
+                },
+                "HighAvailability": {
+                    "description": "High Availability \u0026 Replication",
+                    "type": "boolean",
+                    "default": false
+                },
+                "IId": {
+                    "description": "{NameId, SystemId}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    ]
+                },
+                "KeyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.KeyValue"
+                    }
+                },
+                "MasterUserName": {
+                    "description": "Authentication",
+                    "type": "string",
+                    "example": "admin"
+                },
+                "MasterUserPassword": {
+                    "description": "Master user password (for Create request only)",
+                    "type": "string"
+                },
+                "Port": {
+                    "description": "DB listen port",
+                    "type": "string",
+                    "example": "3306"
+                },
+                "PublicAccess": {
+                    "description": "Access",
+                    "type": "boolean",
+                    "default": false
+                },
+                "ReplicationType": {
+                    "description": "async | semi-sync | sync (for response)",
+                    "type": "string",
+                    "example": "async"
+                },
+                "SecurityGroupIIDs": {
+                    "description": "Associated Security Groups",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.IID"
+                    }
+                },
+                "Status": {
+                    "description": "Status (for response)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.RDBMSStatus"
+                        }
+                    ],
+                    "example": "Available"
+                },
+                "StorageSize": {
+                    "description": "in GB",
+                    "type": "string",
+                    "example": "100"
+                },
+                "StorageType": {
+                    "description": "Storage",
+                    "type": "string",
+                    "example": "gp2"
+                },
+                "SubnetIIDs": {
+                    "description": "Network",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.IID"
+                    }
+                },
+                "TagList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.KeyValue"
+                    }
+                },
+                "VpcIID": {
+                    "description": "Owner VPC IID",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    ]
+                }
+            }
+        },
+        "spider.RDBMSMetaInfo": {
+            "description": "RDBMS Meta Information for CSP-specific capabilities",
+            "type": "object",
+            "properties": {
+                "StorageSizeRange": {
+                    "description": "Min/Max storage size in GB",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.StorageSizeRange"
+                        }
+                    ]
+                },
+                "StorageTypeOptions": {
+                    "description": "Available storage types per engine. e.g., {\"mysql\": [\"gp2\", \"gp3\", \"io1\"]}",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "SupportedEngines": {
+                    "description": "filled by the cloud driver",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "SupportsBackup": {
+                    "description": "true if managed automatic backup is supported",
+                    "type": "boolean"
+                },
+                "SupportsDeletionProtection": {
+                    "description": "true if deletion protection is available",
+                    "type": "boolean"
+                },
+                "SupportsEncryption": {
+                    "description": "true if storage encryption is available",
+                    "type": "boolean"
+                },
+                "SupportsHighAvailability": {
+                    "description": "true if HA/Multi-AZ can be configured",
+                    "type": "boolean"
+                },
+                "SupportsPublicAccess": {
+                    "description": "true if public access can be toggled",
+                    "type": "boolean"
+                }
+            }
+        },
+        "spider.RDBMSStatus": {
+            "type": "string",
+            "enum": [
+                "Creating",
+                "Available",
+                "Deleting",
+                "Stopped",
+                "Error"
+            ],
+            "x-enum-varnames": [
+                "RDBMSCreating",
+                "RDBMSAvailable",
+                "RDBMSDeleting",
+                "RDBMSStopped",
+                "RDBMSError"
+            ]
+        },
         "spider.RSType": {
             "type": "string",
             "enum": [
@@ -12564,7 +13429,8 @@ const docTemplate = `{
                 "myimage",
                 "cluster",
                 "nodegroup",
-                "filesystem"
+                "filesystem",
+                "rdbms"
             ],
             "x-enum-varnames": [
                 "ALL",
@@ -12580,7 +13446,8 @@ const docTemplate = `{
                 "MYIMAGE",
                 "CLUSTER",
                 "NODEGROUP",
-                "FILESYSTEM"
+                "FILESYSTEM",
+                "RDBMS"
             ]
         },
         "spider.RegionInfo": {
@@ -12710,6 +13577,21 @@ const docTemplate = `{
                     "description": "TCP, UDP: 1~65535, ICMP, ALL: -1",
                     "type": "string",
                     "example": "22"
+                }
+            }
+        },
+        "spider.StorageSizeRange": {
+            "type": "object",
+            "properties": {
+                "Max": {
+                    "description": "Maximum storage in GB",
+                    "type": "integer",
+                    "example": 65536
+                },
+                "Min": {
+                    "description": "Minimum storage in GB",
+                    "type": "integer",
+                    "example": 20
                 }
             }
         },
@@ -13077,18 +13959,6 @@ const docTemplate = `{
                 "Suspending": "from running to suspended",
                 "Terminating": "from running, suspended to terminated"
             },
-            "x-enum-descriptions": [
-                "from launch to running",
-                "",
-                "from running to suspended",
-                "",
-                "from suspended to running",
-                "from running to running",
-                "from running, suspended to terminated",
-                "",
-                "VM does not exist",
-                ""
-            ],
             "x-enum-varnames": [
                 "Creating",
                 "Running",
@@ -14270,6 +15140,10 @@ const docTemplate = `{
                     "description": "support: true, do not support: false",
                     "type": "boolean"
                 },
+                "rdbmshandler": {
+                    "description": "support: true, do not support: false",
+                    "type": "boolean"
+                },
                 "regionZoneHandler": {
                     "description": "Metadata Handler",
                     "type": "boolean"
@@ -15249,6 +16123,181 @@ const docTemplate = `{
                         "\"vpc\"",
                         "\"ebs\"]"
                     ]
+                }
+            }
+        },
+        "spider.RDBMSCreateRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "IDTransformMode": {
+                    "description": "ON: transform CSP ID, OFF: no-transform CSP ID",
+                    "type": "string",
+                    "example": "ON"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "DBEngine",
+                        "DBEngineVersion",
+                        "DBInstanceSpec",
+                        "MasterUserName",
+                        "MasterUserPassword",
+                        "Name",
+                        "StorageSize",
+                        "VPCName"
+                    ],
+                    "properties": {
+                        "BackupRetentionDays": {
+                            "type": "integer",
+                            "example": 7
+                        },
+                        "BackupTime": {
+                            "type": "string",
+                            "example": "03:00"
+                        },
+                        "DBEngine": {
+                            "type": "string",
+                            "example": "mysql"
+                        },
+                        "DBEngineVersion": {
+                            "type": "string",
+                            "example": "8.0"
+                        },
+                        "DBInstanceSpec": {
+                            "type": "string",
+                            "example": "db.t3.medium"
+                        },
+                        "DatabaseName": {
+                            "type": "string",
+                            "example": "mydb"
+                        },
+                        "DeletionProtection": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "Encryption": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "HighAvailability": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "MasterUserName": {
+                            "type": "string",
+                            "example": "admin"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string",
+                            "example": "password123!"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "rdbms-01"
+                        },
+                        "Port": {
+                            "type": "string",
+                            "example": "3306"
+                        },
+                        "PublicAccess": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "SecurityGroupNames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "sg-01"
+                            ]
+                        },
+                        "StorageSize": {
+                            "description": "in GB",
+                            "type": "string",
+                            "example": "100"
+                        },
+                        "StorageType": {
+                            "type": "string",
+                            "example": "gp2"
+                        },
+                        "SubnetNames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "subnet-01"
+                            ]
+                        },
+                        "TagList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.KeyValue"
+                            }
+                        },
+                        "VPCName": {
+                            "type": "string",
+                            "example": "vpc-01"
+                        }
+                    }
+                }
+            }
+        },
+        "spider.RDBMSListResponse": {
+            "type": "object",
+            "required": [
+                "rdbms"
+            ],
+            "properties": {
+                "rdbms": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.RDBMSInfo"
+                    }
+                }
+            }
+        },
+        "spider.RDBMSRegisterRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "CSPId",
+                        "Name",
+                        "VPCName"
+                    ],
+                    "properties": {
+                        "CSPId": {
+                            "type": "string",
+                            "example": "csp-rdbms-1234"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "rdbms-01"
+                        },
+                        "VPCName": {
+                            "type": "string",
+                            "example": "vpc-01"
+                        }
+                    }
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -488,6 +488,87 @@
                 }
             }
         },
+        "/allrdbms": {
+            "get": {
+                "description": "Retrieve a comprehensive list of all RDBMS instances associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List All RDBMS in a Connection",
+                "operationId": "list-all-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of all RDBMS instances within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both.",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/allrdbmsinfo": {
+            "get": {
+                "description": "Retrieve a list of all RDBMS information associated with all connections.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List All RDBMS Info",
+                "operationId": "list-all-rdbms-info",
+                "responses": {
+                    "200": {
+                        "description": "List of all RDBMS information across all connections",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/allsecuritygroup": {
             "get": {
                 "description": "Retrieve a comprehensive list of all Security Groups associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
@@ -2213,6 +2294,69 @@
                 }
             }
         },
+        "/countrdbms": {
+            "get": {
+                "description": "Get the total number of RDBMS instances across all connections.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Count All RDBMS",
+                "operationId": "count-all-rdbms",
+                "responses": {
+                    "200": {
+                        "description": "Total count of RDBMS instances",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/countrdbms/{ConnectionName}": {
+            "get": {
+                "description": "Get the total number of RDBMS instances for a specific connection.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Count RDBMS by Connection",
+                "operationId": "count-rdbms-by-connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Total count of RDBMS instances for the connection",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/counts3/{ConnectionName}": {
             "get": {
                 "description": "Get the total number of S3 buckets for a specific connection.",
@@ -2930,6 +3074,66 @@
                     {
                         "type": "string",
                         "description": "The CSP NLB ID to delete",
+                        "name": "Id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/csprdbms/{Id}": {
+            "delete": {
+                "description": "Delete a specified CSP RDBMS.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Delete CSP RDBMS",
+                "operationId": "delete-csp-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting a CSP RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP RDBMS ID to delete",
                         "name": "Id",
                         "in": "path",
                         "required": true
@@ -4264,6 +4468,58 @@
                     },
                     "404": {
                         "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/getrdbmsowner": {
+            "get": {
+                "description": "Retrieve the Owner VPC of a given RDBMS CSP ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS Owner VPC",
+                "operationId": "get-rdbms-owner-vpc",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP RDBMS ID",
+                        "name": "CSPId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Owner VPC IID",
+                        "schema": {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
                         "schema": {
                             "$ref": "#/definitions/spider.SimpleMsg"
                         }
@@ -6335,6 +6591,275 @@
                 }
             }
         },
+        "/rdbms": {
+            "get": {
+                "description": "Retrieve a list of RDBMS instances associated with a specific connection.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "List RDBMS",
+                "operationId": "list-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of RDBMS instances",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new Relational Database (RDBMS) with the specified configuration.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Create RDBMS",
+                "operationId": "create-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for creating an RDBMS",
+                        "name": "RDBMSCreateRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the created RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/rdbms/{Name}": {
+            "get": {
+                "description": "Retrieve details of a specific RDBMS instance.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS",
+                "operationId": "get-rdbms",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to get an RDBMS for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to retrieve",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a specified RDBMS instance.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Delete RDBMS",
+                "operationId": "delete-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting an RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to delete",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Force delete the RDBMS. ex) true or false(default: false)",
+                        "name": "force",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/rdbmsmetainfo": {
+            "get": {
+                "description": "Retrieve CSP-specific RDBMS capability information (supported engines, features, storage options).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Get RDBMS Meta Information",
+                "operationId": "get-rdbms-metainfo",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "RDBMS MetaInfo for the CSP",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSMetaInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/readyz": {
             "get": {
                 "description": "Checks the health of CB-Spider service and its dependencies via /readyz endpoint. 🕷️ [[User Guide](https://github.com/cloud-barista/cb-spider/wiki/Readiness-Check-Guide)]",
@@ -7168,6 +7693,119 @@
                     {
                         "type": "string",
                         "description": "The name of the NLB to unregister",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the unregister operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regrdbms": {
+            "post": {
+                "description": "Register a new RDBMS with the specified name and CSP ID.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Register RDBMS",
+                "operationId": "register-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for registering an RDBMS",
+                        "name": "RDBMSRegisterRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSRegisterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the registered RDBMS",
+                        "schema": {
+                            "$ref": "#/definitions/spider.RDBMSInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regrdbms/{Name}": {
+            "delete": {
+                "description": "Unregister an RDBMS with the specified name.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[RDBMS Management]"
+                ],
+                "summary": "Unregister RDBMS",
+                "operationId": "unregister-rdbms",
+                "parameters": [
+                    {
+                        "description": "Request body for unregistering an RDBMS",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the RDBMS to unregister",
                         "name": "Name",
                         "in": "path",
                         "required": true
@@ -11233,13 +11871,11 @@
                 },
                 "avgCreationTime": {
                     "description": "Average VM creation time in seconds",
-                    "type": "number",
-                    "format": "float64"
+                    "type": "number"
                 },
                 "creationCount": {
                     "description": "Number of successful VM creations",
-                    "type": "integer",
-                    "format": "int64"
+                    "type": "integer"
                 },
                 "csp": {
                     "type": "string"
@@ -12545,6 +13181,235 @@
                 }
             }
         },
+        "spider.RDBMSInfo": {
+            "description": "Relational Database (RDBMS) Information",
+            "type": "object",
+            "required": [
+                "DBEngine",
+                "DBEngineVersion",
+                "DBInstanceSpec",
+                "IId",
+                "MasterUserName",
+                "Status",
+                "StorageSize",
+                "VpcIID"
+            ],
+            "properties": {
+                "BackupRetentionDays": {
+                    "description": "Backup",
+                    "type": "integer",
+                    "example": 7
+                },
+                "BackupTime": {
+                    "description": "Preferred backup time (HH:MM in UTC)",
+                    "type": "string",
+                    "example": "03:00"
+                },
+                "CreatedTime": {
+                    "type": "string"
+                },
+                "DBEngine": {
+                    "description": "DB Engine",
+                    "type": "string",
+                    "example": "mysql"
+                },
+                "DBEngineVersion": {
+                    "description": "e.g., \"8.0\", \"10.6\", \"15\"",
+                    "type": "string",
+                    "example": "8.0"
+                },
+                "DBInstanceSpec": {
+                    "description": "Instance Spec",
+                    "type": "string",
+                    "example": "db.t3.medium"
+                },
+                "DBInstanceType": {
+                    "description": "Primary | ReadReplica (for response)",
+                    "type": "string",
+                    "example": "Primary"
+                },
+                "DatabaseName": {
+                    "description": "Database",
+                    "type": "string",
+                    "example": "mydb"
+                },
+                "DeletionProtection": {
+                    "description": "Protection",
+                    "type": "boolean",
+                    "default": false
+                },
+                "Encryption": {
+                    "description": "Encryption",
+                    "type": "boolean",
+                    "default": false
+                },
+                "Endpoint": {
+                    "description": "Connection endpoint (for response)",
+                    "type": "string"
+                },
+                "HighAvailability": {
+                    "description": "High Availability \u0026 Replication",
+                    "type": "boolean",
+                    "default": false
+                },
+                "IId": {
+                    "description": "{NameId, SystemId}",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    ]
+                },
+                "KeyValueList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.KeyValue"
+                    }
+                },
+                "MasterUserName": {
+                    "description": "Authentication",
+                    "type": "string",
+                    "example": "admin"
+                },
+                "MasterUserPassword": {
+                    "description": "Master user password (for Create request only)",
+                    "type": "string"
+                },
+                "Port": {
+                    "description": "DB listen port",
+                    "type": "string",
+                    "example": "3306"
+                },
+                "PublicAccess": {
+                    "description": "Access",
+                    "type": "boolean",
+                    "default": false
+                },
+                "ReplicationType": {
+                    "description": "async | semi-sync | sync (for response)",
+                    "type": "string",
+                    "example": "async"
+                },
+                "SecurityGroupIIDs": {
+                    "description": "Associated Security Groups",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.IID"
+                    }
+                },
+                "Status": {
+                    "description": "Status (for response)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.RDBMSStatus"
+                        }
+                    ],
+                    "example": "Available"
+                },
+                "StorageSize": {
+                    "description": "in GB",
+                    "type": "string",
+                    "example": "100"
+                },
+                "StorageType": {
+                    "description": "Storage",
+                    "type": "string",
+                    "example": "gp2"
+                },
+                "SubnetIIDs": {
+                    "description": "Network",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.IID"
+                    }
+                },
+                "TagList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.KeyValue"
+                    }
+                },
+                "VpcIID": {
+                    "description": "Owner VPC IID",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.IID"
+                        }
+                    ]
+                }
+            }
+        },
+        "spider.RDBMSMetaInfo": {
+            "description": "RDBMS Meta Information for CSP-specific capabilities",
+            "type": "object",
+            "properties": {
+                "StorageSizeRange": {
+                    "description": "Min/Max storage size in GB",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/spider.StorageSizeRange"
+                        }
+                    ]
+                },
+                "StorageTypeOptions": {
+                    "description": "Available storage types per engine. e.g., {\"mysql\": [\"gp2\", \"gp3\", \"io1\"]}",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "SupportedEngines": {
+                    "description": "filled by the cloud driver",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "SupportsBackup": {
+                    "description": "true if managed automatic backup is supported",
+                    "type": "boolean"
+                },
+                "SupportsDeletionProtection": {
+                    "description": "true if deletion protection is available",
+                    "type": "boolean"
+                },
+                "SupportsEncryption": {
+                    "description": "true if storage encryption is available",
+                    "type": "boolean"
+                },
+                "SupportsHighAvailability": {
+                    "description": "true if HA/Multi-AZ can be configured",
+                    "type": "boolean"
+                },
+                "SupportsPublicAccess": {
+                    "description": "true if public access can be toggled",
+                    "type": "boolean"
+                }
+            }
+        },
+        "spider.RDBMSStatus": {
+            "type": "string",
+            "enum": [
+                "Creating",
+                "Available",
+                "Deleting",
+                "Stopped",
+                "Error"
+            ],
+            "x-enum-varnames": [
+                "RDBMSCreating",
+                "RDBMSAvailable",
+                "RDBMSDeleting",
+                "RDBMSStopped",
+                "RDBMSError"
+            ]
+        },
         "spider.RSType": {
             "type": "string",
             "enum": [
@@ -12561,7 +13426,8 @@
                 "myimage",
                 "cluster",
                 "nodegroup",
-                "filesystem"
+                "filesystem",
+                "rdbms"
             ],
             "x-enum-varnames": [
                 "ALL",
@@ -12577,7 +13443,8 @@
                 "MYIMAGE",
                 "CLUSTER",
                 "NODEGROUP",
-                "FILESYSTEM"
+                "FILESYSTEM",
+                "RDBMS"
             ]
         },
         "spider.RegionInfo": {
@@ -12707,6 +13574,21 @@
                     "description": "TCP, UDP: 1~65535, ICMP, ALL: -1",
                     "type": "string",
                     "example": "22"
+                }
+            }
+        },
+        "spider.StorageSizeRange": {
+            "type": "object",
+            "properties": {
+                "Max": {
+                    "description": "Maximum storage in GB",
+                    "type": "integer",
+                    "example": 65536
+                },
+                "Min": {
+                    "description": "Minimum storage in GB",
+                    "type": "integer",
+                    "example": 20
                 }
             }
         },
@@ -13074,18 +13956,6 @@
                 "Suspending": "from running to suspended",
                 "Terminating": "from running, suspended to terminated"
             },
-            "x-enum-descriptions": [
-                "from launch to running",
-                "",
-                "from running to suspended",
-                "",
-                "from suspended to running",
-                "from running to running",
-                "from running, suspended to terminated",
-                "",
-                "VM does not exist",
-                ""
-            ],
             "x-enum-varnames": [
                 "Creating",
                 "Running",
@@ -14267,6 +15137,10 @@
                     "description": "support: true, do not support: false",
                     "type": "boolean"
                 },
+                "rdbmshandler": {
+                    "description": "support: true, do not support: false",
+                    "type": "boolean"
+                },
                 "regionZoneHandler": {
                     "description": "Metadata Handler",
                     "type": "boolean"
@@ -15246,6 +16120,181 @@
                         "\"vpc\"",
                         "\"ebs\"]"
                     ]
+                }
+            }
+        },
+        "spider.RDBMSCreateRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "IDTransformMode": {
+                    "description": "ON: transform CSP ID, OFF: no-transform CSP ID",
+                    "type": "string",
+                    "example": "ON"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "DBEngine",
+                        "DBEngineVersion",
+                        "DBInstanceSpec",
+                        "MasterUserName",
+                        "MasterUserPassword",
+                        "Name",
+                        "StorageSize",
+                        "VPCName"
+                    ],
+                    "properties": {
+                        "BackupRetentionDays": {
+                            "type": "integer",
+                            "example": 7
+                        },
+                        "BackupTime": {
+                            "type": "string",
+                            "example": "03:00"
+                        },
+                        "DBEngine": {
+                            "type": "string",
+                            "example": "mysql"
+                        },
+                        "DBEngineVersion": {
+                            "type": "string",
+                            "example": "8.0"
+                        },
+                        "DBInstanceSpec": {
+                            "type": "string",
+                            "example": "db.t3.medium"
+                        },
+                        "DatabaseName": {
+                            "type": "string",
+                            "example": "mydb"
+                        },
+                        "DeletionProtection": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "Encryption": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "HighAvailability": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "MasterUserName": {
+                            "type": "string",
+                            "example": "admin"
+                        },
+                        "MasterUserPassword": {
+                            "type": "string",
+                            "example": "password123!"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "rdbms-01"
+                        },
+                        "Port": {
+                            "type": "string",
+                            "example": "3306"
+                        },
+                        "PublicAccess": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "SecurityGroupNames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "sg-01"
+                            ]
+                        },
+                        "StorageSize": {
+                            "description": "in GB",
+                            "type": "string",
+                            "example": "100"
+                        },
+                        "StorageType": {
+                            "type": "string",
+                            "example": "gp2"
+                        },
+                        "SubnetNames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "subnet-01"
+                            ]
+                        },
+                        "TagList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.KeyValue"
+                            }
+                        },
+                        "VPCName": {
+                            "type": "string",
+                            "example": "vpc-01"
+                        }
+                    }
+                }
+            }
+        },
+        "spider.RDBMSListResponse": {
+            "type": "object",
+            "required": [
+                "rdbms"
+            ],
+            "properties": {
+                "rdbms": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/spider.RDBMSInfo"
+                    }
+                }
+            }
+        },
+        "spider.RDBMSRegisterRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "CSPId",
+                        "Name",
+                        "VPCName"
+                    ],
+                    "properties": {
+                        "CSPId": {
+                            "type": "string",
+                            "example": "csp-rdbms-1234"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "rdbms-01"
+                        },
+                        "VPCName": {
+                            "type": "string",
+                            "example": "vpc-01"
+                        }
+                    }
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -202,11 +202,9 @@ definitions:
         type: string
       avgCreationTime:
         description: Average VM creation time in seconds
-        format: float64
         type: number
       creationCount:
         description: Number of successful VM creations
-        format: int64
         type: integer
       csp:
         type: string
@@ -1154,6 +1152,174 @@ definitions:
     - Unit
     - Used
     type: object
+  spider.RDBMSInfo:
+    description: Relational Database (RDBMS) Information
+    properties:
+      BackupRetentionDays:
+        description: Backup
+        example: 7
+        type: integer
+      BackupTime:
+        description: Preferred backup time (HH:MM in UTC)
+        example: "03:00"
+        type: string
+      CreatedTime:
+        type: string
+      DBEngine:
+        description: DB Engine
+        example: mysql
+        type: string
+      DBEngineVersion:
+        description: e.g., "8.0", "10.6", "15"
+        example: "8.0"
+        type: string
+      DBInstanceSpec:
+        description: Instance Spec
+        example: db.t3.medium
+        type: string
+      DBInstanceType:
+        description: Primary | ReadReplica (for response)
+        example: Primary
+        type: string
+      DatabaseName:
+        description: Database
+        example: mydb
+        type: string
+      DeletionProtection:
+        default: false
+        description: Protection
+        type: boolean
+      Encryption:
+        default: false
+        description: Encryption
+        type: boolean
+      Endpoint:
+        description: Connection endpoint (for response)
+        type: string
+      HighAvailability:
+        default: false
+        description: High Availability & Replication
+        type: boolean
+      IId:
+        allOf:
+        - $ref: '#/definitions/spider.IID'
+        description: '{NameId, SystemId}'
+      KeyValueList:
+        items:
+          $ref: '#/definitions/spider.KeyValue'
+        type: array
+      MasterUserName:
+        description: Authentication
+        example: admin
+        type: string
+      MasterUserPassword:
+        description: Master user password (for Create request only)
+        type: string
+      Port:
+        description: DB listen port
+        example: "3306"
+        type: string
+      PublicAccess:
+        default: false
+        description: Access
+        type: boolean
+      ReplicationType:
+        description: async | semi-sync | sync (for response)
+        example: async
+        type: string
+      SecurityGroupIIDs:
+        description: Associated Security Groups
+        items:
+          $ref: '#/definitions/spider.IID'
+        type: array
+      Status:
+        allOf:
+        - $ref: '#/definitions/spider.RDBMSStatus'
+        description: Status (for response)
+        example: Available
+      StorageSize:
+        description: in GB
+        example: "100"
+        type: string
+      StorageType:
+        description: Storage
+        example: gp2
+        type: string
+      SubnetIIDs:
+        description: Network
+        items:
+          $ref: '#/definitions/spider.IID'
+        type: array
+      TagList:
+        items:
+          $ref: '#/definitions/spider.KeyValue'
+        type: array
+      VpcIID:
+        allOf:
+        - $ref: '#/definitions/spider.IID'
+        description: Owner VPC IID
+    required:
+    - DBEngine
+    - DBEngineVersion
+    - DBInstanceSpec
+    - IId
+    - MasterUserName
+    - Status
+    - StorageSize
+    - VpcIID
+    type: object
+  spider.RDBMSMetaInfo:
+    description: RDBMS Meta Information for CSP-specific capabilities
+    properties:
+      StorageSizeRange:
+        allOf:
+        - $ref: '#/definitions/spider.StorageSizeRange'
+        description: Min/Max storage size in GB
+      StorageTypeOptions:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        description: 'Available storage types per engine. e.g., {"mysql": ["gp2",
+          "gp3", "io1"]}'
+        type: object
+      SupportedEngines:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        description: filled by the cloud driver
+        type: object
+      SupportsBackup:
+        description: true if managed automatic backup is supported
+        type: boolean
+      SupportsDeletionProtection:
+        description: true if deletion protection is available
+        type: boolean
+      SupportsEncryption:
+        description: true if storage encryption is available
+        type: boolean
+      SupportsHighAvailability:
+        description: true if HA/Multi-AZ can be configured
+        type: boolean
+      SupportsPublicAccess:
+        description: true if public access can be toggled
+        type: boolean
+    type: object
+  spider.RDBMSStatus:
+    enum:
+    - Creating
+    - Available
+    - Deleting
+    - Stopped
+    - Error
+    type: string
+    x-enum-varnames:
+    - RDBMSCreating
+    - RDBMSAvailable
+    - RDBMSDeleting
+    - RDBMSStopped
+    - RDBMSError
   spider.RSType:
     enum:
     - all
@@ -1170,6 +1336,7 @@ definitions:
     - cluster
     - nodegroup
     - filesystem
+    - rdbms
     type: string
     x-enum-varnames:
     - ALL
@@ -1186,6 +1353,7 @@ definitions:
     - CLUSTER
     - NODEGROUP
     - FILESYSTEM
+    - RDBMS
   spider.RegionInfo:
     properties:
       Region:
@@ -1275,6 +1443,17 @@ definitions:
     - FromPort
     - IPProtocol
     - ToPort
+    type: object
+  spider.StorageSizeRange:
+    properties:
+      Max:
+        description: Maximum storage in GB
+        example: 65536
+        type: integer
+      Min:
+        description: Minimum storage in GB
+        example: 20
+        type: integer
     type: object
   spider.SubnetInfo:
     properties:
@@ -1536,17 +1715,6 @@ definitions:
       Resuming: from suspended to running
       Suspending: from running to suspended
       Terminating: from running, suspended to terminated
-    x-enum-descriptions:
-    - from launch to running
-    - ""
-    - from running to suspended
-    - ""
-    - from suspended to running
-    - from running to running
-    - from running, suspended to terminated
-    - ""
-    - VM does not exist
-    - ""
     x-enum-varnames:
     - Creating
     - Running
@@ -2389,6 +2557,9 @@ definitions:
       quotaInfoHandler:
         description: 'support: true, do not support: false'
         type: boolean
+      rdbmshandler:
+        description: 'support: true, do not support: false'
+        type: boolean
       regionZoneHandler:
         description: Metadata Handler
         type: boolean
@@ -3078,6 +3249,133 @@ definitions:
         type: array
     required:
     - ServiceTypes
+    type: object
+  spider.RDBMSCreateRequest:
+    properties:
+      ConnectionName:
+        example: aws-connection
+        type: string
+      IDTransformMode:
+        description: 'ON: transform CSP ID, OFF: no-transform CSP ID'
+        example: "ON"
+        type: string
+      ReqInfo:
+        properties:
+          BackupRetentionDays:
+            example: 7
+            type: integer
+          BackupTime:
+            example: "03:00"
+            type: string
+          DBEngine:
+            example: mysql
+            type: string
+          DBEngineVersion:
+            example: "8.0"
+            type: string
+          DBInstanceSpec:
+            example: db.t3.medium
+            type: string
+          DatabaseName:
+            example: mydb
+            type: string
+          DeletionProtection:
+            default: false
+            type: boolean
+          Encryption:
+            default: false
+            type: boolean
+          HighAvailability:
+            default: false
+            type: boolean
+          MasterUserName:
+            example: admin
+            type: string
+          MasterUserPassword:
+            example: password123!
+            type: string
+          Name:
+            example: rdbms-01
+            type: string
+          Port:
+            example: "3306"
+            type: string
+          PublicAccess:
+            default: false
+            type: boolean
+          SecurityGroupNames:
+            example:
+            - sg-01
+            items:
+              type: string
+            type: array
+          StorageSize:
+            description: in GB
+            example: "100"
+            type: string
+          StorageType:
+            example: gp2
+            type: string
+          SubnetNames:
+            example:
+            - subnet-01
+            items:
+              type: string
+            type: array
+          TagList:
+            items:
+              $ref: '#/definitions/spider.KeyValue'
+            type: array
+          VPCName:
+            example: vpc-01
+            type: string
+        required:
+        - DBEngine
+        - DBEngineVersion
+        - DBInstanceSpec
+        - MasterUserName
+        - MasterUserPassword
+        - Name
+        - StorageSize
+        - VPCName
+        type: object
+    required:
+    - ConnectionName
+    - ReqInfo
+    type: object
+  spider.RDBMSListResponse:
+    properties:
+      rdbms:
+        items:
+          $ref: '#/definitions/spider.RDBMSInfo'
+        type: array
+    required:
+    - rdbms
+    type: object
+  spider.RDBMSRegisterRequest:
+    properties:
+      ConnectionName:
+        example: aws-connection
+        type: string
+      ReqInfo:
+        properties:
+          CSPId:
+            example: csp-rdbms-1234
+            type: string
+          Name:
+            example: rdbms-01
+            type: string
+          VPCName:
+            example: vpc-01
+            type: string
+        required:
+        - CSPId
+        - Name
+        - VPCName
+        type: object
+    required:
+    - ConnectionName
+    - ReqInfo
     type: object
   spider.RegionZoneListResponse:
     properties:
@@ -4081,6 +4379,65 @@ paths:
       summary: List All NLB Info
       tags:
       - '[NLB Management]'
+  /allrdbms:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a comprehensive list of all RDBMS instances associated
+        with a specific connection, <br> including those mapped between CB-Spider
+        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
+        in the CSP.
+      operationId: list-all-rdbms
+      parameters:
+      - description: The name of the Connection to list RDBMS for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of all RDBMS instances within the specified connection,
+            including RDBMS in CB-Spider only, CSP only, and mapped between both.
+          schema:
+            $ref: '#/definitions/spider.AllResourceListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: List All RDBMS in a Connection
+      tags:
+      - '[RDBMS Management]'
+  /allrdbmsinfo:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a list of all RDBMS information associated with all connections.
+      operationId: list-all-rdbms-info
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of all RDBMS information across all connections
+          schema:
+            $ref: '#/definitions/spider.AllResourceListResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: List All RDBMS Info
+      tags:
+      - '[RDBMS Management]'
   /allsecuritygroup:
     get:
       consumes:
@@ -5287,6 +5644,48 @@ paths:
       summary: Count NLBs by Connection
       tags:
       - '[NLB Management]'
+  /countrdbms:
+    get:
+      description: Get the total number of RDBMS instances across all connections.
+      operationId: count-all-rdbms
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Total count of RDBMS instances
+          schema:
+            $ref: '#/definitions/spider.CountResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Count All RDBMS
+      tags:
+      - '[RDBMS Management]'
+  /countrdbms/{ConnectionName}:
+    get:
+      description: Get the total number of RDBMS instances for a specific connection.
+      operationId: count-rdbms-by-connection
+      parameters:
+      - description: The name of the Connection
+        in: path
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Total count of RDBMS instances for the connection
+          schema:
+            $ref: '#/definitions/spider.CountResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Count RDBMS by Connection
+      tags:
+      - '[RDBMS Management]'
   /counts3/{ConnectionName}:
     get:
       description: Get the total number of S3 buckets for a specific connection.
@@ -5793,6 +6192,47 @@ paths:
       summary: Delete CSP NLB
       tags:
       - '[NLB Management]'
+  /csprdbms/{Id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a specified CSP RDBMS.
+      operationId: delete-csp-rdbms
+      parameters:
+      - description: Request body for deleting a CSP RDBMS
+        in: body
+        name: ConnectionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.ConnectionRequest'
+      - description: The CSP RDBMS ID to delete
+        in: path
+        name: Id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result of the delete operation
+          schema:
+            $ref: '#/definitions/spider.BooleanInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Delete CSP RDBMS
+      tags:
+      - '[RDBMS Management]'
   /cspsecuritygroup/{Id}:
     delete:
       consumes:
@@ -6683,6 +7123,41 @@ paths:
       summary: Get NLB Owner VPC
       tags:
       - '[NLB Management]'
+  /getrdbmsowner:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve the Owner VPC of a given RDBMS CSP ID.
+      operationId: get-rdbms-owner-vpc
+      parameters:
+      - description: The name of the Connection
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      - description: The CSP RDBMS ID
+        in: query
+        name: CSPId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Owner VPC IID
+          schema:
+            $ref: '#/definitions/spider.IID'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Get RDBMS Owner VPC
+      tags:
+      - '[RDBMS Management]'
   /getsecuritygroupowner:
     post:
       consumes:
@@ -8103,6 +8578,190 @@ paths:
       summary: List Quota Service Types
       tags:
       - '[Cloud Metadata] Quota Info'
+  /rdbms:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a list of RDBMS instances associated with a specific connection.
+      operationId: list-rdbms
+      parameters:
+      - description: The name of the Connection to list RDBMS for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of RDBMS instances
+          schema:
+            $ref: '#/definitions/spider.RDBMSListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: List RDBMS
+      tags:
+      - '[RDBMS Management]'
+    post:
+      consumes:
+      - application/json
+      description: Create a new Relational Database (RDBMS) with the specified configuration.
+      operationId: create-rdbms
+      parameters:
+      - description: Request body for creating an RDBMS
+        in: body
+        name: RDBMSCreateRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.RDBMSCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Details of the created RDBMS
+          schema:
+            $ref: '#/definitions/spider.RDBMSInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Create RDBMS
+      tags:
+      - '[RDBMS Management]'
+  /rdbms/{Name}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a specified RDBMS instance.
+      operationId: delete-rdbms
+      parameters:
+      - description: Request body for deleting an RDBMS
+        in: body
+        name: ConnectionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.ConnectionRequest'
+      - description: The name of the RDBMS to delete
+        in: path
+        name: Name
+        required: true
+        type: string
+      - description: 'Force delete the RDBMS. ex) true or false(default: false)'
+        in: query
+        name: force
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result of the delete operation
+          schema:
+            $ref: '#/definitions/spider.BooleanInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Delete RDBMS
+      tags:
+      - '[RDBMS Management]'
+    get:
+      consumes:
+      - application/json
+      description: Retrieve details of a specific RDBMS instance.
+      operationId: get-rdbms
+      parameters:
+      - description: The name of the Connection to get an RDBMS for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      - description: The name of the RDBMS to retrieve
+        in: path
+        name: Name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Details of the RDBMS
+          schema:
+            $ref: '#/definitions/spider.RDBMSInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Get RDBMS
+      tags:
+      - '[RDBMS Management]'
+  /rdbmsmetainfo:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve CSP-specific RDBMS capability information (supported engines,
+        features, storage options).
+      operationId: get-rdbms-metainfo
+      parameters:
+      - description: The name of the Connection
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: RDBMS MetaInfo for the CSP
+          schema:
+            $ref: '#/definitions/spider.RDBMSMetaInfo'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Get RDBMS Meta Information
+      tags:
+      - '[RDBMS Management]'
   /readyz:
     get:
       consumes:
@@ -8695,6 +9354,83 @@ paths:
       summary: Unregister NLB
       tags:
       - '[NLB Management]'
+  /regrdbms:
+    post:
+      consumes:
+      - application/json
+      description: Register a new RDBMS with the specified name and CSP ID.
+      operationId: register-rdbms
+      parameters:
+      - description: Request body for registering an RDBMS
+        in: body
+        name: RDBMSRegisterRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.RDBMSRegisterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Details of the registered RDBMS
+          schema:
+            $ref: '#/definitions/spider.RDBMSInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Register RDBMS
+      tags:
+      - '[RDBMS Management]'
+  /regrdbms/{Name}:
+    delete:
+      consumes:
+      - application/json
+      description: Unregister an RDBMS with the specified name.
+      operationId: unregister-rdbms
+      parameters:
+      - description: Request body for unregistering an RDBMS
+        in: body
+        name: ConnectionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.ConnectionRequest'
+      - description: The name of the RDBMS to unregister
+        in: path
+        name: Name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result of the unregister operation
+          schema:
+            $ref: '#/definitions/spider.BooleanInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Unregister RDBMS
+      tags:
+      - '[RDBMS Management]'
   /regsecuritygroup:
     post:
       consumes:

--- a/cloud-control-manager/cloud-driver/call-log/calllogger.go
+++ b/cloud-control-manager/cloud-driver/call-log/calllogger.go
@@ -66,6 +66,9 @@ const (
 
 	//=========== FileSystem
 	FILESYSTEM RES_TYPE = "FILESYSTEM"
+
+	//=========== RDBMS
+	RDBMS RES_TYPE = "RDBMS"
 )
 
 type CALLLogger struct {

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/AlibabaDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/AlibabaDriver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/nas"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/quotas"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 
 	"time"
@@ -74,6 +75,8 @@ func (AlibabaDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{ires.SG, ires.KEY, ires.VM, ires.NLB, ires.DISK, ires.MYIMAGE}
 
 	drvCapabilityInfo.QuotaInfoHandler = true
+
+	drvCapabilityInfo.RDBMSHandler = true
 
 	drvCapabilityInfo.VPC_CIDR = true
 
@@ -134,6 +137,11 @@ func (driver *AlibabaDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (i
 		return nil, err
 	}
 
+	RDSClient, err := getRDSClient(connectionInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	iConn := alicon.AlibabaCloudConnection{
 		CredentialInfo: connectionInfo.CredentialInfo,
 		Region:         connectionInfo.RegionInfo,
@@ -158,6 +166,7 @@ func (driver *AlibabaDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (i
 		Ecs2014Client:    Ecs2014Client,
 		BssClient:        BssClient,
 		QuotaClient:      QuotaClient,
+		RDSClient:        RDSClient,
 
 		// Connection for AnyCall
 		AnyCallClient: ECSClient,
@@ -440,4 +449,26 @@ func getQuotaClient(connectionInfo idrv.ConnectionInfo) (*quotas.Client, error) 
 	}
 
 	return quotaClient, nil
+}
+
+func getRDSClient(connectionInfo idrv.ConnectionInfo) (*rds.Client, error) {
+	cblog.Info("AlibabaDriver : getRDSClient() - Region : [" + connectionInfo.RegionInfo.Region + "]")
+
+	credential := &credentials.AccessKeyCredential{
+		AccessKeyId:     connectionInfo.CredentialInfo.ClientId,
+		AccessKeySecret: connectionInfo.CredentialInfo.ClientSecret,
+	}
+
+	config := sdk.NewConfig()
+	config.Timeout = time.Duration(300) * time.Second
+	config.AutoRetry = true
+	config.MaxRetryTime = 3
+
+	rdsClient, err := rds.NewClientWithOptions(connectionInfo.RegionInfo.Region, config, credential)
+	if err != nil {
+		cblog.Error("Could not create alibaba's rds client", err)
+		return nil, err
+	}
+
+	return rdsClient, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/connect/AlibabaCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/connect/AlibabaCloudConnection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/nas"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/quotas"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	cblog "github.com/cloud-barista/cb-log"
@@ -63,6 +64,7 @@ type AlibabaCloudConnection struct {
 	Ecs2014Client *ecs2014.Client
 	BssClient     *bssopenapi.Client
 	QuotaClient   *quotas.Client
+	RDSClient     *rds.Client
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -201,4 +203,10 @@ func (cloudConn *AlibabaCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfo
 
 func (cloudConn *AlibabaCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, errors.New("Alibaba Driver: not implemented")
+}
+
+func (cloudConn *AlibabaCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("Alibaba Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := alirs.AlibabaRDBMSHandler{Region: cloudConn.Region, Client: cloudConn.RDSClient}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
@@ -1,0 +1,562 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/rds"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type AlibabaRDBMSHandler struct {
+	Region idrv.RegionInfo
+	Client *rds.Client
+}
+
+func (handler *AlibabaRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("Alibaba RDS GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql":      {"5.7", "8.0"},
+			"mariadb":    {"10.3"},
+			"postgresql": {"10.0", "11.0", "12.0", "13.0", "14.0", "15.0", "16.0"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: true,
+		SupportsEncryption:         true,
+		StorageTypeOptions: map[string][]string{
+			"mysql":      {"cloud_ssd", "cloud_essd", "cloud_essd2", "cloud_essd3", "local_ssd"},
+			"mariadb":    {"cloud_ssd", "cloud_essd"},
+			"postgresql": {"cloud_ssd", "cloud_essd", "cloud_essd2", "cloud_essd3", "local_ssd"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 20,
+			Max: 32768,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+func (handler *AlibabaRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "DescribeDBInstances()")
+	start := call.Start()
+
+	request := rds.CreateDescribeDBInstancesRequest()
+	request.RegionId = handler.Region.Region
+
+	var iidList []*irs.IID
+	pageNumber := 1
+	for {
+		request.PageNumber = requests.NewInteger(pageNumber)
+		request.PageSize = requests.NewInteger(100)
+
+		response, err := handler.Client.DescribeDBInstances(request)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+
+		for _, db := range response.Items.DBInstance {
+			iid := &irs.IID{
+				NameId:   db.DBInstanceDescription,
+				SystemId: db.DBInstanceId,
+			}
+			if iid.NameId == "" {
+				iid.NameId = db.DBInstanceId
+			}
+			iidList = append(iidList, iid)
+		}
+
+		if len(response.Items.DBInstance) < 100 {
+			break
+		}
+		pageNumber++
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return iidList, nil
+}
+
+func (handler *AlibabaRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateDBInstance()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required")
+	}
+	if rdbmsReqInfo.MasterUserName == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	request := rds.CreateCreateDBInstanceRequest()
+	request.RegionId = handler.Region.Region
+	request.Engine = strings.ToUpper(rdbmsReqInfo.DBEngine[:1]) + strings.ToLower(rdbmsReqInfo.DBEngine[1:])
+	// Alibaba expects: MySQL, MariaDB, PostgreSQL
+	switch strings.ToLower(rdbmsReqInfo.DBEngine) {
+	case "mysql":
+		request.Engine = "MySQL"
+	case "mariadb":
+		request.Engine = "MariaDB"
+	case "postgresql":
+		request.Engine = "PostgreSQL"
+	default:
+		return irs.RDBMSInfo{}, fmt.Errorf("unsupported engine: %s", rdbmsReqInfo.DBEngine)
+	}
+
+	request.EngineVersion = rdbmsReqInfo.DBEngineVersion
+	request.DBInstanceClass = rdbmsReqInfo.DBInstanceSpec
+	request.DBInstanceStorage = requests.Integer(rdbmsReqInfo.StorageSize)
+	request.DBInstanceDescription = rdbmsReqInfo.IId.NameId
+	request.SecurityIPList = "0.0.0.0/0" // Default, user can modify later
+	request.PayType = "Postpaid"
+	request.InstanceNetworkType = "VPC"
+	request.DBInstanceNetType = "Intranet"
+
+	// Storage type
+	if rdbmsReqInfo.StorageType != "" {
+		request.DBInstanceStorageType = rdbmsReqInfo.StorageType
+	} else {
+		request.DBInstanceStorageType = "cloud_essd"
+	}
+
+	// VPC and Subnet (VSwitch)
+	if rdbmsReqInfo.VpcIID.SystemId != "" {
+		request.VPCId = rdbmsReqInfo.VpcIID.SystemId
+	}
+	if len(rdbmsReqInfo.SubnetIIDs) > 0 && rdbmsReqInfo.SubnetIIDs[0].SystemId != "" {
+		request.VSwitchId = rdbmsReqInfo.SubnetIIDs[0].SystemId
+	}
+
+	// Zone
+	if handler.Region.Zone != "" {
+		request.ZoneId = handler.Region.Zone
+	}
+
+	// Port
+	if rdbmsReqInfo.Port != "" {
+		request.Port = rdbmsReqInfo.Port
+	}
+
+	// HA (Category)
+	if rdbmsReqInfo.HighAvailability {
+		request.Category = "HighAvailability"
+	} else {
+		request.Category = "Basic"
+	}
+
+	// Tags
+	if len(rdbmsReqInfo.TagList) > 0 {
+		tags := make([]rds.CreateDBInstanceTag, 0, len(rdbmsReqInfo.TagList))
+		for _, tag := range rdbmsReqInfo.TagList {
+			tags = append(tags, rds.CreateDBInstanceTag{
+				Key:   tag.Key,
+				Value: tag.Value,
+			})
+		}
+		request.Tag = &tags
+	}
+
+	response, err := handler.Client.CreateDBInstance(request)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	// Wait for the instance to be running
+	dbInstanceId := response.DBInstanceId
+	err = handler.waitForDBInstanceStatus(dbInstanceId, "Running", 600)
+	if err != nil {
+		cblogger.Warn("Instance created but wait for Running state failed: ", err)
+	}
+
+	// Allocate public endpoint if PublicAccess is requested
+	if rdbmsReqInfo.PublicAccess {
+		allocReq := rds.CreateAllocateInstancePublicConnectionRequest()
+		allocReq.DBInstanceId = dbInstanceId
+		allocReq.ConnectionStringPrefix = dbInstanceId + "-pub"
+		allocReq.Port = "3306"
+		if strings.ToLower(rdbmsReqInfo.DBEngine) == "postgresql" {
+			allocReq.Port = "5432"
+		}
+		_, allocErr := handler.Client.AllocateInstancePublicConnection(allocReq)
+		if allocErr != nil {
+			cblogger.Errorf("Failed to allocate public connection for [%s]: %v", dbInstanceId, allocErr)
+			return irs.RDBMSInfo{}, fmt.Errorf("failed to allocate public connection: %w", allocErr)
+		}
+		cblogger.Infof("Public connection allocated for [%s]", dbInstanceId)
+
+		// Wait for Running state again after public connection allocation
+		err = handler.waitForDBInstanceStatus(dbInstanceId, "Running", 120)
+		if err != nil {
+			cblogger.Warnf("Wait for Running after public connection allocation: %v", err)
+		}
+	}
+
+	// Create master user account
+	if rdbmsReqInfo.MasterUserName != "" {
+		acctReq := rds.CreateCreateAccountRequest()
+		acctReq.DBInstanceId = dbInstanceId
+		acctReq.AccountName = rdbmsReqInfo.MasterUserName
+		acctReq.AccountPassword = rdbmsReqInfo.MasterUserPassword
+		acctReq.AccountType = "Super"
+		_, acctErr := handler.Client.CreateAccount(acctReq)
+		if acctErr != nil {
+			cblogger.Errorf("Failed to create master account [%s] for [%s]: %v", rdbmsReqInfo.MasterUserName, dbInstanceId, acctErr)
+			return irs.RDBMSInfo{}, fmt.Errorf("failed to create master account: %w", acctErr)
+		}
+		cblogger.Infof("Master account [%s] created for [%s]", rdbmsReqInfo.MasterUserName, dbInstanceId)
+	}
+
+	// Set deletion protection if requested
+	if rdbmsReqInfo.DeletionProtection {
+		modReq := rds.CreateModifyDBInstanceDeletionProtectionRequest()
+		modReq.DBInstanceId = dbInstanceId
+		modReq.DeletionProtection = "true"
+		_, modErr := handler.Client.ModifyDBInstanceDeletionProtection(modReq)
+		if modErr != nil {
+			cblogger.Warn("Failed to set deletion protection: ", modErr)
+		}
+	}
+
+	// Get the created instance info
+	return handler.GetRDBMS(irs.IID{SystemId: dbInstanceId})
+}
+
+func (handler *AlibabaRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "DescribeDBInstances()")
+	start := call.Start()
+
+	request := rds.CreateDescribeDBInstancesRequest()
+	request.RegionId = handler.Region.Region
+
+	var rdbmsList []*irs.RDBMSInfo
+	pageNumber := 1
+	for {
+		request.PageNumber = requests.NewInteger(pageNumber)
+		request.PageSize = requests.NewInteger(100)
+
+		response, err := handler.Client.DescribeDBInstances(request)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+
+		for _, db := range response.Items.DBInstance {
+			// Get detailed attribute for each instance
+			attrInfo, err := handler.getDBInstanceAttribute(db.DBInstanceId)
+			if err != nil {
+				cblogger.Warn("Failed to get attribute for ", db.DBInstanceId, ": ", err)
+				// Use basic info from list
+				rdbmsInfo := handler.convertListItemToRDBMSInfo(&db)
+				rdbmsList = append(rdbmsList, &rdbmsInfo)
+				continue
+			}
+			rdbmsList = append(rdbmsList, &attrInfo)
+		}
+
+		if len(response.Items.DBInstance) < 100 {
+			break
+		}
+		pageNumber++
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsList, nil
+}
+
+func (handler *AlibabaRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DescribeDBInstanceAttribute()")
+	start := call.Start()
+
+	rdbmsInfo, err := handler.getDBInstanceAttribute(rdbmsIID.SystemId)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsInfo, nil
+}
+
+func (handler *AlibabaRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DeleteDBInstance()")
+	start := call.Start()
+
+	// Check and disable deletion protection first
+	attrInfo, err := handler.getDBInstanceAttribute(rdbmsIID.SystemId)
+	if err == nil && attrInfo.DeletionProtection {
+		modReq := rds.CreateModifyDBInstanceDeletionProtectionRequest()
+		modReq.DBInstanceId = rdbmsIID.SystemId
+		modReq.DeletionProtection = "false"
+		_, modErr := handler.Client.ModifyDBInstanceDeletionProtection(modReq)
+		if modErr != nil {
+			cblogger.Warn("Failed to disable deletion protection: ", modErr)
+		}
+	}
+
+	request := rds.CreateDeleteDBInstanceRequest()
+	request.DBInstanceId = rdbmsIID.SystemId
+
+	_, err = handler.Client.DeleteDBInstance(request)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func (handler *AlibabaRDBMSHandler) getDBInstanceAttribute(dbInstanceId string) (irs.RDBMSInfo, error) {
+	request := rds.CreateDescribeDBInstanceAttributeRequest()
+	request.DBInstanceId = dbInstanceId
+
+	response, err := handler.Client.DescribeDBInstanceAttribute(request)
+	if err != nil {
+		return irs.RDBMSInfo{}, err
+	}
+
+	if len(response.Items.DBInstanceAttribute) == 0 {
+		return irs.RDBMSInfo{}, fmt.Errorf("DB instance not found: %s", dbInstanceId)
+	}
+
+	attr := response.Items.DBInstanceAttribute[0]
+	rdbmsInfo := handler.convertAttributeToRDBMSInfo(&attr)
+
+	// Retrieve public endpoint via DescribeDBInstanceNetInfo
+	netReq := rds.CreateDescribeDBInstanceNetInfoRequest()
+	netReq.DBInstanceId = dbInstanceId
+	netResp, netErr := handler.Client.DescribeDBInstanceNetInfo(netReq)
+	if netErr == nil && netResp != nil {
+		for _, netInfo := range netResp.DBInstanceNetInfos.DBInstanceNetInfo {
+			if netInfo.IPType == "Public" {
+				rdbmsInfo.Endpoint = netInfo.IPAddress
+				rdbmsInfo.Port = netInfo.Port
+				rdbmsInfo.PublicAccess = true
+				break
+			}
+		}
+	}
+
+	// Retrieve master username via DescribeAccounts
+	acctReq := rds.CreateDescribeAccountsRequest()
+	acctReq.DBInstanceId = dbInstanceId
+	acctResp, acctErr := handler.Client.DescribeAccounts(acctReq)
+	if acctErr == nil && acctResp != nil {
+		for _, acct := range acctResp.Accounts.DBInstanceAccount {
+			if acct.AccountName != "" {
+				rdbmsInfo.MasterUserName = acct.AccountName
+				break
+			}
+		}
+	}
+
+	return rdbmsInfo, nil
+}
+
+func (handler *AlibabaRDBMSHandler) convertAttributeToRDBMSInfo(attr *rds.DBInstanceAttribute) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	rdbmsInfo.IId = irs.IID{
+		NameId:   attr.DBInstanceDescription,
+		SystemId: attr.DBInstanceId,
+	}
+	if rdbmsInfo.IId.NameId == "" {
+		rdbmsInfo.IId.NameId = attr.DBInstanceId
+	}
+
+	rdbmsInfo.DBEngine = strings.ToLower(attr.Engine)
+	rdbmsInfo.DBEngineVersion = attr.EngineVersion
+	rdbmsInfo.DBInstanceSpec = attr.DBInstanceClass
+	rdbmsInfo.StorageType = attr.DBInstanceStorageType
+	rdbmsInfo.StorageSize = strconv.Itoa(attr.DBInstanceStorage)
+	rdbmsInfo.Port = attr.Port
+	rdbmsInfo.Endpoint = attr.ConnectionString
+	rdbmsInfo.MasterUserName = "" // Retrieved via DescribeAccounts in getDBInstanceAttribute
+	rdbmsInfo.DatabaseName = ""
+
+	// VPC
+	rdbmsInfo.VpcIID = irs.IID{SystemId: attr.VpcId}
+
+	// Subnet (VSwitch)
+	if attr.VSwitchId != "" {
+		rdbmsInfo.SubnetIIDs = []irs.IID{{SystemId: attr.VSwitchId}}
+	}
+
+	// Status
+	rdbmsInfo.Status = convertAlibabaStatusToRDBMSStatus(attr.DBInstanceStatus)
+
+	// HA
+	if attr.Category == "HighAvailability" || attr.Category == "AlwaysOn" || attr.Category == "Finance" {
+		rdbmsInfo.HighAvailability = true
+	}
+
+	// Deletion protection
+	rdbmsInfo.DeletionProtection = attr.DeletionProtection
+
+	// Created time
+	if attr.CreationTime != "" {
+		t, err := time.Parse("2006-01-02T15:04:05Z", attr.CreationTime)
+		if err == nil {
+			rdbmsInfo.CreatedTime = t
+		}
+	}
+
+	// Backup/Encryption are not directly exposed in attribute - return NA/defaults
+	rdbmsInfo.BackupRetentionDays = 0 // Can be retrieved through DescribeBackupPolicy, but not included in attribute
+	rdbmsInfo.BackupTime = "NA"
+	rdbmsInfo.Encryption = false // Requires separate DescribeDBInstanceSSL/encryption API
+	rdbmsInfo.ReplicationType = "NA"
+
+	// PublicAccess is determined by DescribeDBInstanceNetInfo in getDBInstanceAttribute
+	rdbmsInfo.PublicAccess = false
+
+	// KeyValueList
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(attr)
+
+	return rdbmsInfo
+}
+
+func (handler *AlibabaRDBMSHandler) convertListItemToRDBMSInfo(db *rds.DBInstance) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	rdbmsInfo.IId = irs.IID{
+		NameId:   db.DBInstanceDescription,
+		SystemId: db.DBInstanceId,
+	}
+	if rdbmsInfo.IId.NameId == "" {
+		rdbmsInfo.IId.NameId = db.DBInstanceId
+	}
+
+	rdbmsInfo.DBEngine = strings.ToLower(db.Engine)
+	rdbmsInfo.DBEngineVersion = db.EngineVersion
+	rdbmsInfo.DBInstanceSpec = db.DBInstanceClass
+	rdbmsInfo.StorageType = db.DBInstanceStorageType
+	rdbmsInfo.Port = "NA"
+	rdbmsInfo.Endpoint = db.ConnectionString
+	rdbmsInfo.MasterUserName = "NA"
+	rdbmsInfo.DatabaseName = "NA"
+	rdbmsInfo.StorageSize = "NA"
+	rdbmsInfo.BackupTime = "NA"
+	rdbmsInfo.ReplicationType = "NA"
+
+	rdbmsInfo.VpcIID = irs.IID{SystemId: db.VpcId}
+	if db.VSwitchId != "" {
+		rdbmsInfo.SubnetIIDs = []irs.IID{{SystemId: db.VSwitchId}}
+	}
+
+	rdbmsInfo.Status = convertAlibabaStatusToRDBMSStatus(db.DBInstanceStatus)
+
+	if db.Category == "HighAvailability" || db.Category == "AlwaysOn" || db.Category == "Finance" {
+		rdbmsInfo.HighAvailability = true
+	}
+
+	if db.CreateTime != "" {
+		t, err := time.Parse("2006-01-02T15:04:05Z", db.CreateTime)
+		if err == nil {
+			rdbmsInfo.CreatedTime = t
+		}
+	}
+
+	return rdbmsInfo
+}
+
+func convertAlibabaStatusToRDBMSStatus(status string) irs.RDBMSStatus {
+	switch status {
+	case "Creating", "Restoring", "Importing":
+		return irs.RDBMSCreating
+	case "Running":
+		return irs.RDBMSAvailable
+	case "Deleting":
+		return irs.RDBMSDeleting
+	case "DBInstanceClassChanging", "GuardDBInstanceCreating", "ReplicaCreating",
+		"Rebooting", "Transing", "TransingToOthers", "EngineVersionUpgrading",
+		"MinorVersionUpgrading", "NET_CREATING", "NET_DELETING",
+		"Switching", "DISK_EXPANDING":
+		return irs.RDBMSAvailable
+	case "Locked", "LockMode":
+		return irs.RDBMSStopped
+	default:
+		return irs.RDBMSError
+	}
+}
+
+func (handler *AlibabaRDBMSHandler) waitForDBInstanceStatus(dbInstanceId string, targetStatus string, timeoutSec int) error {
+	for elapsed := 0; elapsed < timeoutSec; elapsed += 15 {
+		request := rds.CreateDescribeDBInstanceAttributeRequest()
+		request.DBInstanceId = dbInstanceId
+
+		response, err := handler.Client.DescribeDBInstanceAttribute(request)
+		if err != nil {
+			return err
+		}
+
+		if len(response.Items.DBInstanceAttribute) > 0 {
+			if response.Items.DBInstanceAttribute[0].DBInstanceStatus == targetStatus {
+				return nil
+			}
+		}
+
+		time.Sleep(15 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for instance %s to reach status %s", dbInstanceId, targetStatus)
+}

--- a/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/AwsDriver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/aws/aws-sdk-go/service/sts"
 	cblogger "github.com/cloud-barista/cb-log"
@@ -76,6 +77,7 @@ func (AwsDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.ClusterHandler = true
 	drvCapabilityInfo.FileSystemHandler = true
 	drvCapabilityInfo.QuotaInfoHandler = true
+	drvCapabilityInfo.RDBMSHandler = true
 
 	drvCapabilityInfo.TagHandler = true
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{ires.VPC, ires.SUBNET, ires.SG, ires.KEY, ires.VM, ires.NLB, ires.DISK, ires.MYIMAGE, ires.CLUSTER, ires.FILESYSTEM}
@@ -338,6 +340,15 @@ func getEFSClient(connectionInfo idrv.ConnectionInfo) (*efs.EFS, error) {
 	return efs.New(sess), nil
 }
 
+func getRDSClient(connectionInfo idrv.ConnectionInfo) (*rds.RDS, error) {
+	sess, err := newAWSSession(connectionInfo, connectionInfo.RegionInfo.Region)
+	if err != nil {
+		cblog.Error("Could not create AWS session", err)
+		return nil, err
+	}
+	return rds.New(sess), nil
+}
+
 func getServiceQuotasClient(connectionInfo idrv.ConnectionInfo) (*servicequotas.ServiceQuotas, error) {
 	sess, err := newAWSSession(connectionInfo, connectionInfo.RegionInfo.Region)
 	if err != nil {
@@ -369,6 +380,7 @@ func (driver *AwsDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 	autoScalingClient, err := getAutoScalingClient(connectionInfo)
 	efsClient, err := getEFSClient(connectionInfo)
 	serviceQuotasClient, err := getServiceQuotasClient(connectionInfo)
+	rdsClient, err := getRDSClient(connectionInfo)
 	//vmClient, err := getVMClient(connectionInfo.RegionInfo)
 	if err != nil {
 		return nil, err
@@ -410,6 +422,7 @@ func (driver *AwsDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 		CloudWatchClient:    cloudwatchClient,
 		FileSystemClient:    efsClient,
 		ServiceQuotasClient: serviceQuotasClient,
+		RDSClient:           rdsClient,
 	}
 
 	return &iConn, nil // return type: (icon.CloudConnection, error)

--- a/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/connect/AwsCloudConnection.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/efs"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/pricing"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/aws/aws-sdk-go/service/sts"
 
@@ -75,6 +76,7 @@ type AwsCloudConnection struct {
 	CloudWatchClient    *cloudwatch.CloudWatch
 	FileSystemClient    *efs.EFS
 	ServiceQuotasClient *servicequotas.ServiceQuotas
+	RDSClient           *rds.RDS
 }
 
 var cblogger *logrus.Logger
@@ -243,5 +245,11 @@ func (cloudConn *AwsCloudConnection) CreateMonitoringHandler() (irs.MonitoringHa
 		VMClient:       cloudConn.VMClient,
 		ClusterHandler: clusterHandler,
 	}
+	return &handler, nil
+}
+
+func (cloudConn *AwsCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	tagHandler := cloudConn.CreateAwsTagHandler()
+	handler := ars.AwsRDBMSHandler{Region: cloudConn.Region, Client: cloudConn.RDSClient, EC2Client: cloudConn.VNetworkClient, TagHandler: &tagHandler}
 	return &handler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
@@ -1,0 +1,538 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/rds"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type AwsRDBMSHandler struct {
+	Region     idrv.RegionInfo
+	Client     *rds.RDS
+	EC2Client  *ec2.EC2
+	TagHandler *AwsTagHandler
+}
+
+// GetMetaInfo returns metadata about AWS RDS capabilities.
+func (handler *AwsRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("AWS RDS GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql":      {"5.7", "8.0", "8.4"},
+			"mariadb":    {"10.4", "10.5", "10.6", "10.11"},
+			"postgresql": {"13", "14", "15", "16", "17"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: true,
+		SupportsEncryption:         true,
+		StorageTypeOptions: map[string][]string{
+			"mysql":      {"gp2", "gp3", "io1", "io2"},
+			"mariadb":    {"gp2", "gp3", "io1", "io2"},
+			"postgresql": {"gp2", "gp3", "io1", "io2"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 20,
+			Max: 65536,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+// ListIID returns a list of RDBMS IIDs.
+func (handler *AwsRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "DescribeDBInstances()")
+	start := call.Start()
+
+	input := &rds.DescribeDBInstancesInput{}
+	var iidList []*irs.IID
+
+	err := handler.Client.DescribeDBInstancesPages(input, func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbInstance := range page.DBInstances {
+			iid := &irs.IID{
+				NameId:   aws.StringValue(dbInstance.DBInstanceIdentifier),
+				SystemId: aws.StringValue(dbInstance.DBInstanceIdentifier),
+			}
+			iidList = append(iidList, iid)
+		}
+		return true
+	})
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return iidList, nil
+}
+
+// CreateRDBMS creates a new RDS instance.
+func (handler *AwsRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateDBInstance()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required")
+	}
+	if rdbmsReqInfo.MasterUserName == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	storageSize, err := strconv.ParseInt(rdbmsReqInfo.StorageSize, 10, 64)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
+	}
+
+	// Create DB Subnet Group if VPC and Subnets are provided
+	subnetGroupName := ""
+	if rdbmsReqInfo.VpcIID.SystemId != "" && len(rdbmsReqInfo.SubnetIIDs) > 0 {
+		subnetGroupName = "cb-spider-" + rdbmsReqInfo.IId.NameId
+		err := handler.createDBSubnetGroup(subnetGroupName, rdbmsReqInfo.SubnetIIDs)
+		if err != nil {
+			return irs.RDBMSInfo{}, fmt.Errorf("failed to create DB subnet group: %w", err)
+		}
+	}
+
+	// Build CreateDBInstance input
+	input := &rds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String(rdbmsReqInfo.IId.NameId),
+		DBInstanceClass:      aws.String(rdbmsReqInfo.DBInstanceSpec),
+		Engine:               aws.String(rdbmsReqInfo.DBEngine),
+		EngineVersion:        aws.String(rdbmsReqInfo.DBEngineVersion),
+		MasterUsername:       aws.String(rdbmsReqInfo.MasterUserName),
+		MasterUserPassword:   aws.String(rdbmsReqInfo.MasterUserPassword),
+		AllocatedStorage:     aws.Int64(storageSize),
+	}
+
+	// DB Subnet Group
+	if subnetGroupName != "" {
+		input.DBSubnetGroupName = aws.String(subnetGroupName)
+	}
+
+	// Security Groups
+	if len(rdbmsReqInfo.SecurityGroupIIDs) > 0 {
+		var sgIDs []*string
+		for _, sg := range rdbmsReqInfo.SecurityGroupIIDs {
+			sgIDs = append(sgIDs, aws.String(sg.SystemId))
+		}
+		input.VpcSecurityGroupIds = sgIDs
+	}
+
+	// Storage Type (Advanced - default: gp2)
+	if rdbmsReqInfo.StorageType != "" {
+		input.StorageType = aws.String(rdbmsReqInfo.StorageType)
+	}
+
+	// Port
+	if rdbmsReqInfo.Port != "" {
+		port, err := strconv.ParseInt(rdbmsReqInfo.Port, 10, 64)
+		if err == nil {
+			input.Port = aws.Int64(port)
+		}
+	}
+
+	// Database Name
+	if rdbmsReqInfo.DatabaseName != "" {
+		input.DBName = aws.String(rdbmsReqInfo.DatabaseName)
+	}
+
+	// High Availability (Multi-AZ)
+	input.MultiAZ = aws.Bool(rdbmsReqInfo.HighAvailability)
+
+	// Backup
+	if rdbmsReqInfo.BackupRetentionDays > 0 {
+		input.BackupRetentionPeriod = aws.Int64(int64(rdbmsReqInfo.BackupRetentionDays))
+	}
+	if rdbmsReqInfo.BackupTime != "" {
+		// AWS expects "HH:MM-HH:MM" format for preferred backup window
+		input.PreferredBackupWindow = aws.String(rdbmsReqInfo.BackupTime)
+	}
+
+	// Public Access
+	input.PubliclyAccessible = aws.Bool(rdbmsReqInfo.PublicAccess)
+
+	// Encryption
+	input.StorageEncrypted = aws.Bool(rdbmsReqInfo.Encryption)
+
+	// Deletion Protection
+	input.DeletionProtection = aws.Bool(rdbmsReqInfo.DeletionProtection)
+
+	// Tags
+	var rdsTags []*rds.Tag
+	for _, tag := range rdbmsReqInfo.TagList {
+		rdsTags = append(rdsTags, &rds.Tag{
+			Key:   aws.String(tag.Key),
+			Value: aws.String(tag.Value),
+		})
+	}
+	// Add Name tag
+	rdsTags = append(rdsTags, &rds.Tag{
+		Key:   aws.String("Name"),
+		Value: aws.String(rdbmsReqInfo.IId.NameId),
+	})
+	input.Tags = rdsTags
+
+	// Create the RDS instance
+	result, err := handler.Client.CreateDBInstance(input)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		// Clean up subnet group on failure
+		if subnetGroupName != "" {
+			handler.deleteDBSubnetGroup(subnetGroupName)
+		}
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	rdbmsInfo := handler.convertDBInstanceToRDBMSInfo(result.DBInstance)
+	return rdbmsInfo, nil
+}
+
+// ListRDBMS returns a list of all RDBMS instances.
+func (handler *AwsRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "DescribeDBInstances()")
+	start := call.Start()
+
+	input := &rds.DescribeDBInstancesInput{}
+	var rdbmsList []*irs.RDBMSInfo
+
+	err := handler.Client.DescribeDBInstancesPages(input, func(page *rds.DescribeDBInstancesOutput, lastPage bool) bool {
+		for _, dbInstance := range page.DBInstances {
+			rdbmsInfo := handler.convertDBInstanceToRDBMSInfo(dbInstance)
+			rdbmsList = append(rdbmsList, &rdbmsInfo)
+		}
+		return true
+	})
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsList, nil
+}
+
+// GetRDBMS returns the details of a specific RDBMS instance.
+func (handler *AwsRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DescribeDBInstances()")
+	start := call.Start()
+
+	input := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(rdbmsIID.SystemId),
+	}
+
+	result, err := handler.Client.DescribeDBInstances(input)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	if len(result.DBInstances) == 0 {
+		return irs.RDBMSInfo{}, fmt.Errorf("RDBMS instance not found: %s", rdbmsIID.SystemId)
+	}
+
+	rdbmsInfo := handler.convertDBInstanceToRDBMSInfo(result.DBInstances[0])
+	return rdbmsInfo, nil
+}
+
+// DeleteRDBMS deletes an RDBMS instance.
+func (handler *AwsRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DeleteDBInstance()")
+	start := call.Start()
+
+	// First, get the instance to find the subnet group name
+	descInput := &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(rdbmsIID.SystemId),
+	}
+	descResult, err := handler.Client.DescribeDBInstances(descInput)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+
+	var subnetGroupName string
+	if len(descResult.DBInstances) > 0 && descResult.DBInstances[0].DBSubnetGroup != nil {
+		subnetGroupName = aws.StringValue(descResult.DBInstances[0].DBSubnetGroup.DBSubnetGroupName)
+	}
+
+	// Disable deletion protection if enabled
+	if len(descResult.DBInstances) > 0 && aws.BoolValue(descResult.DBInstances[0].DeletionProtection) {
+		modInput := &rds.ModifyDBInstanceInput{
+			DBInstanceIdentifier: aws.String(rdbmsIID.SystemId),
+			DeletionProtection:   aws.Bool(false),
+		}
+		_, err := handler.Client.ModifyDBInstance(modInput)
+		if err != nil {
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return false, fmt.Errorf("failed to disable deletion protection: %w", err)
+		}
+	}
+
+	// Delete the DB instance
+	input := &rds.DeleteDBInstanceInput{
+		DBInstanceIdentifier:   aws.String(rdbmsIID.SystemId),
+		SkipFinalSnapshot:      aws.Bool(true),
+		DeleteAutomatedBackups: aws.Bool(true),
+	}
+
+	_, err = handler.Client.DeleteDBInstance(input)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			cblogger.Error(aerr.Error())
+		}
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	// Wait for deletion then clean up subnet group
+	if subnetGroupName != "" && strings.HasPrefix(subnetGroupName, "cb-spider-") {
+		cblogger.Infof("Waiting for DB instance deletion to clean up subnet group: %s", subnetGroupName)
+		err := handler.waitForDBInstanceDeleted(rdbmsIID.SystemId)
+		if err != nil {
+			cblogger.Warnf("Failed to wait for DB instance deletion: %v", err)
+		} else {
+			handler.deleteDBSubnetGroup(subnetGroupName)
+		}
+	}
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func (handler *AwsRDBMSHandler) createDBSubnetGroup(groupName string, subnetIIDs []irs.IID) error {
+	var subnetIDs []*string
+	for _, subnet := range subnetIIDs {
+		subnetIDs = append(subnetIDs, aws.String(subnet.SystemId))
+	}
+
+	input := &rds.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        aws.String(groupName),
+		DBSubnetGroupDescription: aws.String("CB-Spider RDBMS subnet group for " + groupName),
+		SubnetIds:                subnetIDs,
+	}
+
+	_, err := handler.Client.CreateDBSubnetGroup(input)
+	return err
+}
+
+func (handler *AwsRDBMSHandler) deleteDBSubnetGroup(groupName string) {
+	input := &rds.DeleteDBSubnetGroupInput{
+		DBSubnetGroupName: aws.String(groupName),
+	}
+	_, err := handler.Client.DeleteDBSubnetGroup(input)
+	if err != nil {
+		cblogger.Warnf("Failed to delete DB subnet group %s: %v", groupName, err)
+	}
+}
+
+func (handler *AwsRDBMSHandler) waitForDBInstanceDeleted(dbInstanceId string) error {
+	maxWait := 30 * time.Minute
+	pollInterval := 30 * time.Second
+	deadline := time.Now().Add(maxWait)
+
+	for time.Now().Before(deadline) {
+		input := &rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: aws.String(dbInstanceId),
+		}
+		_, err := handler.Client.DescribeDBInstances(input)
+		if err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if aerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
+					return nil // Instance deleted
+				}
+			}
+			return err
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("timeout waiting for DB instance %s to be deleted", dbInstanceId)
+}
+
+func (handler *AwsRDBMSHandler) convertDBInstanceToRDBMSInfo(dbInstance *rds.DBInstance) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	dbId := aws.StringValue(dbInstance.DBInstanceIdentifier)
+	rdbmsInfo.IId = irs.IID{
+		NameId:   dbId,
+		SystemId: dbId,
+	}
+
+	// VPC
+	if dbInstance.DBSubnetGroup != nil {
+		rdbmsInfo.VpcIID = irs.IID{
+			SystemId: aws.StringValue(dbInstance.DBSubnetGroup.VpcId),
+		}
+		// Subnets
+		for _, subnet := range dbInstance.DBSubnetGroup.Subnets {
+			rdbmsInfo.SubnetIIDs = append(rdbmsInfo.SubnetIIDs, irs.IID{
+				SystemId: aws.StringValue(subnet.SubnetIdentifier),
+			})
+		}
+	}
+
+	// DB Engine
+	rdbmsInfo.DBEngine = aws.StringValue(dbInstance.Engine)
+	rdbmsInfo.DBEngineVersion = aws.StringValue(dbInstance.EngineVersion)
+
+	// Instance Spec
+	rdbmsInfo.DBInstanceSpec = aws.StringValue(dbInstance.DBInstanceClass)
+	if aws.BoolValue(dbInstance.MultiAZ) {
+		rdbmsInfo.DBInstanceType = "Multi-AZ"
+	} else {
+		rdbmsInfo.DBInstanceType = "Primary"
+	}
+
+	// Storage
+	rdbmsInfo.StorageType = aws.StringValue(dbInstance.StorageType)
+	if dbInstance.AllocatedStorage != nil {
+		rdbmsInfo.StorageSize = strconv.FormatInt(aws.Int64Value(dbInstance.AllocatedStorage), 10)
+	}
+
+	// Security Groups
+	for _, sg := range dbInstance.VpcSecurityGroups {
+		rdbmsInfo.SecurityGroupIIDs = append(rdbmsInfo.SecurityGroupIIDs, irs.IID{
+			SystemId: aws.StringValue(sg.VpcSecurityGroupId),
+		})
+	}
+
+	// Port
+	if dbInstance.Endpoint != nil && dbInstance.Endpoint.Port != nil {
+		rdbmsInfo.Port = strconv.FormatInt(aws.Int64Value(dbInstance.Endpoint.Port), 10)
+	} else if dbInstance.DbInstancePort != nil {
+		rdbmsInfo.Port = strconv.FormatInt(aws.Int64Value(dbInstance.DbInstancePort), 10)
+	}
+
+	// Authentication
+	rdbmsInfo.MasterUserName = aws.StringValue(dbInstance.MasterUsername)
+	// MasterUserPassword is never returned by AWS API
+
+	// Database
+	rdbmsInfo.DatabaseName = aws.StringValue(dbInstance.DBName)
+
+	// High Availability
+	rdbmsInfo.HighAvailability = aws.BoolValue(dbInstance.MultiAZ)
+	if dbInstance.StatusInfos != nil {
+		for _, info := range dbInstance.StatusInfos {
+			if aws.StringValue(info.StatusType) == "read replication" {
+				rdbmsInfo.ReplicationType = "async"
+			}
+		}
+	}
+
+	// Backup
+	if dbInstance.BackupRetentionPeriod != nil {
+		rdbmsInfo.BackupRetentionDays = int(aws.Int64Value(dbInstance.BackupRetentionPeriod))
+	}
+	rdbmsInfo.BackupTime = aws.StringValue(dbInstance.PreferredBackupWindow)
+
+	// Access
+	rdbmsInfo.PublicAccess = aws.BoolValue(dbInstance.PubliclyAccessible)
+	if dbInstance.Endpoint != nil {
+		rdbmsInfo.Endpoint = fmt.Sprintf("%s:%d",
+			aws.StringValue(dbInstance.Endpoint.Address),
+			aws.Int64Value(dbInstance.Endpoint.Port))
+	}
+
+	// Encryption
+	rdbmsInfo.Encryption = aws.BoolValue(dbInstance.StorageEncrypted)
+
+	// Protection
+	rdbmsInfo.DeletionProtection = aws.BoolValue(dbInstance.DeletionProtection)
+
+	// Status
+	rdbmsInfo.Status = convertRDSStatusToRDBMSStatus(aws.StringValue(dbInstance.DBInstanceStatus))
+
+	// Created Time
+	if dbInstance.InstanceCreateTime != nil {
+		rdbmsInfo.CreatedTime = *dbInstance.InstanceCreateTime
+	}
+
+	// KeyValueList - capture CSP-specific data
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(dbInstance)
+
+	return rdbmsInfo
+}
+
+func convertRDSStatusToRDBMSStatus(rdsStatus string) irs.RDBMSStatus {
+	switch strings.ToLower(rdsStatus) {
+	case "creating", "backing-up", "modifying", "upgrading", "configuring-enhanced-monitoring",
+		"configuring-iam-database-auth", "configuring-log-exports", "converting-to-vpc",
+		"moving-to-vpc", "rebooting", "renaming", "resetting-master-credentials",
+		"starting", "storage-optimization":
+		return irs.RDBMSCreating
+	case "available":
+		return irs.RDBMSAvailable
+	case "deleting":
+		return irs.RDBMSDeleting
+	case "stopped", "stopping", "storage-full":
+		return irs.RDBMSStopped
+	case "failed", "inaccessible-encryption-credentials", "incompatible-network",
+		"incompatible-option-group", "incompatible-parameters", "incompatible-restore",
+		"restore-error":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3"
@@ -292,6 +293,14 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 	if err != nil {
 		return nil, err
 	}
+	Ctx, mysqlServersClient, err := getMySQLServersClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		return nil, err
+	}
+	Ctx, mysqlFirewallRulesClient, err := getMySQLFirewallRulesClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		return nil, err
+	}
 	iConn := azcon.AzureCloudConnection{
 		CredentialInfo:                  connectionInfo.CredentialInfo,
 		Region:                          connectionInfo.RegionInfo,
@@ -325,6 +334,8 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 		DnsZoneClient:                   dnsZoneClient,
 		FileShareClient:                 fileShareClient,
 		AccountsClient:                  accountsClient,
+		MySQLServersClient:              mysqlServersClient,
+		MySQLFirewallRulesClient:        mysqlFirewallRulesClient,
 	}
 
 	return &iConn, nil
@@ -749,6 +760,32 @@ func getAccountsClient(credInfo idrv.CredentialInfo) (context.Context, *armstora
 		return nil, nil, err
 	}
 	client, err := armstorage.NewAccountsClient(credInfo.SubscriptionId, cred, newArmClientOptions())
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx, _ := context.WithTimeout(context.Background(), cspTimeout*time.Second)
+	return ctx, client, nil
+}
+
+func getMySQLServersClient(credInfo idrv.CredentialInfo) (context.Context, *armmysqlfs.ServersClient, error) {
+	cred, err := getCred(credInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := armmysqlfs.NewServersClient(credInfo.SubscriptionId, cred, newArmClientOptions())
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx, _ := context.WithTimeout(context.Background(), cspTimeout*time.Second)
+	return ctx, client, nil
+}
+
+func getMySQLFirewallRulesClient(credInfo idrv.CredentialInfo) (context.Context, *armmysqlfs.FirewallRulesClient, error) {
+	cred, err := getCred(credInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	client, err := armmysqlfs.NewFirewallRulesClient(credInfo.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3"
@@ -70,6 +71,8 @@ type AzureCloudConnection struct {
 	DnsZoneClient                   *armdns.ZonesClient
 	FileShareClient                 *armstorage.FileSharesClient
 	AccountsClient                  *armstorage.AccountsClient
+	MySQLServersClient              *armmysqlfs.ServersClient
+	MySQLFirewallRulesClient        *armmysqlfs.FirewallRulesClient
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -305,4 +308,16 @@ func (cloudConn *AzureCloudConnection) CreateMonitoringHandler() (irs.Monitoring
 		MetricClient:                    cloudConn.MetricClient,
 	}
 	return &monitoringHandler, nil
+}
+
+func (cloudConn *AzureCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("Azure Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := azrs.AzureRDBMSHandler{
+		CredentialInfo:      cloudConn.CredentialInfo,
+		Region:              cloudConn.Region,
+		Ctx:                 cloudConn.Ctx,
+		ServersClient:       cloudConn.MySQLServersClient,
+		FirewallRulesClient: cloudConn.MySQLFirewallRulesClient,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
@@ -1,0 +1,436 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type AzureRDBMSHandler struct {
+	CredentialInfo      idrv.CredentialInfo
+	Region              idrv.RegionInfo
+	Ctx                 context.Context
+	ServersClient       *armmysqlfs.ServersClient
+	FirewallRulesClient *armmysqlfs.FirewallRulesClient
+}
+
+func (handler *AzureRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("Azure MySQL Flexible Server GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql": {"5.7", "8.0.21"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: false,
+		SupportsEncryption:         true,
+		StorageTypeOptions: map[string][]string{
+			"mysql": {"GeneralPurpose", "BusinessCritical", "Burstable"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 20,
+			Max: 16384,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+func (handler *AzureRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "Servers.NewListByResourceGroupPager()")
+	start := call.Start()
+
+	resourceGroup := handler.Region.Region
+	var iidList []*irs.IID
+
+	pager := handler.ServersClient.NewListByResourceGroupPager(resourceGroup, nil)
+	for pager.More() {
+		page, err := pager.NextPage(handler.Ctx)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+		for _, server := range page.Value {
+			name := ""
+			if server.Name != nil {
+				name = *server.Name
+			}
+			iidList = append(iidList, &irs.IID{NameId: name, SystemId: name})
+		}
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return iidList, nil
+}
+
+func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "Servers.BeginCreate()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required")
+	}
+	if rdbmsReqInfo.MasterUserName == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	resourceGroup := handler.Region.Region
+	location := handler.Region.Region
+
+	storageSizeGB, err := strconv.ParseInt(rdbmsReqInfo.StorageSize, 10, 32)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
+	}
+	storageSizeGB32 := int32(storageSizeGB)
+
+	// Map engine version
+	version := armmysqlfs.ServerVersionEight021
+	switch rdbmsReqInfo.DBEngineVersion {
+	case "5.7":
+		version = armmysqlfs.ServerVersionFive7
+	case "8.0.21", "8.0":
+		version = armmysqlfs.ServerVersionEight021
+	}
+
+	// High Availability
+	haMode := armmysqlfs.HighAvailabilityModeDisabled
+	if rdbmsReqInfo.HighAvailability {
+		haMode = armmysqlfs.HighAvailabilityModeZoneRedundant
+	}
+
+	// Backup retention
+	backupRetention := int32(7)
+	if rdbmsReqInfo.BackupRetentionDays > 0 {
+		backupRetention = int32(rdbmsReqInfo.BackupRetentionDays)
+	}
+
+	// Flexible Server create mode
+	createMode := armmysqlfs.CreateModeDefault
+
+	// PublicNetworkAccess
+	publicAccess := armmysqlfs.EnableStatusEnumDisabled
+	if rdbmsReqInfo.PublicAccess {
+		publicAccess = armmysqlfs.EnableStatusEnumEnabled
+	}
+
+	parameters := armmysqlfs.Server{
+		Location: &location,
+		Properties: &armmysqlfs.ServerProperties{
+			AdministratorLogin:         &rdbmsReqInfo.MasterUserName,
+			AdministratorLoginPassword: &rdbmsReqInfo.MasterUserPassword,
+			Version:                    &version,
+			CreateMode:                 &createMode,
+			Storage: &armmysqlfs.Storage{
+				StorageSizeGB: &storageSizeGB32,
+			},
+			Backup: &armmysqlfs.Backup{
+				BackupRetentionDays: &backupRetention,
+			},
+			HighAvailability: &armmysqlfs.HighAvailability{
+				Mode: &haMode,
+			},
+			Network: &armmysqlfs.Network{
+				PublicNetworkAccess: &publicAccess,
+			},
+		},
+		SKU: &armmysqlfs.SKU{
+			Name: &rdbmsReqInfo.DBInstanceSpec,
+			Tier: skuTierFromSpec(rdbmsReqInfo.DBInstanceSpec),
+		},
+	}
+
+	// Tags
+	if len(rdbmsReqInfo.TagList) > 0 {
+		tags := make(map[string]*string)
+		for _, tag := range rdbmsReqInfo.TagList {
+			v := tag.Value
+			tags[tag.Key] = &v
+		}
+		parameters.Tags = tags
+	}
+
+	poller, err := handler.ServersClient.BeginCreate(handler.Ctx, resourceGroup, rdbmsReqInfo.IId.NameId, parameters, nil)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	resp, err := poller.PollUntilDone(handler.Ctx, nil)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("failed waiting for server creation: %w", err)
+	}
+
+	// Add firewall rule to allow all IPs when PublicAccess is enabled
+	if rdbmsReqInfo.PublicAccess && handler.FirewallRulesClient != nil {
+		serverName := rdbmsReqInfo.IId.NameId
+		if resp.Server.Name != nil {
+			serverName = *resp.Server.Name
+		}
+		startIP := "0.0.0.0"
+		endIP := "255.255.255.255"
+		fwRule := armmysqlfs.FirewallRule{
+			Properties: &armmysqlfs.FirewallRuleProperties{
+				StartIPAddress: &startIP,
+				EndIPAddress:   &endIP,
+			},
+		}
+		fwPoller, fwErr := handler.FirewallRulesClient.BeginCreateOrUpdate(
+			handler.Ctx, resourceGroup, serverName, "AllowAll", fwRule, nil)
+		if fwErr != nil {
+			cblogger.Warn("failed to create firewall rule: ", fwErr)
+		} else {
+			_, fwErr = fwPoller.PollUntilDone(handler.Ctx, nil)
+			if fwErr != nil {
+				cblogger.Warn("failed waiting for firewall rule creation: ", fwErr)
+			}
+		}
+	}
+
+	return handler.convertToRDBMSInfo(&resp.Server), nil
+}
+
+func (handler *AzureRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "Servers.NewListByResourceGroupPager()")
+	start := call.Start()
+
+	resourceGroup := handler.Region.Region
+	var rdbmsList []*irs.RDBMSInfo
+
+	pager := handler.ServersClient.NewListByResourceGroupPager(resourceGroup, nil)
+	for pager.More() {
+		page, err := pager.NextPage(handler.Ctx)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+		for _, server := range page.Value {
+			rdbmsInfo := handler.convertToRDBMSInfo(server)
+			rdbmsList = append(rdbmsList, &rdbmsInfo)
+		}
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsList, nil
+}
+
+func (handler *AzureRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "Servers.Get()")
+	start := call.Start()
+
+	resourceGroup := handler.Region.Region
+	resp, err := handler.ServersClient.Get(handler.Ctx, resourceGroup, rdbmsIID.SystemId, nil)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return handler.convertToRDBMSInfo(&resp.Server), nil
+}
+
+func (handler *AzureRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "Servers.BeginDelete()")
+	start := call.Start()
+
+	resourceGroup := handler.Region.Region
+
+	poller, err := handler.ServersClient.BeginDelete(handler.Ctx, resourceGroup, rdbmsIID.SystemId, nil)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	_, err = poller.PollUntilDone(handler.Ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed waiting for server deletion: %w", err)
+	}
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func skuTierFromSpec(spec string) *armmysqlfs.SKUTier {
+	tierBurstable := armmysqlfs.SKUTierBurstable
+	tierGP := armmysqlfs.SKUTierGeneralPurpose
+	tierMO := armmysqlfs.SKUTierMemoryOptimized
+
+	specLower := strings.ToLower(spec)
+	switch {
+	case strings.HasPrefix(specLower, "standard_b"):
+		return &tierBurstable
+	case strings.HasPrefix(specLower, "standard_e"):
+		return &tierMO
+	default:
+		return &tierGP
+	}
+}
+
+func (handler *AzureRDBMSHandler) convertToRDBMSInfo(server *armmysqlfs.Server) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	if server.Name != nil {
+		rdbmsInfo.IId = irs.IID{
+			NameId:   *server.Name,
+			SystemId: *server.Name,
+		}
+	}
+
+	// VPC - Azure MySQL Flexible Server networking is managed separately
+	rdbmsInfo.VpcIID = irs.IID{SystemId: "NA"}
+
+	// Engine
+	rdbmsInfo.DBEngine = "mysql"
+	if server.Properties != nil {
+		if server.Properties.Version != nil {
+			rdbmsInfo.DBEngineVersion = string(*server.Properties.Version)
+		}
+
+		// FQDN as endpoint
+		if server.Properties.FullyQualifiedDomainName != nil {
+			rdbmsInfo.Endpoint = *server.Properties.FullyQualifiedDomainName + ":3306"
+		}
+
+		// Admin user
+		if server.Properties.AdministratorLogin != nil {
+			rdbmsInfo.MasterUserName = *server.Properties.AdministratorLogin
+		}
+
+		// Status
+		if server.Properties.State != nil {
+			rdbmsInfo.Status = convertFlexibleServerStatus(string(*server.Properties.State))
+		}
+
+		// Storage
+		if server.Properties.Storage != nil {
+			if server.Properties.Storage.StorageSizeGB != nil {
+				rdbmsInfo.StorageSize = strconv.FormatInt(int64(*server.Properties.Storage.StorageSizeGB), 10)
+			}
+		}
+
+		// Backup
+		if server.Properties.Backup != nil {
+			if server.Properties.Backup.BackupRetentionDays != nil {
+				rdbmsInfo.BackupRetentionDays = int(*server.Properties.Backup.BackupRetentionDays)
+			}
+		}
+
+		// High Availability
+		if server.Properties.HighAvailability != nil && server.Properties.HighAvailability.Mode != nil {
+			rdbmsInfo.HighAvailability = (*server.Properties.HighAvailability.Mode != armmysqlfs.HighAvailabilityModeDisabled)
+		}
+
+		// Replication
+		if server.Properties.ReplicationRole != nil {
+			rdbmsInfo.ReplicationType = string(*server.Properties.ReplicationRole)
+		}
+
+		// PublicAccess
+		if server.Properties.Network != nil && server.Properties.Network.PublicNetworkAccess != nil {
+			rdbmsInfo.PublicAccess = (*server.Properties.Network.PublicNetworkAccess == armmysqlfs.EnableStatusEnumEnabled)
+		}
+	}
+
+	// SKU
+	if server.SKU != nil {
+		if server.SKU.Name != nil {
+			rdbmsInfo.DBInstanceSpec = *server.SKU.Name
+		}
+		if server.SKU.Tier != nil {
+			rdbmsInfo.DBInstanceType = string(*server.SKU.Tier)
+		}
+	}
+
+	// Port
+	rdbmsInfo.Port = "3306"
+	rdbmsInfo.StorageType = "NA"
+	rdbmsInfo.DatabaseName = ""
+	rdbmsInfo.BackupTime = "NA"
+	rdbmsInfo.DeletionProtection = false
+
+	// CreatedTime from SystemData
+	if server.SystemData != nil && server.SystemData.CreatedAt != nil {
+		rdbmsInfo.CreatedTime = *server.SystemData.CreatedAt
+	}
+
+	// Tags
+	for k, v := range server.Tags {
+		val := ""
+		if v != nil {
+			val = *v
+		}
+		rdbmsInfo.TagList = append(rdbmsInfo.TagList, irs.KeyValue{Key: k, Value: val})
+	}
+
+	// KeyValueList
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(server)
+
+	return rdbmsInfo
+}
+
+func convertFlexibleServerStatus(state string) irs.RDBMSStatus {
+	switch strings.ToLower(state) {
+	case "ready":
+		return irs.RDBMSAvailable
+	case "stopped", "disabled", "dropping":
+		return irs.RDBMSStopped
+	case "starting", "updating":
+		return irs.RDBMSCreating
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/GCPDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/GCPDriver.go
@@ -35,6 +35,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/option"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 var cblog *logrus.Logger
@@ -74,6 +75,8 @@ func (GCPDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{ires.VM, ires.DISK, ires.CLUSTER}
 
 	drvCapabilityInfo.QuotaInfoHandler = true
+
+	drvCapabilityInfo.RDBMSHandler = true
 
 	drvCapabilityInfo.VPC_CIDR = false
 
@@ -148,6 +151,14 @@ func (driver *GCPDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.
 		BillingCatalogClient: billingCatalogClient,
 		CostEstimationClient: costEstimationClient,
 		FilestoreClient:      filestoreClient,
+	}
+
+	// Cloud SQL Admin client - initialize after connection struct
+	sqlAdminClient, err := getSQLAdminClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		cblog.Warn("Could not create Cloud SQL Admin client: ", err)
+	} else {
+		iConn.SQLAdminClient = sqlAdminClient
 	}
 
 	//cblog.Info("################## resource ConnectionInfo ##################")
@@ -349,4 +360,31 @@ func getFilestoreClient(credential idrv.CredentialInfo) (context.Context, *files
 	}
 
 	return ctx, filestoreClient, nil
+}
+
+func getSQLAdminClient(credential idrv.CredentialInfo) (*sqladmin.Service, error) {
+	gcpType := "service_account"
+	data := make(map[string]string)
+
+	data["type"] = gcpType
+	data["private_key"] = credential.PrivateKey
+	data["client_email"] = credential.ClientEmail
+
+	res, _ := json.Marshal(data)
+	authURL := "https://www.googleapis.com/auth/cloud-platform"
+
+	conf, err := goo.JWTConfigFromJSON(res, authURL)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	client := conf.Client(ctx)
+
+	sqlAdminClient, err := sqladmin.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+
+	return sqlAdminClient, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/connect/GCP_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/connect/GCP_CloudConnection.go
@@ -24,6 +24,7 @@ import (
 	cbb "google.golang.org/api/cloudbilling/v1beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 var cblogger *logrus.Logger
@@ -56,6 +57,7 @@ type GCPCloudConnection struct {
 	BillingCatalogClient *cloudbilling.APIService
 	CostEstimationClient *cbb.Service
 	FilestoreClient      *filestore.CloudFilestoreManagerClient
+	SQLAdminClient       *sqladmin.Service
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -213,4 +215,10 @@ func (cloudConn *GCPCloudConnection) CreateMonitoringHandler() (irs.MonitoringHa
 		ContainerClient: cloudConn.ContainerClient,
 	}
 	return &monitoringHandler, nil
+}
+
+func (cloudConn *GCPCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("GCP Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := gcprs.GCPRDBMSHandler{Region: cloudConn.Region, Credential: cloudConn.Credential, Client: cloudConn.SQLAdminClient}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
@@ -1,0 +1,505 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
+)
+
+type GCPRDBMSHandler struct {
+	Region     idrv.RegionInfo
+	Credential idrv.CredentialInfo
+	Client     *sqladmin.Service
+}
+
+func (handler *GCPRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("GCP Cloud SQL GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql":      {"5.7", "8.0", "8.4"},
+			"postgresql": {"13", "14", "15", "16", "17"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: true,
+		SupportsEncryption:         true, // CMEK supported
+		StorageTypeOptions: map[string][]string{
+			"mysql":      {"PD_SSD", "PD_HDD"},
+			"postgresql": {"PD_SSD", "PD_HDD"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 10,
+			Max: 65536,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+func (handler *GCPRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "Instances.List()")
+	start := call.Start()
+
+	projectId := handler.Credential.ClientEmail
+	// GCP project ID is typically extracted from credential info
+	// In CB-Spider, the ProjectID is often stored in the credential
+	projectId = handler.getProjectId()
+
+	resp, err := handler.Client.Instances.List(projectId).Do()
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	var iidList []*irs.IID
+	for _, instance := range resp.Items {
+		iid := &irs.IID{
+			NameId:   instance.Name,
+			SystemId: instance.Name,
+		}
+		iidList = append(iidList, iid)
+	}
+
+	return iidList, nil
+}
+
+func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "Instances.Insert()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required")
+	}
+	if rdbmsReqInfo.MasterUserName == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	storageSizeGB, err := strconv.ParseInt(rdbmsReqInfo.StorageSize, 10, 64)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
+	}
+
+	projectId := handler.getProjectId()
+
+	// Map engine to GCP database version format
+	databaseVersion := handler.mapDatabaseVersion(rdbmsReqInfo.DBEngine, rdbmsReqInfo.DBEngineVersion)
+
+	// Build settings
+	settings := &sqladmin.Settings{
+		Tier:           rdbmsReqInfo.DBInstanceSpec, // e.g., "db-custom-2-7680"
+		DataDiskSizeGb: storageSizeGB,
+	}
+
+	// Storage Type
+	if rdbmsReqInfo.StorageType != "" {
+		settings.DataDiskType = rdbmsReqInfo.StorageType
+	}
+
+	// High Availability
+	if rdbmsReqInfo.HighAvailability {
+		settings.AvailabilityType = "REGIONAL"
+	} else {
+		settings.AvailabilityType = "ZONAL"
+	}
+
+	// Backup Configuration
+	backupConfig := &sqladmin.BackupConfiguration{
+		Enabled: true,
+	}
+	if rdbmsReqInfo.BackupRetentionDays > 0 {
+		backupConfig.TransactionLogRetentionDays = int64(rdbmsReqInfo.BackupRetentionDays)
+	}
+	if rdbmsReqInfo.BackupTime != "" {
+		backupConfig.StartTime = rdbmsReqInfo.BackupTime
+	}
+	settings.BackupConfiguration = backupConfig
+
+	// IP Configuration (Public Access, Network)
+	ipConfig := &sqladmin.IpConfiguration{}
+	if rdbmsReqInfo.PublicAccess {
+		ipConfig.Ipv4Enabled = true
+		// Allow all external access (like Azure's AllowAll firewall rule)
+		ipConfig.AuthorizedNetworks = []*sqladmin.AclEntry{
+			{
+				Value: "0.0.0.0/0",
+				Name:  "AllowAll",
+			},
+		}
+	} else {
+		ipConfig.Ipv4Enabled = false
+	}
+
+	// VPC Network - GCP uses private service connection
+	if rdbmsReqInfo.VpcIID.SystemId != "" {
+		ipConfig.PrivateNetwork = rdbmsReqInfo.VpcIID.SystemId
+	}
+	settings.IpConfiguration = ipConfig
+
+	// Deletion Protection
+	settings.DeletionProtectionEnabled = rdbmsReqInfo.DeletionProtection
+
+	// Build the instance
+	dbInstance := &sqladmin.DatabaseInstance{
+		Name:            rdbmsReqInfo.IId.NameId,
+		DatabaseVersion: databaseVersion,
+		Settings:        settings,
+		Region:          handler.Region.Region,
+		RootPassword:    rdbmsReqInfo.MasterUserPassword,
+	}
+
+	// User labels (tags)
+	if len(rdbmsReqInfo.TagList) > 0 {
+		labels := make(map[string]string)
+		for _, tag := range rdbmsReqInfo.TagList {
+			labels[strings.ToLower(tag.Key)] = strings.ToLower(tag.Value)
+		}
+		settings.UserLabels = labels
+	}
+
+	// Create the instance
+	op, err := handler.Client.Instances.Insert(projectId, dbInstance).Do()
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	// Wait for operation completion
+	err = handler.waitForOperation(projectId, op.Name)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("failed waiting for instance creation: %w", err)
+	}
+
+	// Set master user password via Users API
+	user := &sqladmin.User{
+		Name:     rdbmsReqInfo.MasterUserName,
+		Password: rdbmsReqInfo.MasterUserPassword,
+	}
+	_, err = handler.Client.Users.Insert(projectId, rdbmsReqInfo.IId.NameId, user).Do()
+	if err != nil {
+		cblogger.Warnf("Failed to create master user: %v", err)
+	}
+
+	// Set initial database if specified
+	if rdbmsReqInfo.DatabaseName != "" {
+		db := &sqladmin.Database{
+			Name: rdbmsReqInfo.DatabaseName,
+		}
+		_, err = handler.Client.Databases.Insert(projectId, rdbmsReqInfo.IId.NameId, db).Do()
+		if err != nil {
+			cblogger.Warnf("Failed to create initial database: %v", err)
+		}
+	}
+
+	// Get the created instance
+	return handler.GetRDBMS(irs.IID{NameId: rdbmsReqInfo.IId.NameId, SystemId: rdbmsReqInfo.IId.NameId})
+}
+
+func (handler *GCPRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "Instances.List()")
+	start := call.Start()
+
+	projectId := handler.getProjectId()
+	resp, err := handler.Client.Instances.List(projectId).Do()
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	var rdbmsList []*irs.RDBMSInfo
+	for _, instance := range resp.Items {
+		rdbmsInfo := handler.convertToRDBMSInfo(instance)
+		rdbmsList = append(rdbmsList, &rdbmsInfo)
+	}
+
+	return rdbmsList, nil
+}
+
+func (handler *GCPRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "Instances.Get()")
+	start := call.Start()
+
+	projectId := handler.getProjectId()
+	instance, err := handler.Client.Instances.Get(projectId, rdbmsIID.SystemId).Do()
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return handler.convertToRDBMSInfo(instance), nil
+}
+
+func (handler *GCPRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "Instances.Delete()")
+	start := call.Start()
+
+	projectId := handler.getProjectId()
+
+	// Check and disable deletion protection if needed
+	instance, err := handler.Client.Instances.Get(projectId, rdbmsIID.SystemId).Do()
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	if instance.Settings != nil && instance.Settings.DeletionProtectionEnabled {
+		instance.Settings.DeletionProtectionEnabled = false
+		_, err = handler.Client.Instances.Update(projectId, rdbmsIID.SystemId, instance).Do()
+		if err != nil {
+			return false, fmt.Errorf("failed to disable deletion protection: %w", err)
+		}
+	}
+
+	op, err := handler.Client.Instances.Delete(projectId, rdbmsIID.SystemId).Do()
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	err = handler.waitForOperation(projectId, op.Name)
+	if err != nil {
+		return false, fmt.Errorf("failed waiting for instance deletion: %w", err)
+	}
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func (handler *GCPRDBMSHandler) getProjectId() string {
+	return handler.Credential.ProjectID
+}
+
+func (handler *GCPRDBMSHandler) mapDatabaseVersion(engine, version string) string {
+	switch strings.ToLower(engine) {
+	case "mysql":
+		return "MYSQL_" + strings.ReplaceAll(version, ".", "_")
+	case "postgresql":
+		return "POSTGRES_" + strings.Split(version, ".")[0]
+	default:
+		return strings.ToUpper(engine) + "_" + strings.ReplaceAll(version, ".", "_")
+	}
+}
+
+func (handler *GCPRDBMSHandler) waitForOperation(projectId, opName string) error {
+	maxWait := 30 * time.Minute
+	pollInterval := 15 * time.Second
+	deadline := time.Now().Add(maxWait)
+
+	for time.Now().Before(deadline) {
+		op, err := handler.Client.Operations.Get(projectId, opName).Do()
+		if err != nil {
+			return err
+		}
+		if op.Status == "DONE" {
+			if op.Error != nil && len(op.Error.Errors) > 0 {
+				return fmt.Errorf("operation failed: %s", op.Error.Errors[0].Message)
+			}
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("timeout waiting for operation %s", opName)
+}
+
+func (handler *GCPRDBMSHandler) convertToRDBMSInfo(instance *sqladmin.DatabaseInstance) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	rdbmsInfo.IId = irs.IID{
+		NameId:   instance.Name,
+		SystemId: instance.Name,
+	}
+
+	// Parse engine and version from DatabaseVersion (e.g., "MYSQL_8_0", "POSTGRES_15")
+	engine, version := handler.parseDatabaseVersion(instance.DatabaseVersion)
+	rdbmsInfo.DBEngine = engine
+	rdbmsInfo.DBEngineVersion = version
+
+	// Instance Spec
+	if instance.Settings != nil {
+		rdbmsInfo.DBInstanceSpec = instance.Settings.Tier
+
+		// Storage
+		rdbmsInfo.StorageSize = strconv.FormatInt(instance.Settings.DataDiskSizeGb, 10)
+		rdbmsInfo.StorageType = instance.Settings.DataDiskType
+
+		// High Availability
+		rdbmsInfo.HighAvailability = (instance.Settings.AvailabilityType == "REGIONAL")
+		if rdbmsInfo.HighAvailability {
+			rdbmsInfo.DBInstanceType = "REGIONAL"
+			rdbmsInfo.ReplicationType = "sync"
+		} else {
+			rdbmsInfo.DBInstanceType = "ZONAL"
+		}
+
+		// Backup
+		if instance.Settings.BackupConfiguration != nil {
+			if instance.Settings.BackupConfiguration.Enabled {
+				rdbmsInfo.BackupRetentionDays = int(instance.Settings.BackupConfiguration.TransactionLogRetentionDays)
+				rdbmsInfo.BackupTime = instance.Settings.BackupConfiguration.StartTime
+			}
+		}
+
+		// IP Configuration
+		if instance.Settings.IpConfiguration != nil {
+			rdbmsInfo.PublicAccess = instance.Settings.IpConfiguration.Ipv4Enabled
+			// VPC
+			if instance.Settings.IpConfiguration.PrivateNetwork != "" {
+				rdbmsInfo.VpcIID = irs.IID{
+					SystemId: instance.Settings.IpConfiguration.PrivateNetwork,
+				}
+			}
+		}
+
+		// Deletion Protection
+		rdbmsInfo.DeletionProtection = instance.Settings.DeletionProtectionEnabled
+
+		// Tags (labels)
+		for k, v := range instance.Settings.UserLabels {
+			rdbmsInfo.TagList = append(rdbmsInfo.TagList, irs.KeyValue{Key: k, Value: v})
+		}
+	}
+
+	// Authentication - retrieve master user from Users API
+	rdbmsInfo.MasterUserName = "" // default empty
+	projectId := handler.getProjectId()
+	userListResp, userErr := handler.Client.Users.List(projectId, instance.Name).Do()
+	if userErr == nil && userListResp != nil {
+		for _, u := range userListResp.Items {
+			// Skip built-in system accounts
+			if u.Name != "" && u.Name != "root" && u.Name != "postgres" &&
+				u.Name != "cloudsqlsuperuser" && u.Name != "cloudsqladmin" &&
+				u.Name != "cloudsqlreplica" {
+				rdbmsInfo.MasterUserName = u.Name
+				break
+			}
+		}
+	}
+
+	// Endpoint
+	if len(instance.IpAddresses) > 0 {
+		for _, ip := range instance.IpAddresses {
+			if ip.Type == "PRIMARY" || ip.Type == "PRIVATE" {
+				rdbmsInfo.Endpoint = ip.IpAddress
+				break
+			}
+		}
+	}
+
+	// Port - GCP uses standard ports
+	switch strings.ToLower(engine) {
+	case "mysql":
+		rdbmsInfo.Port = "3306"
+	case "postgresql":
+		rdbmsInfo.Port = "5432"
+	}
+
+	// Encryption - GCP encrypts by default
+	rdbmsInfo.Encryption = true
+
+	// Status
+	rdbmsInfo.Status = convertGCPStatusToRDBMSStatus(instance.State)
+
+	// Created Time
+	if instance.CreateTime != "" {
+		t, err := time.Parse(time.RFC3339, instance.CreateTime)
+		if err == nil {
+			rdbmsInfo.CreatedTime = t
+		}
+	}
+
+	// SecurityGroupIIDs - Not applicable for GCP Cloud SQL
+	// SubnetIIDs - Not applicable for GCP Cloud SQL (uses VPC peering)
+
+	// KeyValueList
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(instance)
+
+	return rdbmsInfo
+}
+
+func (handler *GCPRDBMSHandler) parseDatabaseVersion(dbVersion string) (string, string) {
+	// e.g., "MYSQL_8_0" -> "mysql", "8.0"
+	// e.g., "POSTGRES_15" -> "postgresql", "15"
+	parts := strings.SplitN(dbVersion, "_", 2)
+	if len(parts) < 2 {
+		return strings.ToLower(dbVersion), ""
+	}
+	engine := strings.ToLower(parts[0])
+	if engine == "postgres" {
+		engine = "postgresql"
+	}
+	version := strings.ReplaceAll(parts[1], "_", ".")
+	return engine, version
+}
+
+func convertGCPStatusToRDBMSStatus(state string) irs.RDBMSStatus {
+	switch strings.ToUpper(state) {
+	case "RUNNABLE":
+		return irs.RDBMSAvailable
+	case "PENDING_CREATE", "MAINTENANCE":
+		return irs.RDBMSCreating
+	case "SUSPENDED", "STOPPED":
+		return irs.RDBMSStopped
+	case "PENDING_DELETE":
+		return irs.RDBMSDeleting
+	case "FAILED":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/ibm/IBMCloudDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/IBMCloudDriver.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"time"
 
+	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ibm/connect"
 	ibms "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ibm/resources"
@@ -47,6 +49,8 @@ func (IbmCloudDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.ClusterHandler = true
 	drvCapabilityInfo.FileSystemHandler = true
 	drvCapabilityInfo.QuotaInfoHandler = false
+
+	drvCapabilityInfo.RDBMSHandler = true
 
 	drvCapabilityInfo.TagHandler = true
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{ires.VPC, ires.SUBNET, ires.SG, ires.KEY, ires.VM, ires.NLB, ires.DISK, ires.MYIMAGE, ires.CLUSTER}
@@ -123,14 +127,34 @@ func (driver *IbmCloudDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (
 		return nil, err
 	}
 
+	resourceControllerService, err := resourcecontrollerv2.NewResourceControllerV2(&resourcecontrollerv2.ResourceControllerV2Options{
+		Authenticator: &core.IamAuthenticator{
+			ApiKey: connectionInfo.CredentialInfo.ApiKey,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cloudDBService, err := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
+		Authenticator: &core.IamAuthenticator{
+			ApiKey: connectionInfo.CredentialInfo.ApiKey,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	iConn := connect.IbmCloudConnection{
-		CredentialInfo: connectionInfo.CredentialInfo,
-		Region:         connectionInfo.RegionInfo,
-		VpcService:     vpcService,
-		ClusterService: clusterService,
-		TaggingService: taggingService,
-		SearchService:  searchService,
-		Ctx:            ctx,
+		CredentialInfo:     connectionInfo.CredentialInfo,
+		Region:             connectionInfo.RegionInfo,
+		VpcService:         vpcService,
+		ClusterService:     clusterService,
+		TaggingService:     taggingService,
+		SearchService:      searchService,
+		ResourceController: resourceControllerService,
+		CloudDBService:     cloudDBService,
+		Ctx:                ctx,
 	}
 	return &iConn, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibm/connect/Ibm_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/connect/Ibm_CloudConnection.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 
+	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
 	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
 
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	cblog "github.com/cloud-barista/cb-log"
 	ibmrs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ibm/resources"
@@ -24,13 +26,15 @@ func init() {
 }
 
 type IbmCloudConnection struct {
-	CredentialInfo idrv.CredentialInfo
-	Region         idrv.RegionInfo
-	VpcService     *vpcv1.VpcV1
-	ClusterService *kubernetesserviceapiv1.KubernetesServiceApiV1
-	TaggingService *globaltaggingv1.GlobalTaggingV1
-	SearchService  *globalsearchv2.GlobalSearchV2
-	Ctx            context.Context
+	CredentialInfo     idrv.CredentialInfo
+	Region             idrv.RegionInfo
+	VpcService         *vpcv1.VpcV1
+	ClusterService     *kubernetesserviceapiv1.KubernetesServiceApiV1
+	TaggingService     *globaltaggingv1.GlobalTaggingV1
+	SearchService      *globalsearchv2.GlobalSearchV2
+	ResourceController *resourcecontrollerv2.ResourceControllerV2
+	CloudDBService     *clouddatabasesv5.CloudDatabasesV5
+	Ctx                context.Context
 }
 
 func (cloudConn *IbmCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
@@ -224,4 +228,16 @@ func (cloudConn *IbmCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfoHand
 
 func (cloudConn *IbmCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, errors.New("Ibm Cloud Driver: not implemented")
+}
+
+func (cloudConn *IbmCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("Ibm Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := ibmrs.IbmRDBMSHandler{
+		CredentialInfo:     cloudConn.CredentialInfo,
+		Region:             cloudConn.Region,
+		Ctx:                cloudConn.Ctx,
+		ResourceController: cloudConn.ResourceController,
+		CloudDBService:     cloudConn.CloudDBService,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
@@ -1,0 +1,394 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
+	"github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+// IBM Cloud Databases service plan IDs (from IBM Global Catalog)
+const (
+	ibmMySQLPlanID      = "databases-for-mysql-standard"
+	ibmPostgreSQLPlanID = "databases-for-postgresql-standard"
+	ibmServiceIDMySQL   = "databases-for-mysql"
+	ibmServiceIDPG      = "databases-for-postgresql"
+)
+
+type IbmRDBMSHandler struct {
+	CredentialInfo     idrv.CredentialInfo
+	Region             idrv.RegionInfo
+	Ctx                context.Context
+	ResourceController *resourcecontrollerv2.ResourceControllerV2
+	CloudDBService     *clouddatabasesv5.CloudDatabasesV5
+}
+
+func (handler *IbmRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("IBM Cloud GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql":      {"5.7", "8.0"},
+			"postgresql": {"12", "13", "14", "15", "16"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: true, // IBM uses resource locking
+		SupportsEncryption:         true, // Always encrypted at rest
+		StorageTypeOptions: map[string][]string{
+			"mysql":      {"standard"},
+			"postgresql": {"standard"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 5,
+			Max: 4096,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+func (handler *IbmRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "ListResourceInstances()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+
+	// List MySQL instances
+	mysqlIIDs, err := handler.listResourceInstancesByType(ibmServiceIDMySQL)
+	if err != nil {
+		hiscallInfo.ElapsedTime = call.Elapsed(start)
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	iidList = append(iidList, mysqlIIDs...)
+
+	// List PostgreSQL instances
+	pgIIDs, err := handler.listResourceInstancesByType(ibmServiceIDPG)
+	if err != nil {
+		cblogger.Warn("Failed to list PostgreSQL instances: ", err)
+	} else {
+		iidList = append(iidList, pgIIDs...)
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return iidList, nil
+}
+
+func (handler *IbmRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateResourceInstance()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required (mysql or postgresql)")
+	}
+
+	// Determine resource plan ID based on engine
+	var resourcePlanID string
+	switch rdbmsReqInfo.DBEngine {
+	case "mysql":
+		resourcePlanID = ibmMySQLPlanID
+	case "postgresql":
+		resourcePlanID = ibmPostgreSQLPlanID
+	default:
+		return irs.RDBMSInfo{}, fmt.Errorf("unsupported engine: %s (supported: mysql, postgresql)", rdbmsReqInfo.DBEngine)
+	}
+
+	// Build parameters
+	params := map[string]interface{}{}
+	if rdbmsReqInfo.DBEngineVersion != "" {
+		params["version"] = rdbmsReqInfo.DBEngineVersion
+	}
+	if rdbmsReqInfo.MasterUserPassword != "" {
+		params["admin_password"] = rdbmsReqInfo.MasterUserPassword
+	}
+	if rdbmsReqInfo.HighAvailability {
+		params["members"] = 3 // IBM HA uses 3 members
+	}
+
+	// Target region
+	target := handler.Region.Region
+
+	createOpts := &resourcecontrollerv2.CreateResourceInstanceOptions{
+		Name:           &rdbmsReqInfo.IId.NameId,
+		Target:         &target,
+		ResourcePlanID: &resourcePlanID,
+		Parameters:     params,
+	}
+
+	// Tags
+	if len(rdbmsReqInfo.TagList) > 0 {
+		tags := make([]string, 0, len(rdbmsReqInfo.TagList))
+		for _, tag := range rdbmsReqInfo.TagList {
+			tags = append(tags, tag.Key+":"+tag.Value)
+		}
+		createOpts.Tags = tags
+	}
+
+	result, _, err := handler.ResourceController.CreateResourceInstance(createOpts)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	// Wait for active state
+	instanceId := ""
+	if result.GUID != nil {
+		instanceId = *result.GUID
+	}
+	if instanceId != "" {
+		err = handler.waitForResourceInstanceState(instanceId, "active", 1200)
+		if err != nil {
+			cblogger.Warn("Instance created but wait for active state failed: ", err)
+		}
+	}
+
+	return handler.convertResourceInstanceToRDBMSInfo(result), nil
+}
+
+func (handler *IbmRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "ListResourceInstances()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+
+	// List MySQL instances
+	mysqlInstances, err := handler.listResourceInstances(ibmServiceIDMySQL)
+	if err != nil {
+		hiscallInfo.ElapsedTime = call.Elapsed(start)
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, err
+	}
+	for _, inst := range mysqlInstances {
+		info := handler.convertResourceInstanceToRDBMSInfo(&inst)
+		rdbmsList = append(rdbmsList, &info)
+	}
+
+	// List PostgreSQL instances
+	pgInstances, err := handler.listResourceInstances(ibmServiceIDPG)
+	if err != nil {
+		cblogger.Warn("Failed to list PostgreSQL instances: ", err)
+	} else {
+		for _, inst := range pgInstances {
+			info := handler.convertResourceInstanceToRDBMSInfo(&inst)
+			rdbmsList = append(rdbmsList, &info)
+		}
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsList, nil
+}
+
+func (handler *IbmRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "GetResourceInstance()")
+	start := call.Start()
+
+	getOpts := &resourcecontrollerv2.GetResourceInstanceOptions{
+		ID: &rdbmsIID.SystemId,
+	}
+
+	result, _, err := handler.ResourceController.GetResourceInstance(getOpts)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return handler.convertResourceInstanceToRDBMSInfo(result), nil
+}
+
+func (handler *IbmRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DeleteResourceInstance()")
+	start := call.Start()
+
+	deleteOpts := &resourcecontrollerv2.DeleteResourceInstanceOptions{
+		ID: &rdbmsIID.SystemId,
+	}
+
+	_, err := handler.ResourceController.DeleteResourceInstance(deleteOpts)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func (handler *IbmRDBMSHandler) listResourceInstancesByType(serviceID string) ([]*irs.IID, error) {
+	instances, err := handler.listResourceInstances(serviceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var iidList []*irs.IID
+	for _, inst := range instances {
+		name := ""
+		sysId := ""
+		if inst.Name != nil {
+			name = *inst.Name
+		}
+		if inst.GUID != nil {
+			sysId = *inst.GUID
+		}
+		iidList = append(iidList, &irs.IID{NameId: name, SystemId: sysId})
+	}
+	return iidList, nil
+}
+
+func (handler *IbmRDBMSHandler) listResourceInstances(serviceID string) ([]resourcecontrollerv2.ResourceInstance, error) {
+	var allInstances []resourcecontrollerv2.ResourceInstance
+
+	listOpts := &resourcecontrollerv2.ListResourceInstancesOptions{
+		ResourceID: &serviceID,
+	}
+
+	result, _, err := handler.ResourceController.ListResourceInstances(listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	if result != nil && result.Resources != nil {
+		allInstances = append(allInstances, result.Resources...)
+	}
+
+	return allInstances, nil
+}
+
+func (handler *IbmRDBMSHandler) convertResourceInstanceToRDBMSInfo(inst *resourcecontrollerv2.ResourceInstance) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	if inst.Name != nil {
+		rdbmsInfo.IId.NameId = *inst.Name
+	}
+	if inst.GUID != nil {
+		rdbmsInfo.IId.SystemId = *inst.GUID
+	}
+
+	// Determine engine from resource plan ID
+	if inst.ResourcePlanID != nil {
+		switch *inst.ResourcePlanID {
+		case ibmMySQLPlanID:
+			rdbmsInfo.DBEngine = "mysql"
+			rdbmsInfo.Port = "3306"
+		case ibmPostgreSQLPlanID:
+			rdbmsInfo.DBEngine = "postgresql"
+			rdbmsInfo.Port = "5432"
+		}
+	}
+
+	// State
+	if inst.State != nil {
+		rdbmsInfo.Status = convertIBMStateToRDBMSStatus(*inst.State)
+	}
+
+	// Created time
+	if inst.CreatedAt != nil {
+		rdbmsInfo.CreatedTime = time.Time(*inst.CreatedAt)
+	}
+
+	// Parameters (version, etc.)
+	if inst.Parameters != nil {
+		if ver, ok := inst.Parameters["version"]; ok {
+			if verStr, ok := ver.(string); ok {
+				rdbmsInfo.DBEngineVersion = verStr
+			}
+		}
+	}
+
+	// IBM Cloud Databases are always encrypted at rest
+	rdbmsInfo.Encryption = true
+	rdbmsInfo.MasterUserName = "admin" // IBM default
+	rdbmsInfo.DatabaseName = "NA"
+	rdbmsInfo.StorageSize = "NA"
+	rdbmsInfo.StorageType = "standard"
+	rdbmsInfo.DBInstanceSpec = "NA"
+	rdbmsInfo.BackupTime = "NA"
+	rdbmsInfo.ReplicationType = "NA"
+	rdbmsInfo.Endpoint = "NA"
+	rdbmsInfo.VpcIID = irs.IID{SystemId: "NA"}
+	rdbmsInfo.DeletionProtection = false
+	rdbmsInfo.PublicAccess = false
+
+	// KeyValueList
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(inst)
+
+	return rdbmsInfo
+}
+
+func convertIBMStateToRDBMSStatus(state string) irs.RDBMSStatus {
+	switch state {
+	case "active":
+		return irs.RDBMSAvailable
+	case "provisioning":
+		return irs.RDBMSCreating
+	case "inactive", "removed":
+		return irs.RDBMSStopped
+	case "failed":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}
+
+func (handler *IbmRDBMSHandler) waitForResourceInstanceState(instanceId string, targetState string, timeoutSec int) error {
+	for elapsed := 0; elapsed < timeoutSec; elapsed += 30 {
+		getOpts := &resourcecontrollerv2.GetResourceInstanceOptions{
+			ID: &instanceId,
+		}
+
+		result, _, err := handler.ResourceController.GetResourceInstance(getOpts)
+		if err != nil {
+			return err
+		}
+
+		if result != nil && result.State != nil && *result.State == targetState {
+			return nil
+		}
+
+		time.Sleep(30 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for instance %s to reach state %s", instanceId, targetState)
+}

--- a/cloud-control-manager/cloud-driver/drivers/kt/KTDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/KTDriver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
 	"github.com/sirupsen/logrus"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	ktvpcsdk "github.com/cloud-barista/ktcloudvpc-sdk-go"
@@ -74,6 +75,8 @@ func (KTCloudVpcDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 
 	drvCapabilityInfo.SINGLE_VPC = true
 
+	drvCapabilityInfo.RDBMSHandler = true
+
 	return drvCapabilityInfo
 }
 
@@ -121,7 +124,12 @@ func (driver *KTCloudVpcDriver) ConnectCloud(connInfo idrv.ConnectionInfo) (icon
 	NASClient, err := getNASClient(providerClient, connInfo)
 	if err != nil {
 		return nil, err
-	}	
+	}
+
+	DBClient, err := getDBClient(providerClient, connInfo)
+	if err != nil {
+		cblogger.Warnf("KT Cloud VPC Driver: failed to create DB(Trove) client: %v", err)
+	}
 
 	iConn := ktvpccon.KTCloudVpcConnection{
 		RegionInfo:    connInfo.RegionInfo,
@@ -131,6 +139,7 @@ func (driver *KTCloudVpcDriver) ConnectCloud(connInfo idrv.ConnectionInfo) (icon
 		VolumeClient:  VolumeClient,
 		NLBClient:     NLBClient,
 		NASClient:     NASClient,
+		DBClient:      DBClient,
 	}
 	return &iConn, nil
 }
@@ -204,6 +213,17 @@ func getNLBClient(providerClient *ktvpcsdk.ProviderClient, connInfo idrv.Connect
 
 func getNASClient(providerClient *ktvpcsdk.ProviderClient, connInfo idrv.ConnectionInfo) (*ktvpcsdk.ServiceClient, error) {
 	client, err := ostack.NewSharedFileSystemV2(providerClient, ktvpcsdk.EndpointOpts{
+		Region: connInfo.RegionInfo.Zone,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, err
+}
+
+func getDBClient(providerClient *ktvpcsdk.ProviderClient, connInfo idrv.ConnectionInfo) (*ktvpcsdk.ServiceClient, error) {
+	client, err := ostack.NewDBV1(providerClient, ktvpcsdk.EndpointOpts{
 		Region: connInfo.RegionInfo.Zone,
 	})
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/kt/connect/KT_Connection.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/connect/KT_Connection.go
@@ -41,6 +41,7 @@ type KTCloudVpcConnection struct {
 	VolumeClient   *ktvpcsdk.ServiceClient
 	NLBClient      *ktvpcsdk.ServiceClient
 	NASClient      *ktvpcsdk.ServiceClient
+	DBClient       *ktvpcsdk.ServiceClient
 }
 
 func (cloudConn *KTCloudVpcConnection) CreateVMHandler() (irs.VMHandler, error) {
@@ -146,4 +147,13 @@ func (cloudConn *KTCloudVpcConnection) CreateTagHandler() (irs.TagHandler, error
 
 func (cloudConn *KTCloudVpcConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, fmt.Errorf("KT Cloud VPC Driver: not implemented")
+}
+
+func (cloudConn *KTCloudVpcConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("KT Cloud VPC Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := ktvpcrs.KTVpcRDBMSHandler{
+		RegionInfo: cloudConn.RegionInfo,
+		DBClient:   cloudConn.DBClient,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/RDBMSHandler.go
@@ -1,0 +1,386 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	ktvpcsdk "github.com/cloud-barista/ktcloudvpc-sdk-go"
+	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/db/v1/datastores"
+	"github.com/cloud-barista/ktcloudvpc-sdk-go/openstack/db/v1/instances"
+	"github.com/cloud-barista/ktcloudvpc-sdk-go/pagination"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type KTVpcRDBMSHandler struct {
+	RegionInfo idrv.RegionInfo
+	DBClient   *ktvpcsdk.ServiceClient
+}
+
+// GetMetaInfo returns metadata about KT Cloud Trove capabilities.
+func (handler *KTVpcRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called GetMetaInfo()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	supportedEngines := make(map[string][]string)
+
+	// Query available datastores dynamically from Trove
+	allPages, err := datastores.List(handler.DBClient).AllPages()
+	if err != nil {
+		cblogger.Warn(fmt.Sprintf("Failed to list datastores from KT Trove, using defaults: %v", err))
+		supportedEngines["mysql"] = []string{"5.7", "8.0"}
+	} else {
+		dsList, err := datastores.ExtractDatastores(allPages)
+		if err != nil {
+			cblogger.Warn(fmt.Sprintf("Failed to extract datastores: %v", err))
+		} else {
+			for _, ds := range dsList {
+				dsName := strings.ToLower(ds.Name)
+				if dsName == "mysql" || dsName == "mariadb" || dsName == "postgresql" {
+					var versions []string
+					for _, v := range ds.Versions {
+						versions = append(versions, v.Name)
+					}
+					supportedEngines[dsName] = versions
+				}
+			}
+		}
+	}
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: supportedEngines,
+
+		SupportsHighAvailability:   false, // KT Trove HA is deployment-specific
+		SupportsBackup:             true,
+		SupportsPublicAccess:       false,
+		SupportsDeletionProtection: false,
+		SupportsEncryption:         false,
+
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 1,
+			Max: 300,
+		},
+	}
+
+	loggingInfo(callLogInfo, start)
+	return metaInfo, nil
+}
+
+// ListIID returns a list of RDBMS instance IIDs.
+func (handler *KTVpcRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	cblogger.Info("KT Cloud VPC Driver: called ListIID()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListIID", "instances.List()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			iid := &irs.IID{
+				NameId:   inst.Name,
+				SystemId: inst.ID,
+			}
+			iidList = append(iidList, iid)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		newErr := fmt.Errorf("Failed to list RDBMS IIDs. [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+
+	loggingInfo(callLogInfo, start)
+	return iidList, nil
+}
+
+// CreateRDBMS creates a new KT Cloud Trove database instance.
+func (handler *KTVpcRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called CreateRDBMS()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "instances.Create()")
+	start := call.Start()
+
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS instance name is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec (FlavorRef) is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	storageSize, err := strconv.Atoi(rdbmsReqInfo.StorageSize)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize '%s': %w", rdbmsReqInfo.StorageSize, err)
+	}
+
+	engineType := strings.ToLower(rdbmsReqInfo.DBEngine)
+
+	createOpts := instances.CreateOpts{
+		Name:      rdbmsReqInfo.IId.NameId,
+		FlavorRef: rdbmsReqInfo.DBInstanceSpec,
+		Size:      storageSize,
+		Datastore: &instances.DatastoreOpts{
+			Type:    engineType,
+			Version: rdbmsReqInfo.DBEngineVersion,
+		},
+	}
+
+	// Set network if SubnetIIDs provided
+	if len(rdbmsReqInfo.SubnetIIDs) > 0 {
+		var networks []instances.NetworkOpts
+		for _, subnetIID := range rdbmsReqInfo.SubnetIIDs {
+			netID := subnetIID.SystemId
+			if netID == "" {
+				netID = subnetIID.NameId
+			}
+			networks = append(networks, instances.NetworkOpts{
+				UUID: netID,
+			})
+		}
+		createOpts.Networks = networks
+	}
+
+	result := instances.Create(handler.DBClient, createOpts)
+	createdInstance, err := result.Extract()
+	if err != nil {
+		newErr := fmt.Errorf("Failed to create RDBMS instance. [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.RDBMSInfo{}, newErr
+	}
+
+	loggingInfo(callLogInfo, start)
+	return convertKtInstanceToRDBMSInfo(createdInstance), nil
+}
+
+// ListRDBMS returns a list of all RDBMS instances.
+func (handler *KTVpcRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called ListRDBMS()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListRDBMS", "instances.List()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			info := convertKtInstanceToRDBMSInfo(&inst)
+			rdbmsList = append(rdbmsList, &info)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		newErr := fmt.Errorf("Failed to list RDBMS instances. [%v]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+
+	loggingInfo(callLogInfo, start)
+	return rdbmsList, nil
+}
+
+// GetRDBMS retrieves a specific RDBMS instance by IID.
+func (handler *KTVpcRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	cblogger.Info("KT Cloud VPC Driver: called GetRDBMS()")
+
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, instanceID, "instances.Get()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			loggingError(callLogInfo, err)
+			return irs.RDBMSInfo{}, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Get(handler.DBClient, instanceID)
+	inst, err := result.Extract()
+	if err != nil {
+		newErr := fmt.Errorf("Failed to get RDBMS instance '%s'. [%v]", instanceID, err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.RDBMSInfo{}, newErr
+	}
+
+	loggingInfo(callLogInfo, start)
+	return convertKtInstanceToRDBMSInfo(inst), nil
+}
+
+// DeleteRDBMS deletes a Trove database instance.
+func (handler *KTVpcRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	cblogger.Info("KT Cloud VPC Driver: called DeleteRDBMS()")
+
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, instanceID, "instances.Delete()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			loggingError(callLogInfo, err)
+			return false, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Delete(handler.DBClient, instanceID)
+	if result.Err != nil {
+		newErr := fmt.Errorf("Failed to delete RDBMS instance '%s'. [%v]", instanceID, result.Err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	loggingInfo(callLogInfo, start)
+	return true, nil
+}
+
+// ---- Helper functions ----
+
+func (handler *KTVpcRDBMSHandler) findInstanceIDByName(name string) (string, error) {
+	var foundID string
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			if inst.Name == name {
+				foundID = inst.ID
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("Failed to find RDBMS instance by name '%s'. [%v]", name, err)
+	}
+	if foundID == "" {
+		return "", fmt.Errorf("RDBMS instance with name '%s' not found", name)
+	}
+	return foundID, nil
+}
+
+func convertKtInstanceToRDBMSInfo(inst *instances.Instance) irs.RDBMSInfo {
+	endpoint := "NA"
+	if inst.Hostname != "" {
+		endpoint = inst.Hostname
+	} else if len(inst.IP) > 0 {
+		endpoint = inst.IP[0]
+	} else if len(inst.Addresses) > 0 {
+		endpoint = inst.Addresses[0].Address
+	}
+
+	port := "NA"
+	engineType := strings.ToLower(inst.Datastore.Type)
+	switch {
+	case strings.Contains(engineType, "mysql") || strings.Contains(engineType, "mariadb"):
+		port = "3306"
+	case strings.Contains(engineType, "postgresql"):
+		port = "5432"
+	}
+
+	return irs.RDBMSInfo{
+		IId: irs.IID{
+			NameId:   inst.Name,
+			SystemId: inst.ID,
+		},
+		VpcIID: irs.IID{NameId: "NA", SystemId: "NA"},
+
+		DBEngine:        inst.Datastore.Type,
+		DBEngineVersion: inst.Datastore.Version,
+		DBInstanceSpec:  inst.Flavor.ID,
+		DBInstanceType:  "Primary",
+
+		StorageType: "NA",
+		StorageSize: strconv.Itoa(inst.Volume.Size),
+
+		Port:     port,
+		Endpoint: endpoint,
+
+		MasterUserName: "NA",
+		DatabaseName:   "NA",
+
+		HighAvailability: false,
+		ReplicationType:  "NA",
+
+		BackupRetentionDays: 0,
+		BackupTime:          "NA",
+
+		PublicAccess:       false,
+		Encryption:         false,
+		DeletionProtection: false,
+
+		Status:      convertKtTroveStatusToRDBMSStatus(inst.Status),
+		CreatedTime: inst.Created,
+
+		KeyValueList: []irs.KeyValue{
+			{Key: "Hostname", Value: inst.Hostname},
+			{Key: "VolumeUsed", Value: fmt.Sprintf("%.2f", inst.Volume.Used)},
+		},
+	}
+}
+
+func convertKtTroveStatusToRDBMSStatus(status string) irs.RDBMSStatus {
+	switch strings.ToUpper(status) {
+	case "BUILD", "BACKUP", "RESTART_REQUIRED":
+		return irs.RDBMSCreating
+	case "ACTIVE":
+		return irs.RDBMSAvailable
+	case "SHUTDOWN":
+		return irs.RDBMSStopped
+	case "DELETED":
+		return irs.RDBMSDeleting
+	case "ERROR", "FAILED":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/ktclassic/connect/KTClassic_Connection.go
+++ b/cloud-control-manager/cloud-driver/drivers/ktclassic/connect/KTClassic_Connection.go
@@ -141,6 +141,10 @@ func (cloudConn *KtCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfoHandl
 	return nil, fmt.Errorf("KT Classic Cloud Driver: QuotaInfoHandler not supported")
 }
 
+func (cloudConn *KtCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	return nil, fmt.Errorf("KT Classic Cloud Driver: RDBMSHandler not supported")
+}
+
 func (cloudConn *KtCloudConnection) IsConnected() (bool, error) {
 	cblogger.Info("KT Cloud Driver: called IsConnected()!")
 	if cloudConn == nil {

--- a/cloud-control-manager/cloud-driver/drivers/mock/connect/MockCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/connect/MockCloudConnection.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"errors"
+	"fmt"
 	cblog "github.com/cloud-barista/cb-log"
 	mkrs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/mock/resources"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -132,4 +133,8 @@ func (cloudConn *MockConnection) CreateQuotaInfoHandler() (irs.QuotaInfoHandler,
 
 func (cloudConn *MockConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, errors.New("Mock Driver: not implemented")
+}
+
+func (cloudConn *MockConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	return nil, fmt.Errorf("Mock Driver: RDBMSHandler not supported")
 }

--- a/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
@@ -23,8 +23,10 @@ import (
 	ncloud "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
 	vas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
+	vmysql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
 	vnks "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnks"
 	vpc "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	vpostgresql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpostgresql"
 	vserver "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 	vnas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnas"
 
@@ -71,6 +73,8 @@ func (NcpVpcDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{}
 
 	drvCapabilityInfo.VPC_CIDR = true
+
+	drvCapabilityInfo.RDBMSHandler = true
 
 	return drvCapabilityInfo
 }
@@ -149,6 +153,26 @@ func getVnasClient(connectionInfo idrv.ConnectionInfo) (*vnas.APIClient, error) 
 	return client, nil
 }
 
+func getMysqlClient(connectionInfo idrv.ConnectionInfo) (*vmysql.APIClient, error) {
+	apiKeys := ncloud.APIKey{
+		AccessKey: connectionInfo.CredentialInfo.ClientId,
+		SecretKey: connectionInfo.CredentialInfo.ClientSecret,
+	}
+
+	client := vmysql.NewAPIClient(vmysql.NewConfiguration(&apiKeys))
+	return client, nil
+}
+
+func getPostgresqlClient(connectionInfo idrv.ConnectionInfo) (*vpostgresql.APIClient, error) {
+	apiKeys := ncloud.APIKey{
+		AccessKey: connectionInfo.CredentialInfo.ClientId,
+		SecretKey: connectionInfo.CredentialInfo.ClientSecret,
+	}
+
+	client := vpostgresql.NewAPIClient(vpostgresql.NewConfiguration(&apiKeys))
+	return client, nil
+}
+
 func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	// 1. get info of credential and region for Test A Cloud from connectionInfo.
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
@@ -188,6 +212,16 @@ func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ic
 		return nil, err
 	}
 
+	mysqlClient, err := getMysqlClient(connectionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	postgresClient, err := getPostgresqlClient(connectionInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	iConn := ncpcon.NcpVpcCloudConnection{
 		CredentialInfo: connectionInfo.CredentialInfo,
 		RegionInfo:     connectionInfo.RegionInfo,
@@ -197,6 +231,8 @@ func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ic
 		VnksClient:     vnksClient,
 		VasClient:      vasClient,
 		VnasClient:     vnasClient,
+		MysqlClient:    mysqlClient,
+		PostgresClient: postgresClient,
 	}
 
 	return &iConn, nil

--- a/cloud-control-manager/cloud-driver/drivers/ncp/connect/NcpVpcCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/connect/NcpVpcCloudConnection.go
@@ -21,12 +21,14 @@ import (
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
-	vpc "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
-	vserver "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
-	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
-	vnks "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnks"
 	vas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
+	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
+	vmysql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
 	vnas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnas"
+	vnks "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vnks"
+	vpc "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpc"
+	vpostgresql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpostgresql"
+	vserver "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 	// ncprs "github.com/cloud-barista/ncp/ncp/resources" // For local testing
 	ncprs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ncp/resources"
 )
@@ -40,6 +42,8 @@ type NcpVpcCloudConnection struct {
 	VnksClient     *vnks.APIClient
 	VasClient      *vas.APIClient
 	VnasClient     *vnas.APIClient
+	MysqlClient    *vmysql.APIClient
+	PostgresClient *vpostgresql.APIClient
 }
 
 var cblogger *logrus.Logger
@@ -202,4 +206,15 @@ func (cloudConn *NcpVpcCloudConnection) Close() error {
 
 func (cloudConn *NcpVpcCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, fmt.Errorf("NCP VPC Cloud Driver: not implemented")
+}
+
+// CreateRDBMSHandler implements connect.CloudConnection.
+func (cloudConn *NcpVpcCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("NCP VPC Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := ncprs.NcpVpcRDBMSHandler{
+		RegionInfo:     cloudConn.RegionInfo,
+		MysqlClient:    cloudConn.MysqlClient,
+		PostgresClient: cloudConn.PostgresClient,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
@@ -1,0 +1,606 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vpostgresql"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type NcpVpcRDBMSHandler struct {
+	RegionInfo     idrv.RegionInfo
+	MysqlClient    *vmysql.APIClient
+	PostgresClient *vpostgresql.APIClient
+}
+
+// GetMetaInfo returns metadata about NCP RDBMS capabilities.
+func (handler *NcpVpcRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("NCP VPC RDBMSHandler GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql":      {"8.0"},
+			"postgresql": {"13", "14", "15"},
+		},
+
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       false, // NCP DB instances are VPC-only
+		SupportsDeletionProtection: true,  // MySQL only (IsDeleteProtection)
+		SupportsEncryption:         true,
+
+		StorageTypeOptions: map[string][]string{
+			"mysql":      {"SSD"},
+			"postgresql": {"SSD"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 10,
+			Max: 6000,
+		},
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return metaInfo, nil
+}
+
+// ListIID returns a list of all RDBMS instance IIDs (MySQL + PostgreSQL).
+func (handler *NcpVpcRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListIID", "GetCloudMysqlInstanceList()+GetCloudPostgresqlInstanceList()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+
+	// List MySQL instances
+	mysqlResp, err := handler.MysqlClient.V2Api.GetCloudMysqlInstanceList(&vmysql.GetCloudMysqlInstanceListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list MySQL instances: %w", err)
+	}
+	for _, inst := range mysqlResp.CloudMysqlInstanceList {
+		iidList = append(iidList, &irs.IID{
+			NameId:   derefStr(inst.CloudMysqlServiceName),
+			SystemId: derefStr(inst.CloudMysqlInstanceNo),
+		})
+	}
+
+	// List PostgreSQL instances
+	pgResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlInstanceList(&vpostgresql.GetCloudPostgresqlInstanceListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list PostgreSQL instances: %w", err)
+	}
+	for _, inst := range pgResp.CloudPostgresqlInstanceList {
+		iidList = append(iidList, &irs.IID{
+			NameId:   derefStr(inst.CloudPostgresqlServiceName),
+			SystemId: derefStr(inst.CloudPostgresqlInstanceNo),
+		})
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return iidList, nil
+}
+
+// CreateRDBMS creates a new NCP managed database instance.
+func (handler *NcpVpcRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	engineType := strings.ToLower(rdbmsReqInfo.DBEngine)
+
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateRDBMS()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS instance name is required")
+	}
+	if rdbmsReqInfo.VpcIID.SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("VpcIID.SystemId (VpcNo) is required")
+	}
+	if len(rdbmsReqInfo.SubnetIIDs) == 0 || rdbmsReqInfo.SubnetIIDs[0].SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("at least one SubnetIID.SystemId (SubnetNo) is required")
+	}
+	if rdbmsReqInfo.MasterUserName == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+
+	switch engineType {
+	case "mysql":
+		return handler.createMysqlInstance(rdbmsReqInfo, hiscallInfo, start)
+	case "postgresql":
+		return handler.createPostgresqlInstance(rdbmsReqInfo, hiscallInfo, start)
+	default:
+		return irs.RDBMSInfo{}, fmt.Errorf("unsupported DBEngine '%s': NCP supports mysql and postgresql", rdbmsReqInfo.DBEngine)
+	}
+}
+
+func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hiscallInfo call.CLOUDLOGSCHEMA, start time.Time) (irs.RDBMSInfo, error) {
+	isHa := reqInfo.HighAvailability
+	isBackup := true
+	hostIp := "%"
+	dbName := reqInfo.DatabaseName
+	if dbName == "" {
+		dbName = "mydb"
+	}
+
+	createReq := &vmysql.CreateCloudMysqlInstanceRequest{
+		RegionCode:                 &handler.RegionInfo.Region,
+		VpcNo:                      &reqInfo.VpcIID.SystemId,
+		SubnetNo:                   &reqInfo.SubnetIIDs[0].SystemId,
+		CloudMysqlServiceName:      &reqInfo.IId.NameId,
+		CloudMysqlServerNamePrefix: &reqInfo.IId.NameId,
+		CloudMysqlUserName:         &reqInfo.MasterUserName,
+		CloudMysqlUserPassword:     &reqInfo.MasterUserPassword,
+		HostIp:                     &hostIp,
+		CloudMysqlDatabaseName:     &dbName,
+		IsHa:                       &isHa,
+		IsBackup:                   &isBackup,
+	}
+
+	if reqInfo.DBInstanceSpec != "" {
+		createReq.CloudMysqlProductCode = &reqInfo.DBInstanceSpec
+	}
+	if reqInfo.DBEngineVersion != "" {
+		createReq.EngineVersionCode = &reqInfo.DBEngineVersion
+	}
+	if reqInfo.StorageType != "" {
+		createReq.DataStorageTypeCode = &reqInfo.StorageType
+	}
+	if reqInfo.Encryption {
+		createReq.IsStorageEncryption = &reqInfo.Encryption
+	}
+	if reqInfo.DeletionProtection {
+		createReq.IsDeleteProtection = &reqInfo.DeletionProtection
+	}
+	if reqInfo.BackupRetentionDays > 0 {
+		period := int32(reqInfo.BackupRetentionDays)
+		createReq.BackupFileRetentionPeriod = &period
+	}
+	if reqInfo.BackupTime != "" {
+		createReq.BackupTime = &reqInfo.BackupTime
+	}
+	if reqInfo.Port != "" {
+		port, err := strconv.Atoi(reqInfo.Port)
+		if err == nil {
+			p := int32(port)
+			createReq.CloudMysqlPort = &p
+		}
+	}
+
+	resp, err := handler.MysqlClient.V2Api.CreateCloudMysqlInstance(createReq)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to create MySQL instance: %w", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+
+	if len(resp.CloudMysqlInstanceList) == 0 {
+		return irs.RDBMSInfo{}, errors.New("MySQL instance created but no instance returned in response")
+	}
+
+	return handler.convertMysqlInstanceToRDBMSInfo(resp.CloudMysqlInstanceList[0]), nil
+}
+
+func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInfo, hiscallInfo call.CLOUDLOGSCHEMA, start time.Time) (irs.RDBMSInfo, error) {
+	isHa := reqInfo.HighAvailability
+	isBackup := true
+	clientCidr := "0.0.0.0/0"
+	dbName := reqInfo.DatabaseName
+	if dbName == "" {
+		dbName = "mydb"
+	}
+
+	createReq := &vpostgresql.CreateCloudPostgresqlInstanceRequest{
+		RegionCode:                      &handler.RegionInfo.Region,
+		VpcNo:                           &reqInfo.VpcIID.SystemId,
+		SubnetNo:                        &reqInfo.SubnetIIDs[0].SystemId,
+		CloudPostgresqlServiceName:      &reqInfo.IId.NameId,
+		CloudPostgresqlServerNamePrefix: &reqInfo.IId.NameId,
+		CloudPostgresqlUserName:         &reqInfo.MasterUserName,
+		CloudPostgresqlUserPassword:     &reqInfo.MasterUserPassword,
+		ClientCidr:                      &clientCidr,
+		CloudPostgresqlDatabaseName:     &dbName,
+		IsHa:                            &isHa,
+		IsBackup:                        &isBackup,
+	}
+
+	if reqInfo.DBInstanceSpec != "" {
+		createReq.CloudPostgresqlProductCode = &reqInfo.DBInstanceSpec
+	}
+	if reqInfo.DBEngineVersion != "" {
+		createReq.EngineVersionCode = &reqInfo.DBEngineVersion
+	}
+	if reqInfo.StorageType != "" {
+		createReq.DataStorageTypeCode = &reqInfo.StorageType
+	}
+	if reqInfo.Encryption {
+		createReq.IsStorageEncryption = &reqInfo.Encryption
+	}
+	if reqInfo.BackupRetentionDays > 0 {
+		period := int32(reqInfo.BackupRetentionDays)
+		createReq.BackupFileRetentionPeriod = &period
+	}
+	if reqInfo.BackupTime != "" {
+		createReq.BackupTime = &reqInfo.BackupTime
+	}
+	if reqInfo.Port != "" {
+		port, err := strconv.Atoi(reqInfo.Port)
+		if err == nil {
+			p := int32(port)
+			createReq.CloudPostgresqlPort = &p
+		}
+	}
+
+	resp, err := handler.PostgresClient.V2Api.CreateCloudPostgresqlInstance(createReq)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to create PostgreSQL instance: %w", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+
+	if len(resp.CloudPostgresqlInstanceList) == 0 {
+		return irs.RDBMSInfo{}, errors.New("PostgreSQL instance created but no instance returned in response")
+	}
+
+	return handler.convertPostgresqlInstanceToRDBMSInfo(resp.CloudPostgresqlInstanceList[0]), nil
+}
+
+// ListRDBMS returns a list of all RDBMS instances (MySQL + PostgreSQL).
+func (handler *NcpVpcRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListRDBMS", "GetCloudMysqlInstanceList()+GetCloudPostgresqlInstanceList()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+
+	// List MySQL instances
+	mysqlResp, err := handler.MysqlClient.V2Api.GetCloudMysqlInstanceList(&vmysql.GetCloudMysqlInstanceListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list MySQL instances: %w", err)
+	}
+	for _, inst := range mysqlResp.CloudMysqlInstanceList {
+		info := handler.convertMysqlInstanceToRDBMSInfo(inst)
+		rdbmsList = append(rdbmsList, &info)
+	}
+
+	// List PostgreSQL instances
+	pgResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlInstanceList(&vpostgresql.GetCloudPostgresqlInstanceListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list PostgreSQL instances: %w", err)
+	}
+	for _, inst := range pgResp.CloudPostgresqlInstanceList {
+		info := handler.convertPostgresqlInstanceToRDBMSInfo(inst)
+		rdbmsList = append(rdbmsList, &info)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return rdbmsList, nil
+}
+
+// GetRDBMS retrieves a specific RDBMS instance by IID.
+func (handler *NcpVpcRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, rdbmsIID.NameId, "GetRDBMS()")
+	start := call.Start()
+
+	// Try MySQL first
+	if rdbmsIID.SystemId != "" {
+		mysqlResp, err := handler.MysqlClient.V2Api.GetCloudMysqlInstanceDetail(&vmysql.GetCloudMysqlInstanceDetailRequest{
+			RegionCode:           &handler.RegionInfo.Region,
+			CloudMysqlInstanceNo: &rdbmsIID.SystemId,
+		})
+		if err == nil && len(mysqlResp.CloudMysqlInstanceList) > 0 {
+			LoggingInfo(hiscallInfo, start)
+			return handler.convertMysqlInstanceToRDBMSInfo(mysqlResp.CloudMysqlInstanceList[0]), nil
+		}
+
+		// Try PostgreSQL
+		pgResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlInstanceDetail(&vpostgresql.GetCloudPostgresqlInstanceDetailRequest{
+			RegionCode:                &handler.RegionInfo.Region,
+			CloudPostgresqlInstanceNo: &rdbmsIID.SystemId,
+		})
+		if err == nil && len(pgResp.CloudPostgresqlInstanceList) > 0 {
+			LoggingInfo(hiscallInfo, start)
+			return handler.convertPostgresqlInstanceToRDBMSInfo(pgResp.CloudPostgresqlInstanceList[0]), nil
+		}
+
+		notFoundErr := fmt.Errorf("RDBMS instance with SystemId '%s' not found", rdbmsIID.SystemId)
+		LoggingError(hiscallInfo, notFoundErr)
+		return irs.RDBMSInfo{}, notFoundErr
+	}
+
+	// Search by NameId
+	if rdbmsIID.NameId != "" {
+		// Search MySQL
+		mysqlResp, err := handler.MysqlClient.V2Api.GetCloudMysqlInstanceList(&vmysql.GetCloudMysqlInstanceListRequest{
+			RegionCode:            &handler.RegionInfo.Region,
+			CloudMysqlServiceName: &rdbmsIID.NameId,
+		})
+		if err == nil && len(mysqlResp.CloudMysqlInstanceList) > 0 {
+			LoggingInfo(hiscallInfo, start)
+			return handler.convertMysqlInstanceToRDBMSInfo(mysqlResp.CloudMysqlInstanceList[0]), nil
+		}
+
+		// Search PostgreSQL
+		pgResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlInstanceList(&vpostgresql.GetCloudPostgresqlInstanceListRequest{
+			RegionCode:                 &handler.RegionInfo.Region,
+			CloudPostgresqlServiceName: &rdbmsIID.NameId,
+		})
+		if err == nil && len(pgResp.CloudPostgresqlInstanceList) > 0 {
+			LoggingInfo(hiscallInfo, start)
+			return handler.convertPostgresqlInstanceToRDBMSInfo(pgResp.CloudPostgresqlInstanceList[0]), nil
+		}
+	}
+
+	notFoundErr := fmt.Errorf("RDBMS instance '%s/%s' not found", rdbmsIID.NameId, rdbmsIID.SystemId)
+	LoggingError(hiscallInfo, notFoundErr)
+	return irs.RDBMSInfo{}, notFoundErr
+}
+
+// DeleteRDBMS deletes an NCP managed database instance.
+func (handler *NcpVpcRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.RegionInfo.Region, call.RDBMS, rdbmsIID.NameId, "DeleteRDBMS()")
+	start := call.Start()
+
+	// Need to find the instance first to determine engine type
+	info, err := handler.GetRDBMS(rdbmsIID)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return false, fmt.Errorf("failed to find RDBMS instance for deletion: %w", err)
+	}
+
+	engineType := strings.ToLower(info.DBEngine)
+	systemID := info.IId.SystemId
+
+	switch {
+	case strings.Contains(engineType, "mysql"):
+		_, err = handler.MysqlClient.V2Api.DeleteCloudMysqlInstance(&vmysql.DeleteCloudMysqlInstanceRequest{
+			RegionCode:           &handler.RegionInfo.Region,
+			CloudMysqlInstanceNo: &systemID,
+		})
+	case strings.Contains(engineType, "postgresql"):
+		_, err = handler.PostgresClient.V2Api.DeleteCloudPostgresqlInstance(&vpostgresql.DeleteCloudPostgresqlInstanceRequest{
+			RegionCode:                &handler.RegionInfo.Region,
+			CloudPostgresqlInstanceNo: &systemID,
+		})
+	default:
+		return false, fmt.Errorf("unknown engine type '%s' for instance '%s'", engineType, systemID)
+	}
+
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return false, fmt.Errorf("failed to delete RDBMS instance '%s': %w", systemID, err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
+}
+
+// ---- Helper functions ----
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func derefBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
+}
+
+func derefInt32(i *int32) int32 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func derefInt64(i *int64) int64 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func (handler *NcpVpcRDBMSHandler) convertMysqlInstanceToRDBMSInfo(inst *vmysql.CloudMysqlInstance) irs.RDBMSInfo {
+	info := irs.RDBMSInfo{
+		IId: irs.IID{
+			NameId:   derefStr(inst.CloudMysqlServiceName),
+			SystemId: derefStr(inst.CloudMysqlInstanceNo),
+		},
+
+		DBEngine:        "mysql",
+		DBEngineVersion: derefStr(inst.EngineVersion),
+
+		HighAvailability: derefBool(inst.IsHa),
+		Encryption:       false,
+
+		BackupRetentionDays: int(derefInt32(inst.BackupFileRetentionPeriod)),
+		BackupTime:          derefStr(inst.BackupTime),
+
+		Port:               strconv.Itoa(int(derefInt32(inst.CloudMysqlPort))),
+		MasterUserName:     "NA", // Not exposed in list/detail API
+		DatabaseName:       "NA", // Not exposed in list/detail API
+		DeletionProtection: false,
+		PublicAccess:       false,
+		ReplicationType:    "async",
+
+		Status: convertNcpMysqlStatusToRDBMSStatus(inst.CloudMysqlInstanceStatusName),
+	}
+
+	if inst.CreateDate != nil {
+		t, err := time.Parse("2006-01-02T15:04:05+0900", *inst.CreateDate)
+		if err == nil {
+			info.CreatedTime = t
+		}
+	}
+
+	// Extract details from first server instance
+	if len(inst.CloudMysqlServerInstanceList) > 0 {
+		serverInst := inst.CloudMysqlServerInstanceList[0]
+		info.VpcIID = irs.IID{NameId: "NA", SystemId: derefStr(serverInst.VpcNo)}
+		info.DBInstanceSpec = derefStr(serverInst.CloudMysqlProductCode)
+		info.Endpoint = derefStr(serverInst.PrivateDomain)
+		info.Encryption = derefBool(serverInst.IsStorageEncryption)
+
+		storageSizeBytes := derefInt64(serverInst.DataStorageSize)
+		info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+
+		if serverInst.DataStorageType != nil && serverInst.DataStorageType.CodeName != nil {
+			info.StorageType = *serverInst.DataStorageType.CodeName
+		} else {
+			info.StorageType = "NA"
+		}
+
+		if len(inst.CloudMysqlServerInstanceList) > 0 {
+			var subnetIIDs []irs.IID
+			for _, si := range inst.CloudMysqlServerInstanceList {
+				subnetIIDs = append(subnetIIDs, irs.IID{NameId: "NA", SystemId: derefStr(si.SubnetNo)})
+			}
+			info.SubnetIIDs = subnetIIDs
+		}
+
+		if serverInst.CloudMysqlServerRole != nil && serverInst.CloudMysqlServerRole.CodeName != nil {
+			info.DBInstanceType = *serverInst.CloudMysqlServerRole.CodeName
+		}
+	}
+
+	return info
+}
+
+func (handler *NcpVpcRDBMSHandler) convertPostgresqlInstanceToRDBMSInfo(inst *vpostgresql.CloudPostgresqlInstance) irs.RDBMSInfo {
+	info := irs.RDBMSInfo{
+		IId: irs.IID{
+			NameId:   derefStr(inst.CloudPostgresqlServiceName),
+			SystemId: derefStr(inst.CloudPostgresqlInstanceNo),
+		},
+
+		DBEngine:        "postgresql",
+		DBEngineVersion: derefStr(inst.EngineVersion),
+
+		HighAvailability: derefBool(inst.IsHa),
+		Encryption:       false,
+
+		BackupRetentionDays: int(derefInt32(inst.BackupFileRetentionPeriod)),
+		BackupTime:          derefStr(inst.BackupTime),
+
+		Port:               strconv.Itoa(int(derefInt32(inst.CloudPostgresqlPort))),
+		MasterUserName:     "NA",
+		DatabaseName:       "NA",
+		DeletionProtection: false, // PostgreSQL does not support deletion protection
+		PublicAccess:       false,
+		ReplicationType:    "async",
+
+		Status: convertNcpPostgresqlStatusToRDBMSStatus(inst.CloudPostgresqlInstanceStatusName),
+	}
+
+	if inst.CreateDate != nil {
+		t, err := time.Parse("2006-01-02T15:04:05+0900", *inst.CreateDate)
+		if err == nil {
+			info.CreatedTime = t
+		}
+	}
+
+	// Extract details from first server instance
+	if len(inst.CloudPostgresqlServerInstanceList) > 0 {
+		serverInst := inst.CloudPostgresqlServerInstanceList[0]
+		info.VpcIID = irs.IID{NameId: "NA", SystemId: derefStr(serverInst.VpcNo)}
+		info.DBInstanceSpec = derefStr(serverInst.CloudPostgresqlProductCode)
+		info.Endpoint = derefStr(serverInst.PrivateDomain)
+		info.Encryption = derefBool(serverInst.IsStorageEncryption)
+
+		storageSizeBytes := derefInt64(serverInst.DataStorageSize)
+		info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+
+		if serverInst.DataStorageType != nil && serverInst.DataStorageType.CodeName != nil {
+			info.StorageType = *serverInst.DataStorageType.CodeName
+		} else {
+			info.StorageType = "NA"
+		}
+
+		if len(inst.CloudPostgresqlServerInstanceList) > 0 {
+			var subnetIIDs []irs.IID
+			for _, si := range inst.CloudPostgresqlServerInstanceList {
+				subnetIIDs = append(subnetIIDs, irs.IID{NameId: "NA", SystemId: derefStr(si.SubnetNo)})
+			}
+			info.SubnetIIDs = subnetIIDs
+		}
+
+		if serverInst.CloudPostgresqlServerRole != nil && serverInst.CloudPostgresqlServerRole.CodeName != nil {
+			info.DBInstanceType = *serverInst.CloudPostgresqlServerRole.CodeName
+		}
+	}
+
+	return info
+}
+
+func convertNcpMysqlStatusToRDBMSStatus(statusName *string) irs.RDBMSStatus {
+	if statusName == nil {
+		return irs.RDBMSError
+	}
+	switch strings.ToLower(*statusName) {
+	case "creating", "setting up", "configuring":
+		return irs.RDBMSCreating
+	case "running":
+		return irs.RDBMSAvailable
+	case "deleting":
+		return irs.RDBMSDeleting
+	case "stopped", "shutting down":
+		return irs.RDBMSStopped
+	default:
+		return irs.RDBMSError
+	}
+}
+
+func convertNcpPostgresqlStatusToRDBMSStatus(statusName *string) irs.RDBMSStatus {
+	if statusName == nil {
+		return irs.RDBMSError
+	}
+	switch strings.ToLower(*statusName) {
+	case "creating", "setting up", "configuring":
+		return irs.RDBMSCreating
+	case "running":
+		return irs.RDBMSAvailable
+	case "deleting":
+		return irs.RDBMSDeleting
+	case "stopped", "shutting down":
+		return irs.RDBMSStopped
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/nhn/NHNDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/NHNDriver.go
@@ -62,6 +62,8 @@ func (NhnCloudDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 
 	drvCapabilityInfo.VPC_CIDR = true
 
+	drvCapabilityInfo.RDBMSHandler = true
+
 	return drvCapabilityInfo
 }
 
@@ -122,6 +124,15 @@ func (driver *NhnCloudDriver) ConnectCloud(connInfo idrv.ConnectionInfo) (icon.C
 		return nil, err
 	}
 
+	DBClient, err := getDBClient(providerClient, connInfo)
+	if err != nil {
+		// Trove may not be available in all NHN regions; log and continue
+		var endpointErr *nhnsdk.ErrEndpointNotFound
+		if !errors.As(err, &endpointErr) {
+			return nil, err
+		}
+	}
+
 	iConn := nhncon.NhnCloudConnection{
 		CredentialInfo: connInfo.CredentialInfo, // Note) Need in RegionZoneHandler
 		RegionInfo:     connInfo.RegionInfo,
@@ -131,6 +142,7 @@ func (driver *NhnCloudDriver) ConnectCloud(connInfo idrv.ConnectionInfo) (icon.C
 		VolumeClient:   VolumeClient,
 		ClusterClient:  ClusterClient,
 		FSClient:       FSClient,
+		DBClient:       DBClient,
 	}
 	return &iConn, nil
 }
@@ -207,4 +219,15 @@ func getFSClient(providerClient *nhnsdk.ProviderClient, connInfo idrv.Connection
 	}
 
 	return fsClient, nil
+}
+
+func getDBClient(providerClient *nhnsdk.ProviderClient, connInfo idrv.ConnectionInfo) (*nhnsdk.ServiceClient, error) {
+	client, err := ostack.NewDBV1(providerClient, nhnsdk.EndpointOpts{
+		Region: connInfo.RegionInfo.Region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, err
 }

--- a/cloud-control-manager/cloud-driver/drivers/nhn/connect/NHN_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/connect/NHN_CloudConnection.go
@@ -45,6 +45,7 @@ type NhnCloudConnection struct {
 	ClusterClient  *nhnsdk.ServiceClient
 	FSClient       *nhnsdk.ServiceClient
 	NetworkClient1 *nhnsdk.ServiceClient
+	DBClient       *nhnsdk.ServiceClient
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -174,4 +175,14 @@ func (cloudConn *NhnCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfoHand
 
 func (cloudConn *NhnCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, fmt.Errorf("NHN Cloud Driver: not implemented")
+}
+
+// CreateRDBMSHandler implements connect.CloudConnection.
+func (cloudConn *NhnCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("NHN Cloud Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := nhnrs.NhnCloudRDBMSHandler{
+		RegionInfo: cloudConn.RegionInfo,
+		DBClient:   cloudConn.DBClient,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -1,0 +1,386 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	nhnsdk "github.com/cloud-barista/nhncloud-sdk-go"
+	"github.com/cloud-barista/nhncloud-sdk-go/openstack/db/v1/datastores"
+	"github.com/cloud-barista/nhncloud-sdk-go/openstack/db/v1/instances"
+	"github.com/cloud-barista/nhncloud-sdk-go/pagination"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type NhnCloudRDBMSHandler struct {
+	RegionInfo idrv.RegionInfo
+	DBClient   *nhnsdk.ServiceClient
+}
+
+// GetMetaInfo returns metadata about NHN Cloud Trove capabilities.
+func (handler *NhnCloudRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Info("NHN Cloud Driver: called GetMetaInfo()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	supportedEngines := make(map[string][]string)
+
+	// Query available datastores dynamically from Trove
+	allPages, err := datastores.List(handler.DBClient).AllPages()
+	if err != nil {
+		cblogger.Warn(fmt.Sprintf("Failed to list datastores from NHN Trove, using defaults: %v", err))
+		supportedEngines["mysql"] = []string{"5.7", "8.0"}
+	} else {
+		dsList, err := datastores.ExtractDatastores(allPages)
+		if err != nil {
+			cblogger.Warn(fmt.Sprintf("Failed to extract datastores: %v", err))
+		} else {
+			for _, ds := range dsList {
+				dsName := strings.ToLower(ds.Name)
+				if dsName == "mysql" || dsName == "mariadb" || dsName == "postgresql" {
+					var versions []string
+					for _, v := range ds.Versions {
+						versions = append(versions, v.Name)
+					}
+					supportedEngines[dsName] = versions
+				}
+			}
+		}
+	}
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: supportedEngines,
+
+		SupportsHighAvailability:   false, // NHN Trove HA is deployment-specific
+		SupportsBackup:             true,
+		SupportsPublicAccess:       false,
+		SupportsDeletionProtection: false,
+		SupportsEncryption:         false,
+
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 1,
+			Max: 300,
+		},
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return metaInfo, nil
+}
+
+// ListIID returns a list of RDBMS instance IIDs.
+func (handler *NhnCloudRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	cblogger.Info("NHN Cloud Driver: called ListIID()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListIID", "instances.List()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			iid := &irs.IID{
+				NameId:   inst.Name,
+				SystemId: inst.ID,
+			}
+			iidList = append(iidList, iid)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		newErr := fmt.Errorf("failed to list RDBMS IIDs: %w", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return iidList, nil
+}
+
+// CreateRDBMS creates a new NHN Cloud Trove database instance.
+func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	cblogger.Info("NHN Cloud Driver: called CreateRDBMS()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "instances.Create()")
+	start := call.Start()
+
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS instance name is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec (FlavorRef) is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	storageSize, err := strconv.Atoi(rdbmsReqInfo.StorageSize)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize '%s': %w", rdbmsReqInfo.StorageSize, err)
+	}
+
+	engineType := strings.ToLower(rdbmsReqInfo.DBEngine)
+
+	createOpts := instances.CreateOpts{
+		Name:      rdbmsReqInfo.IId.NameId,
+		FlavorRef: rdbmsReqInfo.DBInstanceSpec,
+		Size:      storageSize,
+		Datastore: &instances.DatastoreOpts{
+			Type:    engineType,
+			Version: rdbmsReqInfo.DBEngineVersion,
+		},
+	}
+
+	// Set network if SubnetIIDs provided
+	if len(rdbmsReqInfo.SubnetIIDs) > 0 {
+		var networks []instances.NetworkOpts
+		for _, subnetIID := range rdbmsReqInfo.SubnetIIDs {
+			netID := subnetIID.SystemId
+			if netID == "" {
+				netID = subnetIID.NameId
+			}
+			networks = append(networks, instances.NetworkOpts{
+				UUID: netID,
+			})
+		}
+		createOpts.Networks = networks
+	}
+
+	result := instances.Create(handler.DBClient, createOpts)
+	createdInstance, err := result.Extract()
+	if err != nil {
+		newErr := fmt.Errorf("failed to create RDBMS instance: %w", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.RDBMSInfo{}, newErr
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return convertNhnInstanceToRDBMSInfo(createdInstance), nil
+}
+
+// ListRDBMS returns a list of all RDBMS instances.
+func (handler *NhnCloudRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	cblogger.Info("NHN Cloud Driver: called ListRDBMS()")
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "ListRDBMS", "instances.List()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			info := convertNhnInstanceToRDBMSInfo(&inst)
+			rdbmsList = append(rdbmsList, &info)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		newErr := fmt.Errorf("failed to list RDBMS instances: %w", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return rdbmsList, nil
+}
+
+// GetRDBMS retrieves a specific RDBMS instance by IID.
+func (handler *NhnCloudRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	cblogger.Info("NHN Cloud Driver: called GetRDBMS()")
+
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, instanceID, "instances.Get()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			LoggingError(callLogInfo, err)
+			return irs.RDBMSInfo{}, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Get(handler.DBClient, instanceID)
+	inst, err := result.Extract()
+	if err != nil {
+		newErr := fmt.Errorf("failed to get RDBMS instance '%s': %w", instanceID, err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.RDBMSInfo{}, newErr
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return convertNhnInstanceToRDBMSInfo(inst), nil
+}
+
+// DeleteRDBMS deletes a Trove database instance.
+func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	cblogger.Info("NHN Cloud Driver: called DeleteRDBMS()")
+
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, instanceID, "instances.Delete()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			LoggingError(callLogInfo, err)
+			return false, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Delete(handler.DBClient, instanceID)
+	if result.Err != nil {
+		newErr := fmt.Errorf("failed to delete RDBMS instance '%s': %w", instanceID, result.Err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+
+	LoggingInfo(callLogInfo, start)
+	return true, nil
+}
+
+// ---- Helper functions ----
+
+func (handler *NhnCloudRDBMSHandler) findInstanceIDByName(name string) (string, error) {
+	var foundID string
+
+	err := instances.List(handler.DBClient).EachPage(func(page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			if inst.Name == name {
+				foundID = inst.ID
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to find RDBMS instance by name '%s': %w", name, err)
+	}
+	if foundID == "" {
+		return "", fmt.Errorf("RDBMS instance with name '%s' not found", name)
+	}
+	return foundID, nil
+}
+
+func convertNhnInstanceToRDBMSInfo(inst *instances.Instance) irs.RDBMSInfo {
+	endpoint := "NA"
+	if inst.Hostname != "" {
+		endpoint = inst.Hostname
+	} else if len(inst.IP) > 0 {
+		endpoint = inst.IP[0]
+	} else if len(inst.Addresses) > 0 {
+		endpoint = inst.Addresses[0].Address
+	}
+
+	port := "NA"
+	engineType := strings.ToLower(inst.Datastore.Type)
+	switch {
+	case strings.Contains(engineType, "mysql") || strings.Contains(engineType, "mariadb"):
+		port = "3306"
+	case strings.Contains(engineType, "postgresql"):
+		port = "5432"
+	}
+
+	return irs.RDBMSInfo{
+		IId: irs.IID{
+			NameId:   inst.Name,
+			SystemId: inst.ID,
+		},
+		VpcIID: irs.IID{NameId: "NA", SystemId: "NA"},
+
+		DBEngine:        inst.Datastore.Type,
+		DBEngineVersion: inst.Datastore.Version,
+		DBInstanceSpec:  inst.Flavor.ID,
+		DBInstanceType:  "Primary",
+
+		StorageType: "NA",
+		StorageSize: strconv.Itoa(inst.Volume.Size),
+
+		Port:     port,
+		Endpoint: endpoint,
+
+		MasterUserName: "NA",
+		DatabaseName:   "NA",
+
+		HighAvailability: false,
+		ReplicationType:  "NA",
+
+		BackupRetentionDays: 0,
+		BackupTime:          "NA",
+
+		PublicAccess:       false,
+		Encryption:         false,
+		DeletionProtection: false,
+
+		Status:      convertNhnTroveStatusToRDBMSStatus(inst.Status),
+		CreatedTime: inst.Created,
+
+		KeyValueList: []irs.KeyValue{
+			{Key: "Hostname", Value: inst.Hostname},
+			{Key: "VolumeUsed", Value: fmt.Sprintf("%.2f", inst.Volume.Used)},
+		},
+	}
+}
+
+func convertNhnTroveStatusToRDBMSStatus(status string) irs.RDBMSStatus {
+	switch strings.ToUpper(status) {
+	case "BUILD", "BACKUP", "RESTART_REQUIRED":
+		return irs.RDBMSCreating
+	case "ACTIVE":
+		return irs.RDBMSAvailable
+	case "SHUTDOWN":
+		return irs.RDBMSStopped
+	case "DELETED":
+		return irs.RDBMSDeleting
+	case "ERROR", "FAILED":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/OpenStackDriver.go
@@ -65,6 +65,8 @@ func (OpenStackDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 
 	drvCapabilityInfo.VPC_CIDR = false
 
+	drvCapabilityInfo.RDBMSHandler = true
+
 	return drvCapabilityInfo
 }
 
@@ -186,6 +188,15 @@ func clientCreator(connInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	if err != nil {
 		cblogger.Warnf("Failed to initialize SharedFileSystem(Manila) client. FileSystem features will be unavailable: %v", err)
 		iConn.SharedFileSystemClient = nil
+	}
+
+	// Trove (Database-as-a-Service) client - optional, some deployments may not have Trove
+	iConn.DBClient, err = openstack.NewDBV1(provider, gophercloud.EndpointOpts{
+		Region: connInfo.RegionInfo.Region,
+	})
+	if err != nil {
+		// Trove may not be available in all OpenStack deployments; log and continue
+		fmt.Printf("Warning: failed to create Trove DB client: %v\n", err)
 	}
 
 	return &iConn, nil

--- a/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/connect/OpenStack_CloudConnection.go
@@ -41,6 +41,7 @@ type OpenStackCloudConnection struct {
 	NLBClient              *gophercloud.ServiceClient
 	SharedFileSystemClient *gophercloud.ServiceClient
 	IdentityClient         *gophercloud.ServiceClient
+	DBClient               *gophercloud.ServiceClient
 }
 
 func (cloudConn *OpenStackCloudConnection) CreateImageHandler() (irs.ImageHandler, error) {
@@ -218,4 +219,15 @@ func (cloudConn *OpenStackCloudConnection) CreateQuotaInfoHandler() (irs.QuotaIn
 
 func (cloudConn *OpenStackCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, errors.New("OpenStack Driver: not implemented")
+}
+
+// CreateRDBMSHandler implements connect.CloudConnection.
+func (cloudConn *OpenStackCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("OpenStack Driver: called CreateRDBMSHandler()!")
+	rdbmsHandler := osrs.OpenStackRDBMSHandler{
+		CredentialInfo: cloudConn.CredentialInfo,
+		Region:         cloudConn.Region,
+		DBClient:       cloudConn.DBClient,
+	}
+	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
@@ -1,0 +1,403 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/instances"
+	"github.com/gophercloud/gophercloud/v2/pagination"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+)
+
+type OpenStackRDBMSHandler struct {
+	CredentialInfo idrv.CredentialInfo
+	Region         idrv.RegionInfo
+	DBClient       *gophercloud.ServiceClient
+}
+
+// GetMetaInfo returns metadata about OpenStack Trove capabilities.
+func (handler *OpenStackRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("OpenStack Trove GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	supportedEngines := make(map[string][]string)
+
+	// Query available datastores dynamically from Trove
+	allPages, err := datastores.List(handler.DBClient).AllPages(context.TODO())
+	if err != nil {
+		cblogger.Warn(fmt.Sprintf("Failed to list datastores from Trove, using static defaults: %v", err))
+		// Fallback to common Trove defaults
+		supportedEngines["mysql"] = []string{"5.7", "8.0"}
+		supportedEngines["mariadb"] = []string{"10.4", "10.5", "10.6"}
+		supportedEngines["postgresql"] = []string{"13", "14", "15", "16"}
+	} else {
+		dsList, err := datastores.ExtractDatastores(allPages)
+		if err != nil {
+			cblogger.Warn(fmt.Sprintf("Failed to extract datastores: %v", err))
+		} else {
+			for _, ds := range dsList {
+				dsName := strings.ToLower(ds.Name)
+				// Filter to supported RDBMS types
+				if dsName == "mysql" || dsName == "mariadb" || dsName == "postgresql" {
+					var versions []string
+					for _, v := range ds.Versions {
+						versions = append(versions, v.Name)
+					}
+					supportedEngines[dsName] = versions
+				}
+			}
+		}
+	}
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: supportedEngines,
+
+		SupportsHighAvailability:   false, // Trove replication is separate from HA; varies by deployment
+		SupportsBackup:             true,  // Trove supports backup API
+		SupportsPublicAccess:       false, // Trove instances are typically private network only
+		SupportsDeletionProtection: false, // Trove does not provide deletion protection
+		SupportsEncryption:         false, // Trove does not expose storage encryption option
+
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 1,
+			Max: 300,
+		},
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return metaInfo, nil
+}
+
+// ListIID returns a list of RDBMS instance IIDs.
+func (handler *OpenStackRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, "ListIID", "instances.List()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+
+	err := instances.List(handler.DBClient).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			iid := &irs.IID{
+				NameId:   inst.Name,
+				SystemId: inst.ID,
+			}
+			iidList = append(iidList, iid)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list RDBMS IIDs: %w", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return iidList, nil
+}
+
+// CreateRDBMS creates a new Trove database instance.
+func (handler *OpenStackRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, rdbmsReqInfo.IId.NameId, "instances.Create()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS instance name is required")
+	}
+	if rdbmsReqInfo.DBEngine == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngine is required")
+	}
+	if rdbmsReqInfo.DBEngineVersion == "" {
+		return irs.RDBMSInfo{}, errors.New("DBEngineVersion is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec (FlavorRef) is required")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+
+	storageSize, err := strconv.Atoi(rdbmsReqInfo.StorageSize)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize '%s': %w", rdbmsReqInfo.StorageSize, err)
+	}
+
+	// Map engine name to Trove datastore type
+	engineType := strings.ToLower(rdbmsReqInfo.DBEngine)
+
+	createOpts := instances.CreateOpts{
+		Name:      rdbmsReqInfo.IId.NameId,
+		FlavorRef: rdbmsReqInfo.DBInstanceSpec,
+		Size:      storageSize,
+		Datastore: &instances.DatastoreOpts{
+			Type:    engineType,
+			Version: rdbmsReqInfo.DBEngineVersion,
+		},
+	}
+
+	if rdbmsReqInfo.StorageType != "" {
+		createOpts.VolumeType = rdbmsReqInfo.StorageType
+	}
+
+	// Set network if SubnetIIDs provided
+	if len(rdbmsReqInfo.SubnetIIDs) > 0 {
+		var networks []instances.NetworkOpts
+		for _, subnetIID := range rdbmsReqInfo.SubnetIIDs {
+			netID := subnetIID.SystemId
+			if netID == "" {
+				netID = subnetIID.NameId
+			}
+			networks = append(networks, instances.NetworkOpts{
+				UUID: netID,
+			})
+		}
+		createOpts.Networks = networks
+	}
+
+	// Set availability zone if provided in Region
+	if handler.Region.Zone != "" {
+		createOpts.AvailabilityZone = handler.Region.Zone
+	}
+
+	result := instances.Create(context.TODO(), handler.DBClient, createOpts)
+	createdInstance, err := result.Extract()
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to create RDBMS instance: %w", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+
+	rdbmsInfo := handler.convertInstanceToRDBMSInfo(createdInstance)
+	return rdbmsInfo, nil
+}
+
+// ListRDBMS returns a list of all RDBMS instances.
+func (handler *OpenStackRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, "ListRDBMS", "instances.List()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+
+	err := instances.List(handler.DBClient).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			info := handler.convertInstanceToRDBMSInfo(&inst)
+			rdbmsList = append(rdbmsList, &info)
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return nil, fmt.Errorf("failed to list RDBMS instances: %w", err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return rdbmsList, nil
+}
+
+// GetRDBMS retrieves a specific RDBMS instance by IID.
+func (handler *OpenStackRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, instanceID, "instances.Get()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return irs.RDBMSInfo{}, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Get(context.TODO(), handler.DBClient, instanceID)
+	inst, err := result.Extract()
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to get RDBMS instance '%s': %w", instanceID, err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+
+	rdbmsInfo := handler.convertInstanceToRDBMSInfo(inst)
+	return rdbmsInfo, nil
+}
+
+// DeleteRDBMS deletes a Trove database instance.
+func (handler *OpenStackRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	instanceID := rdbmsIID.SystemId
+	if instanceID == "" {
+		instanceID = rdbmsIID.NameId
+	}
+
+	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, instanceID, "instances.Delete()")
+	start := call.Start()
+
+	// If only NameId is provided, find by name
+	if rdbmsIID.SystemId == "" {
+		foundID, err := handler.findInstanceIDByName(rdbmsIID.NameId)
+		if err != nil {
+			LoggingError(hiscallInfo, err)
+			return false, err
+		}
+		instanceID = foundID
+	}
+
+	result := instances.Delete(context.TODO(), handler.DBClient, instanceID)
+	if result.Err != nil {
+		cblogger.Error(result.Err)
+		LoggingError(hiscallInfo, result.Err)
+		return false, fmt.Errorf("failed to delete RDBMS instance '%s': %w", instanceID, result.Err)
+	}
+
+	LoggingInfo(hiscallInfo, start)
+	return true, nil
+}
+
+// ---- Helper functions ----
+
+// findInstanceIDByName finds a Trove instance's system ID by its name.
+func (handler *OpenStackRDBMSHandler) findInstanceIDByName(name string) (string, error) {
+	var foundID string
+
+	err := instances.List(handler.DBClient).EachPage(context.TODO(), func(_ context.Context, page pagination.Page) (bool, error) {
+		instanceList, err := instances.ExtractInstances(page)
+		if err != nil {
+			return false, err
+		}
+		for _, inst := range instanceList {
+			if inst.Name == name {
+				foundID = inst.ID
+				return false, nil // stop iteration
+			}
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to find RDBMS instance by name '%s': %w", name, err)
+	}
+	if foundID == "" {
+		return "", fmt.Errorf("RDBMS instance with name '%s' not found", name)
+	}
+	return foundID, nil
+}
+
+// convertInstanceToRDBMSInfo converts a Trove Instance to RDBMSInfo.
+func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances.Instance) irs.RDBMSInfo {
+	// Extract IP address
+	endpoint := "NA"
+	if inst.Hostname != "" {
+		endpoint = inst.Hostname
+	} else if len(inst.IP) > 0 {
+		endpoint = inst.IP[0]
+	} else if len(inst.Addresses) > 0 {
+		endpoint = inst.Addresses[0].Address
+	}
+
+	// Determine default port based on engine type
+	port := "NA"
+	engineType := strings.ToLower(inst.Datastore.Type)
+	switch {
+	case strings.Contains(engineType, "mysql") || strings.Contains(engineType, "mariadb"):
+		port = "3306"
+	case strings.Contains(engineType, "postgresql"):
+		port = "5432"
+	}
+
+	return irs.RDBMSInfo{
+		IId: irs.IID{
+			NameId:   inst.Name,
+			SystemId: inst.ID,
+		},
+		VpcIID: irs.IID{NameId: "NA", SystemId: "NA"},
+
+		DBEngine:        inst.Datastore.Type,
+		DBEngineVersion: inst.Datastore.Version,
+		DBInstanceSpec:  inst.Flavor.ID,
+		DBInstanceType:  "Primary",
+
+		StorageType: "NA",
+		StorageSize: strconv.Itoa(inst.Volume.Size),
+
+		Port:     port,
+		Endpoint: endpoint,
+
+		MasterUserName: "NA", // Trove uses root user managed via EnableRootUser API
+		DatabaseName:   "NA", // Not exposed in instance info
+
+		HighAvailability: false, // Trove HA is deployment-specific
+		ReplicationType:  "NA",
+
+		BackupRetentionDays: 0,
+		BackupTime:          "NA",
+
+		PublicAccess:       false,
+		Encryption:         false, // Trove does not expose encryption status
+		DeletionProtection: false, // Trove does not support deletion protection
+
+		Status:      convertTroveStatusToRDBMSStatus(inst.Status),
+		CreatedTime: inst.Created,
+
+		KeyValueList: []irs.KeyValue{
+			{Key: "Hostname", Value: inst.Hostname},
+			{Key: "VolumeUsed", Value: fmt.Sprintf("%.2f", inst.Volume.Used)},
+		},
+	}
+}
+
+// convertTroveStatusToRDBMSStatus maps Trove status strings to RDBMSStatus.
+func convertTroveStatusToRDBMSStatus(status string) irs.RDBMSStatus {
+	switch strings.ToUpper(status) {
+	case "BUILD", "BACKUP", "RESTART_REQUIRED":
+		return irs.RDBMSCreating
+	case "ACTIVE":
+		return irs.RDBMSAvailable
+	case "SHUTDOWN":
+		return irs.RDBMSStopped
+	case "DELETED":
+		return irs.RDBMSDeleting
+	case "ERROR", "FAILED":
+		return irs.RDBMSError
+	default:
+		return irs.RDBMSError
+	}
+}

--- a/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/TencentDriver.go
@@ -20,6 +20,7 @@ import (
 	ires "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
 	cbs "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs/v20170312"
+	cdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb/v20170320"
 	cfs "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs/v20190719"
 	clb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
@@ -66,6 +67,8 @@ func (TencentDriver) GetDriverCapability() idrv.DriverCapabilityInfo {
 	drvCapabilityInfo.TagSupportResourceType = []ires.RSType{ires.VPC, ires.SUBNET, ires.SG, ires.KEY, ires.VM, ires.NLB, ires.DISK, ires.MYIMAGE, ires.CLUSTER, ires.FILESYSTEM}
 
 	drvCapabilityInfo.VPC_CIDR = true
+
+	drvCapabilityInfo.RDBMSHandler = true
 
 	return drvCapabilityInfo
 }
@@ -264,6 +267,27 @@ func getFileSystemClient(connectionInfo idrv.ConnectionInfo) (*cfs.Client, error
 	return client, nil
 }
 
+func getCDBClient(connectionInfo idrv.ConnectionInfo) (*cdb.Client, error) {
+	cblogger.Debug("TencentDriver : getCDBClient() - Region : [" + connectionInfo.RegionInfo.Region + "]")
+
+	credential := common.NewCredential(
+		connectionInfo.CredentialInfo.ClientId,
+		connectionInfo.CredentialInfo.ClientSecret,
+	)
+
+	cpf := profile.NewClientProfile()
+	cpf.HttpProfile.Endpoint = "cdb.tencentcloudapi.com"
+	cpf.Language = "en-US"
+	client, err := cdb.NewClient(credential, connectionInfo.RegionInfo.Region, cpf)
+	if err != nil {
+		cblogger.Error("Could not create CDB client")
+		cblogger.Error(err)
+		return nil, err
+	}
+
+	return client, nil
+}
+
 func (driver *TencentDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	// 1. get info of credential and region for Test A Cloud from connectionInfo.
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
@@ -317,6 +341,12 @@ func (driver *TencentDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (i
 		return nil, err
 	}
 
+	cdbClient, err := getCDBClient(connectionInfo)
+	if err != nil {
+		cblogger.Error(err)
+		return nil, err
+	}
+
 	iConn := tcon.TencentCloudConnection{
 		CredentialInfo:   connectionInfo.CredentialInfo,
 		Region:           connectionInfo.RegionInfo,
@@ -333,6 +363,7 @@ func (driver *TencentDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (i
 		TagClient:        tagClient,
 		ClusterClient:    clusterClient,
 		FileSystemClient: fileSystemClient,
+		CDBClient:        cdbClient,
 	}
 
 	return &iConn, nil // return type: (icon.CloudConnection, error)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/connect/TencentCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/connect/TencentCloudConnection.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	cbs "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs/v20170312"
+	cdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb/v20170320"
 	cfs "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs/v20190719"
 	clb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb/v20180317"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
@@ -45,6 +46,7 @@ type TencentCloudConnection struct {
 	TagClient        *tag.Client
 	ClusterClient    *tke.Client
 	FileSystemClient *cfs.Client
+	CDBClient        *cdb.Client
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -178,4 +180,10 @@ func (cloudConn *TencentCloudConnection) CreateQuotaInfoHandler() (irs.QuotaInfo
 
 func (cloudConn *TencentCloudConnection) CreateMonitoringHandler() (irs.MonitoringHandler, error) {
 	return nil, errors.New("Tencent Driver: not implemented")
+}
+
+func (cloudConn *TencentCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
+	cblogger.Info("Tencent Cloud Driver: called CreateRDBMSHandler()!")
+	handler := trs.TencentRDBMSHandler{Region: cloudConn.Region, Client: cloudConn.CDBClient}
+	return &handler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
@@ -1,0 +1,456 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
+	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
+	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
+	cdb "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb/v20170320"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+)
+
+type TencentRDBMSHandler struct {
+	Region idrv.RegionInfo
+	Client *cdb.Client
+}
+
+func (handler *TencentRDBMSHandler) GetMetaInfo() (irs.RDBMSMetaInfo, error) {
+	cblogger.Debug("Tencent CDB GetMetaInfo() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
+	start := call.Start()
+
+	metaInfo := irs.RDBMSMetaInfo{
+		SupportedEngines: map[string][]string{
+			"mysql": {"5.5", "5.6", "5.7", "8.0"},
+		},
+		SupportsHighAvailability:   true,
+		SupportsBackup:             true,
+		SupportsPublicAccess:       true,
+		SupportsDeletionProtection: false, // Tencent CDB uses isolate/offline pattern, not deletion protection
+		SupportsEncryption:         true,
+		StorageTypeOptions: map[string][]string{
+			"mysql": {"CLOUD_SSD", "CLOUD_HSSD"},
+		},
+		StorageSizeRange: irs.StorageSizeRange{
+			Min: 25,
+			Max: 16000,
+		},
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return metaInfo, nil
+}
+
+func (handler *TencentRDBMSHandler) ListIID() ([]*irs.IID, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "DescribeDBInstances()")
+	start := call.Start()
+
+	var iidList []*irs.IID
+	var offset uint64 = 0
+	var limit uint64 = 100
+
+	for {
+		request := cdb.NewDescribeDBInstancesRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := handler.Client.DescribeDBInstances(request)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+
+		if response.Response == nil || response.Response.Items == nil {
+			break
+		}
+
+		for _, inst := range response.Response.Items {
+			name := ""
+			sysId := ""
+			if inst.InstanceName != nil {
+				name = *inst.InstanceName
+			}
+			if inst.InstanceId != nil {
+				sysId = *inst.InstanceId
+			}
+			iid := &irs.IID{
+				NameId:   name,
+				SystemId: sysId,
+			}
+			iidList = append(iidList, iid)
+		}
+
+		total := int64(0)
+		if response.Response.TotalCount != nil {
+			total = *response.Response.TotalCount
+		}
+		if int64(offset+limit) >= total {
+			break
+		}
+		offset += limit
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return iidList, nil
+}
+
+func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateDBInstanceHour()")
+	start := call.Start()
+
+	// Validate required fields
+	if rdbmsReqInfo.IId.NameId == "" {
+		return irs.RDBMSInfo{}, errors.New("RDBMS NameId is required")
+	}
+	if rdbmsReqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required (Memory in MB)")
+	}
+	if rdbmsReqInfo.StorageSize == "" {
+		return irs.RDBMSInfo{}, errors.New("StorageSize is required (in GB)")
+	}
+	if rdbmsReqInfo.MasterUserPassword == "" {
+		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	}
+
+	// Parse Memory (DBInstanceSpec is memory in MB for Tencent CDB)
+	memory, err := strconv.ParseInt(rdbmsReqInfo.DBInstanceSpec, 10, 64)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid DBInstanceSpec (Memory in MB): %s", rdbmsReqInfo.DBInstanceSpec)
+	}
+
+	// Parse storage size (volume in GB)
+	volume, err := strconv.ParseInt(rdbmsReqInfo.StorageSize, 10, 64)
+	if err != nil {
+		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
+	}
+
+	request := cdb.NewCreateDBInstanceHourRequest()
+	request.Memory = &memory
+	request.Volume = &volume
+	request.GoodsNum = common.Int64Ptr(1)
+	request.InstanceName = &rdbmsReqInfo.IId.NameId
+	request.Password = &rdbmsReqInfo.MasterUserPassword
+
+	// Engine version
+	if rdbmsReqInfo.DBEngineVersion != "" {
+		request.EngineVersion = &rdbmsReqInfo.DBEngineVersion
+	}
+
+	// VPC and Subnet
+	if rdbmsReqInfo.VpcIID.SystemId != "" {
+		request.UniqVpcId = &rdbmsReqInfo.VpcIID.SystemId
+	}
+	if len(rdbmsReqInfo.SubnetIIDs) > 0 && rdbmsReqInfo.SubnetIIDs[0].SystemId != "" {
+		request.UniqSubnetId = &rdbmsReqInfo.SubnetIIDs[0].SystemId
+	}
+
+	// Zone
+	if handler.Region.Zone != "" {
+		request.Zone = &handler.Region.Zone
+	}
+
+	// Port
+	if rdbmsReqInfo.Port != "" {
+		port, portErr := strconv.ParseInt(rdbmsReqInfo.Port, 10, 64)
+		if portErr == nil {
+			request.Port = &port
+		}
+	}
+
+	// HA - ProtectMode: 0=async, 1=semi-sync, 2=strong-sync
+	if rdbmsReqInfo.HighAvailability {
+		protectMode := int64(1) // semi-sync for HA
+		request.ProtectMode = &protectMode
+	}
+
+	// Security Groups
+	if len(rdbmsReqInfo.SecurityGroupIIDs) > 0 {
+		sgIds := make([]*string, 0, len(rdbmsReqInfo.SecurityGroupIIDs))
+		for _, sg := range rdbmsReqInfo.SecurityGroupIIDs {
+			id := sg.SystemId
+			sgIds = append(sgIds, &id)
+		}
+		request.SecurityGroup = sgIds
+	}
+
+	// Tags
+	if len(rdbmsReqInfo.TagList) > 0 {
+		tags := make([]*cdb.TagInfo, 0, len(rdbmsReqInfo.TagList))
+		for _, tag := range rdbmsReqInfo.TagList {
+			k := tag.Key
+			v := tag.Value
+			tags = append(tags, &cdb.TagInfo{
+				TagKey:   &k,
+				TagValue: []*string{&v},
+			})
+		}
+		request.ResourceTags = tags
+	}
+
+	response, err := handler.Client.CreateDBInstanceHour(request)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	if response.Response == nil || len(response.Response.InstanceIds) == 0 {
+		return irs.RDBMSInfo{}, errors.New("no instance ID returned from CreateDBInstanceHour")
+	}
+
+	instanceId := *response.Response.InstanceIds[0]
+
+	// Wait for instance to be running (status=1)
+	err = handler.waitForInstanceStatus(instanceId, 1, 600)
+	if err != nil {
+		cblogger.Warn("Instance created but wait for Running status failed: ", err)
+	}
+
+	return handler.GetRDBMS(irs.IID{NameId: rdbmsReqInfo.IId.NameId, SystemId: instanceId})
+}
+
+func (handler *TencentRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListRDBMS", "DescribeDBInstances()")
+	start := call.Start()
+
+	var rdbmsList []*irs.RDBMSInfo
+	var offset uint64 = 0
+	var limit uint64 = 100
+
+	for {
+		request := cdb.NewDescribeDBInstancesRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := handler.Client.DescribeDBInstances(request)
+		if err != nil {
+			hiscallInfo.ElapsedTime = call.Elapsed(start)
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
+
+		if response.Response == nil || response.Response.Items == nil {
+			break
+		}
+
+		for _, inst := range response.Response.Items {
+			rdbmsInfo := handler.convertToRDBMSInfo(inst)
+			rdbmsList = append(rdbmsList, &rdbmsInfo)
+		}
+
+		total := int64(0)
+		if response.Response.TotalCount != nil {
+			total = *response.Response.TotalCount
+		}
+		if int64(offset+limit) >= total {
+			break
+		}
+		offset += limit
+	}
+
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Info(call.String(hiscallInfo))
+
+	return rdbmsList, nil
+}
+
+func (handler *TencentRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "DescribeDBInstances()")
+	start := call.Start()
+
+	request := cdb.NewDescribeDBInstancesRequest()
+	request.InstanceIds = []*string{&rdbmsIID.SystemId}
+
+	response, err := handler.Client.DescribeDBInstances(request)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	if response.Response == nil || len(response.Response.Items) == 0 {
+		return irs.RDBMSInfo{}, fmt.Errorf("DB instance not found: %s", rdbmsIID.SystemId)
+	}
+
+	return handler.convertToRDBMSInfo(response.Response.Items[0]), nil
+}
+
+func (handler *TencentRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "IsolateDBInstance()")
+	start := call.Start()
+
+	// Step 1: Isolate the instance
+	isolateReq := cdb.NewIsolateDBInstanceRequest()
+	isolateReq.InstanceId = &rdbmsIID.SystemId
+
+	_, err := handler.Client.IsolateDBInstance(isolateReq)
+	hiscallInfo.ElapsedTime = call.Elapsed(start)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return false, err
+	}
+	calllogger.Info(call.String(hiscallInfo))
+
+	// Step 2: Offline the isolated instance (permanent delete)
+	offlineReq := cdb.NewOfflineIsolatedInstancesRequest()
+	offlineReq.InstanceIds = []*string{&rdbmsIID.SystemId}
+
+	_, err = handler.Client.OfflineIsolatedInstances(offlineReq)
+	if err != nil {
+		cblogger.Warn("Isolate succeeded but Offline failed (instance will be in recycle bin): ", err)
+		// Still return true since isolate succeeded
+		return true, nil
+	}
+
+	return true, nil
+}
+
+// ===== Helper Functions =====
+
+func (handler *TencentRDBMSHandler) convertToRDBMSInfo(inst *cdb.InstanceInfo) irs.RDBMSInfo {
+	rdbmsInfo := irs.RDBMSInfo{}
+
+	if inst.InstanceName != nil {
+		rdbmsInfo.IId.NameId = *inst.InstanceName
+	}
+	if inst.InstanceId != nil {
+		rdbmsInfo.IId.SystemId = *inst.InstanceId
+	}
+
+	rdbmsInfo.DBEngine = "mysql" // Tencent CDB is MySQL only
+	if inst.EngineVersion != nil {
+		rdbmsInfo.DBEngineVersion = *inst.EngineVersion
+	}
+
+	// Instance spec (memory)
+	if inst.Memory != nil {
+		rdbmsInfo.DBInstanceSpec = strconv.FormatInt(*inst.Memory, 10)
+	}
+
+	// Storage
+	if inst.Volume != nil {
+		rdbmsInfo.StorageSize = strconv.FormatInt(*inst.Volume, 10)
+	}
+	rdbmsInfo.StorageType = "NA" // Not directly exposed in InstanceInfo
+
+	// Endpoint
+	if inst.Vip != nil {
+		rdbmsInfo.Endpoint = *inst.Vip
+		if inst.Vport != nil {
+			rdbmsInfo.Endpoint += ":" + strconv.FormatInt(*inst.Vport, 10)
+		}
+	}
+	if inst.Vport != nil {
+		rdbmsInfo.Port = strconv.FormatInt(*inst.Vport, 10)
+	}
+
+	// VPC
+	if inst.UniqVpcId != nil {
+		rdbmsInfo.VpcIID = irs.IID{SystemId: *inst.UniqVpcId}
+	}
+
+	// Subnet
+	if inst.UniqSubnetId != nil {
+		rdbmsInfo.SubnetIIDs = []irs.IID{{SystemId: *inst.UniqSubnetId}}
+	}
+
+	// Status
+	if inst.Status != nil {
+		rdbmsInfo.Status = convertTencentStatusToRDBMSStatus(*inst.Status)
+	}
+
+	// HA (ProtectMode)
+	if inst.ProtectMode != nil {
+		rdbmsInfo.HighAvailability = (*inst.ProtectMode > 0)
+	}
+
+	// Master username
+	rdbmsInfo.MasterUserName = "root" // Tencent CDB default
+
+	// Created time
+	if inst.CreateTime != nil {
+		t, err := time.Parse("2006-01-02 15:04:05", *inst.CreateTime)
+		if err == nil {
+			rdbmsInfo.CreatedTime = t
+		}
+	}
+
+	// WanStatus (public access)
+	if inst.WanStatus != nil {
+		rdbmsInfo.PublicAccess = (*inst.WanStatus == 1)
+	}
+
+	rdbmsInfo.DatabaseName = "NA"
+	rdbmsInfo.BackupTime = "NA"
+	rdbmsInfo.ReplicationType = "NA"
+	rdbmsInfo.DeletionProtection = false
+	rdbmsInfo.Encryption = false
+
+	// KeyValueList
+	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(inst)
+
+	return rdbmsInfo
+}
+
+func convertTencentStatusToRDBMSStatus(status int64) irs.RDBMSStatus {
+	switch status {
+	case 0:
+		return irs.RDBMSCreating
+	case 1:
+		return irs.RDBMSAvailable
+	case 4:
+		return irs.RDBMSDeleting
+	case 5:
+		return irs.RDBMSStopped
+	default:
+		return irs.RDBMSError
+	}
+}
+
+func (handler *TencentRDBMSHandler) waitForInstanceStatus(instanceId string, targetStatus int64, timeoutSec int) error {
+	for elapsed := 0; elapsed < timeoutSec; elapsed += 15 {
+		request := cdb.NewDescribeDBInstancesRequest()
+		request.InstanceIds = []*string{&instanceId}
+
+		response, err := handler.Client.DescribeDBInstances(request)
+		if err != nil {
+			return err
+		}
+
+		if response.Response != nil && len(response.Response.Items) > 0 {
+			if response.Response.Items[0].Status != nil && *response.Response.Items[0].Status == targetStatus {
+				return nil
+			}
+		}
+
+		time.Sleep(15 * time.Second)
+	}
+	return fmt.Errorf("timeout waiting for instance %s to reach status %d", instanceId, targetStatus)
+}

--- a/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
+++ b/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
@@ -36,6 +36,7 @@ type DriverCapabilityInfo struct {
 	ClusterHandler    bool // support: true, do not support: false
 	FileSystemHandler bool // support: true, do not support: false
 	QuotaInfoHandler  bool // support: true, do not support: false
+	RDBMSHandler      bool // support: true, do not support: false
 
 	TagHandler bool // support: true, do not support: false
 	// ex) {ires.VPC, ires.SUBNET, ires.SG, ires.KEY, ires.VM, ires.NLB, ires.DISK, ires.MYIMAGE, ires.CLUSTER}

--- a/cloud-control-manager/cloud-driver/interfaces/connect/CloudConnect.go
+++ b/cloud-control-manager/cloud-driver/interfaces/connect/CloudConnect.go
@@ -42,6 +42,8 @@ type CloudConnection interface {
 	CreateFileSystemHandler() (irs.FileSystemHandler, error)
 	CreateQuotaInfoHandler() (irs.QuotaInfoHandler, error)
 
+	CreateRDBMSHandler() (irs.RDBMSHandler, error)
+
 	IsConnected() (bool, error)
 	Close() error
 }

--- a/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
@@ -1,0 +1,132 @@
+// Cloud Driver Interface of CB-Spider.
+// The CB-Spider is a sub-Framework of the Cloud-Barista Multi-Cloud Project.
+// The CB-Spider Mission is to connect all the clouds with a single interface.
+//
+//      * Cloud-Barista: https://github.com/cloud-barista
+//
+// This is Resouces interfaces of Cloud Driver.
+//
+// by CB-Spider Team, April 2026.
+
+package resources
+
+import "time"
+
+// -------- Const
+type RDBMSStatus string
+
+const (
+	RDBMSCreating  RDBMSStatus = "Creating"
+	RDBMSAvailable RDBMSStatus = "Available"
+	RDBMSDeleting  RDBMSStatus = "Deleting"
+	RDBMSStopped   RDBMSStatus = "Stopped"
+	RDBMSError     RDBMSStatus = "Error"
+)
+
+// -------- Meta Info Structures
+
+// RDBMSMetaInfo provides CSP-specific capability information for RDBMS provisioning.
+// Use GetMetaInfo() to discover what each CSP supports before creating an RDBMS instance.
+// @description RDBMS Meta Information for CSP-specific capabilities
+type RDBMSMetaInfo struct {
+	// filled by the cloud driver
+	SupportedEngines map[string][]string `json:"SupportedEngines"` // Supported DB engine names → versions. e.g., {"mysql": ["8.0", "8.4"], "postgresql": ["15", "16"]}
+
+	SupportsHighAvailability   bool `json:"SupportsHighAvailability"`   // true if HA/Multi-AZ can be configured
+	SupportsBackup             bool `json:"SupportsBackup"`             // true if managed automatic backup is supported
+	SupportsPublicAccess       bool `json:"SupportsPublicAccess"`       // true if public access can be toggled
+	SupportsDeletionProtection bool `json:"SupportsDeletionProtection"` // true if deletion protection is available
+	SupportsEncryption         bool `json:"SupportsEncryption"`         // true if storage encryption is available
+
+	StorageTypeOptions map[string][]string `json:"StorageTypeOptions,omitempty"` // Available storage types per engine. e.g., {"mysql": ["gp2", "gp3", "io1"]}
+	StorageSizeRange   StorageSizeRange    `json:"StorageSizeRange,omitempty"`   // Min/Max storage size in GB
+}
+
+// StorageSizeRange represents the minimum and maximum storage size in GB.
+type StorageSizeRange struct {
+	Min int64 `json:"Min" example:"20"`    // Minimum storage in GB
+	Max int64 `json:"Max" example:"65536"` // Maximum storage in GB
+}
+
+// -------- Info Structure
+
+// RDBMSInfo represents the details of a Relational Database instance.
+// @description Relational Database (RDBMS) Information
+type RDBMSInfo struct {
+	IId    IID `json:"IId" validate:"required"`    // {NameId, SystemId}
+	VpcIID IID `json:"VpcIID" validate:"required"` // Owner VPC IID
+
+	// DB Engine
+	DBEngine        string `json:"DBEngine" validate:"required" example:"mysql"`      // mysql | mariadb | postgresql
+	DBEngineVersion string `json:"DBEngineVersion" validate:"required" example:"8.0"` // e.g., "8.0", "10.6", "15"
+
+	// Instance Spec
+	DBInstanceSpec string `json:"DBInstanceSpec" validate:"required" example:"db.t3.medium"` // CSP instance class/type
+	DBInstanceType string `json:"DBInstanceType,omitempty" example:"Primary"`                // Primary | ReadReplica (for response)
+
+	// Storage
+	StorageType string `json:"StorageType,omitempty" example:"gp2"`           // e.g., "gp2", "io1", "SSD", "cloud_essd"
+	StorageSize string `json:"StorageSize" validate:"required" example:"100"` // in GB
+
+	// Network
+	SubnetIIDs        []IID  `json:"SubnetIIDs,omitempty"`          // Subnet IIDs for DB placement
+	SecurityGroupIIDs []IID  `json:"SecurityGroupIIDs,omitempty"`   // Associated Security Groups
+	Port              string `json:"Port,omitempty" example:"3306"` // DB listen port
+
+	// Authentication
+	MasterUserName     string `json:"MasterUserName" validate:"required" example:"admin"` // Master user name
+	MasterUserPassword string `json:"MasterUserPassword,omitempty"`                       // Master user password (for Create request only)
+
+	// Database
+	DatabaseName string `json:"DatabaseName,omitempty" example:"mydb"` // Initial database name
+
+	// High Availability & Replication
+	HighAvailability bool   `json:"HighAvailability,omitempty" default:"false"` // Multi-AZ / HA enabled
+	ReplicationType  string `json:"ReplicationType,omitempty" example:"async"`  // async | semi-sync | sync (for response)
+
+	// Backup
+	BackupRetentionDays int    `json:"BackupRetentionDays,omitempty" example:"7"` // Automated backup retention period in days
+	BackupTime          string `json:"BackupTime,omitempty" example:"03:00"`      // Preferred backup time (HH:MM in UTC)
+
+	// Access
+	PublicAccess bool   `json:"PublicAccess,omitempty" default:"false"` // Whether publicly accessible
+	Endpoint     string `json:"Endpoint,omitempty"`                     // Connection endpoint (for response)
+
+	// Encryption
+	Encryption bool `json:"Encryption,omitempty" default:"false"` // Storage encryption enabled
+
+	// Protection
+	DeletionProtection bool `json:"DeletionProtection,omitempty" default:"false"` // Deletion protection enabled
+
+	//**************************************************************************************************
+	//** (1) Basic setup: If not set by the user, these fields use CSP default values.
+	//** (2) Advanced setup: If set by the user, these fields enable CSP-specific RDBMS features.
+	//**    → Use GetMetaInfo() to discover CSP-supported options before setting advanced fields.
+	//**    Advanced fields: StorageType, HighAvailability, PublicAccess, Encryption, DeletionProtection
+	//**************************************************************************************************
+
+	// Status (for response)
+	Status RDBMSStatus `json:"Status,omitempty" validate:"required" example:"Available"`
+
+	CreatedTime  time.Time  `json:"CreatedTime,omitempty"`
+	TagList      []KeyValue `json:"TagList,omitempty" validate:"omitempty"`
+	KeyValueList []KeyValue `json:"KeyValueList,omitempty" validate:"omitempty"`
+}
+
+// -------- RDBMS Handler API
+type RDBMSHandler interface {
+
+	// Meta API
+	GetMetaInfo() (RDBMSMetaInfo, error)
+
+	//------ RDBMS Management
+	ListIID() ([]*IID, error)
+	CreateRDBMS(rdbmsReqInfo RDBMSInfo) (RDBMSInfo, error)
+	ListRDBMS() ([]*RDBMSInfo, error)
+	GetRDBMS(rdbmsIID IID) (RDBMSInfo, error)
+	DeleteRDBMS(rdbmsIID IID) (bool, error)
+
+	//------ Instance Control (TBD: support will be decided later)
+	// ChangeSpec(rdbmsIID IID, newSpec string) (RDBMSInfo, error)        // Change instance class/spec
+	// ChangeStorageSize(rdbmsIID IID, newSize string) (bool, error)      // Expand storage
+}

--- a/cloud-control-manager/cloud-driver/interfaces/resources/ResourceType.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/ResourceType.go
@@ -33,6 +33,8 @@ const (
 	NODEGROUP    RSType = "nodegroup"
 
 	FILESYSTEM RSType = "filesystem"
+
+	RDBMS RSType = "rdbms"
 )
 
 func RSTypeString(rsType RSType) string {
@@ -63,6 +65,8 @@ func RSTypeString(rsType RSType) string {
 		return "Kubernetes NodeGroup"
 	case FILESYSTEM:
 		return "FileSystem"
+	case RDBMS:
+		return "Relational Database"
 	default:
 		return string(rsType) + " is not supported Resource!!"
 
@@ -100,6 +104,8 @@ func StringToRSType(str string) (RSType, error) {
 		return NODEGROUP, nil
 	case "filesystem":
 		return FILESYSTEM, nil
+	case "rdbms":
+		return RDBMS, nil
 	default:
 		return "", fmt.Errorf("%s is not a valid resource type", str)
 	}

--- a/cloud-control-manager/iid-manager/IIDManager.go
+++ b/cloud-control-manager/iid-manager/IIDManager.go
@@ -182,6 +182,8 @@ func getIDXNumber(rsType string) int {
 		return 8
 	case "nodegroup":
 		return 9
+	case "rdbms":
+		return 10
 	default:
 		return -1
 	}

--- a/cloud-driver-libs/cloudos_meta.yaml
+++ b/cloud-driver-libs/cloudos_meta.yaml
@@ -15,8 +15,8 @@ AWS:
   rootdisktype: standard / gp2 / gp3
   disktype: standard / gp2 / gp3 / io1 / io2 / st1 / sc1
   disksize: standard|1|1024|GB / gp2|1|16384|GB / gp3|1|16384|GB / io1|4|16384|GB / io2|4|16384|GB / st1|125|16384|GB / sc1|125|16384|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 255 / 256 / 255 / 255 / 255 / 256 / 32 / 127 / 100
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 255 / 256 / 255 / 255 / 255 / 256 / 32 / 127 / 100 / 0 / 63
   defaultregiontoquery: ap-northeast-2 / ap-northeast-2a
 
 AZURE:
@@ -26,8 +26,8 @@ AZURE:
   # type issues: https://github.com/cloud-barista/cb-spider/pull/529#issue-1051678985
   rootdisktype: PremiumSSD / StandardSSD / StandardHDD
   disktype: PremiumSSD / StandardSSD / StandardHDD
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 64 / 80 / 64 / 80 / 64 / 80 / 80 / 80 / 63
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 64 / 80 / 64 / 80 / 64 / 80 / 80 / 80 / 63 / 0 / 63
   defaultregiontoquery: koreacentral / 1
 
 GCP:
@@ -37,9 +37,9 @@ GCP:
   rootdisktype: pd-standard / pd-balanced / pd-ssd / pd-extreme
   disktype: pd-standard / pd-balanced / pd-ssd / pd-extreme
   disksize: pd-standard|10|65536|GB / pd-balanced|10|65536|GB / pd-ssd|10|65536|GB / pd-extreme|500|65536|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
   #idmaxlength: 63 / 63 / 63 / 0 / 63
-  idmaxlength: 63 / 63 / 57 / 0 / 63 / 63 / 63 / 63 / 40
+  idmaxlength: 63 / 63 / 57 / 0 / 63 / 63 / 63 / 63 / 40 / 0 / 63
 
 ALIBABA:
   region: Region / Zone
@@ -51,8 +51,8 @@ ALIBABA:
   #rootdisksize: cloud_efficiency|20|32768|GB / cloud|5|2000|GB / cloud_ssd|20|32768|GB
   disktype: cloud / cloud_efficiency / cloud_ssd / cloud_essd
   disksize: cloud|5|2000|GB / cloud_efficiency|20|32768|GB / cloud_ssd|20|32768|GB / cloud_essd_PL0|40|32768|GB / cloud_essd_PL1|20|32768|GB / cloud_essd_PL2|461|32768|GB / cloud_essd_PL3|1261|32768|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 128 / 128 / 128 / 128 / 128 / 128 / 80 / 128 / 63
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 128 / 128 / 128 / 128 / 128 / 128 / 80 / 128 / 63 / 0 / 128
   defaultregiontoquery: ap-northeast-2 / ap-northeast-2a
 
 TENCENT:
@@ -64,8 +64,8 @@ TENCENT:
   rootdisksize: CLOUD_PREMIUM|50|16000|GB / CLOUD_SSD|50|16000|GB
   disktype: CLOUD_PREMIUM / CLOUD_SSD / CLOUD_HSSD / CLOUD_BASIC / CLOUD_TSSD
   disksize: CLOUD_PREMIUM|10|32000|GB / CLOUD_SSD|20|32000|GB / CLOUD_HSSD|20|32000|GB / CLOUD_BASIC|10|32000|GB / CLOUD_TSSD|10|32000|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 60 / 60 / 60 / 25 / 88 / 60 / 60 / 60 / 50
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 60 / 60 / 60 / 25 / 88 / 60 / 60 / 60 / 50 / 0 / 60
   defaultregiontoquery: ap-seoul / ap-seoul-1
 
 IBM:
@@ -76,16 +76,16 @@ IBM:
   rootdisksize: general-purpose|100|250|GB / sdp|100|250|GB
   disktype: general-purpose / 5iops-tier / 10iops-tier / sdp
   disksize: general-purpose|10|16000|GB / 5iops-tier|10|9600|GB / 10iops-tier|10|4800|GB / sdp|1|32000|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 63 / 63 / 63 / 63 / 63 / 63 / 63 / 63 / 32 / 63
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 63 / 63 / 63 / 63 / 63 / 63 / 63 / 63 / 32 / 63 / 63
   defaultregiontoquery: us-south / us-south-1
 
 OPENSTACK:
   region: Region / Zone
   credential: IdentityEndpoint / Username / Password / DomainName / ProjectID
   credentialcsp: IdentityEndpoint / Username / Password / DomainName / ProjectID
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 0
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 0 / 0 / 255
   
 NCP:
   region: Region / Zone
@@ -95,8 +95,8 @@ NCP:
   rootdisksize: HDD|10|2000|GB
   disktype: SSD / HDD
   disksize: SSD|100|16380|GB / HDD|100|16380|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 30 / 30 / 30 / 30 / 30 / 30 / 30 / 30 / 20 / 20
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 30 / 30 / 30 / 30 / 30 / 30 / 30 / 30 / 20 / 20 / 30
 
 NHN:
   region: Region / Zone
@@ -106,8 +106,8 @@ NHN:
   rootdisksize: General_HDD|20|1000|GB / General_SSD|20|1000|GB
   disktype: General_HDD / General_SSD
   disksize: General_HDD|10|2000|GB / General_SSD|10|2000|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 32 / 32 / 255 / 32 / 90 / 255 / 80 / 255 / 32
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 32 / 32 / 255 / 32 / 90 / 255 / 80 / 255 / 32 / 0 / 32
 
 KTCLASSIC:
   region: Region / Zone
@@ -117,8 +117,8 @@ KTCLASSIC:
   rootdisksize: HDD|20|50|GB / SSD|20|50|GB
   disktype: HDD / SSD-Provisioned
   disksize: HDD|10|500|GB / SSD-Provisioned|100|800|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster
-  idmaxlength: 30 / 30 / 30 / 100 / 63 / 50 / 30 / 32 / 0
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 30 / 30 / 30 / 100 / 63 / 50 / 30 / 32 / 0 / 0 / 30
 
 KT:
   region: Region / Zone
@@ -128,8 +128,8 @@ KT:
   rootdisksize: HDD|50|100|GB / SSD|50|100|GB
   disktype: HDD / SSD
   disksize: HDD|10|2000|GB / SSD|10|2000|GB
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 30 / 48 / 30 / 100 / 63 / 50 / 30 / 50 / 0 / 20
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 30 / 48 / 30 / 100 / 63 / 50 / 30 / 50 / 0 / 20 / 30
 
 #--- Emulation
 
@@ -137,8 +137,8 @@ MOCK:
   region: Region
   credential: MockName
   credentialcsp: MockName
-  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem
-  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255
+  # idmaxlength: VPC / Subnet / SecurityGroup / KeyPair / VM / Disk / NLB / MyImage / Cluster / FileSystem / RDBMS
+  idmaxlength: 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 255 / 0 / 255
   rootdisktype: SSD /HDD / MEM
   disktype: SSD / HDD / MEM
   disksize: SSD|1|16384|GB / HDD|1|16384|GB / MEM|10|512|GB

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/swaggo/swag v1.16.3
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.0.415
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.48
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.0.206
 	golang.org/x/crypto v0.50.0
@@ -46,6 +46,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v8 v8.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v9 v9.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
@@ -53,6 +54,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Azure/go-autorest/autorest/to v0.4.0
+	github.com/IBM/cloud-databases-go-sdk v0.8.1
 	github.com/IBM/platform-services-go-sdk v0.97.2
 	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27
 	github.com/alibabacloud-go/cs-20151215/v4 v4.5.8
@@ -66,12 +68,14 @@ require (
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-openapi/strfmt v0.25.0
+	github.com/go-sql-driver/mysql v1.10.0
 	github.com/goccy/go-json v0.10.5
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/itchyny/gojq v0.12.17
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/labstack/echo/v4 v4.13.3
+	github.com/lib/pq v1.12.3
 	github.com/minio/minio-go/v7 v7.0.94
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/rs/zerolog v1.34.0
@@ -80,6 +84,7 @@ require (
 	github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.531+incompatible
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.1.48
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.492
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.94
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs v1.1.8
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.964
 	golang.org/x/mod v0.34.0
@@ -95,6 +100,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/longrunning v0.8.0 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ cloud.google.com/go/storage v1.56.0/go.mod h1:Tpuj6t4NweCLzlNbw9Z9iwxEkrSem20Aet
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
@@ -81,6 +83,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxw
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.2.0 h1:+lnLQhKh3cgSOIOVH61UZ3s/l9d+bAZp5d/spt1+7UI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.2.0/go.mod h1:tStOHrivWUrcBolspvKV70Us1ckESYGYSHdG4LX8zyY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0 h1:3jDMffAwnvs6qmOqhjNVHB29AKxs6brnzJeo65E1YwM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0/go.mod h1:0mKVz3WT8oNjBunT1zD/HPwMleQ72QClMa7Gmsm+6Kc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0 h1:CbHDMVJhcJSmXenq+UDWyIjumzVkZIb5pVUGzsCok5M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0/go.mod h1:raqbEXrok4aycS74XoU6p9Hne1dliAFpHLizlp+qJoM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0 h1:67nFqWXpo0x5Nz0XEb1yI7s8D+EHy8NsTinYw9sZnLk=
@@ -124,6 +128,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
+github.com/IBM/cloud-databases-go-sdk v0.8.1 h1:ULQ5L8V/9z79/qS185LqbIK2LD4kMtk3Hdhp4lFMVcw=
+github.com/IBM/cloud-databases-go-sdk v0.8.1/go.mod h1:JYucI1PdwqbAd8XGdDAchxzxRP7bxOh1zUnseovHKsc=
 github.com/IBM/go-sdk-core/v5 v5.21.2 h1:mJ5QbLPOm4g5qhZiVB6wbSllfpeUExftGoyPek2hk4M=
 github.com/IBM/go-sdk-core/v5 v5.21.2/go.mod h1:ngpMgwkjur1VNUjqn11LPk3o5eCyOCRbcfg/0YAY7Hc=
 github.com/IBM/platform-services-go-sdk v0.97.2 h1:CdiLSFB0+oaAsucgVnpwn31YTAr47qFROPes4zXJalk=
@@ -323,6 +329,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.28.0 h1:Q7ibns33JjyW48gHkuFT91qX48KG0ktULL6FgHdG688=
 github.com/go-playground/validator/v10 v10.28.0/go.mod h1:GoI6I1SjPBh9p7ykNE/yj3fFYbyDOpwMn5KXd+m2hUU=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
@@ -520,6 +528,8 @@ github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -667,6 +677,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.1.48 h1:LyOX4QhW
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.1.48/go.mod h1:E/ud9tYqHrw35EMnK0vG4EN6zcpkXAO8vCz8mCLBY08=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.492 h1:TJ08B6Kf1j5jwbm7BjdQWjBOOPFuNuK9aSF0iMnfjmE=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.492/go.mod h1:BIAILC4/ULX0fuBMgNgE41HtD3aGkAjlYGkBM7O4L64=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.94 h1:OW9fV8GIGRNhniE8oGS+0pL0kxBHj4N9t6Yj3ylaqWE=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cdb v1.3.94/go.mod h1:v5cDZ49IfyHIC9DLTWVFCE7UXBSO9Hbk9NEw5/90LEw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs v1.1.8 h1:+NQ6wGZeA5HuXOnlvWqzgCQrPSntb5iQJb6r06itVmA=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cfs v1.1.8/go.mod h1:pK49vc9Bmsr2atBKzuMQSGwGmsCjr6QifKz8VSPlVsM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/clb v1.0.415 h1:ylKa86lV1peXO76JzvckpYzDK4UmmmVDlOFmD11NC8E=
@@ -676,8 +688,9 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.492/go.mod 
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.964/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1064/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.8/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
-github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.48 h1:aoRUrz2ag27jQWcOKHgeE+toSti6/xPqHKMLruOtJuM=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.1.48/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94 h1:sVjwZ/e34Z11iKCpwpUXBjWjspw+ITYeJW0ffBgKEuY=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.3.94/go.mod h1:r5r4xbfxSaeR04b166HGsBa/R4U3SueirEUpXGuw+Q0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064 h1:6WUrKJwDKao+kzT4cOj2HRi9hjOP6JC9g/25CYYXPyk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.1064/go.mod h1:N7W89ge68ClQl0/EtEQtDhvkqziMw2NhcTiWtKKztI0=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag v1.0.964 h1:YxlaK/2zEyC6cL+1Cz0ZmN6lKghx46QgbdzEFddh9qM=


### PR DESCRIPTION
- Add initial RDBMS support to CB-Spider across the common interface, runtime layer, and REST API
- Introduce RDBMS handlers for 10 CSP drivers as the first implementation baseline
- Add Admin Web and Swagger updates for RDBMS-related operations
- Complete basic validation for AWS, Azure, GCP, and Alibaba drivers
- Leave the remaining CSP drivers included as initial implementations pending further validation and stabilization
- Establish the foundation for incremental CSP-specific RDBMS refinement in follow-up PRs