### PR TITLE
[Server:Common-Runtime] Fix: Remove Root Disk Type Validation to Delegate to CSP

### DIFF
--- a/api-runtime/common-runtime/ClusterManager.go
+++ b/api-runtime/common-runtime/ClusterManager.go
@@ -1399,10 +1399,6 @@ func translateRootDiskInfo(providerName string, reqInfo *cres.NodeGroupInfo) err
 				typeNum = typeMax
 			}
 			reqInfo.RootDiskType = cloudOSMetaInfo.RootDiskType[typeNum-1]
-		} else if !validateRootDiskType(reqInfo.RootDiskType, cloudOSMetaInfo.RootDiskType) {
-			errMSG := reqInfo.RootDiskType + " is not a valid Root Disk Type of " + providerName + "!"
-			cblog.Error(errMSG)
-			return fmt.Errorf(errMSG)
 		}
 	}
 

--- a/api-runtime/common-runtime/VMManager.go
+++ b/api-runtime/common-runtime/VMManager.go
@@ -1361,10 +1361,6 @@ func translateRootDiskSetupInfo(providerName string, reqInfo *cres.VMReqInfo) er
 				typeNum = typeMax
 			}
 			reqInfo.RootDiskType = cloudOSMetaInfo.RootDiskType[typeNum-1]
-		} else if !validateRootDiskType(reqInfo.RootDiskType, cloudOSMetaInfo.RootDiskType) {
-			errMSG := reqInfo.RootDiskType + " is not a valid Root Disk Type of " + providerName + "!"
-			cblog.Error(errMSG)
-			return fmt.Errorf(errMSG)
 		}
 	}
 
@@ -1381,15 +1377,6 @@ func translateRootDiskSetupInfo(providerName string, reqInfo *cres.VMReqInfo) er
 		}
 	}
 	return nil
-}
-
-func validateRootDiskType(diskType string, diskTypeList []string) bool {
-	for _, v := range diskTypeList {
-		if diskType == v {
-			return true
-		}
-	}
-	return false
 }
 
 func validateRootDiskSize(strSize string) error {


### PR DESCRIPTION
- Remove `validateRootDiskType()` call and function definition from VMManager.go
- Remove `validateRootDiskType()` call from ClusterManager.go
- CB-Spider's static allowlist in cloudos_meta.yaml was blocking valid CSP disk types (e.g., `cloud_auto`, `cloud_essd_entry` for Alibaba) that are not yet listed