### PR TITLE
Fix IBM cloud driver: spec pagination and VM provisioning error handling

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
@@ -442,34 +442,55 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 		NameId:   *createInstance.Name,
 		SystemId: *createInstance.ID,
 	}
+	const pollIntervalSec = 5
+	const maxWaitSec = 600 // IBM GPU instances (gx3*) can take 5-10 min
 	curRetryCnt := 0
-	maxRetryCnt := 120
+	maxRetryCnt := maxWaitSec / pollIntervalSec
 	for {
 		finalInstance, err := getRawInstance(createInstanceIId, vmHandler.VpcService, vmHandler.Ctx)
 		if err != nil {
 			removeFloatingIpsErr := removeFloatingIps(finalInstance, vmHandler.VpcService, vmHandler.Ctx)
-			// 생성 완료후 running 기다리는중 에러.
-			// 제거 로직을 위해 removeFloatingIp
 			if removeFloatingIpsErr != nil {
-				// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
-				newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
-				err = errors.New(newErrText)
+				err = errors.New(err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM")
 				createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
 			}
-			// 제거 로직을 위해 deleteInstance
 			deleteErr := deleteInstance(*createInstance.ID, vmHandler.VpcService, vmHandler.Ctx)
 			if deleteErr != nil {
-				newErrText := err.Error() + deleteErr.Error()
-				err = errors.New(newErrText)
+				err = errors.New(err.Error() + deleteErr.Error())
+			}
+			createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
+			cblogger.Error(createErr.Error())
+			LoggingError(hiscallInfo, createErr)
+			return irs.VMInfo{}, createErr
+		}
+		if *finalInstance.Status == "failed" {
+			// IBM instance entered failed state — collect StatusReasons for diagnosis
+			var reasonParts []string
+			for _, r := range finalInstance.StatusReasons {
+				if r.Code != nil && r.Message != nil {
+					reasonParts = append(reasonParts, fmt.Sprintf("%s: %s", *r.Code, *r.Message))
+				}
+			}
+			reason := "IBM instance entered failed status"
+			if len(reasonParts) > 0 {
+				reason += " (" + strings.Join(reasonParts, "; ") + ")"
+			}
+			err = errors.New(reason)
+			removeFloatingIpsErr := removeFloatingIps(finalInstance, vmHandler.VpcService, vmHandler.Ctx)
+			if removeFloatingIpsErr != nil {
+				err = errors.New(err.Error() + "; cleanup error: " + removeFloatingIpsErr.Error())
 				createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
 			}
-			err = errors.New("failed to create VM")
+			deleteErr := deleteInstance(*createInstance.ID, vmHandler.VpcService, vmHandler.Ctx)
+			if deleteErr != nil {
+				err = errors.New(err.Error() + "; cleanup error: " + deleteErr.Error())
+			}
 			createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)
@@ -479,28 +500,17 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			finalInstanceInfo, err := vmHandler.setVmInfo(finalInstance)
 			if err != nil {
 				removeFloatingIpsErr := removeFloatingIps(finalInstance, vmHandler.VpcService, vmHandler.Ctx)
-				// 생성 완료후 running 기다리는중 에러.
-				// 제거 로직을 위해 removeFloatingIp
 				if removeFloatingIpsErr != nil {
-					// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
-					newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
-					err = errors.New(newErrText)
+					err = errors.New(err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM")
 					createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 					cblogger.Error(createErr.Error())
 					LoggingError(hiscallInfo, createErr)
 					return irs.VMInfo{}, createErr
 				}
-				// 제거 로직을 위해 deleteInstance
 				deleteErr := deleteInstance(*createInstance.ID, vmHandler.VpcService, vmHandler.Ctx)
 				if deleteErr != nil {
-					newErrText := err.Error() + deleteErr.Error()
-					err = errors.New(newErrText)
-					createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
-					cblogger.Error(createErr.Error())
-					LoggingError(hiscallInfo, createErr)
-					return irs.VMInfo{}, createErr
+					err = errors.New(err.Error() + deleteErr.Error())
 				}
-				err = errors.New("failed to create VM")
 				createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
@@ -513,32 +523,21 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			return finalInstanceInfo, nil
 		}
 		curRetryCnt++
-		time.Sleep(1 * time.Second)
+		time.Sleep(time.Duration(pollIntervalSec) * time.Second)
 		if curRetryCnt > maxRetryCnt {
-			err = errors.New(fmt.Sprintf("failed to create VM, exceeded maximum retry count %d", maxRetryCnt))
+			err = errors.New(fmt.Sprintf("IBM instance did not reach running status within %d seconds (last status: %s)", maxWaitSec, *finalInstance.Status))
 			removeFloatingIpsErr := removeFloatingIps(finalInstance, vmHandler.VpcService, vmHandler.Ctx)
-			// 생성 완료후 running 기다리는중 에러.
-			// 제거 로직을 위해 removeFloatingIp
 			if removeFloatingIpsErr != nil {
-				// 제거 로직을 위해 removeFloatingIp Error => instance에 대한 에러 + removeError + delete error
-				newErrText := err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM"
-				err = errors.New(newErrText)
+				err = errors.New(err.Error() + removeFloatingIpsErr.Error() + "and failed delete VM")
 				createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 				cblogger.Error(createErr.Error())
 				LoggingError(hiscallInfo, createErr)
 				return irs.VMInfo{}, createErr
 			}
-			// 제거 로직을 위해 deleteInstance
 			deleteErr := deleteInstance(*createInstance.ID, vmHandler.VpcService, vmHandler.Ctx)
 			if deleteErr != nil {
-				newErrText := err.Error() + deleteErr.Error()
-				err = errors.New(newErrText)
-				createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
-				cblogger.Error(createErr.Error())
-				LoggingError(hiscallInfo, createErr)
-				return irs.VMInfo{}, createErr
+				err = errors.New(err.Error() + deleteErr.Error())
 			}
-			err = errors.New("failed to create VM")
 			createErr := errors.New(fmt.Sprintf("Failed to Create VM. err = %s", err.Error()))
 			cblogger.Error(createErr.Error())
 			LoggingError(hiscallInfo, createErr)

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMSpecHandler.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -35,15 +37,32 @@ func (vmSpecHandler *IbmVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, error) {
 		return nil, getErr
 	}
 
-	for _, profile := range profiles.Profiles {
-		vmSpecInfo, err := setVmSpecInfo(profile, vmSpecHandler.Region.Region)
-		if err != nil {
-			getErr := errors.New(fmt.Sprintf("Failed to List VMSpec. err = %s", err.Error()))
-			cblogger.Error(getErr.Error())
-			LoggingError(hiscallInfo, getErr)
-			return nil, getErr
+	for {
+		for _, profile := range profiles.Profiles {
+			vmSpecInfo, err := setVmSpecInfo(profile, vmSpecHandler.Region.Region)
+			if err != nil {
+				getErr := errors.New(fmt.Sprintf("Failed to List VMSpec. err = %s", err.Error()))
+				cblogger.Error(getErr.Error())
+				LoggingError(hiscallInfo, getErr)
+				return nil, getErr
+			}
+			specList = append(specList, &vmSpecInfo)
 		}
-		specList = append(specList, &vmSpecInfo)
+		nextStr, _ := getSpecNextHref(profiles.Next)
+		if nextStr != "" {
+			options = &vpcv1.ListInstanceProfilesOptions{
+				Start: core.StringPtr(nextStr),
+			}
+			profiles, _, err = vmSpecHandler.VpcService.ListInstanceProfilesWithContext(vmSpecHandler.Ctx, options)
+			if err != nil {
+				getErr := errors.New(fmt.Sprintf("Failed to List VMSpec. err = %s", err.Error()))
+				cblogger.Error(getErr.Error())
+				LoggingError(hiscallInfo, getErr)
+				return nil, getErr
+			}
+		} else {
+			break
+		}
 	}
 	LoggingInfo(hiscallInfo, start)
 	return specList, nil
@@ -90,15 +109,32 @@ func (vmSpecHandler *IbmVmSpecHandler) ListOrgVMSpec() (string, error) {
 		LoggingError(hiscallInfo, getErr)
 		return "", getErr
 	}
-	for _, profile := range profiles.Profiles {
-		vmSpecInfo, err := setVmSpecInfo(profile, vmSpecHandler.Region.Region)
-		if err != nil {
-			getErr := errors.New(fmt.Sprintf("Failed to List OrgVMSpec. err = %s", err.Error()))
-			cblogger.Error(getErr.Error())
-			LoggingError(hiscallInfo, getErr)
-			return "", getErr
+	for {
+		for _, profile := range profiles.Profiles {
+			vmSpecInfo, err := setVmSpecInfo(profile, vmSpecHandler.Region.Region)
+			if err != nil {
+				getErr := errors.New(fmt.Sprintf("Failed to List OrgVMSpec. err = %s", err.Error()))
+				cblogger.Error(getErr.Error())
+				LoggingError(hiscallInfo, getErr)
+				return "", getErr
+			}
+			specList = append(specList, &vmSpecInfo)
 		}
-		specList = append(specList, &vmSpecInfo)
+		nextStr, _ := getSpecNextHref(profiles.Next)
+		if nextStr != "" {
+			options = &vpcv1.ListInstanceProfilesOptions{
+				Start: core.StringPtr(nextStr),
+			}
+			profiles, _, err = vmSpecHandler.VpcService.ListInstanceProfilesWithContext(vmSpecHandler.Ctx, options)
+			if err != nil {
+				getErr := errors.New(fmt.Sprintf("Failed to List OrgVMSpec. err = %s", err.Error()))
+				cblogger.Error(getErr.Error())
+				LoggingError(hiscallInfo, getErr)
+				return "", getErr
+			}
+		} else {
+			break
+		}
 	}
 	jsonBytes, err := json.Marshal(specList)
 	if err != nil {
@@ -147,10 +183,18 @@ func (vmSpecHandler *IbmVmSpecHandler) GetOrgVMSpec(Name string) (string, error)
 }
 
 func getGpuMfr(name string) string {
-	if strings.HasPrefix(name, "gx2") || strings.HasPrefix(name, "gx3") {
-		return "NVIDIA"
+	if !strings.HasPrefix(name, "gx") {
+		return "NA"
 	}
-	return "NA"
+	// Determine manufacturer from GPU model suffix (e.g., gaudi3 → Intel, mi300x → AMD)
+	model := strings.ToLower(getGpuModel(name))
+	if strings.HasPrefix(model, "gaudi") {
+		return "Intel"
+	}
+	if strings.HasPrefix(model, "mi") {
+		return "AMD"
+	}
+	return "NVIDIA"
 }
 
 func getGpuCount(name string) string {
@@ -194,7 +238,6 @@ func getGpuModel(name string) string {
 }
 
 func getGpuInfo(name string) (string, string, string) {
-	//check NVIDIA gpu
 	mfr := getGpuMfr(name)
 	if mfr == "NA" {
 		return mfr, "-1", "NA"
@@ -257,6 +300,23 @@ func setVmSpecInfoWithVMSpecName(Name string, region string) (irs.VMSpecInfo, er
 	}
 
 	return vmSpecInfo, nil
+}
+
+func getSpecNextHref(next *vpcv1.PageLink) (string, error) {
+	if next != nil {
+		href := *next.Href
+		u, err := url.Parse(href)
+		if err != nil {
+			return "", err
+		}
+		paramMap, _ := url.ParseQuery(u.RawQuery)
+		if paramMap != nil {
+			if safe := paramMap["start"]; len(safe) > 0 {
+				return safe[0], nil
+			}
+		}
+	}
+	return "", errors.New("NOT NEXT")
 }
 
 func getRawSpec(specName string, vpcService *vpcv1.VpcV1, ctx context.Context) (vpcv1.InstanceProfile, error) {


### PR DESCRIPTION
Fix IBM cloud driver: spec pagination and VM provisioning error handling.

### VMSpecHandler: Fixed spec list truncation. 
  - Issue: IBM VPC API paginates instance profiles (it was 50/page by default ..). only fetched the first page, causing GPU specs (gx3*, gx3d*) to be silently skipped. 
  - Fix: Added pagination loop following the same pattern as ImageHandler.



### VMHandler: Fixed VM provisioning reliability
 - Added status=failed early exit with IBM's StatusReasons (e.g. cannot_start_capacity) instead of waiting for timeout
 - Removed error message overwrites that discarded the actual failure reason
 - Increased timeout from 120s to 600s to cover GPU instance provisioning time
 - Reduced polling interval from 1s to 5s (for system performance and stability especially for CB-TB)

**This fix needs to be handled as a hot fix.** (need to be added to CB-TB pre release version.)