### PR TITLE
Fix IBM cloud-init to properly inject SSH public key for cb-user

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
@@ -182,6 +182,7 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		}
 		userData = string(fileDataCloudInit)
 		userData = strings.ReplaceAll(userData, "{{username}}", CBDefaultVmUserName)
+		userData = strings.ReplaceAll(userData, "{{public_key}}", *key.PublicKey)
 	}
 
 	// 2.Create VM

--- a/cloud-driver-libs/.cloud-init-ibm/cloud-init
+++ b/cloud-driver-libs/.cloud-init-ibm/cloud-init
@@ -1,9 +1,20 @@
 #!/bin/bash
 #### add Cloud-Barista user
-useradd -s /bin/bash cb-user -rm -G sudo
+if getent group sudo > /dev/null 2>&1; then
+    SUDO_GROUP=sudo
+elif getent group wheel > /dev/null 2>&1; then
+    SUDO_GROUP=wheel
+else
+    groupadd sudo && SUDO_GROUP=sudo
+fi
+useradd -s /bin/bash -m -G $SUDO_GROUP cb-user
 mkdir -p /home/cb-user/.ssh
 echo "{{public_key}}" >> /home/cb-user/.ssh/authorized_keys
 chmod 700 /home/cb-user/.ssh
 chmod 600 /home/cb-user/.ssh/authorized_keys
 chown -R cb-user:cb-user /home/cb-user/.ssh
-echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
+if command -v restorecon > /dev/null 2>&1; then
+    restorecon -Rv /home/cb-user/.ssh
+fi
+echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/cb-user
+chmod 440 /etc/sudoers.d/cb-user

--- a/cloud-driver-libs/.cloud-init-ibm/cloud-init
+++ b/cloud-driver-libs/.cloud-init-ibm/cloud-init
@@ -1,8 +1,9 @@
 #!/bin/bash
 #### add Cloud-Barista user
-useradd -s /bin/bash cb-user -rm -G sudo;
-mkdir /home/cb-user/.ssh; 
-cp -r /root/.ssh/ /home/cb-user/;
-cp -r /home/ubuntu/.ssh/ /home/cb-user/;
-chown -R cb-user:cb-user /home/cb-user;
-echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers;
+useradd -s /bin/bash cb-user -rm -G sudo
+mkdir -p /home/cb-user/.ssh
+echo "{{public_key}}" >> /home/cb-user/.ssh/authorized_keys
+chmod 700 /home/cb-user/.ssh
+chmod 600 /home/cb-user/.ssh/authorized_keys
+chown -R cb-user:cb-user /home/cb-user/.ssh
+echo "cb-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
The previous cloud-init script copied `.ssh` from root/ubuntu user, which is fragile (those directories may not exist or may not contain the intended keypair) and did not inject the actual key specified at VM creation time.
This leads remote command error in CB-TB.

This PR fix IBM cloud-init to inject the keypair's public key directly into
authorized_keys instead of copying .ssh from root/ubuntu user.

- Add {{public_key}} placeholder substitution in VMHandler.go
- Set correct permissions (700/.ssh, 600/authorized_keys) and ownership
- + enable CentOS configuration (this was not supported before.)

Tested it with CB-TB 
(note that the cloud-init approach has not been covered all operating systems so far.)

<img width="738" height="428" alt="image" src="https://github.com/user-attachments/assets/729a53ab-6c55-432e-b5c7-25c1614b858e" />


---

<img width="738" height="206" alt="image" src="https://github.com/user-attachments/assets/18574e1a-cb0e-4840-ad76-ac76b959575f" />

