### PR TITLE
[SpiderWatch:Tencent-Cluster] Fix: Improve cluster test reliability of SpdierWatch and prevent Tencent nil panic

### DIFF
--- a/api-runtime/rest-runtime/admin-web/html/cluster.html
+++ b/api-runtime/rest-runtime/admin-web/html/cluster.html
@@ -1381,7 +1381,7 @@
                         vmSpecInput.value = 'Standard_B2s';
                         break;
                     case 'IBM':
-                        versionInput.value = '1.32.13';
+                        versionInput.value = '1.35.5';
                         break;
                     case 'NHNCLOUD':
                         versionInput.value = 'v1.28.3';

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -713,28 +713,32 @@ func getNodeGroupInfo(access_key, access_secret, region_id, cluster_id, node_gro
 		auto_scale_enalbed = true
 	}
 
+	// Always initialize with basic info; details filled in when launch config and ASG are available.
+	// If the node group is being deleted, its launch config and ASG may already be gone,
+	// causing an empty set — which would leave nodeGroupInfo nil and panic on subsequent access.
+	nodeGroupInfo = &irs.NodeGroupInfo{
+		IId: irs.IID{
+			NameId:   *res.Response.NodePool.Name,
+			SystemId: *res.Response.NodePool.NodePoolId,
+		},
+		Status:        status,
+		OnAutoScaling: auto_scale_enalbed,
+		Nodes:         []irs.IID{},
+		KeyValueList:  []irs.KeyValue{},
+	}
+
 	if len(launch_config.Response.LaunchConfigurationSet) > 0 && len(auto_scaling_group.Response.AutoScalingGroupSet) > 0 {
-		nodeGroupInfo = &irs.NodeGroupInfo{
-			IId: irs.IID{
-				NameId:   *res.Response.NodePool.Name,
-				SystemId: *res.Response.NodePool.NodePoolId,
-			},
-			ImageIID: irs.IID{
-				NameId:   "",
-				SystemId: *launch_config.Response.LaunchConfigurationSet[0].ImageId,
-			},
-			VMSpecName:      *launch_config.Response.LaunchConfigurationSet[0].InstanceType,
-			RootDiskType:    *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskType,
-			RootDiskSize:    fmt.Sprintf("%d", *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskSize),
-			KeyPairIID:      irs.IID{NameId: "", SystemId: *launch_config.Response.LaunchConfigurationSet[0].LoginSettings.KeyIds[0]},
-			Status:          status,
-			OnAutoScaling:   auto_scale_enalbed,
-			MinNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MinSize),
-			MaxNodeSize:     int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MaxSize),
-			DesiredNodeSize: int(*auto_scaling_group.Response.AutoScalingGroupSet[0].DesiredCapacity),
-			Nodes:           []irs.IID{}, // to be implemented
-			KeyValueList:    []irs.KeyValue{},
+		nodeGroupInfo.ImageIID = irs.IID{
+			NameId:   "",
+			SystemId: *launch_config.Response.LaunchConfigurationSet[0].ImageId,
 		}
+		nodeGroupInfo.VMSpecName = *launch_config.Response.LaunchConfigurationSet[0].InstanceType
+		nodeGroupInfo.RootDiskType = *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskType
+		nodeGroupInfo.RootDiskSize = fmt.Sprintf("%d", *launch_config.Response.LaunchConfigurationSet[0].SystemDisk.DiskSize)
+		nodeGroupInfo.KeyPairIID = irs.IID{NameId: "", SystemId: *launch_config.Response.LaunchConfigurationSet[0].LoginSettings.KeyIds[0]}
+		nodeGroupInfo.MinNodeSize = int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MinSize)
+		nodeGroupInfo.MaxNodeSize = int(*auto_scaling_group.Response.AutoScalingGroupSet[0].MaxSize)
+		nodeGroupInfo.DesiredNodeSize = int(*auto_scaling_group.Response.AutoScalingGroupSet[0].DesiredCapacity)
 	}
 
 	nodes, err := tencent.DescribeClusterInstances(access_key, access_secret, region_id, cluster_id)

--- a/spiderwatch/conf/spiderwatch.yaml
+++ b/spiderwatch/conf/spiderwatch.yaml
@@ -336,7 +336,7 @@ csps:
       health_timeout: "default"
       health_threshold: "default"
     cluster_test:
-      version: "1.32.13"
+      version: "1.35.5"
       # IBM IKS: NodeGroup included in cluster create (Type-II)
       # IBM IKS uses Static Token (credentials embedded in kubeconfig)
       kubeconfig_type: "static"
