### PR TITLE
Uses rounding to avoid systematic undercount of GPU VRAM

### DIFF
--- a/cloud-control-manager/cloud-driver/interfaces/resources/UnitConversion.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/UnitConversion.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 )
 
@@ -30,8 +31,9 @@ func ConvertMiBToGB(mibStr string) (string, error) {
 }
 
 // ConvertMiBToGBInt64 converts MiB (int64) to a GB string (int string).
+// Uses rounding to avoid systematic undercount (e.g. 22888 MiB → 23.997 GB → 24, not 23).
 func ConvertMiBToGBInt64(mib int64) string {
-	gb := int(float64(mib) / 1024.0 * 1.073741824)
+	gb := int(math.Round(float64(mib) / 1024.0 * 1.073741824))
 	return strconv.Itoa(gb)
 }
 

--- a/cloud-control-manager/cloud-driver/interfaces/resources/UnitConversion.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/UnitConversion.go
@@ -33,8 +33,8 @@ func ConvertMiBToGB(mibStr string) (string, error) {
 // ConvertMiBToGBInt64 converts MiB (int64) to a GB string (int string).
 // Uses rounding to avoid systematic undercount (e.g. 22888 MiB → 23.997 GB → 24, not 23).
 func ConvertMiBToGBInt64(mib int64) string {
-	gb := int(math.Round(float64(mib) / 1024.0 * 1.073741824))
-	return strconv.Itoa(gb)
+	gb := int64(math.Round(float64(mib) / 1024.0 * 1.073741824))
+	return strconv.FormatInt(gb, 10)
 }
 
 // ConvertGBToMiB converts a GB string to a MiB string (int string).


### PR DESCRIPTION
(문제)
- 현재 Spec 등의 값 정규화를 위해서, 소수점을 truncation 하고 있음
- 주로 이를 활용하는 경우는 MiB 를 GB로 변경하는 작업임
- 소수점 절사에 의해서, GPU 메모리 등이, 실제 사양보다 하향 표기되고 있음
- AWS의 GPU vram의 경우, 모든 주요 GPU 스펙이 1GB씩 낮게 등록됨
  - 예시: AWS EC2 API가 NVIDIA L4 GPU 메모리를 22888 MiB(= 24 GB의 정확한 이진 변환: 24×10⁹÷1048576 = 22888.18 MiB)로 반환하는데, ConvertMiBToGBInt64 함수가 소수점 절사를 사용해서 23.997 → 23 로 오표기

(개선)
- 변환이 필요한 경우를 고려(MB 대비(24), MiB 소수점(23.997)으로 조금만 작은 수)하면, 소수점 절사보다, round를 적용하는 것이 대부분의 경우에 바람직
- 기존에 `0`GB 으로 오표기되던 Disk 사이즈 문제도 일부 해결 될 것임