@@ -412,7 +412,7 @@ csps:
       # NCP NKS: node pool is created with the cluster (Type-II)
       node_group_type: "type2"
       node_group_image_name: ""
-      node_group_vm_spec_name: "r2.c4m16"
+      node_group_vm_spec_name: "s2-g3"
       node_group_root_disk_type: "default"
       node_group_root_disk_size: "100"
       node_group_on_auto_scaling: "true"

--- a/spiderwatch/internal/runner/runner.go
+++ b/spiderwatch/internal/runner/runner.go
@@ -3013,7 +3013,7 @@ func (r *Runner) testClusterCRUD(ctx context.Context, client *http.Client, cfg *
 
 		// 5c. NGINX-HTTP-CHECK — poll until nginx responds with HTTP 2xx.
 		nginxHTTPOp := st.op("nginx-http-check", func() error {
-			const maxAttempts = 40 // 40 × 30 s = 20 min (IBM LB DNS propagation can take 10–20 min)
+			const maxAttempts = 80 // 80 × 30 s = 40 min (IBM LB DNS propagation can take up to 30 min)
 			const interval = 30 * time.Second
 			target := "http://" + nginxLBAddr + "/"
 			httpCli := &http.Client{Timeout: 10 * time.Second}
@@ -3083,26 +3083,43 @@ func (r *Runner) testClusterCRUD(ctx context.Context, client *http.Client, cfg *
 		//    Must run BEFORE remove-nodegroup.
 		if st.nginxDeployed {
 			nginxDeleteTestOp := st.op("nginx-delete", func() error {
-				const maxDeleteAttempts = 10
+				const maxDeleteAttempts = 20
 				const deleteRetryInterval = 30 * time.Second
 				// nginxGone checks whether both nginx resources have already been deleted.
-				nginxGone := func() bool {
+				// Returns (gone, checkOK): checkOK is false if kubectl itself failed (can't confirm).
+				nginxGone := func() (bool, bool) {
 					getCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", st.kubeconfigPath,
 						"get", "deployment/nginx-deployment", "service/nginx-service",
 						"--ignore-not-found", "-o", "name")
-					getOut, _ := getCmd.Output()
-					return strings.TrimSpace(string(getOut)) == ""
+					getOut, getErr := getCmd.Output()
+					if getErr != nil {
+						return false, false // kubectl itself failed; cannot confirm
+					}
+					return strings.TrimSpace(string(getOut)) == "", true
 				}
 				var lastDeleteErr error
 				for deleteAttempt := 1; deleteAttempt <= maxDeleteAttempts; deleteAttempt++ {
-					cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", st.kubeconfigPath,
-						"delete", "-f", "-", "--ignore-not-found=true", "--wait=false")
+					// After 10 normal attempts, escalate to force-delete to handle
+					// cases where connection resets prevent graceful deletion (e.g. Tencent CLB).
+					// Use a short timeout context (2 minutes) for each kubectl attempt to prevent
+					// indefinite hangs when API server becomes unresponsive.
+					deleteCtx, deleteCancel := context.WithTimeout(ctx, 2*time.Minute)
+					var cmd *exec.Cmd
+					if deleteAttempt > 10 {
+						cmd = exec.CommandContext(deleteCtx, "kubectl", "--kubeconfig", st.kubeconfigPath,
+							"delete", "-f", "-", "--ignore-not-found=true", "--wait=false", "--timeout=2m",
+							"--force", "--grace-period=0")
+					} else {
+						cmd = exec.CommandContext(deleteCtx, "kubectl", "--kubeconfig", st.kubeconfigPath,
+							"delete", "-f", "-", "--ignore-not-found=true", "--wait=false", "--timeout=2m")
+					}
 					cmd.Stdin = strings.NewReader(nginxDeployYAML)
 					out, kerr := cmd.CombinedOutput()
 					outStr := strings.TrimSpace(string(out))
 					if kerr != nil {
+						deleteCancel() // release timeout context resources
 						// Connection reset may occur even when deletion succeeded — verify.
-						if nginxGone() {
+						if gone, checkOK := nginxGone(); checkOK && gone {
 							log.Infof("runner: nginx-delete: resources already gone (delete err: %v)", kerr)
 							st.nginxDeployed = false
 							return nil
@@ -3116,6 +3133,7 @@ func (r *Runner) testClusterCRUD(ctx context.Context, client *http.Client, cfg *
 						}
 						continue
 					}
+					deleteCancel() // release timeout context resources
 					log.Infof("runner: nginx-delete: %s", outStr)
 					st.nginxDeployed = false
 					return nil
@@ -3632,26 +3650,43 @@ func (r *Runner) testCleanup(ctx context.Context, client *http.Client, cfg *conf
 				if err := fetchKubeconfig(); err != nil {
 					return fmt.Errorf("fetch kubeconfig: %v", err)
 				}
-				const maxDeleteAttempts = 10
+				const maxDeleteAttempts = 20
 				const deleteRetryInterval = 30 * time.Second
 				// nginxGone checks whether both nginx resources have already been deleted.
-				nginxGone := func() bool {
+				// Returns (gone, checkOK): checkOK is false if kubectl itself failed (can't confirm).
+				nginxGone := func() (bool, bool) {
 					getCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", cleanupKubeconfigPath,
 						"get", "deployment/nginx-deployment", "service/nginx-service",
 						"--ignore-not-found", "-o", "name")
-					getOut, _ := getCmd.Output()
-					return strings.TrimSpace(string(getOut)) == ""
+					getOut, getErr := getCmd.Output()
+					if getErr != nil {
+						return false, false // kubectl itself failed; cannot confirm
+					}
+					return strings.TrimSpace(string(getOut)) == "", true
 				}
 				var lastDeleteErr error
 				for deleteAttempt := 1; deleteAttempt <= maxDeleteAttempts; deleteAttempt++ {
-					cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", cleanupKubeconfigPath,
-						"delete", "-f", "-", "--ignore-not-found=true", "--wait=false")
+					// After 10 normal attempts, escalate to force-delete to handle
+					// cases where connection resets prevent graceful deletion (e.g. Tencent CLB).
+					// Use a short timeout context (2 minutes) for each kubectl attempt to prevent
+					// indefinite hangs when API server becomes unresponsive.
+					deleteCtx, deleteCancel := context.WithTimeout(ctx, 2*time.Minute)
+					var cmd *exec.Cmd
+					if deleteAttempt > 10 {
+						cmd = exec.CommandContext(deleteCtx, "kubectl", "--kubeconfig", cleanupKubeconfigPath,
+							"delete", "-f", "-", "--ignore-not-found=true", "--wait=false", "--timeout=2m",
+							"--force", "--grace-period=0")
+					} else {
+						cmd = exec.CommandContext(deleteCtx, "kubectl", "--kubeconfig", cleanupKubeconfigPath,
+							"delete", "-f", "-", "--ignore-not-found=true", "--wait=false", "--timeout=2m")
+					}
 					cmd.Stdin = strings.NewReader(nginxDeployYAML)
 					out, kerr := cmd.CombinedOutput()
 					outStr := strings.TrimSpace(string(out))
 					if kerr != nil {
+						deleteCancel() // release timeout context resources
 						// Connection reset may occur even when deletion succeeded — verify.
-						if nginxGone() {
+						if gone, checkOK := nginxGone(); checkOK && gone {
 							log.Infof("runner: nginx-delete: resources already gone (delete err: %v)", kerr)
 							st.nginxDeployed = false
 							return nil
@@ -3665,6 +3700,7 @@ func (r *Runner) testCleanup(ctx context.Context, client *http.Client, cfg *conf
 						}
 						continue
 					}
+					deleteCancel() // release timeout context resources
 					log.Infof("runner: kubectl delete nginx: %s", outStr)
 					st.nginxDeployed = false
 					return nil


### PR DESCRIPTION
## Overview
Improves SpiderWatch cluster test reliability and fixes Tencent driver nil panic during nodegroup deletion.

## Key Changes

**1. Tencent Driver (`ClusterHandler.go`)**
- Fix nil panic when querying nodegroups during deletion
- Initialize `nodeGroupInfo` with basic fields upfront before populating details

**2. SpiderWatch Runner (`runner.go`)**
- Increase kubectl delete attempts: 10 → 20
- Add force-delete after 10 attempts (`--force --grace-period=0`)
- Add 2-minute timeout per kubectl attempt
- Improve error detection: distinguish kubectl failure from resource absence
- Handles connection resets during Tencent CLB deletion

**3. SpiderWatch Config (`spiderwatch.yaml`, `runner.go`)**
- Extend nginx HTTP check timeout: 20min → 40min (IBM LB DNS propagation)
- Update IBM Kubernetes version: 1.32.13 -> 1.35.5
- Update NCP Kubernetes VM spec: r2.c4m16 -> s2-g3
