### PR TITLE
[RDBMS/MySQL] Feat: Enhance API standardization, AdminWeb UI, and add automated test suite

### DIFF
--- a/api-runtime/common-runtime/CommonManager.go
+++ b/api-runtime/common-runtime/CommonManager.go
@@ -64,6 +64,10 @@ var clusterSPLock = splock.New()
 var fsSPLock = splock.New()
 var rdbmsSPLock = splock.New()
 
+// vpcSharedResourceSPLock protects VPC-level shared resources (e.g., GCP Service Networking Peering, Azure Private DNS Zone)
+// that are created/deleted per VPC but shared by multiple RDBMS instances.
+var vpcSharedResourceSPLock = splock.New()
+
 // ====================================================================
 // Common column name and struct for GORM
 const CONNECTION_NAME_COLUMN = "connection_name"

--- a/api-runtime/common-runtime/RDBMSManager.go
+++ b/api-runtime/common-runtime/RDBMSManager.go
@@ -911,7 +911,7 @@ func openRDBMSSQLConn(info *cres.RDBMSInfo, masterUserPassword string) (*sql.DB,
 
 	engine := strings.ToLower(string(info.DBEngine))
 	host := info.Endpoint
-	port := info.Port
+	port := ""
 	user := info.MasterUserName
 
 	// Strip port embedded in endpoint ("host:port" form)
@@ -921,9 +921,7 @@ func openRDBMSSQLConn(info *cres.RDBMSInfo, masterUserPassword string) (*sql.DB,
 		var p int
 		if _, err := fmt.Sscanf(portPart, "%d", &p); err == nil {
 			host = hostPart
-			if port == "" {
-				port = portPart
-			}
+			port = portPart
 		}
 	}
 

--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -530,7 +530,7 @@ func getRoutes() []route {
 		{"DELETE", "/rdbms/:Name", DeleteRDBMS},
 
 		//-- RDBMS database management (CSP-native API; drivers that support RDBMSDatabaseManager)
-		{"POST", "/rdbms/:Name/databases/create", CreateRDBMSDatabase},
+		{"POST", "/rdbms/:Name/databases", CreateRDBMSDatabase},
 		{"GET", "/rdbms/:Name/databases", ListRDBMSDatabases},
 		{"DELETE", "/rdbms/:Name/databases/:DBName", DeleteRDBMSDatabase},
 

--- a/api-runtime/rest-runtime/RDBMSRest.go
+++ b/api-runtime/rest-runtime/RDBMSRest.go
@@ -116,21 +116,17 @@ type RDBMSCreateRequest struct {
 		StorageSize     string `json:"StorageSize" validate:"required" example:"100"` // in GB
 
 		StorageType string `json:"StorageType,omitempty" validate:"omitempty" example:"gp2"`
-		Port        string `json:"Port,omitempty" validate:"omitempty" example:"3306"`
 
 		SubnetNames        []string `json:"SubnetNames,omitempty" validate:"omitempty" example:"subnet-01"`
 		SecurityGroupNames []string `json:"SecurityGroupNames,omitempty" validate:"omitempty" example:"sg-01"`
 
 		MasterUserName     string `json:"MasterUserName" validate:"required" example:"admin"`
 		MasterUserPassword string `json:"MasterUserPassword" validate:"required" example:"password123!"`
-		DatabaseName       string `json:"DatabaseName,omitempty" validate:"omitempty" example:"mydb"`
 
-		HighAvailability    bool   `json:"HighAvailability,omitempty" default:"false"`
-		BackupRetentionDays int    `json:"BackupRetentionDays,omitempty" example:"7"`
-		BackupTime          string `json:"BackupTime,omitempty" validate:"omitempty" example:"03:00"`
+		HighAvailability    bool `json:"HighAvailability,omitempty" default:"false"`
+		BackupRetentionDays int  `json:"BackupRetentionDays,omitempty" example:"7"` // Backup retention days (CSP will auto-assign backup time)
 
 		PublicAccess       bool `json:"PublicAccess,omitempty" default:"false"`
-		Encryption         bool `json:"Encryption,omitempty" default:"false"`
 		DeletionProtection bool `json:"DeletionProtection,omitempty" default:"false"`
 
 		TagList []cres.KeyValue `json:"TagList,omitempty" validate:"omitempty"`
@@ -159,6 +155,10 @@ func CreateRDBMS(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
+	if req.ReqInfo.VPCName == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "VPCName is required")
+	}
+
 	// Build SubnetIIDs from names
 	subnetIIDs := []cres.IID{}
 	for _, name := range req.ReqInfo.SubnetNames {
@@ -181,22 +181,20 @@ func CreateRDBMS(c echo.Context) error {
 		DBInstanceSpec:  req.ReqInfo.DBInstanceSpec,
 		StorageType:     req.ReqInfo.StorageType,
 		StorageSize:     req.ReqInfo.StorageSize,
-		Port:            req.ReqInfo.Port,
 
 		SubnetIIDs:        subnetIIDs,
 		SecurityGroupIIDs: sgIIDs,
 
 		MasterUserName:     req.ReqInfo.MasterUserName,
 		MasterUserPassword: req.ReqInfo.MasterUserPassword,
-		DatabaseName:       req.ReqInfo.DatabaseName,
 
 		HighAvailability:    req.ReqInfo.HighAvailability,
 		BackupRetentionDays: req.ReqInfo.BackupRetentionDays,
-		BackupTime:          req.ReqInfo.BackupTime,
+		// BackupTime is not configurable at creation (CSP auto-assigns)
 
 		PublicAccess:       req.ReqInfo.PublicAccess,
-		Encryption:         req.ReqInfo.Encryption,
 		DeletionProtection: req.ReqInfo.DeletionProtection,
+		// Encryption is not configurable at creation (CSP default)
 
 		TagList: req.ReqInfo.TagList,
 	}
@@ -541,7 +539,7 @@ type RDBMSDatabaseListResponse struct {
 // @Failure 400 {object} SimpleMsg "Bad Request"
 // @Failure 501 {object} SimpleMsg "Not Supported by driver"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
-// @Router /rdbms/{Name}/databases/create [post]
+// @Router /rdbms/{Name}/databases [post]
 func CreateRDBMSDatabase(c echo.Context) error {
 	cblog.Info("call CreateRDBMSDatabase()")
 

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
@@ -75,16 +75,12 @@ func fetchRDBMSInfo(connConfig, rdbmsName string) (*cres.RDBMSInfo, error) {
 }
 
 // openDBConnection creates a database/sql connection to the RDBMS instance.
-// dbNameOverride, if non-empty, takes precedence over info.DatabaseName.
+// dbNameOverride specifies the database name to connect to.
 func openDBConnection(info *cres.RDBMSInfo, password, dbNameOverride string) (*sql.DB, string, error) {
 	engine := strings.ToLower(info.DBEngine)
 	endpoint := info.Endpoint
-	port := info.Port
 	user := info.MasterUserName
-	dbName := info.DatabaseName
-	if dbNameOverride != "" {
-		dbName = dbNameOverride
-	}
+	dbName := dbNameOverride
 	// Treat "NA" as no database specified (some drivers return "NA" as placeholder)
 	if strings.EqualFold(dbName, "NA") {
 		dbName = ""
@@ -100,15 +96,14 @@ func openDBConnection(info *cres.RDBMSInfo, password, dbNameOverride string) (*s
 
 	// Strip port from endpoint if it already contains one (e.g., "host.rds.amazonaws.com:3306")
 	host := endpoint
+	port := ""
 	if idx := strings.LastIndex(endpoint, ":"); idx > 0 {
 		hostPart := endpoint[:idx]
 		portPart := endpoint[idx+1:]
 		// Check if the part after ':' looks like a port number
 		if _, err := fmt.Sscanf(portPart, "%d", new(int)); err == nil {
 			host = hostPart
-			if port == "" {
-				port = portPart
-			}
+			port = portPart
 		}
 	}
 

--- a/api-runtime/rest-runtime/admin-web/html/left_menu.html
+++ b/api-runtime/rest-runtime/admin-web/html/left_menu.html
@@ -219,7 +219,7 @@
     </div>
     <div class="menu-item" onclick="checkConnectionAndRedirect('rdbms', event)">
         <img id="rdbms-img" src="./images/left-menu/rdbms.png" alt="RDBMS Icon" onerror="this.src='./images/left-menu/disk.png'">
-        <div class="menu-text">RDB (WIP)</div>
+        <div class="menu-text">RDBMS</div>
     </div>
     <div class="divider"></div> <!-- Divider after RDBMS -->
 </body>

--- a/api-runtime/rest-runtime/admin-web/html/rdbms.html
+++ b/api-runtime/rest-runtime/admin-web/html/rdbms.html
@@ -806,6 +806,94 @@
         cursor: pointer;
     }
 
+    /* Custom dropdown for Security Groups */
+    .sg-custom-select {
+        position: relative;
+        flex: 2;
+    }
+
+    .sg-selected-display {
+        background-color: #f3f3fd;
+        border: 1px solid #767676;
+        padding: 2px 8px 2px 4px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-height: 22px;
+    }
+
+    .sg-selected-display:hover {
+        border-color: #555;
+    }
+
+    .sg-selected-display span:first-child {
+        font-size: 14px;
+        text-align: left;
+        flex: 1;
+    }
+
+    .sg-dropdown-arrow {
+        font-size: 12px;
+        font-weight: bold;
+        color: #666;
+        margin-left: 5px;
+    }
+
+    .sg-dropdown-list {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: white;
+        border: 1px solid #767676;
+        border-top: none;
+        max-height: 150px;
+        overflow-y: auto;
+        z-index: 1000;
+        display: none;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        padding: 0;
+        margin: 0;
+    }
+
+    .sg-dropdown-list * {
+        box-sizing: border-box;
+    }
+
+    .sg-dropdown-list.open {
+        display: block;
+    }
+
+    .sg-dropdown-item {
+        padding: 3px;
+        margin: 0;
+        cursor: pointer;
+        display: block;
+        line-height: 20px;
+    }
+
+    .sg-dropdown-item:hover {
+        background-color: #f0f0f0;
+    }
+
+    .sg-dropdown-item input[type="checkbox"] {
+        margin: 0;
+        padding: 0;
+        vertical-align: middle;
+        width: 13px;
+        height: 13px;
+        display: inline-block;
+    }
+
+    .sg-dropdown-item label {
+        cursor: pointer;
+        margin: 0;
+        padding-left: 5px;
+        display: inline-block;
+        vertical-align: middle;
+    }
+
 </style>
 </head>
 <body>
@@ -885,10 +973,6 @@
                         <tr>
                             <th>Endpoint</th>
                             <td style="font-size: 11px; word-break: break-all;">{{$rdbms.Endpoint}}</td>
-                        </tr>
-                        <tr>
-                            <th>Port</th>
-                            <td>{{$rdbms.Port}}</td>
                         </tr>
                     </table>
                 </td>
@@ -1170,7 +1254,7 @@
                     </div>
                     <div class="form-group">
                         <label for="vpcName">VPC Name:</label>
-                        <select id="vpcName" name="vpcName" required style="width: 65%;"></select>
+                        <select id="vpcName" name="vpcName" required onchange="updateSubnets(); loadSecurityGroups();" style="width: 65%;"></select>
                     </div>
                 </fieldset>
 
@@ -1179,7 +1263,7 @@
                     <legend>DB Engine:</legend>
                     <div class="form-group">
                         <label for="dbEngine">Engine:</label>
-                        <select id="dbEngine" name="dbEngine" required style="background-color: #E6E6FA; width: 65%;">
+                        <select id="dbEngine" name="dbEngine" required style="background-color: #E6E6FA; width: 65%;" onchange="loadRDBMSMetaInfo()">
                             <option value="mysql">mysql</option>
                             <option value="mariadb">mariadb</option>
                             <option value="postgresql">postgresql</option>
@@ -1187,7 +1271,9 @@
                     </div>
                     <div class="form-group">
                         <label for="dbEngineVersion">Version:</label>
-                        <input type="text" id="dbEngineVersion" name="dbEngineVersion" required placeholder="e.g., 8.0" style="background-color: #F5F5DC; width: 65%;">
+                        <select id="dbEngineVersion" name="dbEngineVersion" required style="background-color: #F5F5DC; width: 65%;">
+                            <option value="">Loading...</option>
+                        </select>
                     </div>
                 </fieldset>
 
@@ -1196,19 +1282,20 @@
                     <legend>Instance Spec:</legend>
                     <div class="form-group">
                         <label for="dbInstanceSpec">Instance Spec:</label>
-                        <input type="text" id="dbInstanceSpec" name="dbInstanceSpec" required placeholder="e.g., db.t3.medium" style="width: 65%;">
+                        <select id="dbInstanceSpec" name="dbInstanceSpec" required style="width: 65%;">
+                            <option value="">Loading...</option>
+                        </select>
                     </div>
                     <div class="form-group">
                         <label for="storageSize">Storage (GB):</label>
                         <input type="number" id="storageSize" name="storageSize" required min="1" value="20" style="background-color: #F5F5DC; width: 65%;">
+                        <small id="storageSizeHint" style="color: #666; margin-left: 10px;"></small>
                     </div>
                     <div class="form-group">
                         <label for="storageType">Storage Type:</label>
-                        <input type="text" id="storageType" name="storageType" placeholder="e.g., gp2 (optional)" style="width: 65%;">
-                    </div>
-                    <div class="form-group">
-                        <label for="port">Port:</label>
-                        <input type="text" id="port" name="port" placeholder="e.g., 3306 (optional)" style="width: 65%;">
+                        <select id="storageType" name="storageType" style="width: 65%;">
+                            <option value="">Loading...</option>
+                        </select>
                     </div>
                 </fieldset>
 
@@ -1216,12 +1303,24 @@
                 <fieldset class="info-group">
                     <legend>Network:</legend>
                     <div class="form-group">
-                        <label for="subnetNames">Subnet Names:</label>
-                        <input type="text" id="subnetNames" name="subnetNames" placeholder="comma-separated (optional)" style="width: 65%;">
+                        <label for="subnetSelect" id="subnetLabel">Subnets:</label>
+                        <div class="sg-custom-select" id="subnetSelectWrapper" style="width: 65%; display: inline-block;">
+                            <div class="sg-selected-display" id="subnetSelectedDisplay" onclick="toggleSubnetDropdown()">
+                                <span id="subnetSelectedText">Select VPC first</span>
+                                <span class="sg-dropdown-arrow">v</span>
+                            </div>
+                            <div class="sg-dropdown-list" id="subnetDropdownList"></div>
+                        </div>
                     </div>
                     <div class="form-group">
-                        <label for="sgNames">SG Names:</label>
-                        <input type="text" id="sgNames" name="sgNames" placeholder="comma-separated (optional)" style="width: 65%;">
+                        <label for="securityGroupSelect" id="sgLabel">Security Groups:</label>
+                        <div class="sg-custom-select" id="securityGroupSelectWrapper" style="width: 65%; display: inline-block;">
+                            <div class="sg-selected-display" id="sgSelectedDisplay" onclick="toggleSGDropdown()">
+                                <span id="sgSelectedText">Select VPC first</span>
+                                <span class="sg-dropdown-arrow">v</span>
+                            </div>
+                            <div class="sg-dropdown-list" id="sgDropdownList"></div>
+                        </div>
                     </div>
                 </fieldset>
 
@@ -1235,10 +1334,6 @@
                     <div class="form-group">
                         <label for="masterUserPassword">Password:</label>
                         <input type="password" id="masterUserPassword" name="masterUserPassword" required placeholder="Master password" style="width: 65%;">
-                    </div>
-                    <div class="form-group">
-                        <label for="databaseName">DB Name:</label>
-                        <input type="text" id="databaseName" name="databaseName" placeholder="Initial DB name (optional)" style="width: 65%;">
                     </div>
                 </fieldset>
 
@@ -1273,12 +1368,10 @@
                             <option value="true">Yes</option>
                         </select>
                     </div>
-                    <div class="form-group-tags">
-                        <label for="backupRetentionDays">Backup Days:</label>
-                        <input type="number" id="backupRetentionDays" name="backupRetentionDays" value="0" min="0" style="width: 43px;">
-
-                        <label for="backupTime">Backup Time:</label>
-                        <input type="text" id="backupTime" name="backupTime" placeholder="HH:MM" style="width: 43px;">
+                    <div class="form-group">
+                        <label for="backupRetentionDays">Backup Retention Days:</label>
+                        <input type="number" id="backupRetentionDays" name="backupRetentionDays" value="" placeholder="(optional)" min="0" style="width: 65px;">
+                        <small id="backupRetentionHint" style="color: #666; margin-left: 10px;"></small>
                     </div>
                 </fieldset>
 
@@ -1524,24 +1617,24 @@
         const dbInstanceSpec = document.getElementById('dbInstanceSpec').value;
         const storageSize = document.getElementById('storageSize').value;
         const storageType = document.getElementById('storageType').value.trim();
-        const port = document.getElementById('port').value.trim();
 
-        const subnetNamesRaw = document.getElementById('subnetNames').value.trim();
-        const subnetNames = subnetNamesRaw ? subnetNamesRaw.split(',').map(s => s.trim()).filter(s => s) : [];
+        // Get selected subnets (multi-select checkboxes)
+        const selectedSubnets = Array.from(document.querySelectorAll('.subnet-checkbox:checked')).map(checkbox => checkbox.value);
 
-        const sgNamesRaw = document.getElementById('sgNames').value.trim();
-        const sgNames = sgNamesRaw ? sgNamesRaw.split(',').map(s => s.trim()).filter(s => s) : [];
+        // Get selected security groups (multi-select checkboxes)
+        const selectedSecurityGroups = Array.from(document.querySelectorAll('.sg-checkbox:checked')).map(checkbox => checkbox.value);
 
         const masterUserName = document.getElementById('masterUserName').value;
         const masterUserPassword = document.getElementById('masterUserPassword').value;
-        const databaseName = document.getElementById('databaseName').value.trim();
 
         const highAvailability = document.getElementById('highAvailability').value === 'true';
         const publicAccess = document.getElementById('publicAccess').value === 'true';
         const encryption = document.getElementById('encryption').value === 'true';
         const deletionProtection = document.getElementById('deletionProtection').value === 'true';
-        const backupRetentionDays = parseInt(document.getElementById('backupRetentionDays').value) || 0;
-        const backupTime = document.getElementById('backupTime').value.trim();
+        
+        // Handle BackupRetentionDays: empty = -1 (CSP default), 0 = disable backup (AWS only), >0 = explicit value
+        const backupRetentionValue = document.getElementById('backupRetentionDays').value.trim();
+        const backupRetentionDays = backupRetentionValue !== '' ? parseInt(backupRetentionValue) : -1;
 
         const tags = Array.from(document.querySelectorAll('.rdbms-tag-input')).map(tagInput => ({
             Key: tagInput.querySelector('.rdbms-tag-key').value,
@@ -1558,18 +1651,15 @@
                 DBInstanceSpec: dbInstanceSpec,
                 StorageSize: storageSize,
                 StorageType: storageType || undefined,
-                Port: port || undefined,
-                SubnetNames: subnetNames.length > 0 ? subnetNames : undefined,
-                SecurityGroupNames: sgNames.length > 0 ? sgNames : undefined,
+                SubnetNames: selectedSubnets.length > 0 ? selectedSubnets : undefined,
+                SecurityGroupNames: selectedSecurityGroups.length > 0 ? selectedSecurityGroups : undefined,
                 MasterUserName: masterUserName,
                 MasterUserPassword: masterUserPassword,
-                DatabaseName: databaseName || undefined,
                 HighAvailability: highAvailability,
                 PublicAccess: publicAccess,
                 Encryption: encryption,
                 DeletionProtection: deletionProtection,
                 BackupRetentionDays: backupRetentionDays,
-                BackupTime: backupTime || undefined,
                 TagList: tags.length > 0 ? tags : undefined
             }
         };
@@ -1613,38 +1703,54 @@
     }
 
     function showOverlay() {
-        loadVPCs().then(() => {
+        showProgressBar();
+        Promise.all([loadVPCs(), loadRDBMSMetaInfo(), setDefaultMasterUser()]).then(() => {
             const region = '{{.RegionName}}';
             const rdbmsNameInput = document.getElementById('rdbmsName');
             rdbmsNameInput.value = `${region}-rdbms-${Math.random().toString(36).substring(2, 5)}`;
 
+            hideProgressBar();
             document.getElementById('overlay').style.display = 'flex';
             document.addEventListener('keydown', handleEsc);
         }).catch(error => {
-            console.error('Error loading VPCs:', error);
+            hideProgressBar();
+            console.error('Error loading resources:', error);
+            showErrorModal('Loading Error', `Failed to load resources: ${error.message}`);
         });
     }
 
-    function clearFormFields() {
+    async function clearFormFields() {
         const region = '{{.RegionName}}';
         document.getElementById('rdbmsName').value = `${region}-rdbms-${Math.random().toString(36).substring(2, 5)}`;
         document.getElementById('dbEngine').value = 'mysql';
-        document.getElementById('dbEngineVersion').value = '';
-        document.getElementById('dbInstanceSpec').value = '';
+        
+        // Reset MetaInfo-driven selects
+        const versionSelect = document.getElementById('dbEngineVersion');
+        versionSelect.innerHTML = '<option value="">Loading...</option>';
+        const specSelect = document.getElementById('dbInstanceSpec');
+        specSelect.innerHTML = '<option value="">Loading...</option>';
+        const storageTypeSelect = document.getElementById('storageType');
+        storageTypeSelect.innerHTML = '<option value="">Loading...</option>';
+        
         document.getElementById('storageSize').value = '20';
-        document.getElementById('storageType').value = '';
-        document.getElementById('port').value = '';
-        document.getElementById('subnetNames').value = '';
-        document.getElementById('sgNames').value = '';
-        document.getElementById('masterUserName').value = '';
+        document.getElementById('storageSizeHint').textContent = '';
+        
+        // Reset network controls
+        document.getElementById('subnetSelectedText').textContent = 'Select VPC first';
+        document.getElementById('subnetDropdownList').innerHTML = '';
+        document.getElementById('sgSelectedText').textContent = 'Select VPC first';
+        document.getElementById('sgDropdownList').innerHTML = '';
+        
+        // Set CSP-specific default Master User
+        await setDefaultMasterUser();
         document.getElementById('masterUserPassword').value = '';
-        document.getElementById('databaseName').value = '';
         document.getElementById('highAvailability').value = 'false';
         document.getElementById('publicAccess').value = 'false';
         document.getElementById('encryption').value = 'false';
         document.getElementById('deletionProtection').value = 'false';
-        document.getElementById('backupRetentionDays').value = '0';
-        document.getElementById('backupTime').value = '';
+        document.getElementById('backupRetentionDays').value = '';
+        document.getElementById('backupRetentionDays').placeholder = '(optional)';
+        document.getElementById('backupRetentionHint').textContent = '';
         document.querySelectorAll('.rdbms-tag-input').forEach(tagInput => tagInput.remove());
     }
 
@@ -1661,11 +1767,45 @@
         }
     }
 
+    function setDefaultMasterUser() {
+        const connConfig = document.getElementById('connConfig').value;
+        const url = `/spider/connectionconfig/${encodeURIComponent(connConfig)}`;
+        
+        return fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            const masterUserInput = document.getElementById('masterUserName');
+            const providerName = (data.ProviderName || '').toLowerCase();
+            
+            // Set CSP-specific default: Tencent=root, IBM=admin, others=dbadmin
+            if (providerName.includes('tencent')) {
+                masterUserInput.value = 'root';
+                masterUserInput.placeholder = 'e.g., root';
+            } else if (providerName.includes('ibm')) {
+                masterUserInput.value = 'admin';
+                masterUserInput.placeholder = 'e.g., admin';
+            } else {
+                masterUserInput.value = 'dbadmin';
+                masterUserInput.placeholder = 'e.g., dbadmin';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading connection config:', error);
+            // Fallback to dbadmin on error
+            document.getElementById('masterUserName').value = 'dbadmin';
+        });
+    }
+
     function loadVPCs() {
         const connConfig = document.getElementById('connConfig').value;
         const url = `/spider/vpc?ConnectionName=${encodeURIComponent(connConfig)}`;
 
-        return fetchWithProgress(url, {
+        return fetch(url, {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json'
@@ -1680,11 +1820,18 @@
                     const option = document.createElement('option');
                     option.value = vpc.IId.NameId;
                     option.text = `${vpc.IId.NameId} (${vpc.IPv4_CIDR})`;
+                    // Store subnet list as JSON in data attribute for later retrieval
+                    if (vpc.SubnetInfoList && vpc.SubnetInfoList.length > 0) {
+                        option.setAttribute('data-subnets', JSON.stringify(vpc.SubnetInfoList));
+                    }
                     vpcSelect.appendChild(option);
                     if (index === 0) {
                         vpcSelect.value = vpc.IId.NameId;
                     }
                 });
+                // Trigger initial subnet/SG load for first VPC
+                updateSubnets();
+                loadSecurityGroups();
             } else {
                 const option = document.createElement('option');
                 option.value = "";
@@ -1695,8 +1842,314 @@
         })
         .catch(error => {
             console.error('Error loading VPCs:', error);
+            // Don't throw - allow form to open even if VPC loading fails
+            const vpcSelect = document.getElementById('vpcName');
+            vpcSelect.innerHTML = '';
+            const option = document.createElement('option');
+            option.value = "";
+            option.text = "Error loading VPCs";
+            vpcSelect.appendChild(option);
+            vpcSelect.disabled = true;
+        });
+    }
+
+    function loadRDBMSMetaInfo() {
+        const connConfig = document.getElementById('connConfig').value;
+        const dbEngine = document.getElementById('dbEngine').value;
+        const url = `/spider/rdbmsmetainfo?DBEngine=${encodeURIComponent(dbEngine)}&ConnectionName=${encodeURIComponent(connConfig)}`;
+
+        return fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`MetaInfo API returned status ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(metaInfo => {
+            // Update Subnet/SG label required status
+            const subnetLabel = document.getElementById('subnetLabel');
+            const sgLabel = document.getElementById('sgLabel');
+            if (metaInfo.RequiresSubnet) {
+                subnetLabel.innerHTML = 'Subnets: <span style="color: red;">*</span>';
+            } else {
+                subnetLabel.innerHTML = 'Subnets: <span style="color: #999;">(optional)</span>';
+            }
+            if (metaInfo.RequiresSecurityGroup) {
+                sgLabel.innerHTML = 'Security Groups: <span style="color: red;">*</span>';
+            } else {
+                sgLabel.innerHTML = 'Security Groups: <span style="color: #999;">(optional)</span>';
+            }
+
+            // Populate Version select
+            const versionSelect = document.getElementById('dbEngineVersion');
+            versionSelect.innerHTML = '';
+            if (metaInfo.SupportedVersions && metaInfo.SupportedVersions.length > 0) {
+                metaInfo.SupportedVersions.forEach((version, index) => {
+                    const option = document.createElement('option');
+                    option.value = version;
+                    option.text = version;
+                    versionSelect.appendChild(option);
+                });
+            } else {
+                versionSelect.innerHTML = '<option value="">No versions available</option>';
+            }
+
+            // Populate Instance Spec select
+            const specSelect = document.getElementById('dbInstanceSpec');
+            specSelect.innerHTML = '';
+            if (metaInfo.DBInstanceSpecOptions && metaInfo.DBInstanceSpecOptions.length > 0) {
+                metaInfo.DBInstanceSpecOptions.forEach((spec, index) => {
+                    const option = document.createElement('option');
+                    option.value = spec;
+                    option.text = spec;
+                    specSelect.appendChild(option);
+                });
+            } else {
+                specSelect.innerHTML = '<option value="">No specs available</option>';
+            }
+
+            // Populate Storage Type select
+            const storageTypeSelect = document.getElementById('storageType');
+            storageTypeSelect.innerHTML = '';
+            if (metaInfo.StorageTypeOptions && metaInfo.StorageTypeOptions.length > 0) {
+                // Add empty option for optional field
+                const emptyOption = document.createElement('option');
+                emptyOption.value = '';
+                emptyOption.text = '(optional)';
+                storageTypeSelect.appendChild(emptyOption);
+                
+                metaInfo.StorageTypeOptions.forEach((storageType, index) => {
+                    const option = document.createElement('option');
+                    option.value = storageType;
+                    option.text = storageType;
+                    storageTypeSelect.appendChild(option);
+                });
+                
+                // Auto-select first storage type for CSPs that require it (e.g., Alibaba)
+                // User can manually select (optional) if not needed
+                storageTypeSelect.value = metaInfo.StorageTypeOptions[0];
+            } else {
+                // Add empty option if no storage types available
+                const emptyOption = document.createElement('option');
+                emptyOption.value = '';
+                emptyOption.text = '(optional)';
+                storageTypeSelect.appendChild(emptyOption);
+            }
+
+            // Update Storage Size hint
+            const storageSizeHint = document.getElementById('storageSizeHint');
+            const storageSizeInput = document.getElementById('storageSize');
+            if (metaInfo.StorageSizeRange) {
+                const min = metaInfo.StorageSizeRange.Min;
+                const max = metaInfo.StorageSizeRange.Max;
+                storageSizeHint.textContent = `(Range: ${min}-${max} GB)`;
+                storageSizeInput.min = min;
+                storageSizeInput.max = max;
+                // Set default to min if current value is out of range
+                const currentValue = parseInt(storageSizeInput.value);
+                if (currentValue < min) {
+                    storageSizeInput.value = min;
+                }
+            } else {
+                storageSizeHint.textContent = '';
+            }
+
+            // Update Backup Retention Days hint with CSP-specific guidance
+            const backupRetentionHint = document.getElementById('backupRetentionHint');
+            const backupRetentionInput = document.getElementById('backupRetentionDays');
+            if (metaInfo.BackupRetentionRange) {
+                // Get provider name from connection config for AWS-specific guidance
+                const connConfig = document.getElementById('connConfig').value;
+                fetch(`/spider/connectionconfig/${encodeURIComponent(connConfig)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        const providerName = (data.ProviderName || '').toLowerCase();
+                        if (providerName.includes('aws')) {
+                            backupRetentionHint.textContent = `(Range: ${metaInfo.BackupRetentionRange}, 0 = disable backup)`;
+                        } else {
+                            backupRetentionHint.textContent = `(Range: ${metaInfo.BackupRetentionRange})`;
+                        }
+                        // Keep placeholder as (optional) - do not set range values
+                        backupRetentionInput.placeholder = '(optional)';
+                    })
+                    .catch(() => {
+                        backupRetentionHint.textContent = `(Range: ${metaInfo.BackupRetentionRange})`;
+                        backupRetentionInput.placeholder = '(optional)';
+                    });
+            } else {
+                backupRetentionHint.textContent = '';
+                backupRetentionInput.placeholder = '(optional)';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading RDBMS MetaInfo:', error);
+            // Set error states
+            document.getElementById('dbEngineVersion').innerHTML = '<option value="">Error loading versions</option>';
+            document.getElementById('dbInstanceSpec').innerHTML = '<option value="">Error loading specs</option>';
+            document.getElementById('storageType').innerHTML = '<option value="">Error loading types</option>';
             throw error;
         });
+    }
+
+    function updateSubnets() {
+        const vpcSelect = document.getElementById('vpcName');
+        const subnetDropdownList = document.getElementById('subnetDropdownList');
+        const subnetSelectedText = document.getElementById('subnetSelectedText');
+        
+        subnetDropdownList.innerHTML = '';
+        
+        if (!vpcSelect.value) {
+            subnetSelectedText.textContent = 'Select VPC first';
+            return;
+        }
+        
+        const selectedOption = vpcSelect.options[vpcSelect.selectedIndex];
+        const subnetsJSON = selectedOption.getAttribute('data-subnets');
+        
+        if (!subnetsJSON) {
+            subnetSelectedText.textContent = 'No subnets available';
+            return;
+        }
+        
+        try {
+            const subnets = JSON.parse(subnetsJSON);
+            if (subnets && Array.isArray(subnets) && subnets.length > 0) {
+                subnets.forEach((subnet, index) => {
+                    const item = document.createElement('div');
+                    item.className = 'sg-dropdown-item';
+                    
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = subnet.IId.NameId;
+                    checkbox.id = `subnet-${subnet.IId.NameId}`;
+                    checkbox.className = 'subnet-checkbox';
+                    // Auto-check first two subnets for Multi-AZ support
+                    if (index < 2) {
+                        checkbox.checked = true;
+                    }
+                    checkbox.onchange = updateSubnetSelectedDisplay;
+                    
+                    const label = document.createElement('label');
+                    label.htmlFor = `subnet-${subnet.IId.NameId}`;
+                    label.textContent = `${subnet.IId.NameId} (${subnet.IPv4_CIDR})`;
+                    
+                    item.appendChild(checkbox);
+                    item.appendChild(label);
+                    subnetDropdownList.appendChild(item);
+                });
+                
+                // Update display with initially selected items
+                updateSubnetSelectedDisplay();
+            } else {
+                subnetSelectedText.textContent = 'No subnets available';
+            }
+        } catch (e) {
+            console.error('Error parsing subnet data:', e);
+            subnetSelectedText.textContent = 'Error loading subnets';
+        }
+    }
+
+    function toggleSubnetDropdown() {
+        const dropdown = document.getElementById('subnetDropdownList');
+        dropdown.classList.toggle('open');
+    }
+
+    function updateSubnetSelectedDisplay() {
+        const checkboxes = document.querySelectorAll('.subnet-checkbox:checked');
+        const subnetSelectedText = document.getElementById('subnetSelectedText');
+        
+        if (checkboxes.length === 0) {
+            subnetSelectedText.textContent = 'Select subnets';
+        } else if (checkboxes.length === 1) {
+            subnetSelectedText.textContent = checkboxes[0].value;
+        } else {
+            subnetSelectedText.textContent = `${checkboxes.length} selected`;
+        }
+    }
+
+    function loadSecurityGroups() {
+        const connConfig = document.getElementById('connConfig').value;
+        const sgDropdownList = document.getElementById('sgDropdownList');
+        const sgSelectedText = document.getElementById('sgSelectedText');
+        const vpcSelect = document.getElementById('vpcName');
+        
+        if (!vpcSelect.value) {
+            sgSelectedText.textContent = 'Select VPC first';
+            sgDropdownList.innerHTML = '';
+            return;
+        }
+        
+        const vpcName = vpcSelect.options[vpcSelect.selectedIndex].text.split(' ')[0];
+        const url = `/spider/securitygroup/vpc/${encodeURIComponent(vpcName)}?ConnectionName=${encodeURIComponent(connConfig)}`;
+        
+        fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => response.json())
+        .then(data => {
+            sgDropdownList.innerHTML = '';
+
+            if (data.securitygroup && data.securitygroup.length > 0) {
+                data.securitygroup.forEach((sg, index) => {
+                    const item = document.createElement('div');
+                    item.className = 'sg-dropdown-item';
+                    
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.value = sg.IId.NameId;
+                    checkbox.id = `sg-${sg.IId.NameId}`;
+                    checkbox.className = 'sg-checkbox';
+                    // Auto-check first security group
+                    if (index === 0) {
+                        checkbox.checked = true;
+                    }
+                    checkbox.onchange = updateSGSelectedDisplay;
+                    
+                    const label = document.createElement('label');
+                    label.htmlFor = `sg-${sg.IId.NameId}`;
+                    label.textContent = sg.IId.NameId;
+                    
+                    item.appendChild(checkbox);
+                    item.appendChild(label);
+                    sgDropdownList.appendChild(item);
+                });
+                
+                // Update display with initially selected item
+                updateSGSelectedDisplay();
+            } else {
+                sgSelectedText.textContent = 'No security groups available for this VPC';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading security groups:', error);
+            sgSelectedText.textContent = 'Error loading security groups';
+        });
+    }
+
+    function toggleSGDropdown() {
+        const dropdown = document.getElementById('sgDropdownList');
+        dropdown.classList.toggle('open');
+    }
+
+    function updateSGSelectedDisplay() {
+        const checkboxes = document.querySelectorAll('.sg-checkbox:checked');
+        const sgSelectedText = document.getElementById('sgSelectedText');
+        
+        if (checkboxes.length === 0) {
+            sgSelectedText.textContent = 'Select security groups';
+        } else if (checkboxes.length === 1) {
+            sgSelectedText.textContent = checkboxes[0].value;
+        } else {
+            sgSelectedText.textContent = `${checkboxes.length} selected`;
+        }
     }
 
     function addRDBMSTagField() {
@@ -1769,6 +2222,22 @@
                 button.style.display = 'inline-block';
             } else {
                 button.style.display = 'none';
+            }
+        });
+
+        // Close SG dropdown when clicking outside
+        document.addEventListener('click', function(event) {
+            const sgDropdown = document.getElementById('sgDropdownList');
+            const sgDisplay = document.getElementById('sgSelectedDisplay');
+            if (sgDropdown && sgDisplay && !sgDisplay.contains(event.target) && !sgDropdown.contains(event.target)) {
+                sgDropdown.classList.remove('open');
+            }
+            
+            // Close Subnet dropdown when clicking outside
+            const subnetDropdown = document.getElementById('subnetDropdownList');
+            const subnetDisplay = document.getElementById('subnetSelectedDisplay');
+            if (subnetDropdown && subnetDisplay && !subnetDisplay.contains(event.target) && !subnetDropdown.contains(event.target)) {
+                subnetDropdown.classList.remove('open');
             }
         });
     });

--- a/api/docs.go
+++ b/api/docs.go
@@ -6876,9 +6876,7 @@ const docTemplate = `{
                         }
                     }
                 }
-            }
-        },
-        "/rdbms/{Name}/databases/create": {
+            },
             "post": {
                 "description": "Create a database inside an RDBMS instance using the CSP-native API.",
                 "consumes": [
@@ -13400,7 +13398,7 @@ const docTemplate = `{
                     "example": 7
                 },
                 "BackupTime": {
-                    "description": "Preferred backup time (HH:MM in UTC)",
+                    "description": "Preferred backup time (read-only, CSP-managed. Not configurable at creation via Spider.)",
                     "type": "string",
                     "example": "03:00"
                 },
@@ -13427,18 +13425,13 @@ const docTemplate = `{
                     "type": "string",
                     "example": "Primary"
                 },
-                "DatabaseName": {
-                    "description": "Database",
-                    "type": "string",
-                    "example": "mydb"
-                },
                 "DeletionProtection": {
                     "description": "Protection",
                     "type": "boolean",
                     "default": false
                 },
                 "Encryption": {
-                    "description": "Encryption",
+                    "description": "Encryption - read-only, CSP-managed. Not configurable at creation via Spider.",
                     "type": "boolean",
                     "default": false
                 },
@@ -13447,7 +13440,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "HighAvailability": {
-                    "description": "High Availability \u0026 Replication",
+                    "description": "High Availability",
                     "type": "boolean",
                     "default": false
                 },
@@ -13474,20 +13467,10 @@ const docTemplate = `{
                     "description": "Master user password (for Create request only)",
                     "type": "string"
                 },
-                "Port": {
-                    "description": "DB listen port",
-                    "type": "string",
-                    "example": "3306"
-                },
                 "PublicAccess": {
                     "description": "Access",
                     "type": "boolean",
                     "default": false
-                },
-                "ReplicationType": {
-                    "description": "async | semi-sync | sync (for response)",
-                    "type": "string",
-                    "example": "async"
                 },
                 "SecurityGroupIIDs": {
                     "description": "Associated Security Groups",
@@ -13542,10 +13525,33 @@ const docTemplate = `{
             "description": "RDBMS Meta Information for CSP-specific capabilities",
             "type": "object",
             "properties": {
+                "BackupRetentionRange": {
+                    "description": "Backup retention range at creation time (e.g., \"1-35\", \"7-730\"). \"NA\" if not configurable at creation.",
+                    "type": "string"
+                },
                 "DBEngine": {
                     "description": "Requested DB engine name. e.g., mysql, mariadb, postgresql",
                     "type": "string",
                     "example": "mysql"
+                },
+                "DBInstanceSpecOptions": {
+                    "description": "Available DBInstanceSpec values for the requested DB engine. \"NA\" if CSP does not provide spec list API.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "db.t3.medium",
+                        "1000"
+                    ]
+                },
+                "RequiresSecurityGroup": {
+                    "description": "true if SecurityGroupNames is required at creation",
+                    "type": "boolean"
+                },
+                "RequiresSubnet": {
+                    "description": "true if SubnetNames is required at creation",
+                    "type": "boolean"
                 },
                 "StorageSizeRange": {
                     "description": "Min/Max storage size in GB for the requested DB engine",
@@ -16372,12 +16378,9 @@ const docTemplate = `{
                     ],
                     "properties": {
                         "BackupRetentionDays": {
+                            "description": "Backup retention days (CSP will auto-assign backup time)",
                             "type": "integer",
                             "example": 7
-                        },
-                        "BackupTime": {
-                            "type": "string",
-                            "example": "03:00"
                         },
                         "DBEngine": {
                             "type": "string",
@@ -16391,15 +16394,7 @@ const docTemplate = `{
                             "type": "string",
                             "example": "db.t3.medium"
                         },
-                        "DatabaseName": {
-                            "type": "string",
-                            "example": "mydb"
-                        },
                         "DeletionProtection": {
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "Encryption": {
                             "type": "boolean",
                             "default": false
                         },
@@ -16418,10 +16413,6 @@ const docTemplate = `{
                         "Name": {
                             "type": "string",
                             "example": "rdbms-01"
-                        },
-                        "Port": {
-                            "type": "string",
-                            "example": "3306"
                         },
                         "PublicAccess": {
                             "type": "boolean",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -6873,9 +6873,7 @@
                         }
                     }
                 }
-            }
-        },
-        "/rdbms/{Name}/databases/create": {
+            },
             "post": {
                 "description": "Create a database inside an RDBMS instance using the CSP-native API.",
                 "consumes": [
@@ -13397,7 +13395,7 @@
                     "example": 7
                 },
                 "BackupTime": {
-                    "description": "Preferred backup time (HH:MM in UTC)",
+                    "description": "Preferred backup time (read-only, CSP-managed. Not configurable at creation via Spider.)",
                     "type": "string",
                     "example": "03:00"
                 },
@@ -13424,18 +13422,13 @@
                     "type": "string",
                     "example": "Primary"
                 },
-                "DatabaseName": {
-                    "description": "Database",
-                    "type": "string",
-                    "example": "mydb"
-                },
                 "DeletionProtection": {
                     "description": "Protection",
                     "type": "boolean",
                     "default": false
                 },
                 "Encryption": {
-                    "description": "Encryption",
+                    "description": "Encryption - read-only, CSP-managed. Not configurable at creation via Spider.",
                     "type": "boolean",
                     "default": false
                 },
@@ -13444,7 +13437,7 @@
                     "type": "string"
                 },
                 "HighAvailability": {
-                    "description": "High Availability \u0026 Replication",
+                    "description": "High Availability",
                     "type": "boolean",
                     "default": false
                 },
@@ -13471,20 +13464,10 @@
                     "description": "Master user password (for Create request only)",
                     "type": "string"
                 },
-                "Port": {
-                    "description": "DB listen port",
-                    "type": "string",
-                    "example": "3306"
-                },
                 "PublicAccess": {
                     "description": "Access",
                     "type": "boolean",
                     "default": false
-                },
-                "ReplicationType": {
-                    "description": "async | semi-sync | sync (for response)",
-                    "type": "string",
-                    "example": "async"
                 },
                 "SecurityGroupIIDs": {
                     "description": "Associated Security Groups",
@@ -13539,10 +13522,33 @@
             "description": "RDBMS Meta Information for CSP-specific capabilities",
             "type": "object",
             "properties": {
+                "BackupRetentionRange": {
+                    "description": "Backup retention range at creation time (e.g., \"1-35\", \"7-730\"). \"NA\" if not configurable at creation.",
+                    "type": "string"
+                },
                 "DBEngine": {
                     "description": "Requested DB engine name. e.g., mysql, mariadb, postgresql",
                     "type": "string",
                     "example": "mysql"
+                },
+                "DBInstanceSpecOptions": {
+                    "description": "Available DBInstanceSpec values for the requested DB engine. \"NA\" if CSP does not provide spec list API.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "db.t3.medium",
+                        "1000"
+                    ]
+                },
+                "RequiresSecurityGroup": {
+                    "description": "true if SecurityGroupNames is required at creation",
+                    "type": "boolean"
+                },
+                "RequiresSubnet": {
+                    "description": "true if SubnetNames is required at creation",
+                    "type": "boolean"
                 },
                 "StorageSizeRange": {
                     "description": "Min/Max storage size in GB for the requested DB engine",
@@ -16369,12 +16375,9 @@
                     ],
                     "properties": {
                         "BackupRetentionDays": {
+                            "description": "Backup retention days (CSP will auto-assign backup time)",
                             "type": "integer",
                             "example": 7
-                        },
-                        "BackupTime": {
-                            "type": "string",
-                            "example": "03:00"
                         },
                         "DBEngine": {
                             "type": "string",
@@ -16388,15 +16391,7 @@
                             "type": "string",
                             "example": "db.t3.medium"
                         },
-                        "DatabaseName": {
-                            "type": "string",
-                            "example": "mydb"
-                        },
                         "DeletionProtection": {
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "Encryption": {
                             "type": "boolean",
                             "default": false
                         },
@@ -16415,10 +16410,6 @@
                         "Name": {
                             "type": "string",
                             "example": "rdbms-01"
-                        },
-                        "Port": {
-                            "type": "string",
-                            "example": "3306"
                         },
                         "PublicAccess": {
                             "type": "boolean",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1162,7 +1162,8 @@ definitions:
         example: 7
         type: integer
       BackupTime:
-        description: Preferred backup time (HH:MM in UTC)
+        description: Preferred backup time (read-only, CSP-managed. Not configurable
+          at creation via Spider.)
         example: "03:00"
         type: string
       CreatedTime:
@@ -1183,24 +1184,21 @@ definitions:
         description: Primary | ReadReplica (for response)
         example: Primary
         type: string
-      DatabaseName:
-        description: Database
-        example: mydb
-        type: string
       DeletionProtection:
         default: false
         description: Protection
         type: boolean
       Encryption:
         default: false
-        description: Encryption
+        description: Encryption - read-only, CSP-managed. Not configurable at creation
+          via Spider.
         type: boolean
       Endpoint:
         description: Connection endpoint (for response)
         type: string
       HighAvailability:
         default: false
-        description: High Availability & Replication
+        description: High Availability
         type: boolean
       IId:
         allOf:
@@ -1217,18 +1215,10 @@ definitions:
       MasterUserPassword:
         description: Master user password (for Create request only)
         type: string
-      Port:
-        description: DB listen port
-        example: "3306"
-        type: string
       PublicAccess:
         default: false
         description: Access
         type: boolean
-      ReplicationType:
-        description: async | semi-sync | sync (for response)
-        example: async
-        type: string
       SecurityGroupIIDs:
         description: Associated Security Groups
         items:
@@ -1273,10 +1263,29 @@ definitions:
   spider.RDBMSMetaInfo:
     description: RDBMS Meta Information for CSP-specific capabilities
     properties:
+      BackupRetentionRange:
+        description: Backup retention range at creation time (e.g., "1-35", "7-730").
+          "NA" if not configurable at creation.
+        type: string
       DBEngine:
         description: Requested DB engine name. e.g., mysql, mariadb, postgresql
         example: mysql
         type: string
+      DBInstanceSpecOptions:
+        description: Available DBInstanceSpec values for the requested DB engine.
+          "NA" if CSP does not provide spec list API.
+        example:
+        - db.t3.medium
+        - "1000"
+        items:
+          type: string
+        type: array
+      RequiresSecurityGroup:
+        description: true if SecurityGroupNames is required at creation
+        type: boolean
+      RequiresSubnet:
+        description: true if SubnetNames is required at creation
+        type: boolean
       StorageSizeRange:
         allOf:
         - $ref: '#/definitions/spider.StorageSizeRange'
@@ -3281,11 +3290,9 @@ definitions:
       ReqInfo:
         properties:
           BackupRetentionDays:
+            description: Backup retention days (CSP will auto-assign backup time)
             example: 7
             type: integer
-          BackupTime:
-            example: "03:00"
-            type: string
           DBEngine:
             example: mysql
             type: string
@@ -3295,13 +3302,7 @@ definitions:
           DBInstanceSpec:
             example: db.t3.medium
             type: string
-          DatabaseName:
-            example: mydb
-            type: string
           DeletionProtection:
-            default: false
-            type: boolean
-          Encryption:
             default: false
             type: boolean
           HighAvailability:
@@ -3315,9 +3316,6 @@ definitions:
             type: string
           Name:
             example: rdbms-01
-            type: string
-          Port:
-            example: "3306"
             type: string
           PublicAccess:
             default: false
@@ -8813,6 +8811,46 @@ paths:
       summary: List Databases in RDBMS
       tags:
       - '[RDBMS Management]'
+    post:
+      consumes:
+      - application/json
+      description: Create a database inside an RDBMS instance using the CSP-native
+        API.
+      operationId: create-rdbms-database
+      parameters:
+      - description: The name of the RDBMS instance
+        in: path
+        name: Name
+        required: true
+        type: string
+      - description: ConnectionName and DatabaseName
+        in: body
+        name: RDBMSDatabaseRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.RDBMSDatabaseRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Created
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "501":
+          description: Not Supported by driver
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Create Database in RDBMS
+      tags:
+      - '[RDBMS Management]'
   /rdbms/{Name}/databases/{DBName}:
     delete:
       consumes:
@@ -8856,47 +8894,6 @@ paths:
           schema:
             $ref: '#/definitions/spider.SimpleMsg'
       summary: Delete Database in RDBMS
-      tags:
-      - '[RDBMS Management]'
-  /rdbms/{Name}/databases/create:
-    post:
-      consumes:
-      - application/json
-      description: Create a database inside an RDBMS instance using the CSP-native
-        API.
-      operationId: create-rdbms-database
-      parameters:
-      - description: The name of the RDBMS instance
-        in: path
-        name: Name
-        required: true
-        type: string
-      - description: ConnectionName and DatabaseName
-        in: body
-        name: RDBMSDatabaseRequest
-        required: true
-        schema:
-          $ref: '#/definitions/spider.RDBMSDatabaseRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Created
-          schema:
-            $ref: '#/definitions/spider.SimpleMsg'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/spider.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/spider.SimpleMsg'
-        "501":
-          description: Not Supported by driver
-          schema:
-            $ref: '#/definitions/spider.SimpleMsg'
-      summary: Create Database in RDBMS
       tags:
       - '[RDBMS Management]'
   /rdbmsmetainfo:

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
@@ -51,7 +51,7 @@ func (handler *AlibabaRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
-	supportedEngines, storageTypeOptions, storageSizeRange, err := handler.fetchRDBMSMetaOptions(requestedEngine)
+	supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, err := handler.fetchRDBMSMetaOptions(requestedEngine)
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		cblogger.Error(err)
@@ -59,7 +59,7 @@ func (handler *AlibabaRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, true, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "7-730", true, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -70,7 +70,7 @@ func (handler *AlibabaRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 	return metaInfo, nil
 }
 
-func (handler *AlibabaRDBMSHandler) fetchRDBMSMetaOptions(dbEngine string) (map[string][]string, map[string][]string, irs.StorageSizeRange, error) {
+func (handler *AlibabaRDBMSHandler) fetchRDBMSMetaOptions(dbEngine string) (map[string][]string, map[string][]string, map[string][]string, irs.StorageSizeRange, error) {
 	allEngineNames := []alibabaRDBMSEngine{
 		{cbName: "mysql", aliName: "MySQL"},
 		{cbName: "mariadb", aliName: "MariaDB"},
@@ -84,7 +84,7 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSMetaOptions(dbEngine string) (map[
 		}
 	}
 	if len(engineNames) == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DBEngine '%s' is not supported by Alibaba RDS", dbEngine)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DBEngine '%s' is not supported by Alibaba RDS", dbEngine)
 	}
 	engineByAlibabaName := map[string]alibabaRDBMSEngine{}
 	for _, eng := range engineNames {
@@ -103,14 +103,14 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSMetaOptions(dbEngine string) (map[
 		}
 		zonesResp, err := handler.Client.DescribeAvailableZones(zonesReq)
 		if err != nil {
-			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones failed for engine %s: %w", eng.aliName, err)
+			return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones failed for engine %s: %w", eng.aliName, err)
 		}
 		selectedZoneID := handler.Region.Zone
 		if selectedZoneID == "" && len(zonesResp.AvailableZones) > 0 {
 			selectedZoneID = zonesResp.AvailableZones[0].ZoneId
 		}
 		if selectedZoneID == "" {
-			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no zones for %s", eng.aliName)
+			return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no zones for %s", eng.aliName)
 		}
 
 		for _, zone := range zonesResp.AvailableZones {
@@ -155,26 +155,27 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSMetaOptions(dbEngine string) (map[
 	for _, eng := range engineNames {
 		versions := alibabaSortedSet(versionSets[eng.cbName])
 		if len(versions) == 0 {
-			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no engine versions for %s", eng.aliName)
+			return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no engine versions for %s", eng.aliName)
 		}
 		supportedEngines[eng.cbName] = versions
 
 		storageTypes := alibabaSortedSet(storageTypeSets[eng.cbName])
 		if len(storageTypes) == 0 {
-			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no storage types for %s", eng.aliName)
+			return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableZones returned no storage types for %s", eng.aliName)
 		}
 		storageTypeOptions[eng.cbName] = storageTypes
 	}
 
-	storageSizeRange, err := handler.fetchRDBMSStorageSizeRange(engineNames, storageLookups)
+	instanceSpecOptions, storageSizeRange, err := handler.fetchRDBMSInstanceOptions(engineNames, storageLookups)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, err
+		return nil, nil, nil, irs.StorageSizeRange{}, err
 	}
 
-	return supportedEngines, storageTypeOptions, storageSizeRange, nil
+	return supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, nil
 }
 
-func (handler *AlibabaRDBMSHandler) fetchRDBMSStorageSizeRange(engineNames []alibabaRDBMSEngine, storageLookups map[string][]alibabaRDBMSStorageLookup) (irs.StorageSizeRange, error) {
+func (handler *AlibabaRDBMSHandler) fetchRDBMSInstanceOptions(engineNames []alibabaRDBMSEngine, storageLookups map[string][]alibabaRDBMSStorageLookup) (map[string][]string, irs.StorageSizeRange, error) {
+	instanceSpecOptions := map[string][]string{}
 	var minStorage int64
 	var maxStorage int64
 	latestVersionByEngine := map[string]string{}
@@ -187,6 +188,7 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSStorageSizeRange(engineNames []ali
 	}
 
 	for _, eng := range engineNames {
+		instanceSpecSet := map[string]bool{}
 		seenLookup := map[string]bool{}
 		for _, lookup := range storageLookups[eng.aliName] {
 			if lookup.engineVersion != latestVersionByEngine[eng.aliName] {
@@ -208,10 +210,13 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSStorageSizeRange(engineNames []ali
 
 			classesResp, err := handler.describeAvailableClasses(classesReq)
 			if err != nil {
-				return irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableClasses failed for engine %s version %s category %s storage type %s zone %s: %w", eng.aliName, lookup.engineVersion, lookup.category, lookup.storageType, lookup.zoneID, err)
+				return nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeAvailableClasses failed for engine %s version %s category %s storage type %s zone %s: %w", eng.aliName, lookup.engineVersion, lookup.category, lookup.storageType, lookup.zoneID, err)
 			}
 
 			for _, class := range classesResp.DBInstanceClasses {
+				if class.DBInstanceClass != "" {
+					instanceSpecSet[class.DBInstanceClass] = true
+				}
 				classMin, classMax := alibabaStorageRangeValues(class)
 				if classMin > 0 && (minStorage == 0 || classMin < minStorage) {
 					minStorage = classMin
@@ -221,13 +226,18 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSStorageSizeRange(engineNames []ali
 				}
 			}
 		}
+
+		instanceSpecs := alibabaSortedSet(instanceSpecSet)
+		if len(instanceSpecs) > 0 {
+			instanceSpecOptions[eng.cbName] = instanceSpecs
+		}
 	}
 
 	if minStorage == 0 || maxStorage == 0 {
-		return irs.StorageSizeRange{}, errors.New("DescribeAvailableClasses returned no storage size range")
+		return nil, irs.StorageSizeRange{}, errors.New("DescribeAvailableClasses returned no storage size range")
 	}
 
-	return irs.StorageSizeRange{Min: minStorage, Max: maxStorage}, nil
+	return instanceSpecOptions, irs.StorageSizeRange{Min: minStorage, Max: maxStorage}, nil
 }
 
 func (handler *AlibabaRDBMSHandler) describeAvailableClasses(request *rds.DescribeAvailableClassesRequest) (*rds.DescribeAvailableClassesResponse, error) {
@@ -383,6 +393,13 @@ func (handler *AlibabaRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 	if rdbmsReqInfo.StorageSize == "" {
 		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
 	}
+	// Alibaba RDS requires VPC and Subnet (VSwitch) for instance creation
+	if rdbmsReqInfo.VpcIID.SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("VPC (VpcIID.SystemId) is required for Alibaba RDS")
+	}
+	if len(rdbmsReqInfo.SubnetIIDs) == 0 || rdbmsReqInfo.SubnetIIDs[0].SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("Subnet (SubnetIIDs[0].SystemId / VSwitch) is required for Alibaba RDS")
+	}
 
 	request := rds.CreateCreateDBInstanceRequest()
 	request.RegionId = handler.Region.Region
@@ -428,17 +445,22 @@ func (handler *AlibabaRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		request.ZoneId = handler.Region.Zone
 	}
 
-	// Port
-	if rdbmsReqInfo.Port != "" {
-		request.Port = rdbmsReqInfo.Port
-	}
-
 	// HA (Category)
 	if rdbmsReqInfo.HighAvailability {
 		request.Category = "HighAvailability"
 	} else {
 		request.Category = "Basic"
 	}
+
+	// Backup Configuration
+	// Note: Alibaba RDS CreateDBInstance API does not support backup settings.
+	// BackupRetentionDays and BackupTime must be configured via ModifyBackupPolicy API after instance creation.
+	// TODO: Implement post-creation backup configuration using ModifyBackupPolicy API
+	// if rdbmsReqInfo.BackupRetentionDays > 0 || rdbmsReqInfo.BackupTime != "" {
+	//     cblogger.Infof("[Alibaba RDBMS] Backup settings (RetentionDays=%d, Time=%s) will use CSP defaults. "+
+	//         "Post-creation configuration via ModifyBackupPolicy is not yet implemented.",
+	//         rdbmsReqInfo.BackupRetentionDays, rdbmsReqInfo.BackupTime)
+	// }
 
 	// Tags
 	if len(rdbmsReqInfo.TagList) > 0 {
@@ -639,8 +661,12 @@ func (handler *AlibabaRDBMSHandler) getDBInstanceAttribute(dbInstanceId string) 
 	if netErr == nil && netResp != nil {
 		for _, netInfo := range netResp.DBInstanceNetInfos.DBInstanceNetInfo {
 			if netInfo.IPType == "Public" {
-				rdbmsInfo.Endpoint = netInfo.IPAddress
-				rdbmsInfo.Port = netInfo.Port
+				// Add port to endpoint
+				if netInfo.Port != "" {
+					rdbmsInfo.Endpoint = fmt.Sprintf("%s:%s", netInfo.IPAddress, netInfo.Port)
+				} else {
+					rdbmsInfo.Endpoint = netInfo.IPAddress
+				}
 				rdbmsInfo.PublicAccess = true
 				break
 			}
@@ -658,6 +684,17 @@ func (handler *AlibabaRDBMSHandler) getDBInstanceAttribute(dbInstanceId string) 
 				break
 			}
 		}
+	}
+
+	// Retrieve backup policy via DescribeBackupPolicy
+	backupReq := rds.CreateDescribeBackupPolicyRequest()
+	backupReq.DBInstanceId = dbInstanceId
+	backupResp, backupErr := handler.Client.DescribeBackupPolicy(backupReq)
+	if backupErr == nil && backupResp != nil {
+		rdbmsInfo.BackupRetentionDays = backupResp.BackupRetentionPeriod
+		rdbmsInfo.BackupTime = backupResp.PreferredBackupTime
+	} else {
+		cblogger.Debug("Failed to retrieve backup policy: ", backupErr)
 	}
 
 	return rdbmsInfo, nil
@@ -679,10 +716,8 @@ func (handler *AlibabaRDBMSHandler) convertAttributeToRDBMSInfo(attr *rds.DBInst
 	rdbmsInfo.DBInstanceSpec = attr.DBInstanceClass
 	rdbmsInfo.StorageType = attr.DBInstanceStorageType
 	rdbmsInfo.StorageSize = strconv.Itoa(attr.DBInstanceStorage)
-	rdbmsInfo.Port = attr.Port
 	rdbmsInfo.Endpoint = attr.ConnectionString
 	rdbmsInfo.MasterUserName = "" // Retrieved via DescribeAccounts in getDBInstanceAttribute
-	rdbmsInfo.DatabaseName = ""
 
 	// VPC
 	rdbmsInfo.VpcIID = irs.IID{SystemId: attr.VpcId}
@@ -695,10 +730,11 @@ func (handler *AlibabaRDBMSHandler) convertAttributeToRDBMSInfo(attr *rds.DBInst
 	// Status
 	rdbmsInfo.Status = convertAlibabaStatusToRDBMSStatus(attr.DBInstanceStatus)
 
-	// HA
+	// HA and DBInstanceType (Category)
 	if attr.Category == "HighAvailability" || attr.Category == "AlwaysOn" || attr.Category == "Finance" {
 		rdbmsInfo.HighAvailability = true
 	}
+	rdbmsInfo.DBInstanceType = attr.Category
 
 	// Deletion protection
 	rdbmsInfo.DeletionProtection = attr.DeletionProtection
@@ -711,11 +747,11 @@ func (handler *AlibabaRDBMSHandler) convertAttributeToRDBMSInfo(attr *rds.DBInst
 		}
 	}
 
-	// Backup/Encryption are not directly exposed in attribute - return NA/defaults
-	rdbmsInfo.BackupRetentionDays = 0 // Can be retrieved through DescribeBackupPolicy, but not included in attribute
+	// Backup/Encryption are not directly exposed in attribute - requires separate API calls
+	// BackupRetentionDays and BackupTime are retrieved via DescribeBackupPolicy in getDBInstanceAttribute
+	rdbmsInfo.BackupRetentionDays = 0
 	rdbmsInfo.BackupTime = "NA"
 	rdbmsInfo.Encryption = false // Requires separate DescribeDBInstanceSSL/encryption API
-	rdbmsInfo.ReplicationType = "NA"
 
 	// PublicAccess is determined by DescribeDBInstanceNetInfo in getDBInstanceAttribute
 	rdbmsInfo.PublicAccess = false
@@ -741,13 +777,10 @@ func (handler *AlibabaRDBMSHandler) convertListItemToRDBMSInfo(db *rds.DBInstanc
 	rdbmsInfo.DBEngineVersion = db.EngineVersion
 	rdbmsInfo.DBInstanceSpec = db.DBInstanceClass
 	rdbmsInfo.StorageType = db.DBInstanceStorageType
-	rdbmsInfo.Port = "NA"
 	rdbmsInfo.Endpoint = db.ConnectionString
 	rdbmsInfo.MasterUserName = "NA"
-	rdbmsInfo.DatabaseName = "NA"
 	rdbmsInfo.StorageSize = "NA"
 	rdbmsInfo.BackupTime = "NA"
-	rdbmsInfo.ReplicationType = "NA"
 
 	rdbmsInfo.VpcIID = irs.IID{SystemId: db.VpcId}
 	if db.VSwitchId != "" {
@@ -759,6 +792,7 @@ func (handler *AlibabaRDBMSHandler) convertListItemToRDBMSInfo(db *rds.DBInstanc
 	if db.Category == "HighAvailability" || db.Category == "AlwaysOn" || db.Category == "Finance" {
 		rdbmsInfo.HighAvailability = true
 	}
+	rdbmsInfo.DBInstanceType = db.Category
 
 	if db.CreateTime != "" {
 		t, err := time.Parse("2006-01-02T15:04:05Z", db.CreateTime)

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
@@ -130,14 +130,14 @@ func (handler *AwsRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		})
 		storageLookupVersions[eng.awsName] = storageVersions
 	}
-	storageTypeOptions, storageSizeRange, err := handler.fetchRDBMSStorageOptions(engineNames, storageLookupVersions)
+	instanceSpecOptions, storageTypeOptions, storageSizeRange, err := handler.fetchRDBMSInstanceOptions(engineNames, storageLookupVersions)
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		LoggingError(hiscallInfo, err)
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("DescribeOrderableDBInstanceOptions failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, true, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "0-35", true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -148,7 +148,8 @@ func (handler *AwsRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 	return metaInfo, nil
 }
 
-func (handler *AwsRDBMSHandler) fetchRDBMSStorageOptions(engineNames []awsRDBMSEngine, storageLookupVersions map[string][]string) (map[string][]string, irs.StorageSizeRange, error) {
+func (handler *AwsRDBMSHandler) fetchRDBMSInstanceOptions(engineNames []awsRDBMSEngine, storageLookupVersions map[string][]string) (map[string][]string, map[string][]string, irs.StorageSizeRange, error) {
+	instanceSpecOptions := map[string][]string{}
 	storageTypeOptions := map[string][]string{}
 	var minStorage int64
 	var maxStorage int64
@@ -158,8 +159,9 @@ func (handler *AwsRDBMSHandler) fetchRDBMSStorageOptions(engineNames []awsRDBMSE
 	for _, eng := range engineNames {
 		lookupVersions := storageLookupVersions[eng.awsName]
 		if len(lookupVersions) == 0 {
-			return nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s has no versions for storage lookup", eng.awsName)
+			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s has no versions for storage lookup", eng.awsName)
 		}
+		instanceSpecSet := map[string]bool{}
 		storageSet := map[string]bool{}
 		for _, engineVersion := range lookupVersions {
 			input := &rds.DescribeOrderableDBInstanceOptionsInput{
@@ -169,6 +171,9 @@ func (handler *AwsRDBMSHandler) fetchRDBMSStorageOptions(engineNames []awsRDBMSE
 			}
 			err := handler.Client.DescribeOrderableDBInstanceOptionsPagesWithContext(ctx, input, func(page *rds.DescribeOrderableDBInstanceOptionsOutput, lastPage bool) bool {
 				for _, option := range page.OrderableDBInstanceOptions {
+					if option.DBInstanceClass != nil && *option.DBInstanceClass != "" {
+						instanceSpecSet[*option.DBInstanceClass] = true
+					}
 					if option.StorageType != nil && *option.StorageType != "" {
 						storageSet[*option.StorageType] = true
 					}
@@ -182,8 +187,17 @@ func (handler *AwsRDBMSHandler) fetchRDBMSStorageOptions(engineNames []awsRDBMSE
 				return true
 			})
 			if err != nil {
-				return nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s version %s: %w", eng.awsName, engineVersion, err)
+				return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s version %s: %w", eng.awsName, engineVersion, err)
 			}
+		}
+
+		instanceSpecs := make([]string, 0, len(instanceSpecSet))
+		for instanceSpec := range instanceSpecSet {
+			instanceSpecs = append(instanceSpecs, instanceSpec)
+		}
+		sort.Strings(instanceSpecs)
+		if len(instanceSpecs) > 0 {
+			instanceSpecOptions[eng.cbName] = instanceSpecs
 		}
 
 		storageTypes := make([]string, 0, len(storageSet))
@@ -192,16 +206,16 @@ func (handler *AwsRDBMSHandler) fetchRDBMSStorageOptions(engineNames []awsRDBMSE
 		}
 		sort.Strings(storageTypes)
 		if len(storageTypes) == 0 {
-			return nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s returned no storage types", eng.awsName)
+			return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("engine %s returned no storage types", eng.awsName)
 		}
 		storageTypeOptions[eng.cbName] = storageTypes
 	}
 
 	if minStorage == 0 || maxStorage == 0 {
-		return nil, irs.StorageSizeRange{}, fmt.Errorf("storage size range is empty")
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("storage size range is empty")
 	}
 
-	return storageTypeOptions, irs.StorageSizeRange{Min: minStorage, Max: maxStorage}, nil
+	return instanceSpecOptions, storageTypeOptions, irs.StorageSizeRange{Min: minStorage, Max: maxStorage}, nil
 }
 
 func awsCompareVersionStrings(leftVersion, rightVersion string) int {
@@ -311,6 +325,13 @@ func (handler *AwsRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
 	}
 
+	// Ensure VPC has EnableDnsHostnames=true (required for RDS endpoint resolution)
+	if rdbmsReqInfo.VpcIID.SystemId != "" {
+		if err := handler.ensureVPCDnsHostnames(rdbmsReqInfo.VpcIID.SystemId); err != nil {
+			return irs.RDBMSInfo{}, fmt.Errorf("VPC DNS hostname check failed: %w", err)
+		}
+	}
+
 	// Create DB Subnet Group if VPC and Subnets are provided
 	subnetGroupName := ""
 	if rdbmsReqInfo.VpcIID.SystemId != "" && len(rdbmsReqInfo.SubnetIIDs) > 0 {
@@ -351,36 +372,19 @@ func (handler *AwsRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 		input.StorageType = aws.String(rdbmsReqInfo.StorageType)
 	}
 
-	// Port
-	if rdbmsReqInfo.Port != "" {
-		port, err := strconv.ParseInt(rdbmsReqInfo.Port, 10, 64)
-		if err == nil {
-			input.Port = aws.Int64(port)
-		}
-	}
-
-	// Database Name
-	if rdbmsReqInfo.DatabaseName != "" {
-		input.DBName = aws.String(rdbmsReqInfo.DatabaseName)
-	}
-
 	// High Availability (Multi-AZ)
 	input.MultiAZ = aws.Bool(rdbmsReqInfo.HighAvailability)
 
-	// Backup
-	if rdbmsReqInfo.BackupRetentionDays > 0 {
+	// Backup: -1 = not set (use AWS default), 0 = disable backup, >0 = explicit retention days
+	if rdbmsReqInfo.BackupRetentionDays >= 0 {
 		input.BackupRetentionPeriod = aws.Int64(int64(rdbmsReqInfo.BackupRetentionDays))
 	}
-	if rdbmsReqInfo.BackupTime != "" {
-		// AWS expects "HH:MM-HH:MM" format for preferred backup window
-		input.PreferredBackupWindow = aws.String(rdbmsReqInfo.BackupTime)
-	}
+	// BackupTime (PreferredBackupWindow) is not configurable at creation via Spider (AWS auto-assigns)
 
 	// Public Access
 	input.PubliclyAccessible = aws.Bool(rdbmsReqInfo.PublicAccess)
 
-	// Encryption
-	input.StorageEncrypted = aws.Bool(rdbmsReqInfo.Encryption)
+	// Encryption is not configurable at creation via Spider (AWS uses default encryption settings)
 
 	// Deletion Protection
 	input.DeletionProtection = aws.Bool(rdbmsReqInfo.DeletionProtection)
@@ -541,6 +545,41 @@ func (handler *AwsRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
 
 // ===== Helper Functions =====
 
+// ensureVPCDnsHostnames checks whether the VPC has EnableDnsHostnames enabled.
+// If not, it automatically enables it (required for RDS endpoint DNS resolution)
+// and logs the action.
+func (handler *AwsRDBMSHandler) ensureVPCDnsHostnames(vpcID string) error {
+	// 1. Check current EnableDnsHostnames setting
+	descOut, err := handler.EC2Client.DescribeVpcAttribute(&ec2.DescribeVpcAttributeInput{
+		VpcId:     aws.String(vpcID),
+		Attribute: aws.String("enableDnsHostnames"),
+	})
+	if err != nil {
+		return fmt.Errorf("DescribeVpcAttribute(enableDnsHostnames) failed for VPC %s: %w", vpcID, err)
+	}
+
+	if descOut.EnableDnsHostnames != nil && aws.BoolValue(descOut.EnableDnsHostnames.Value) {
+		// Already enabled — nothing to do
+		return nil
+	}
+
+	// 2. EnableDnsHostnames is false — automatically set to true
+	cblogger.Infof("[VPC DNS] VPC '%s' has EnableDnsHostnames=false. Enabling it automatically for RDS endpoint resolution.", vpcID)
+
+	_, err = handler.EC2Client.ModifyVpcAttribute(&ec2.ModifyVpcAttributeInput{
+		VpcId: aws.String(vpcID),
+		EnableDnsHostnames: &ec2.AttributeBooleanValue{
+			Value: aws.Bool(true),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("ModifyVpcAttribute(EnableDnsHostnames=true) failed for VPC %s: %w", vpcID, err)
+	}
+
+	cblogger.Infof("[VPC DNS] VPC '%s' EnableDnsHostnames has been set to true. RDS DNS endpoint resolution is now available.", vpcID)
+	return nil
+}
+
 func (handler *AwsRDBMSHandler) createDBSubnetGroup(groupName string, subnetIIDs []irs.IID) error {
 	var subnetIDs []*string
 	for _, subnet := range subnetIIDs {
@@ -638,28 +677,12 @@ func (handler *AwsRDBMSHandler) convertDBInstanceToRDBMSInfo(dbInstance *rds.DBI
 	}
 
 	// Port
-	if dbInstance.Endpoint != nil && dbInstance.Endpoint.Port != nil {
-		rdbmsInfo.Port = strconv.FormatInt(aws.Int64Value(dbInstance.Endpoint.Port), 10)
-	} else if dbInstance.DbInstancePort != nil {
-		rdbmsInfo.Port = strconv.FormatInt(aws.Int64Value(dbInstance.DbInstancePort), 10)
-	}
-
 	// Authentication
 	rdbmsInfo.MasterUserName = aws.StringValue(dbInstance.MasterUsername)
 	// MasterUserPassword is never returned by AWS API
 
-	// Database
-	rdbmsInfo.DatabaseName = aws.StringValue(dbInstance.DBName)
-
 	// High Availability
 	rdbmsInfo.HighAvailability = aws.BoolValue(dbInstance.MultiAZ)
-	if dbInstance.StatusInfos != nil {
-		for _, info := range dbInstance.StatusInfos {
-			if aws.StringValue(info.StatusType) == "read replication" {
-				rdbmsInfo.ReplicationType = "async"
-			}
-		}
-	}
 
 	// Backup
 	if dbInstance.BackupRetentionPeriod != nil {

--- a/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/AzureDriver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
@@ -305,6 +306,18 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 	if err != nil {
 		return nil, err
 	}
+	mysqlPrivateDNSZonesClient, err := getMySQLPrivateDNSZonesClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		return nil, err
+	}
+	mysqlPrivateDNSVNetLinksClient, err := getMySQLPrivateDNSVNetLinksClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		return nil, err
+	}
+	mysqlBackupsClient, err := getMySQLBackupsClient(connectionInfo.CredentialInfo)
+	if err != nil {
+		return nil, err
+	}
 	iConn := azcon.AzureCloudConnection{
 		CredentialInfo:                  connectionInfo.CredentialInfo,
 		Region:                          connectionInfo.RegionInfo,
@@ -341,6 +354,9 @@ func (driver *AzureDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ico
 		MySQLServersClient:              mysqlServersClient,
 		MySQLFirewallRulesClient:        mysqlFirewallRulesClient,
 		MySQLDatabasesClient:            mysqlDatabasesClient,
+		MySQLPrivateDNSZonesClient:      mysqlPrivateDNSZonesClient,
+		MySQLPrivateDNSVNetLinksClient:  mysqlPrivateDNSVNetLinksClient,
+		MySQLBackupsClient:              mysqlBackupsClient,
 	}
 
 	return &iConn, nil
@@ -804,6 +820,42 @@ func getMySQLDatabasesClient(credInfo idrv.CredentialInfo) (*armmysqlfs.Database
 		return nil, err
 	}
 	client, err := armmysqlfs.NewDatabasesClient(credInfo.SubscriptionId, cred, newArmClientOptions())
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func getMySQLBackupsClient(credInfo idrv.CredentialInfo) (*armmysqlfs.BackupsClient, error) {
+	cred, err := getCred(credInfo)
+	if err != nil {
+		return nil, err
+	}
+	client, err := armmysqlfs.NewBackupsClient(credInfo.SubscriptionId, cred, newArmClientOptions())
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func getMySQLPrivateDNSZonesClient(credInfo idrv.CredentialInfo) (*armprivatedns.PrivateZonesClient, error) {
+	cred, err := getCred(credInfo)
+	if err != nil {
+		return nil, err
+	}
+	client, err := armprivatedns.NewPrivateZonesClient(credInfo.SubscriptionId, cred, newArmClientOptions())
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func getMySQLPrivateDNSVNetLinksClient(credInfo idrv.CredentialInfo) (*armprivatedns.VirtualNetworkLinksClient, error) {
+	cred, err := getCred(credInfo)
+	if err != nil {
+		return nil, err
+	}
+	client, err := armprivatedns.NewVirtualNetworkLinksClient(credInfo.SubscriptionId, cred, newArmClientOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/connect/Azure_CloudConnection.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
 	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/subscription/armsubscription"
@@ -74,6 +75,9 @@ type AzureCloudConnection struct {
 	MySQLServersClient              *armmysqlfs.ServersClient
 	MySQLFirewallRulesClient        *armmysqlfs.FirewallRulesClient
 	MySQLDatabasesClient            *armmysqlfs.DatabasesClient
+	MySQLPrivateDNSZonesClient      *armprivatedns.PrivateZonesClient
+	MySQLPrivateDNSVNetLinksClient  *armprivatedns.VirtualNetworkLinksClient
+	MySQLBackupsClient              *armmysqlfs.BackupsClient
 }
 
 // CreateFileSystemHandler implements connect.CloudConnection.
@@ -314,12 +318,16 @@ func (cloudConn *AzureCloudConnection) CreateMonitoringHandler() (irs.Monitoring
 func (cloudConn *AzureCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler, error) {
 	cblogger.Info("Azure Cloud Driver: called CreateRDBMSHandler()!")
 	rdbmsHandler := azrs.AzureRDBMSHandler{
-		CredentialInfo:      cloudConn.CredentialInfo,
-		Region:              cloudConn.Region,
-		Ctx:                 cloudConn.Ctx,
-		ServersClient:       cloudConn.MySQLServersClient,
-		FirewallRulesClient: cloudConn.MySQLFirewallRulesClient,
-		DatabasesClient:     cloudConn.MySQLDatabasesClient,
+		CredentialInfo:           cloudConn.CredentialInfo,
+		Region:                   cloudConn.Region,
+		Ctx:                      cloudConn.Ctx,
+		ServersClient:            cloudConn.MySQLServersClient,
+		FirewallRulesClient:      cloudConn.MySQLFirewallRulesClient,
+		DatabasesClient:          cloudConn.MySQLDatabasesClient,
+		SubnetClient:             cloudConn.SubnetClient,
+		PrivateDNSZonesClient:    cloudConn.MySQLPrivateDNSZonesClient,
+		PrivateDNSVNetLinkClient: cloudConn.MySQLPrivateDNSVNetLinksClient,
+		BackupsClient:            cloudConn.MySQLBackupsClient,
 	}
 	return &rdbmsHandler, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
@@ -24,27 +24,33 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armmysqlfs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
 type AzureRDBMSHandler struct {
-	CredentialInfo      idrv.CredentialInfo
-	Region              idrv.RegionInfo
-	Ctx                 context.Context
-	ServersClient       *armmysqlfs.ServersClient
-	FirewallRulesClient *armmysqlfs.FirewallRulesClient
-	DatabasesClient     *armmysqlfs.DatabasesClient
+	CredentialInfo           idrv.CredentialInfo
+	Region                   idrv.RegionInfo
+	Ctx                      context.Context
+	ServersClient            *armmysqlfs.ServersClient
+	FirewallRulesClient      *armmysqlfs.FirewallRulesClient
+	DatabasesClient          *armmysqlfs.DatabasesClient
+	SubnetClient             *armnetwork.SubnetsClient
+	PrivateDNSZonesClient    *armprivatedns.PrivateZonesClient
+	PrivateDNSVNetLinkClient *armprivatedns.VirtualNetworkLinksClient
+	BackupsClient            *armmysqlfs.BackupsClient
 }
 
 var azureMySQLFallbackVersions = []string{"5.7", "8.0.21", "8.4", "9.5"}
 
 var azureMySQLFallbackStorageTypeOptions = map[string][]string{
-	"mysql": {"GeneralPurpose", "BusinessCritical", "Burstable"},
+	"mysql": {"Burstable", "GeneralPurpose", "MemoryOptimized"},
 }
 
-var azureMySQLFallbackStorageSizeRange = irs.StorageSizeRange{Min: 20, Max: 16384}
+var azureMySQLFallbackStorageSizeRange = irs.StorageSizeRange{Min: 20, Max: 32768}
 
 // GetMetaInfo returns metadata about Azure Database for MySQL Flexible Server capabilities.
 // Supported engine versions are fetched dynamically via the Azure REST API (api-version 2023-12-30).
@@ -58,14 +64,19 @@ func (handler *AzureRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInf
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	versions, storageTypeOptions, storageSizeRange, err := handler.fetchMySQLMetaOptions(handler.Region.Region)
+	versions, skus, storageTypeOptions, storageSizeRange, err := handler.fetchMySQLMetaOptions(handler.Region.Region)
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		LoggingError(hiscallInfo, err)
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("GetMetaInfo failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, map[string][]string{"mysql": versions}, storageTypeOptions, storageSizeRange, true, true, true, false, true)
+	// Azure MySQL Flexible Server provides SKU list via LocationBasedCapabilitySet API
+	instanceSpecOptions := map[string][]string{
+		"mysql": skus,
+	}
+
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, map[string][]string{"mysql": versions}, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "1-35", false, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -77,9 +88,9 @@ func (handler *AzureRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInf
 }
 
 // fetchMySQLMetaOptions queries the Azure LocationBasedCapabilitySet_Get endpoint
-// (api-version 2023-12-30) to get supported MySQL versions and storage options for the given location.
+// (api-version 2023-12-30) to get supported MySQL versions, SKUs, and storage options for the given location.
 // This endpoint supersedes the legacy /capabilities endpoint and is stable across all regions.
-func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]string, map[string][]string, irs.StorageSizeRange, error) {
+func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]string, []string, map[string][]string, irs.StorageSizeRange, error) {
 	cred, err := azidentity.NewClientSecretCredential(
 		handler.CredentialInfo.TenantId,
 		handler.CredentialInfo.ClientId,
@@ -87,61 +98,64 @@ func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]stri
 		nil,
 	)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to create Azure credential: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
 	token, err := cred.GetToken(handler.Ctx, policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},
 	})
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to get Azure token: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to get Azure token: %w", err)
 	}
 
 	apiURL := fmt.Sprintf(
 		"https://management.azure.com/subscriptions/%s/providers/Microsoft.DBforMySQL/locations/%s/capabilitySets/default?api-version=2023-12-30",
 		handler.CredentialInfo.SubscriptionId, location,
 	)
-	versions, storageTypeOptions, storageSizeRange, err := handler.doCapabilitySetRequest(apiURL, token.Token)
+	versions, skus, storageTypeOptions, storageSizeRange, err := handler.doCapabilitySetRequest(apiURL, token.Token)
 	if err != nil {
 		fallbackVersions := append([]string(nil), azureMySQLFallbackVersions...)
 		fallbackStorageTypeOptions := map[string][]string{
 			"mysql": append([]string(nil), azureMySQLFallbackStorageTypeOptions["mysql"]...),
 		}
-		cblogger.Infof("Azure MySQL capabilitySets API failed for location %s. Using fallback versions %v and storage metadata %v/%+v: %v", location, fallbackVersions, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, err)
-		return fallbackVersions, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, nil
+		cblogger.Infof("Azure MySQL capabilitySets API failed for location %s. Using fallback: versions=%v, storage=%v/%+v: %v", location, fallbackVersions, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, err)
+		return fallbackVersions, []string{}, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, nil
 	}
-	return versions, storageTypeOptions, storageSizeRange, nil
+	return versions, skus, storageTypeOptions, storageSizeRange, nil
 }
 
 // doCapabilitySetRequest calls the Azure LocationBasedCapabilitySet_Get endpoint.
 // URL: GET .../capabilitySets/default?api-version=2023-12-30
-// Response: { "properties": { "supportedServerVersions": [{"name":"..."}] } }
-func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken string) ([]string, map[string][]string, irs.StorageSizeRange, error) {
+// Response: { "properties": { "supportedServerVersions": [{"name":"..."}], "supportedFlexibleServerEditions": [...] } }
+func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken string) ([]string, []string, map[string][]string, irs.StorageSizeRange, error) {
 	req, err := http.NewRequestWithContext(handler.Ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to build capabilitySets request: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to build capabilitySets request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+bearerToken)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets request failed: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to read capabilitySets response: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to read capabilitySets response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var result struct {
 		Properties struct {
 			SupportedFlexibleServerEditions []struct {
-				Name                     string `json:"name"`
+				Name          string `json:"name"`
+				SupportedSkus []struct {
+					Name string `json:"name"`
+				} `json:"supportedSkus"`
 				SupportedStorageEditions []struct {
 					Name           string `json:"name"`
 					MinStorageSize int64  `json:"minStorageSize"`
@@ -154,7 +168,7 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to parse capabilitySets response: %w", err)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to parse capabilitySets response: %w", err)
 	}
 
 	versionSet := map[string]bool{}
@@ -169,6 +183,21 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 		versions = append(versions, v)
 	}
 	sort.Strings(versions)
+
+	// Parse SKUs from supportedFlexibleServerEditions
+	skuSet := map[string]bool{}
+	for _, edition := range result.Properties.SupportedFlexibleServerEditions {
+		for _, sku := range edition.SupportedSkus {
+			if sku.Name != "" {
+				skuSet[sku.Name] = true
+			}
+		}
+	}
+	skus := make([]string, 0, len(skuSet))
+	for s := range skuSet {
+		skus = append(skus, s)
+	}
+	sort.Strings(skus)
 
 	storageTypeSet := map[string]bool{}
 	var minStorageGB int64
@@ -198,12 +227,12 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 	}
 	sort.Strings(storageTypes)
 	if len(storageTypes) == 0 || minStorageGB == 0 || maxStorageGB == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets response did not include storage options")
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets response did not include storage options")
 	}
 
 	storageTypeOptions := map[string][]string{"mysql": storageTypes}
 	storageSizeRange := irs.StorageSizeRange{Min: minStorageGB, Max: maxStorageGB}
-	return versions, storageTypeOptions, storageSizeRange, nil
+	return versions, skus, storageTypeOptions, storageSizeRange, nil
 }
 
 func azureStorageMBToGB(storageMB int64) int64 {
@@ -265,6 +294,25 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
 	}
 
+	// Validate PublicAccess and VPC combination
+	// Case 1: PublicAccess=true, VPCName present → OK (public mode; VPCName is recorded as OwnerVPC but not passed to Azure API)
+	// Case 2: PublicAccess=true, VPCName absent  → OK (public mode with firewall rules)
+	// Case 3: PublicAccess=false, VPCName present → OK (VPC private mode; subnet will be dedicated to MySQL and cannot be used for other resources)
+	// Case 4: PublicAccess=false, VPCName absent  → error (no access path available without VPC)
+	hasVPC := rdbmsReqInfo.VpcIID.NameId != "" || rdbmsReqInfo.VpcIID.SystemId != ""
+	if rdbmsReqInfo.PublicAccess && hasVPC {
+		cblogger.Infof("[Azure RDBMS] PublicAccess=true with VPCName='%s': "+
+			"VPC integration is not used for public-access Azure MySQL Flexible Server. "+
+			"VPCName will be recorded as OwnerVPC but is not passed to the Azure CSP API.",
+			rdbmsReqInfo.VpcIID.NameId)
+	}
+	if !rdbmsReqInfo.PublicAccess && !hasVPC {
+		return irs.RDBMSInfo{}, errors.New(
+			"PublicAccess=false requires a VPCName: " +
+				"Azure MySQL Flexible Server with public access disabled must be deployed in a VPC. " +
+				"Please provide VPCName (and optionally SubnetNames) to enable private access.")
+	}
+
 	resourceGroup := handler.Region.Region
 	location := handler.Region.Region
 
@@ -289,10 +337,11 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 		haMode = armmysqlfs.HighAvailabilityModeZoneRedundant
 	}
 
-	// Backup retention
-	backupRetention := int32(7)
+	// Backup retention: -1 or 0 = not set (use Azure default 7 days), 1-35 = explicit value
+	var backupRetention *int32
 	if rdbmsReqInfo.BackupRetentionDays > 0 {
-		backupRetention = int32(rdbmsReqInfo.BackupRetentionDays)
+		retention := int32(rdbmsReqInfo.BackupRetentionDays)
+		backupRetention = &retention
 	}
 
 	// Flexible Server create mode
@@ -302,6 +351,62 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 	publicAccess := armmysqlfs.EnableStatusEnumDisabled
 	if rdbmsReqInfo.PublicAccess {
 		publicAccess = armmysqlfs.EnableStatusEnumEnabled
+	}
+
+	// VPC private mode: ensure subnet delegation and create Private DNS Zone
+	var delegatedSubnetResourceID, privateDNSZoneResourceID string
+	if !rdbmsReqInfo.PublicAccess && hasVPC {
+		cblogger.Infof("[Azure RDBMS] VPC private mode requested (VPCName=%s). "+
+			"The specified subnet will be dedicated exclusively to Azure MySQL Flexible Server "+
+			"and cannot be used for VMs or other resources.",
+			rdbmsReqInfo.VpcIID.NameId)
+
+		// Use the first subnet if provided, otherwise error
+		if len(rdbmsReqInfo.SubnetIIDs) == 0 {
+			return irs.RDBMSInfo{}, fmt.Errorf(
+				"VPC private mode requires at least one SubnetName: " +
+					"please provide a dedicated subnet for Azure MySQL Flexible Server " +
+					"(the subnet must not contain VMs or other resources)")
+		}
+
+		subnetResourceID := rdbmsReqInfo.SubnetIIDs[0].SystemId
+		vnetName := rdbmsReqInfo.VpcIID.NameId
+
+		// Ensure the subnet has delegation to Microsoft.DBforMySQL/flexibleServers
+		if err := handler.ensureSubnetDelegation(resourceGroup, vnetName, rdbmsReqInfo.SubnetIIDs[0].NameId, subnetResourceID); err != nil {
+			return irs.RDBMSInfo{}, err
+		}
+
+		// Create Private DNS Zone: <serverName>.private.mysql.database.azure.com
+		// NOTE: Current implementation creates a separate DNS Zone per server (not VPC-level shared).
+		// This avoids the concurrency issue that GCP Service Networking Peering has.
+		// Future optimization: Use a single VNet-level zone (e.g., "privatelink.mysql.database.azure.com")
+		// and add A records per server. If that optimization is implemented, use vpcSharedResourceSPLock
+		// to prevent concurrent zone creation/deletion (similar to GCP).
+		dnsZoneName := rdbmsReqInfo.IId.NameId + ".private.mysql.database.azure.com"
+		dnsZoneID, err := handler.ensurePrivateDNSZone(resourceGroup, dnsZoneName)
+		if err != nil {
+			return irs.RDBMSInfo{}, err
+		}
+
+		// Link Private DNS Zone to VNet
+		vnetResourceID := rdbmsReqInfo.VpcIID.SystemId
+		if err := handler.ensurePrivateDNSVNetLink(resourceGroup, dnsZoneName, vnetName, vnetResourceID); err != nil {
+			// best-effort cleanup
+			handler.deletePrivateDNSZone(resourceGroup, dnsZoneName)
+			return irs.RDBMSInfo{}, err
+		}
+
+		delegatedSubnetResourceID = subnetResourceID
+		privateDNSZoneResourceID = dnsZoneID
+	}
+
+	network := &armmysqlfs.Network{
+		PublicNetworkAccess: &publicAccess,
+	}
+	if delegatedSubnetResourceID != "" {
+		network.DelegatedSubnetResourceID = &delegatedSubnetResourceID
+		network.PrivateDNSZoneResourceID = &privateDNSZoneResourceID
 	}
 
 	parameters := armmysqlfs.Server{
@@ -315,14 +420,12 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 				StorageSizeGB: &storageSizeGB32,
 			},
 			Backup: &armmysqlfs.Backup{
-				BackupRetentionDays: &backupRetention,
+				BackupRetentionDays: backupRetention,
 			},
 			HighAvailability: &armmysqlfs.HighAvailability{
 				Mode: &haMode,
 			},
-			Network: &armmysqlfs.Network{
-				PublicNetworkAccess: &publicAccess,
-			},
+			Network: network,
 		},
 		SKU: &armmysqlfs.SKU{
 			Name: &rdbmsReqInfo.DBInstanceSpec,
@@ -345,13 +448,20 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 	if err != nil {
 		cblogger.Error(err)
 		LoggingError(hiscallInfo, err)
+		if privateDNSZoneResourceID != "" {
+			handler.deletePrivateDNSZone(resourceGroup, rdbmsReqInfo.IId.NameId+".private.mysql.database.azure.com")
+		}
 		return irs.RDBMSInfo{}, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
 
 	resp, err := poller.PollUntilDone(handler.Ctx, nil)
 	if err != nil {
-		return irs.RDBMSInfo{}, fmt.Errorf("failed waiting for server creation: %w", err)
+		cblogger.Error(err)
+		if privateDNSZoneResourceID != "" {
+			handler.deletePrivateDNSZone(resourceGroup, rdbmsReqInfo.IId.NameId+".private.mysql.database.azure.com")
+		}
+		return irs.RDBMSInfo{}, err
 	}
 
 	// Add firewall rule to allow all IPs when PublicAccess is enabled
@@ -380,7 +490,11 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 		}
 	}
 
-	return handler.convertToRDBMSInfo(&resp.Server), nil
+	rdbmsInfo := handler.convertToRDBMSInfo(&resp.Server)
+	if hasVPC {
+		rdbmsInfo.VpcIID = rdbmsReqInfo.VpcIID
+	}
+	return rdbmsInfo, nil
 }
 
 func (handler *AzureRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
@@ -448,10 +562,141 @@ func (handler *AzureRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
 		return false, fmt.Errorf("failed waiting for server deletion: %w", err)
 	}
 
+	// NOTE: Private DNS Zone cleanup is not performed here because each server has its own zone
+	// (<serverName>.private.mysql.database.azure.com). The zone is automatically removed by Azure
+	// or can be manually cleaned up if needed.
+	//
+	// If future optimization uses a shared VNet-level zone (e.g., "privatelink.mysql.database.azure.com"),
+	// implement the following logic with vpcSharedResourceSPLock:
+	//   1. Lock vpcSharedResourceSPLock for the VNet
+	//   2. Query all MySQL Flexible Servers in the same VNet via handler.listServersInVNet(vnetResourceID)
+	//   3. If no other servers exist (last server deleted), delete the shared DNS Zone and VNet Link
+	//   4. Unlock vpcSharedResourceSPLock
+
 	return true, nil
 }
 
 // ===== Helper Functions =====
+
+// ensureSubnetDelegation checks whether the subnet is delegated to Microsoft.DBforMySQL/flexibleServers.
+// If not, it adds the delegation automatically and logs the action.
+func (handler *AzureRDBMSHandler) ensureSubnetDelegation(resourceGroup, vnetName, subnetName, subnetResourceID string) error {
+	const delegationService = "Microsoft.DBforMySQL/flexibleServers"
+
+	resp, err := handler.SubnetClient.Get(handler.Ctx, resourceGroup, vnetName, subnetName, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get subnet '%s': %w", subnetName, err)
+	}
+
+	// Check existing delegation
+	for _, d := range resp.Subnet.Properties.Delegations {
+		if d.Properties != nil && d.Properties.ServiceName != nil &&
+			*d.Properties.ServiceName == delegationService {
+			return nil // already delegated
+		}
+	}
+
+	// Add delegation
+	cblogger.Infof("[Azure RDBMS] Subnet '%s' is not delegated to %s. Adding delegation automatically.", subnetName, delegationService)
+
+	delegationName := "MySQLFlexibleServerDelegation"
+	serviceName := delegationService
+	resp.Subnet.Properties.Delegations = append(resp.Subnet.Properties.Delegations, &armnetwork.Delegation{
+		Name: &delegationName,
+		Properties: &armnetwork.ServiceDelegationPropertiesFormat{
+			ServiceName: &serviceName,
+		},
+	})
+
+	poller, err := handler.SubnetClient.BeginCreateOrUpdate(handler.Ctx, resourceGroup, vnetName, subnetName, resp.Subnet, nil)
+	if err != nil {
+		return fmt.Errorf("failed to add delegation to subnet '%s': %w", subnetName, err)
+	}
+	if _, err = poller.PollUntilDone(handler.Ctx, nil); err != nil {
+		return fmt.Errorf("failed waiting for subnet delegation update on '%s': %w", subnetName, err)
+	}
+
+	cblogger.Infof("[Azure RDBMS] Subnet '%s' delegated to %s successfully. "+
+		"This subnet is now exclusively dedicated to Azure MySQL Flexible Server and cannot be used for VMs or other resources.",
+		subnetName, delegationService)
+	return nil
+}
+
+// ensurePrivateDNSZone creates the Private DNS Zone if it does not already exist.
+// Returns the full resource ID of the zone.
+func (handler *AzureRDBMSHandler) ensurePrivateDNSZone(resourceGroup, zoneName string) (string, error) {
+	// Check if already exists
+	existing, err := handler.PrivateDNSZonesClient.Get(handler.Ctx, resourceGroup, zoneName, nil)
+	if err == nil {
+		cblogger.Infof("[Azure RDBMS] Private DNS Zone '%s' already exists.", zoneName)
+		return *existing.ID, nil
+	}
+
+	cblogger.Infof("[Azure RDBMS] Creating Private DNS Zone '%s'.", zoneName)
+	location := "global"
+	poller, err := handler.PrivateDNSZonesClient.BeginCreateOrUpdate(
+		handler.Ctx, resourceGroup, zoneName,
+		armprivatedns.PrivateZone{Location: &location},
+		nil,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create Private DNS Zone '%s': %w", zoneName, err)
+	}
+	result, err := poller.PollUntilDone(handler.Ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed waiting for Private DNS Zone creation '%s': %w", zoneName, err)
+	}
+
+	cblogger.Infof("[Azure RDBMS] Private DNS Zone '%s' created (ID: %s).", zoneName, *result.ID)
+	return *result.ID, nil
+}
+
+// ensurePrivateDNSVNetLink links the Private DNS Zone to the VNet if not already linked.
+func (handler *AzureRDBMSHandler) ensurePrivateDNSVNetLink(resourceGroup, zoneName, vnetName, vnetResourceID string) error {
+	linkName := "cb-spider-" + vnetName
+
+	// Check if already exists
+	_, err := handler.PrivateDNSVNetLinkClient.Get(handler.Ctx, resourceGroup, zoneName, linkName, nil)
+	if err == nil {
+		cblogger.Infof("[Azure RDBMS] Private DNS VNet link '%s' already exists.", linkName)
+		return nil
+	}
+
+	cblogger.Infof("[Azure RDBMS] Linking Private DNS Zone '%s' to VNet '%s'.", zoneName, vnetName)
+	registrationEnabled := false
+	poller, err := handler.PrivateDNSVNetLinkClient.BeginCreateOrUpdate(
+		handler.Ctx, resourceGroup, zoneName, linkName,
+		armprivatedns.VirtualNetworkLink{
+			Location: func() *string { s := "global"; return &s }(),
+			Properties: &armprivatedns.VirtualNetworkLinkProperties{
+				VirtualNetwork:      &armprivatedns.SubResource{ID: &vnetResourceID},
+				RegistrationEnabled: &registrationEnabled,
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create VNet link for Private DNS Zone '%s': %w", zoneName, err)
+	}
+	if _, err = poller.PollUntilDone(handler.Ctx, nil); err != nil {
+		return fmt.Errorf("failed waiting for VNet link creation for Private DNS Zone '%s': %w", zoneName, err)
+	}
+
+	cblogger.Infof("[Azure RDBMS] VNet '%s' linked to Private DNS Zone '%s' successfully.", vnetName, zoneName)
+	return nil
+}
+
+// deletePrivateDNSZone is a best-effort cleanup helper used on CreateRDBMS failure.
+func (handler *AzureRDBMSHandler) deletePrivateDNSZone(resourceGroup, zoneName string) {
+	poller, err := handler.PrivateDNSZonesClient.BeginDelete(handler.Ctx, resourceGroup, zoneName, nil)
+	if err != nil {
+		cblogger.Warnf("[Azure RDBMS] Failed to delete Private DNS Zone '%s' during cleanup: %v", zoneName, err)
+		return
+	}
+	if _, err = poller.PollUntilDone(handler.Ctx, nil); err != nil {
+		cblogger.Warnf("[Azure RDBMS] Failed waiting for Private DNS Zone deletion '%s': %v", zoneName, err)
+	}
+}
 
 func skuTierFromSpec(spec string) *armmysqlfs.SKUTier {
 	tierBurstable := armmysqlfs.SKUTierBurstable
@@ -509,6 +754,9 @@ func (handler *AzureRDBMSHandler) convertToRDBMSInfo(server *armmysqlfs.Server) 
 			if server.Properties.Storage.StorageSizeGB != nil {
 				rdbmsInfo.StorageSize = strconv.FormatInt(int64(*server.Properties.Storage.StorageSizeGB), 10)
 			}
+			if server.Properties.Storage.StorageSKU != nil {
+				rdbmsInfo.StorageType = string(*server.Properties.Storage.StorageSKU)
+			}
 		}
 
 		// Backup
@@ -521,11 +769,6 @@ func (handler *AzureRDBMSHandler) convertToRDBMSInfo(server *armmysqlfs.Server) 
 		// High Availability
 		if server.Properties.HighAvailability != nil && server.Properties.HighAvailability.Mode != nil {
 			rdbmsInfo.HighAvailability = (*server.Properties.HighAvailability.Mode != armmysqlfs.HighAvailabilityModeDisabled)
-		}
-
-		// Replication
-		if server.Properties.ReplicationRole != nil {
-			rdbmsInfo.ReplicationType = string(*server.Properties.ReplicationRole)
 		}
 
 		// PublicAccess
@@ -544,11 +787,10 @@ func (handler *AzureRDBMSHandler) convertToRDBMSInfo(server *armmysqlfs.Server) 
 		}
 	}
 
-	// Port
-	rdbmsInfo.Port = "3306"
-	rdbmsInfo.StorageType = "NA"
-	rdbmsInfo.DatabaseName = ""
-	rdbmsInfo.BackupTime = "NA"
+	if rdbmsInfo.StorageType == "" {
+		rdbmsInfo.StorageType = "NA"
+	}
+	rdbmsInfo.BackupTime = "AUTO" // Azure manages backup schedule automatically
 	rdbmsInfo.DeletionProtection = false
 
 	// CreatedTime from SystemData
@@ -569,6 +811,31 @@ func (handler *AzureRDBMSHandler) convertToRDBMSInfo(server *armmysqlfs.Server) 
 	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(server)
 
 	return rdbmsInfo
+}
+
+func (handler *AzureRDBMSHandler) enrichBackupTime(rdbmsInfo *irs.RDBMSInfo) {
+	if rdbmsInfo.IId.SystemId == "" || handler.BackupsClient == nil {
+		return
+	}
+
+	resourceGroup := handler.Region.Region
+	pager := handler.BackupsClient.NewListByServerPager(resourceGroup, rdbmsInfo.IId.SystemId, nil)
+
+	// Get the first (most recent) backup
+	if pager.More() {
+		page, err := pager.NextPage(handler.Ctx)
+		if err != nil {
+			cblogger.Debug("Failed to retrieve backup list: ", err)
+			return
+		}
+
+		if len(page.Value) > 0 {
+			backup := page.Value[0]
+			if backup.SystemData != nil && backup.SystemData.CreatedAt != nil {
+				rdbmsInfo.BackupTime = backup.SystemData.CreatedAt.Format("2006-01-02T15:04:05Z07:00")
+			}
+		}
+	}
 }
 
 func convertFlexibleServerStatus(state string) irs.RDBMSStatus {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
@@ -51,14 +51,14 @@ func (handler *GCPRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		LoggingError(hiscallInfo, err)
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("fetch Cloud SQL meta options failed: %w", err)
 	}
-	storageSizeRange, err := handler.fetchCloudSQLStorageSizeRange()
+	instanceSpecOptions, storageSizeRange, err := handler.fetchCloudSQLInstanceOptions()
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		LoggingError(hiscallInfo, err)
-		return irs.RDBMSMetaInfo{}, fmt.Errorf("fetch Cloud SQL storage size range failed: %w", err)
+		return irs.RDBMSMetaInfo{}, fmt.Errorf("fetch Cloud SQL instance options failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, true, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "1-7", false, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -154,19 +154,20 @@ func (handler *GCPRDBMSHandler) fetchCloudSQLMetaOptions() (map[string][]string,
 	return supportedEngines, storageTypeOptions, nil
 }
 
-func (handler *GCPRDBMSHandler) fetchCloudSQLStorageSizeRange() (irs.StorageSizeRange, error) {
+func (handler *GCPRDBMSHandler) fetchCloudSQLInstanceOptions() (map[string][]string, irs.StorageSizeRange, error) {
 	projectID := handler.getProjectId()
 	if projectID == "" {
-		return irs.StorageSizeRange{}, fmt.Errorf("GCP project ID is empty")
+		return nil, irs.StorageSizeRange{}, fmt.Errorf("GCP project ID is empty")
 	}
 
 	resp, err := handler.Client.Tiers.List(projectID).Do()
 	if err != nil {
-		return irs.StorageSizeRange{}, fmt.Errorf("Cloud SQL Tiers.List failed: %w", err)
+		return nil, irs.StorageSizeRange{}, fmt.Errorf("Cloud SQL Tiers.List failed: %w", err)
 	}
 
 	const bytesPerGiB = int64(1024 * 1024 * 1024)
 	maxStorageGB := int64(0)
+	tierSet := map[string]bool{}
 	for _, tier := range resp.Items {
 		if tier == nil || tier.DiskQuota <= 0 {
 			continue
@@ -174,16 +175,30 @@ func (handler *GCPRDBMSHandler) fetchCloudSQLStorageSizeRange() (irs.StorageSize
 		if !cloudSQLTierSupportsRegion(tier, handler.Region.Region) {
 			continue
 		}
+		if tier.Tier != "" {
+			tierSet[tier.Tier] = true
+		}
 		storageGB := tier.DiskQuota / bytesPerGiB
 		if storageGB > maxStorageGB {
 			maxStorageGB = storageGB
 		}
 	}
 	if maxStorageGB == 0 {
-		return irs.StorageSizeRange{}, fmt.Errorf("Cloud SQL Tiers.List returned no disk quota for region %s", handler.Region.Region)
+		return nil, irs.StorageSizeRange{}, fmt.Errorf("Cloud SQL Tiers.List returned no disk quota for region %s", handler.Region.Region)
 	}
 
-	return irs.StorageSizeRange{Min: 10, Max: maxStorageGB}, nil
+	tierList := make([]string, 0, len(tierSet))
+	for tier := range tierSet {
+		tierList = append(tierList, tier)
+	}
+	sort.Strings(tierList)
+
+	instanceSpecOptions := map[string][]string{
+		"mysql":      append([]string(nil), tierList...),
+		"postgresql": append([]string(nil), tierList...),
+	}
+
+	return instanceSpecOptions, irs.StorageSizeRange{Min: 10, Max: maxStorageGB}, nil
 }
 
 func cloudSQLTierSupportsRegion(tier *sqladmin.Tier, region string) bool {
@@ -346,12 +361,14 @@ func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 	if rdbmsReqInfo.BackupRetentionDays > 0 {
 		backupConfig.TransactionLogRetentionDays = int64(rdbmsReqInfo.BackupRetentionDays)
 	}
-	if rdbmsReqInfo.BackupTime != "" {
-		backupConfig.StartTime = rdbmsReqInfo.BackupTime
-	}
+	// BackupTime (StartTime) is not configurable at creation via Spider (GCP auto-assigns)
 	settings.BackupConfiguration = backupConfig
 
 	// IP Configuration (Public Access, Network)
+	// GCP Cloud SQL supports three networking modes:
+	//   1. Public IP only: Ipv4Enabled=true, PrivateNetwork not set
+	//   2. Private IP only: Ipv4Enabled=false, PrivateNetwork set (requires Service Networking Peering)
+	//   3. Hybrid (both): Ipv4Enabled=true, PrivateNetwork set (requires Service Networking Peering)
 	ipConfig := &sqladmin.IpConfiguration{}
 	if rdbmsReqInfo.PublicAccess {
 		ipConfig.Ipv4Enabled = true
@@ -366,8 +383,22 @@ func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 		ipConfig.Ipv4Enabled = false
 	}
 
-	// VPC Network - GCP uses private service connection
-	if rdbmsReqInfo.VpcIID.SystemId != "" {
+	// VPC Network - GCP uses Service Networking Peering (private service connection)
+	// Only set PrivateNetwork when PublicAccess=false (Private IP mode)
+	// PublicAccess=true uses public IP only (VPC is for SecurityGroup reference, not for private connectivity)
+	if !rdbmsReqInfo.PublicAccess && rdbmsReqInfo.VpcIID.SystemId != "" {
+		// TODO: Implement Service Networking Peering auto-creation with vpcSharedResourceSPLock.
+		// Current behavior: User must manually create peering via gcloud:
+		//   1. gcloud services enable servicenetworking.googleapis.com
+		//   2. gcloud compute addresses create google-managed-services-{vpc} --global --purpose=VPC_PEERING --prefix-length=16 --network={vpc}
+		//   3. gcloud services vpc-peerings connect --service=servicenetworking.googleapis.com --ranges=google-managed-services-{vpc} --network={vpc}
+		//
+		// Required implementation:
+		//   - Use vpcSharedResourceSPLock.Lock(connectionName, vpcName) to prevent concurrent peering creation
+		//   - Check if peering exists via compute API (addresses.list with purpose=VPC_PEERING)
+		//   - If not exists, create IP range and service connection via servicenetworking API
+		//   - Reference: https://cloud.google.com/sql/docs/mysql/configure-private-services-access
+		cblogger.Warnf("[GCP RDBMS] Private network mode detected (PublicAccess=false). Ensure Service Networking Peering is manually created for VPC '%s'.", rdbmsReqInfo.VpcIID.SystemId)
 		ipConfig.PrivateNetwork = rdbmsReqInfo.VpcIID.SystemId
 	}
 	settings.IpConfiguration = ipConfig
@@ -417,17 +448,6 @@ func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 	_, err = handler.Client.Users.Insert(projectId, rdbmsReqInfo.IId.NameId, user).Do()
 	if err != nil {
 		cblogger.Warnf("Failed to create master user: %v", err)
-	}
-
-	// Set initial database if specified
-	if rdbmsReqInfo.DatabaseName != "" {
-		db := &sqladmin.Database{
-			Name: rdbmsReqInfo.DatabaseName,
-		}
-		_, err = handler.Client.Databases.Insert(projectId, rdbmsReqInfo.IId.NameId, db).Do()
-		if err != nil {
-			cblogger.Warnf("Failed to create initial database: %v", err)
-		}
 	}
 
 	// Get the created instance
@@ -480,13 +500,21 @@ func (handler *GCPRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
 
 	projectId := handler.getProjectId()
 
-	// Check and disable deletion protection if needed
+	// Get instance info to extract VPC (for Service Networking Peering cleanup)
 	instance, err := handler.Client.Instances.Get(projectId, rdbmsIID.SystemId).Do()
 	if err != nil {
 		cblogger.Error(err)
 		LoggingError(hiscallInfo, err)
 		return false, err
 	}
+
+	// Extract VPC for peering cleanup check
+	var vpcNetwork string
+	if instance.Settings != nil && instance.Settings.IpConfiguration != nil {
+		vpcNetwork = instance.Settings.IpConfiguration.PrivateNetwork
+	}
+
+	// Disable deletion protection if needed
 	if instance.Settings != nil && instance.Settings.DeletionProtectionEnabled {
 		instance.Settings.DeletionProtectionEnabled = false
 		_, err = handler.Client.Instances.Update(projectId, rdbmsIID.SystemId, instance).Do()
@@ -507,6 +535,26 @@ func (handler *GCPRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
 	err = handler.waitForOperation(projectId, op.Name)
 	if err != nil {
 		return false, fmt.Errorf("failed waiting for instance deletion: %w", err)
+	}
+
+	// TODO: Implement Service Networking Peering auto-deletion with vpcSharedResourceSPLock.
+	// Current behavior: Peering remains after RDBMS deletion (user must manually delete).
+	//
+	// Required implementation:
+	//   - If vpcNetwork is not empty (private network was used):
+	//     1. Use vpcSharedResourceSPLock.Lock(connectionName, vpcName) for concurrency control
+	//     2. Query all Cloud SQL instances in the same VPC via handler.listInstancesInVPC(vpcNetwork)
+	//     3. If no other instances exist (last instance deleted), delete Service Networking Peering:
+	//        a. gcloud services vpc-peerings delete --service=servicenetworking.googleapis.com --network={vpc}
+	//        b. gcloud compute addresses delete google-managed-services-{vpc} --global
+	//     4. Unlock vpcSharedResourceSPLock
+	//
+	// Race condition without lock:
+	//   - Thread A deletes db-1, checks "db-2 exists" → keeps peering
+	//   - Thread B deletes db-2, checks "db-1 exists" → keeps peering
+	//   - Result: Both deleted but peering remains, VPC deletion fails
+	if vpcNetwork != "" {
+		cblogger.Warnf("[GCP RDBMS] Instance with private network deleted. Service Networking Peering for VPC '%s' remains (manual cleanup required if this was the last instance).", vpcNetwork)
 	}
 
 	return true, nil
@@ -575,7 +623,6 @@ func (handler *GCPRDBMSHandler) convertToRDBMSInfo(instance *sqladmin.DatabaseIn
 		rdbmsInfo.HighAvailability = (instance.Settings.AvailabilityType == "REGIONAL")
 		if rdbmsInfo.HighAvailability {
 			rdbmsInfo.DBInstanceType = "REGIONAL"
-			rdbmsInfo.ReplicationType = "sync"
 		} else {
 			rdbmsInfo.DBInstanceType = "ZONAL"
 		}
@@ -624,22 +671,19 @@ func (handler *GCPRDBMSHandler) convertToRDBMSInfo(instance *sqladmin.DatabaseIn
 		}
 	}
 
-	// Endpoint
+	// Endpoint with port
 	if len(instance.IpAddresses) > 0 {
 		for _, ip := range instance.IpAddresses {
 			if ip.Type == "PRIMARY" || ip.Type == "PRIVATE" {
-				rdbmsInfo.Endpoint = ip.IpAddress
+				// Add default port based on engine
+				port := "3306" // MySQL default
+				if engine == "postgresql" {
+					port = "5432"
+				}
+				rdbmsInfo.Endpoint = fmt.Sprintf("%s:%s", ip.IpAddress, port)
 				break
 			}
 		}
-	}
-
-	// Port - GCP uses standard ports
-	switch strings.ToLower(engine) {
-	case "mysql":
-		rdbmsInfo.Port = "3306"
-	case "postgresql":
-		rdbmsInfo.Port = "5432"
 	}
 
 	// Encryption - GCP encrypts by default
@@ -735,4 +779,26 @@ func (handler *GCPRDBMSHandler) DeleteDatabase(rdbmsSystemId, dbEngine, dbName s
 		return fmt.Errorf("GCP DeleteDatabase: %w", err)
 	}
 	return handler.waitForOperation(projectId, op.Name)
+}
+
+// ===== Service Networking Peering Helpers =====
+
+// listInstancesInVPC returns all Cloud SQL instances that use the specified VPC private network.
+// This is used to determine if a Service Networking Peering can be safely deleted (only when no instances remain).
+func (handler *GCPRDBMSHandler) listInstancesInVPC(vpcNetwork string) ([]*sqladmin.DatabaseInstance, error) {
+	projectId := handler.getProjectId()
+	resp, err := handler.Client.Instances.List(projectId).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Cloud SQL instances: %w", err)
+	}
+
+	var instances []*sqladmin.DatabaseInstance
+	for _, instance := range resp.Items {
+		if instance.Settings != nil && instance.Settings.IpConfiguration != nil {
+			if instance.Settings.IpConfiguration.PrivateNetwork == vpcNetwork {
+				instances = append(instances, instance)
+			}
+		}
+	}
+	return instances, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
@@ -80,6 +80,7 @@ func (handler *IbmRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		LoggingError(hiscallInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
+	instanceSpecOptions := handler.fetchRDBMSInstanceSpecOptions()
 	storageTypeOptions, err := handler.fetchRDBMSStorageTypeOptions(requestedEngine)
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
@@ -93,7 +94,7 @@ func (handler *IbmRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, true, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "NA", false, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -136,6 +137,20 @@ func (handler *IbmRDBMSHandler) fetchRDBMSVersions() (map[string][]string, error
 	}
 
 	return supportedEngines, nil
+}
+
+func (handler *IbmRDBMSHandler) fetchRDBMSInstanceSpecOptions() map[string][]string {
+	// IBM Cloud Databases supports a hardcoded list of host_flavor IDs
+	hostFlavors := make([]string, 0, len(ibmRDBMSHostFlavorIDs))
+	for flavor := range ibmRDBMSHostFlavorIDs {
+		hostFlavors = append(hostFlavors, flavor)
+	}
+	sort.Strings(hostFlavors)
+
+	return map[string][]string{
+		"mysql":      append([]string(nil), hostFlavors...),
+		"postgresql": append([]string(nil), hostFlavors...),
+	}
 }
 
 func (handler *IbmRDBMSHandler) fetchRDBMSStorageTypeOptions(dbEngine string) (map[string][]string, error) {
@@ -400,26 +415,11 @@ func validateIBMCreateRequest(rdbmsReqInfo irs.RDBMSInfo) error {
 	if len(rdbmsReqInfo.SecurityGroupIIDs) > 0 {
 		return errors.New("IBM Cloud Databases provisioning does not support SecurityGroupNames/SecurityGroupIIDs; use IBM Cloud Databases allowlist APIs after creation")
 	}
-	if rdbmsReqInfo.DatabaseName != "" && !isIBMDefaultValue(rdbmsReqInfo.DatabaseName) && rdbmsReqInfo.DatabaseName != "ibmclouddb" {
-		return errors.New("IBM Cloud Databases API does not support creating an initial DatabaseName during provisioning")
-	}
 	if rdbmsReqInfo.BackupRetentionDays > 0 {
 		return errors.New("IBM Cloud Databases API does not support setting BackupRetentionDays during provisioning")
 	}
 	if rdbmsReqInfo.BackupTime != "" && !isIBMDefaultValue(rdbmsReqInfo.BackupTime) {
 		return errors.New("IBM Cloud Databases API does not support setting BackupTime during provisioning")
-	}
-	if rdbmsReqInfo.Port != "" {
-		expectedPort := ""
-		switch rdbmsReqInfo.DBEngine {
-		case "mysql":
-			expectedPort = "3306"
-		case "postgresql":
-			expectedPort = "5432"
-		}
-		if expectedPort != "" && rdbmsReqInfo.Port != expectedPort {
-			return fmt.Errorf("IBM Cloud Databases does not support custom Port during provisioning; %s uses service-managed port %s", rdbmsReqInfo.DBEngine, expectedPort)
-		}
 	}
 	if rdbmsReqInfo.DBInstanceSpec != "" && !isIBMDefaultValue(rdbmsReqInfo.DBInstanceSpec) && !isIBMHostFlavor(rdbmsReqInfo.DBInstanceSpec) {
 		return fmt.Errorf("IBM DBInstanceSpec must be an IBM host_flavor id, got %s", rdbmsReqInfo.DBInstanceSpec)
@@ -792,11 +792,9 @@ func (handler *IbmRDBMSHandler) convertResourceInstanceToRDBMSInfo(inst *resourc
 		switch {
 		case strings.HasPrefix(resourcePlanID, ibmServiceIDMySQL+"-"):
 			rdbmsInfo.DBEngine = "mysql"
-			rdbmsInfo.Port = "3306"
 			rdbmsInfo.StorageType = strings.TrimPrefix(resourcePlanID, ibmServiceIDMySQL+"-")
 		case strings.HasPrefix(resourcePlanID, ibmServiceIDPG+"-"):
 			rdbmsInfo.DBEngine = "postgresql"
-			rdbmsInfo.Port = "5432"
 			rdbmsInfo.StorageType = strings.TrimPrefix(resourcePlanID, ibmServiceIDPG+"-")
 		}
 	}
@@ -823,14 +821,14 @@ func (handler *IbmRDBMSHandler) convertResourceInstanceToRDBMSInfo(inst *resourc
 	// IBM Cloud Databases are always encrypted at rest
 	rdbmsInfo.Encryption = true
 	rdbmsInfo.MasterUserName = ibmDefaultAdminUser // IBM default
-	rdbmsInfo.DatabaseName = "NA"
 	rdbmsInfo.StorageSize = "NA"
 	if rdbmsInfo.StorageType == "" {
 		rdbmsInfo.StorageType = "standard"
 	}
 	rdbmsInfo.DBInstanceSpec = "NA"
-	rdbmsInfo.BackupTime = "NA"
-	rdbmsInfo.ReplicationType = "NA"
+	rdbmsInfo.DBInstanceType = "NA"    // IBM Cloud Databases does not provide instance type information
+	rdbmsInfo.BackupTime = "AUTO"      // IBM manages backup schedule automatically
+	rdbmsInfo.BackupRetentionDays = 30 // IBM Cloud Databases automatic backups are kept for 30 days (not configurable)
 	rdbmsInfo.Endpoint = "NA"
 	rdbmsInfo.VpcIID = irs.IID{SystemId: "NA"}
 	if inst.Locked != nil {
@@ -976,18 +974,12 @@ func applyIBMConnectionInfo(info *irs.RDBMSInfo, response *clouddatabasesv5.GetC
 		if err := applyIBMConnectionHosts(info, connection.Mysql.Hosts); err != nil {
 			return err
 		}
-		if connection.Mysql.Database != nil && *connection.Mysql.Database != "" {
-			info.DatabaseName = *connection.Mysql.Database
-		}
 	case "postgresql":
 		if connection.Postgres == nil {
 			return errors.New("IBM Cloud Databases PostgreSQL connection response did not include postgres endpoint")
 		}
 		if err := applyIBMConnectionHosts(info, connection.Postgres.Hosts); err != nil {
 			return err
-		}
-		if connection.Postgres.Database != nil && *connection.Postgres.Database != "" {
-			info.DatabaseName = *connection.Postgres.Database
 		}
 	default:
 		return fmt.Errorf("IBM Cloud Databases connection response is not supported for DBEngine %s", info.DBEngine)
@@ -1003,7 +995,6 @@ func applyIBMConnectionHosts(info *irs.RDBMSInfo, hosts []clouddatabasesv5.Conne
 	if hosts[0].Port == nil || *hosts[0].Port <= 0 {
 		return errors.New("IBM Cloud Databases connection response did not include endpoint port")
 	}
-	info.Port = strconv.FormatInt(*hosts[0].Port, 10)
 	info.Endpoint = fmt.Sprintf("%s:%d", *hosts[0].Hostname, *hosts[0].Port)
 	return nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
@@ -65,6 +65,7 @@ func (handler *NcpVpcRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaIn
 }
 
 // getMysqlMetaInfo fetches MySQL-specific metadata dynamically from the NCP CSP API.
+// Only G3 generation products are supported.
 func (handler *NcpVpcRDBMSHandler) getMysqlMetaInfo() (irs.RDBMSMetaInfo, error) {
 	// Step 1: query image product list for supported versions.
 	// Image products expose EngineVersionCode.
@@ -78,32 +79,80 @@ func (handler *NcpVpcRDBMSHandler) getMysqlMetaInfo() (irs.RDBMSMetaInfo, error)
 		return irs.RDBMSMetaInfo{}, errors.New("NCP MySQL image product list is empty")
 	}
 
+	// Filter G3 generation products only
 	versionSeen := map[string]bool{}
 	var versions []string
+	var g3ImageProductCode string
 	for _, p := range imgResp.ProductList {
+		// Filter G3 generation only
+		if p.GenerationCode == nil || *p.GenerationCode != "G3" {
+			continue
+		}
 		if p.EngineVersionCode != nil && *p.EngineVersionCode != "" && !versionSeen[*p.EngineVersionCode] {
 			versionSeen[*p.EngineVersionCode] = true
 			versions = append(versions, *p.EngineVersionCode)
+			if g3ImageProductCode == "" && p.ProductCode != nil {
+				g3ImageProductCode = *p.ProductCode
+			}
 		}
 	}
 	if len(versions) == 0 {
-		return irs.RDBMSMetaInfo{}, errors.New("no engine version info found in NCP MySQL image products")
+		return irs.RDBMSMetaInfo{}, errors.New("no G3 generation MySQL versions found in NCP")
 	}
 
-	// StorageTypeOptions: per NCP documentation, G2 supports HDD or SSD, G3 uses SSD automatically.
-	// StorageSizeRange: NCP Cloud DB data storage range per NCP documentation (10~6000 GB).
-	// The NCP SDK does not expose query APIs for these values.
+	// Step 2: Query product list for available instance specs (CloudMysqlProductCode)
+	// Use G3 image product code to query available server specs
+	var instanceSpecs []string
+	if g3ImageProductCode != "" {
+		var err error
+		instanceSpecs, err = handler.fetchMysqlProductSpecs(g3ImageProductCode)
+		if err != nil {
+			cblogger.Infof("Failed to fetch MySQL G3 product specs, using empty list: %v", err)
+			instanceSpecs = []string{}
+		}
+	}
+
+	// StorageTypeOptions: G3 generation uses SSD automatically.
+	// StorageSizeRange: NCP G3 supports 10GB default, 10GB increments up to 6000GB.
 	return irs.RDBMSMetaInfo{
 		DBEngine:                   "mysql",
 		SupportedVersions:          versions,
-		StorageTypeOptions:         []string{"HDD", "SSD"},
+		DBInstanceSpecOptions:      instanceSpecs,
+		StorageTypeOptions:         []string{"SSD"},
 		StorageSizeRange:           irs.StorageSizeRange{Min: 10, Max: 6000},
 		SupportsHighAvailability:   true,
 		SupportsBackup:             true,
 		SupportsPublicAccess:       false, // NCP does not expose a public domain assignment API; must be done manually via NCP Console
 		SupportsDeletionProtection: true,
 		SupportsEncryption:         false, // 2024년 10월 21일부터 신규 서비스 암호화 미제공 (Rocky 8.10)
+		RequiresSubnet:             true,
+		RequiresSecurityGroup:      false,
 	}, nil
+}
+
+// fetchMysqlProductSpecs queries NCP GetCloudMysqlProductList API to retrieve available product codes (instance specs)
+// The imageProductCode parameter is already filtered to G3, so no additional generation filtering is needed.
+func (handler *NcpVpcRDBMSHandler) fetchMysqlProductSpecs(imageProductCode string) ([]string, error) {
+	prodResp, err := handler.MysqlClient.V2Api.GetCloudMysqlProductList(&vmysql.GetCloudMysqlProductListRequest{
+		RegionCode:                 &handler.RegionInfo.Region,
+		CloudMysqlImageProductCode: &imageProductCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query NCP MySQL product list: %w", err)
+	}
+	if len(prodResp.ProductList) == 0 {
+		return []string{}, nil
+	}
+
+	specSeen := map[string]bool{}
+	var specs []string
+	for _, p := range prodResp.ProductList {
+		if p.ProductCode != nil && *p.ProductCode != "" && !specSeen[*p.ProductCode] {
+			specSeen[*p.ProductCode] = true
+			specs = append(specs, *p.ProductCode)
+		}
+	}
+	return specs, nil
 }
 
 // getPostgresqlMetaInfo fetches PostgreSQL-specific metadata dynamically from the NCP CSP API.
@@ -132,12 +181,29 @@ func (handler *NcpVpcRDBMSHandler) getPostgresqlMetaInfo() (irs.RDBMSMetaInfo, e
 		return irs.RDBMSMetaInfo{}, errors.New("no engine version info found in NCP PostgreSQL image products")
 	}
 
+	// Step 2: Query product list for available instance specs (CloudPostgresqlProductCode)
+	// Use the first image product code to query available server specs
+	var imageProductCode string
+	if len(imgResp.ProductList) > 0 && imgResp.ProductList[0].ProductCode != nil {
+		imageProductCode = *imgResp.ProductList[0].ProductCode
+	}
+
+	var instanceSpecs []string
+	if imageProductCode != "" {
+		var err error
+		instanceSpecs, err = handler.fetchPostgresqlProductSpecs(imageProductCode)
+		if err != nil {
+			cblogger.Infof("Failed to fetch PostgreSQL product specs, using empty list: %v", err)
+			instanceSpecs = []string{}
+		}
+	}
+
 	// StorageTypeOptions: per NCP documentation, PostgreSQL (G3) uses SSD automatically.
-	// StorageSizeRange: NCP Cloud DB data storage range per NCP documentation (10~6000 GB).
-	// The NCP SDK does not expose query APIs for these values.
+	// StorageSizeRange: NCP G3 supports 10GB default, 10GB increments up to 6000GB.
 	return irs.RDBMSMetaInfo{
 		DBEngine:                   "postgresql",
 		SupportedVersions:          versions,
+		DBInstanceSpecOptions:      instanceSpecs,
 		StorageTypeOptions:         []string{"SSD"},
 		StorageSizeRange:           irs.StorageSizeRange{Min: 10, Max: 6000},
 		SupportsHighAvailability:   true,
@@ -145,7 +211,33 @@ func (handler *NcpVpcRDBMSHandler) getPostgresqlMetaInfo() (irs.RDBMSMetaInfo, e
 		SupportsPublicAccess:       false,
 		SupportsDeletionProtection: false,
 		SupportsEncryption:         true,
+		RequiresSubnet:             true,
+		RequiresSecurityGroup:      false,
 	}, nil
+}
+
+// fetchPostgresqlProductSpecs queries NCP GetCloudPostgresqlProductList API to retrieve available product codes (instance specs)
+func (handler *NcpVpcRDBMSHandler) fetchPostgresqlProductSpecs(imageProductCode string) ([]string, error) {
+	prodResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlProductList(&vpostgresql.GetCloudPostgresqlProductListRequest{
+		RegionCode:                      &handler.RegionInfo.Region,
+		CloudPostgresqlImageProductCode: &imageProductCode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query NCP PostgreSQL product list: %w", err)
+	}
+	if len(prodResp.ProductList) == 0 {
+		return []string{}, nil
+	}
+
+	specSeen := map[string]bool{}
+	var specs []string
+	for _, p := range prodResp.ProductList {
+		if p.ProductCode != nil && *p.ProductCode != "" && !specSeen[*p.ProductCode] {
+			specSeen[*p.ProductCode] = true
+			specs = append(specs, *p.ProductCode)
+		}
+	}
+	return specs, nil
 }
 
 // ListIID returns a list of all RDBMS instance IIDs (MySQL + PostgreSQL).
@@ -227,9 +319,13 @@ func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hi
 	isHa := reqInfo.HighAvailability
 	isBackup := true
 	hostIp := "%"
-	dbName := reqInfo.DatabaseName
-	if dbName == "" {
-		dbName = "mydb"
+	dbName := "mydb" // NCP requires initial database name
+
+	// Find G3 image product code for the requested engine version
+	imageProductCode, err := handler.findMysqlG3ImageProductCode(reqInfo.DBEngineVersion)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to find G3 image product for MySQL version %s: %w", reqInfo.DBEngineVersion, err)
 	}
 
 	// CloudMysqlServerNamePrefix: max 15 chars, must not end with '-'
@@ -251,42 +347,44 @@ func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hi
 		CloudMysqlDatabaseName:     &dbName,
 		IsHa:                       &isHa,
 		IsBackup:                   &isBackup,
+		CloudMysqlImageProductCode: &imageProductCode,
 	}
 
-	if reqInfo.DBInstanceSpec != "" {
-		createReq.CloudMysqlProductCode = &reqInfo.DBInstanceSpec
+	// DBInstanceSpec is required: it specifies CPU, memory, and base storage configuration
+	if reqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required for NCP MySQL instance creation. Use GetMetaInfo to get available options")
 	}
+	createReq.CloudMysqlProductCode = &reqInfo.DBInstanceSpec
+
 	if reqInfo.DBEngineVersion != "" {
 		createReq.EngineVersionCode = &reqInfo.DBEngineVersion
 	}
-	if reqInfo.StorageSize != "" {
-		// NCP Cloud DB for MySQL does not support setting storage size as an independent parameter.
-		// Storage capacity is bundled with the product code (DBInstanceSpec).
-		cblogger.Warnf("NCP MySQL: StorageSize '%s' GB is ignored — storage is determined by the product code (DBInstanceSpec)", reqInfo.StorageSize)
+
+	// StorageSize: NCP G3 always starts with 10GB and automatically scales up by 10GB as data increases (up to 6000GB).
+	// Storage size cannot be specified at creation time.
+	if reqInfo.StorageSize != "" && reqInfo.StorageSize != "10" {
+		return irs.RDBMSInfo{}, fmt.Errorf("NCP MySQL G3 does not support custom StorageSize at creation. Default is 10GB, automatically scaled up by 10GB as data increases (up to 6000GB). Requested: %s GB", reqInfo.StorageSize)
 	}
+
 	if reqInfo.StorageType != "" {
-		createReq.DataStorageTypeCode = &reqInfo.StorageType
+		// G3 generation automatically uses SSD; DataStorageTypeCode must NOT be specified
+		if strings.ToUpper(reqInfo.StorageType) != "SSD" {
+			return irs.RDBMSInfo{}, fmt.Errorf("NCP MySQL G3 only supports SSD storage type, requested: %s", reqInfo.StorageType)
+		}
+		// Do not set DataStorageTypeCode for G3 (SSD is automatic)
+		cblogger.Infof("NCP MySQL G3: SSD storage type is applied automatically (not set explicitly)")
 	}
-	if reqInfo.Encryption {
-		createReq.IsStorageEncryption = &reqInfo.Encryption
-	}
+	// Encryption is not configurable at creation via Spider (NCP uses default encryption settings)
 	if reqInfo.DeletionProtection {
 		createReq.IsDeleteProtection = &reqInfo.DeletionProtection
 	}
-	if reqInfo.BackupRetentionDays > 0 {
-		period := int32(reqInfo.BackupRetentionDays)
-		createReq.BackupFileRetentionPeriod = &period
+	backupPeriod := reqInfo.BackupRetentionDays
+	if backupPeriod <= 0 {
+		backupPeriod = 1 // NCP default
 	}
-	if reqInfo.BackupTime != "" {
-		createReq.BackupTime = &reqInfo.BackupTime
-	}
-	if reqInfo.Port != "" {
-		port, err := strconv.Atoi(reqInfo.Port)
-		if err == nil {
-			p := int32(port)
-			createReq.CloudMysqlPort = &p
-		}
-	}
+	period := int32(backupPeriod)
+	createReq.BackupFileRetentionPeriod = &period
+	// BackupTime is not configurable at creation via Spider (NCP auto-assigns)
 
 	resp, err := handler.MysqlClient.V2Api.CreateCloudMysqlInstance(createReq)
 	if err != nil {
@@ -305,9 +403,6 @@ func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hi
 
 	if reqInfo.PublicAccess {
 		port := "3306"
-		if reqInfo.Port != "" {
-			port = reqInfo.Port
-		}
 		// NCP only populates AccessControlGroupNoList once the instance reaches "running" state.
 		cblogger.Infof("NCP MySQL: waiting for instance %s to reach running state before configuring ACG...", instanceNo)
 		runningInst, waitErr := handler.waitForMysqlRunningAndGet(instanceNo, 40*time.Minute)
@@ -329,11 +424,8 @@ func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hi
 	}
 
 	info := handler.convertMysqlInstanceToRDBMSInfo(instForInfo)
-	// NCP does not expose master username/dbname via API; populate from request
+	// NCP does not expose master username via API; populate from request
 	info.MasterUserName = reqInfo.MasterUserName
-	if reqInfo.DatabaseName != "" {
-		info.DatabaseName = reqInfo.DatabaseName
-	}
 	return info, nil
 }
 
@@ -341,9 +433,13 @@ func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInf
 	isHa := reqInfo.HighAvailability
 	isBackup := true
 	clientCidr := "0.0.0.0/0"
-	dbName := reqInfo.DatabaseName
-	if dbName == "" {
-		dbName = "mydb"
+	dbName := "mydb" // NCP requires initial database name
+
+	// Find G3 image product code for the requested engine version
+	imageProductCode, err := handler.findPostgresqlG3ImageProductCode(reqInfo.DBEngineVersion)
+	if err != nil {
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSInfo{}, fmt.Errorf("failed to find G3 image product for PostgreSQL version %s: %w", reqInfo.DBEngineVersion, err)
 	}
 
 	createReq := &vpostgresql.CreateCloudPostgresqlInstanceRequest{
@@ -358,34 +454,41 @@ func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInf
 		CloudPostgresqlDatabaseName:     &dbName,
 		IsHa:                            &isHa,
 		IsBackup:                        &isBackup,
+		CloudPostgresqlImageProductCode: &imageProductCode,
 	}
 
-	if reqInfo.DBInstanceSpec != "" {
-		createReq.CloudPostgresqlProductCode = &reqInfo.DBInstanceSpec
+	// DBInstanceSpec is required: it specifies CPU, memory, and base storage configuration
+	if reqInfo.DBInstanceSpec == "" {
+		return irs.RDBMSInfo{}, errors.New("DBInstanceSpec is required for NCP PostgreSQL instance creation. Use GetMetaInfo to get available options")
 	}
+	createReq.CloudPostgresqlProductCode = &reqInfo.DBInstanceSpec
+
 	if reqInfo.DBEngineVersion != "" {
 		createReq.EngineVersionCode = &reqInfo.DBEngineVersion
 	}
+
+	// StorageSize: NCP G3 always starts with 10GB and automatically scales up by 10GB as data increases (up to 6000GB).
+	// Storage size cannot be specified at creation time.
+	if reqInfo.StorageSize != "" && reqInfo.StorageSize != "10" {
+		return irs.RDBMSInfo{}, fmt.Errorf("NCP PostgreSQL G3 does not support custom StorageSize at creation. Default is 10GB, automatically scaled up by 10GB as data increases (up to 6000GB). Requested: %s GB", reqInfo.StorageSize)
+	}
+
 	if reqInfo.StorageType != "" {
-		createReq.DataStorageTypeCode = &reqInfo.StorageType
-	}
-	if reqInfo.Encryption {
-		createReq.IsStorageEncryption = &reqInfo.Encryption
-	}
-	if reqInfo.BackupRetentionDays > 0 {
-		period := int32(reqInfo.BackupRetentionDays)
-		createReq.BackupFileRetentionPeriod = &period
-	}
-	if reqInfo.BackupTime != "" {
-		createReq.BackupTime = &reqInfo.BackupTime
-	}
-	if reqInfo.Port != "" {
-		port, err := strconv.Atoi(reqInfo.Port)
-		if err == nil {
-			p := int32(port)
-			createReq.CloudPostgresqlPort = &p
+		// G3 generation automatically uses SSD; DataStorageTypeCode must NOT be specified
+		if strings.ToUpper(reqInfo.StorageType) != "SSD" {
+			return irs.RDBMSInfo{}, fmt.Errorf("NCP PostgreSQL G3 only supports SSD storage type, requested: %s", reqInfo.StorageType)
 		}
+		// Do not set DataStorageTypeCode for G3 (SSD is automatic)
+		cblogger.Infof("NCP PostgreSQL G3: SSD storage type is applied automatically (not set explicitly)")
 	}
+	// Encryption is not configurable at creation via Spider (NCP uses default encryption settings)
+	backupPeriod := reqInfo.BackupRetentionDays
+	if backupPeriod <= 0 {
+		backupPeriod = 1 // NCP default
+	}
+	period := int32(backupPeriod)
+	createReq.BackupFileRetentionPeriod = &period
+	// BackupTime is not configurable at creation via Spider (NCP auto-assigns)
 
 	resp, err := handler.PostgresClient.V2Api.CreateCloudPostgresqlInstance(createReq)
 	if err != nil {
@@ -404,9 +507,6 @@ func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInf
 
 	if reqInfo.PublicAccess {
 		port := "5432"
-		if reqInfo.Port != "" {
-			port = reqInfo.Port
-		}
 		cblogger.Infof("NCP PostgreSQL: waiting for instance %s to reach running state before configuring ACG...", instanceNo)
 		runningInst, waitErr := handler.waitForPostgresqlRunningAndGet(instanceNo, 40*time.Minute)
 		if waitErr != nil {
@@ -427,11 +527,8 @@ func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInf
 	}
 
 	info := handler.convertPostgresqlInstanceToRDBMSInfo(instForInfo)
-	// NCP does not expose master username/dbname via API; populate from request
+	// NCP does not expose master username via API; populate from request
 	info.MasterUserName = reqInfo.MasterUserName
-	if reqInfo.DatabaseName != "" {
-		info.DatabaseName = reqInfo.DatabaseName
-	}
 	return info, nil
 }
 
@@ -571,6 +668,131 @@ func (handler *NcpVpcRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
 }
 
 // ---- Helper functions ----
+
+// extractStorageSizeFromProductCode parses storage size (GB) from NCP product code.
+// Product code format: SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003
+// .BXXX. pattern indicates storage size (e.g., B050 = 50GB, B100 = 100GB)
+// Returns 0 if pattern not found.
+func extractStorageSizeFromProductCode(productCode string) int {
+	parts := strings.Split(productCode, ".")
+	for _, part := range parts {
+		if len(part) > 1 && part[0] == 'B' {
+			// Extract numeric portion (e.g., "B050" -> "050" -> 50)
+			sizeStr := part[1:]
+			size, err := strconv.Atoi(sizeStr)
+			if err == nil && size > 0 {
+				return size
+			}
+		}
+	}
+	return 0
+}
+
+// calculateStorageRangeFromSpecs calculates min/max storage size from product code list.
+// If no valid storage sizes found, returns (0, 0) to indicate "not applicable".
+func calculateStorageRangeFromSpecs(specs []string) (int, int) {
+	if len(specs) == 0 {
+		return 0, 0
+	}
+
+	minSize := 0
+	maxSize := 0
+	for _, spec := range specs {
+		size := extractStorageSizeFromProductCode(spec)
+		if size > 0 {
+			if minSize == 0 || size < minSize {
+				minSize = size
+			}
+			if size > maxSize {
+				maxSize = size
+			}
+		}
+	}
+
+	// If no storage sizes found, return 0,0
+	if minSize == 0 && maxSize == 0 {
+		return 0, 0
+	}
+	return minSize, maxSize
+}
+
+// findMysqlG3ImageProductCode finds the G3 image product code for the specified MySQL engine version.
+func (handler *NcpVpcRDBMSHandler) findMysqlG3ImageProductCode(engineVersion string) (string, error) {
+	imgResp, err := handler.MysqlClient.V2Api.GetCloudMysqlImageProductList(&vmysql.GetCloudMysqlImageProductListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to query NCP MySQL image product list: %w", err)
+	}
+	if len(imgResp.ProductList) == 0 {
+		return "", errors.New("NCP MySQL image product list is empty")
+	}
+
+	// Find G3 image product with matching engine version
+	for _, p := range imgResp.ProductList {
+		// Filter G3 generation only
+		if p.GenerationCode == nil || *p.GenerationCode != "G3" {
+			continue
+		}
+		// Match engine version if specified
+		if engineVersion != "" {
+			if p.EngineVersionCode != nil && *p.EngineVersionCode == engineVersion {
+				if p.ProductCode != nil && *p.ProductCode != "" {
+					return *p.ProductCode, nil
+				}
+			}
+		} else {
+			// If no version specified, return first G3 image product
+			if p.ProductCode != nil && *p.ProductCode != "" {
+				return *p.ProductCode, nil
+			}
+		}
+	}
+
+	if engineVersion != "" {
+		return "", fmt.Errorf("no G3 image product found for MySQL version %s", engineVersion)
+	}
+	return "", errors.New("no G3 image product found for MySQL")
+}
+
+// findPostgresqlG3ImageProductCode finds the G3 image product code for the specified PostgreSQL engine version.
+func (handler *NcpVpcRDBMSHandler) findPostgresqlG3ImageProductCode(engineVersion string) (string, error) {
+	imgResp, err := handler.PostgresClient.V2Api.GetCloudPostgresqlImageProductList(&vpostgresql.GetCloudPostgresqlImageProductListRequest{
+		RegionCode: &handler.RegionInfo.Region,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to query NCP PostgreSQL image product list: %w", err)
+	}
+	if len(imgResp.ProductList) == 0 {
+		return "", errors.New("NCP PostgreSQL image product list is empty")
+	}
+
+	// Find G3 image product with matching engine version
+	for _, p := range imgResp.ProductList {
+		// PostgreSQL is G3 only, but check anyway
+		if p.GenerationCode != nil && *p.GenerationCode != "G3" {
+			continue
+		}
+		// Match engine version if specified
+		if engineVersion != "" {
+			if p.EngineVersionCode != nil && *p.EngineVersionCode == engineVersion {
+				if p.ProductCode != nil && *p.ProductCode != "" {
+					return *p.ProductCode, nil
+				}
+			}
+		} else {
+			// If no version specified, return first G3 image product
+			if p.ProductCode != nil && *p.ProductCode != "" {
+				return *p.ProductCode, nil
+			}
+		}
+	}
+
+	if engineVersion != "" {
+		return "", fmt.Errorf("no G3 image product found for PostgreSQL version %s", engineVersion)
+	}
+	return "", errors.New("no G3 image product found for PostgreSQL")
+}
 
 func derefStr(s *string) string {
 	if s == nil {
@@ -789,12 +1011,9 @@ func (handler *NcpVpcRDBMSHandler) convertMysqlInstanceToRDBMSInfo(inst *vmysql.
 		BackupRetentionDays: int(derefInt32(inst.BackupFileRetentionPeriod)),
 		BackupTime:          derefStr(inst.BackupTime),
 
-		Port:               strconv.Itoa(int(derefInt32(inst.CloudMysqlPort))),
 		MasterUserName:     handler.getMysqlMasterUserName(derefStr(inst.CloudMysqlInstanceNo)),
-		DatabaseName:       "NA", // Not exposed in list/detail API
 		DeletionProtection: false,
 		PublicAccess:       false,
-		ReplicationType:    "async",
 
 		Status: convertNcpMysqlStatusToRDBMSStatus(inst.CloudMysqlInstanceStatusName),
 	}
@@ -811,22 +1030,44 @@ func (handler *NcpVpcRDBMSHandler) convertMysqlInstanceToRDBMSInfo(inst *vmysql.
 		serverInst := inst.CloudMysqlServerInstanceList[0]
 		info.VpcIID = irs.IID{NameId: "NA", SystemId: derefStr(serverInst.VpcNo)}
 		info.DBInstanceSpec = derefStr(serverInst.CloudMysqlProductCode)
+
+		// Set endpoint with port
+		var domain string
 		if serverInst.PublicDomain != nil && *serverInst.PublicDomain != "" {
-			info.Endpoint = *serverInst.PublicDomain
+			domain = *serverInst.PublicDomain
 			info.PublicAccess = true
 		} else {
-			info.Endpoint = derefStr(serverInst.PrivateDomain)
+			domain = derefStr(serverInst.PrivateDomain)
 			info.PublicAccess = false
 		}
+
+		// Append port to endpoint
+		port := derefInt32(inst.CloudMysqlPort)
+		if port > 0 {
+			info.Endpoint = fmt.Sprintf("%s:%d", domain, port)
+		} else {
+			info.Endpoint = domain
+		}
+
 		info.Encryption = derefBool(serverInst.IsStorageEncryption)
 
+		// Storage size and type: use values from NCP API directly
 		storageSizeBytes := derefInt64(serverInst.DataStorageSize)
-		info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+		if storageSizeBytes > 0 {
+			info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+		} else {
+			info.StorageSize = "NA"
+		}
 
 		if serverInst.DataStorageType != nil && serverInst.DataStorageType.CodeName != nil {
 			info.StorageType = *serverInst.DataStorageType.CodeName
 		} else {
-			info.StorageType = "NA"
+			// G3 generation always uses SSD
+			if derefStr(inst.GenerationCode) == "G3" {
+				info.StorageType = "SSD"
+			} else {
+				info.StorageType = "NA"
+			}
 		}
 
 		if len(inst.CloudMysqlServerInstanceList) > 0 {
@@ -903,12 +1144,9 @@ func (handler *NcpVpcRDBMSHandler) convertPostgresqlInstanceToRDBMSInfo(inst *vp
 		BackupRetentionDays: int(derefInt32(inst.BackupFileRetentionPeriod)),
 		BackupTime:          derefStr(inst.BackupTime),
 
-		Port:               strconv.Itoa(int(derefInt32(inst.CloudPostgresqlPort))),
 		MasterUserName:     handler.getPostgresqlMasterUserName(derefStr(inst.CloudPostgresqlInstanceNo)),
-		DatabaseName:       "NA",
 		DeletionProtection: false, // PostgreSQL does not support deletion protection
 		PublicAccess:       false,
-		ReplicationType:    "async",
 
 		Status: convertNcpPostgresqlStatusToRDBMSStatus(inst.CloudPostgresqlInstanceStatusName),
 	}
@@ -925,22 +1163,44 @@ func (handler *NcpVpcRDBMSHandler) convertPostgresqlInstanceToRDBMSInfo(inst *vp
 		serverInst := inst.CloudPostgresqlServerInstanceList[0]
 		info.VpcIID = irs.IID{NameId: "NA", SystemId: derefStr(serverInst.VpcNo)}
 		info.DBInstanceSpec = derefStr(serverInst.CloudPostgresqlProductCode)
+
+		// Set endpoint with port
+		var domain string
 		if serverInst.PublicDomain != nil && *serverInst.PublicDomain != "" {
-			info.Endpoint = *serverInst.PublicDomain
+			domain = *serverInst.PublicDomain
 			info.PublicAccess = true
 		} else {
-			info.Endpoint = derefStr(serverInst.PrivateDomain)
+			domain = derefStr(serverInst.PrivateDomain)
 			info.PublicAccess = false
 		}
+
+		// Append port to endpoint
+		port := derefInt32(inst.CloudPostgresqlPort)
+		if port > 0 {
+			info.Endpoint = fmt.Sprintf("%s:%d", domain, port)
+		} else {
+			info.Endpoint = domain
+		}
+
 		info.Encryption = derefBool(serverInst.IsStorageEncryption)
 
+		// Storage size and type: use values from NCP API directly
 		storageSizeBytes := derefInt64(serverInst.DataStorageSize)
-		info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+		if storageSizeBytes > 0 {
+			info.StorageSize = strconv.FormatInt(storageSizeBytes/(1024*1024*1024), 10)
+		} else {
+			info.StorageSize = "NA"
+		}
 
 		if serverInst.DataStorageType != nil && serverInst.DataStorageType.CodeName != nil {
 			info.StorageType = *serverInst.DataStorageType.CodeName
 		} else {
-			info.StorageType = "NA"
+			// G3 generation always uses SSD
+			if derefStr(inst.GenerationCode) == "G3" {
+				info.StorageType = "SSD"
+			} else {
+				info.StorageType = "NA"
+			}
 		}
 
 		if len(inst.CloudPostgresqlServerInstanceList) > 0 {

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -106,6 +106,7 @@ type nhnRDSEnrichmentData struct {
 	SubnetCidr      string
 	UsePublicAccess bool
 	DBFlavorName    string
+	BackupConfig    nhnRDSBackupConfig
 }
 
 type nhnRDSNetworkInfo struct {
@@ -121,8 +122,8 @@ type nhnRDSStorageInfo struct {
 }
 
 type nhnRDSBackupSchedule struct {
-	BackupWndBgnTime  string `json:"backupWndBgnTime"`  // HH:mm format — backup window begin time
-	BackupWndDuration int    `json:"backupWndDuration"` // hours
+	BackupWndBgnTime  string `json:"backupWndBgnTime"`  // HH:mm:ss format — backup window begin time
+	BackupWndDuration string `json:"backupWndDuration"` // "ONE_HOUR", "TWO_HOUR", etc.
 }
 
 type nhnRDSBackupConfig struct {
@@ -284,6 +285,13 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 		LoggingError(callLogInfo, newErr)
 		return irs.RDBMSMetaInfo{}, newErr
 	}
+	dbFlavors, err := handler.listRDSDBFlavors(ctx)
+	if err != nil {
+		newErr := fmt.Errorf("failed to list DB flavors from NHN Cloud RDS API: %w", err)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return irs.RDBMSMetaInfo{}, newErr
+	}
 	storageTypes, err := handler.listRDSStorageTypes(ctx)
 	if err != nil {
 		newErr := fmt.Errorf("failed to list storage types from NHN Cloud RDS API: %w", err)
@@ -297,6 +305,11 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
+	if len(dbFlavors) == 0 {
+		err := errors.New("NHN Cloud RDS API returned no DB flavors")
+		LoggingError(callLogInfo, err)
+		return irs.RDBMSMetaInfo{}, err
+	}
 	if len(storageTypes) == 0 {
 		err := errors.New("NHN Cloud RDS API returned no storage types")
 		LoggingError(callLogInfo, err)
@@ -306,13 +319,16 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 	supportedEngines := map[string][]string{
 		"mysql": dbVersions,
 	}
+	instanceSpecOptions := map[string][]string{
+		"mysql": dbFlavors,
+	}
 	storageTypeOptions := map[string][]string{
 		"mysql": storageTypes,
 	}
 
 	storageSizeRange := irs.StorageSizeRange{Min: 20, Max: 2048}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, true, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, false, "1-730", true, false)
 	if err != nil {
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
@@ -338,6 +354,25 @@ func (handler *NhnCloudRDBMSHandler) listRDSDBVersions(ctx context.Context) ([]s
 		}
 	}
 	return versions, nil
+}
+
+func (handler *NhnCloudRDBMSHandler) listRDSDBFlavors(ctx context.Context) ([]string, error) {
+	var result nhnRDSFlavorListResponse
+	if err := handler.getRDS(ctx, "/v3.0/db-flavors", &result); err != nil {
+		return nil, err
+	}
+	if err := checkRDSResponseHeader(result.Header); err != nil {
+		return nil, err
+	}
+
+	flavors := make([]string, 0, len(result.DBFlavors))
+	for _, flavor := range result.DBFlavors {
+		// Use DBFlavorName (e.g., "m2.c2m4") instead of UUID for better readability
+		if flavor.DBFlavorName != "" {
+			flavors = append(flavors, flavor.DBFlavorName)
+		}
+	}
+	return flavors, nil
 }
 
 func (handler *NhnCloudRDBMSHandler) listRDSStorageTypes(ctx context.Context) ([]string, error) {
@@ -538,29 +573,18 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 		storageType = "General SSD"
 	}
 
-	dbPort := 3306
-	if rdbmsReqInfo.Port != "" {
-		if p, convErr := strconv.Atoi(rdbmsReqInfo.Port); convErr == nil {
-			dbPort = p
-		}
-	}
+	dbPort := 3306 // NHN MySQL default port
 
+	// NHN requires backup config - use 7 days as default if not specified
 	backupPeriod := rdbmsReqInfo.BackupRetentionDays
 	if backupPeriod <= 0 {
-		backupPeriod = 1
+		backupPeriod = 7 // NHN default
 	}
+	// BackupTime (backupHour/backupMinute) is not configurable at creation via Spider (NHN uses fixed time)
 	backupHour, backupMinute := 3, 0
-	if rdbmsReqInfo.BackupTime != "" {
-		parts := strings.SplitN(rdbmsReqInfo.BackupTime, ":", 2)
-		if len(parts) == 2 {
-			if h, parseErr := strconv.Atoi(parts[0]); parseErr == nil {
-				backupHour = h
-			}
-			if m, parseErr := strconv.Atoi(parts[1]); parseErr == nil {
-				backupMinute = m
-			}
-		}
-	}
+
+	// Debug: Log backup period being set
+	cblogger.Infof("[NHN RDBMS] Creating DB instance with BackupPeriod: %d days", backupPeriod)
 
 	// NHN RDS provisioning is async — allow up to 15 minutes
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
@@ -630,7 +654,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 			BackupSchedules: []nhnRDSBackupSchedule{
 				{
 					BackupWndBgnTime:  fmt.Sprintf("%02d:%02d", backupHour, backupMinute),
-					BackupWndDuration: 1,
+					BackupWndDuration: "ONE_HOUR",
 				},
 			},
 		},
@@ -673,6 +697,10 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSInfo{}, err
 	}
+
+	// Debug: Log backup information returned after creation
+	cblogger.Infof("[NHN RDBMS] After creation - BackupPeriod from API: %d, BackupSchedules count: %d",
+		getResp.Backup.BackupPeriod, len(getResp.Backup.BackupSchedules))
 
 	enrichment, err := handler.fetchRDBMSEnrichment(ctx, dbInstanceId, getResp.DBFlavorId)
 	if err != nil {
@@ -772,6 +800,10 @@ func (handler *NhnCloudRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, 
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSInfo{}, err
 	}
+
+	// Debug: Log backup information from NHN API response
+	cblogger.Infof("[NHN RDBMS] Backup info from API - BackupPeriod: %d, BackupSchedules count: %d",
+		result.Backup.BackupPeriod, len(result.Backup.BackupSchedules))
 
 	enrichment, err := handler.fetchRDBMSEnrichment(ctx, dbInstanceId, result.DBFlavorId)
 	if err != nil {
@@ -1099,16 +1131,23 @@ func (handler *NhnCloudRDBMSHandler) findRDSInstanceIDByName(ctx context.Context
 func convertNhnRDSInstanceToRDBMSInfo(inst nhnRDSDBInstance, ownerVPCName string, e nhnRDSEnrichmentData) irs.RDBMSInfo {
 	// Prefer publicEndpoint from network-info API; fallback to embedded endpoints
 	endpoint := e.PublicEndpoint
+	port := inst.DBPort // DBPort from instance
 	if endpoint == "" {
 		for _, ep := range inst.Network.Endpoints {
 			if ep.Address != "" {
 				endpoint = ep.Address
+				if ep.Port > 0 {
+					port = ep.Port
+				}
 				break
 			}
 		}
 	}
 	if endpoint == "" {
 		endpoint = "NA"
+	} else if port > 0 {
+		// Append port to endpoint
+		endpoint = fmt.Sprintf("%s:%d", endpoint, port)
 	}
 
 	master := e.MasterUserName
@@ -1137,10 +1176,28 @@ func convertNhnRDSInstanceToRDBMSInfo(inst nhnRDSDBInstance, ownerVPCName string
 
 	publicAccess := e.UsePublicAccess
 
-	backupTime := "00:00"
-	if len(inst.Backup.BackupSchedules) > 0 {
-		backupTime = inst.Backup.BackupSchedules[0].BackupWndBgnTime
+	// Backup info: prefer enrichment data (from /backup-info), fallback to inst.Backup
+	backupPeriod := e.BackupConfig.BackupPeriod
+	if backupPeriod == 0 {
+		backupPeriod = inst.Backup.BackupPeriod
 	}
+	backupTime := "00:00"
+	backupSchedules := e.BackupConfig.BackupSchedules
+	if len(backupSchedules) == 0 {
+		backupSchedules = inst.Backup.BackupSchedules
+	}
+	if len(backupSchedules) > 0 {
+		// NHN returns "HH:MM:SS" format, convert to "HH:MM" for Spider
+		rawTime := backupSchedules[0].BackupWndBgnTime
+		if len(rawTime) >= 5 {
+			backupTime = rawTime[:5] // "03:00:00" -> "03:00"
+		} else {
+			backupTime = rawTime
+		}
+	}
+
+	cblogger.Infof("[NHN RDBMS] Final backup values - Period: %d, Time: %s (enrichment schedules: %d, inst schedules: %d)",
+		backupPeriod, backupTime, len(e.BackupConfig.BackupSchedules), len(inst.Backup.BackupSchedules))
 
 	createdTime, _ := time.Parse(time.RFC3339, inst.CreatedYmdt)
 
@@ -1154,23 +1211,20 @@ func convertNhnRDSInstanceToRDBMSInfo(inst nhnRDSDBInstance, ownerVPCName string
 		DBEngine:        "mysql",
 		DBEngineVersion: inst.DBVersion,
 		DBInstanceSpec:  e.DBFlavorName,
-		DBInstanceType:  "Primary",
+		DBInstanceType:  "NA",
 
 		StorageType: storageType,
 		StorageSize: strconv.Itoa(storageSize),
 
 		SubnetIIDs: subnetIIDs,
 
-		Port:     strconv.Itoa(inst.DBPort),
 		Endpoint: endpoint,
 
 		MasterUserName: master,
-		DatabaseName:   "NA",
 
 		HighAvailability: inst.UseHighAvailability,
-		ReplicationType:  "NA",
 
-		BackupRetentionDays: inst.Backup.BackupPeriod,
+		BackupRetentionDays: backupPeriod,
 		BackupTime:          backupTime,
 
 		PublicAccess:       publicAccess,
@@ -1262,6 +1316,23 @@ func (handler *NhnCloudRDBMSHandler) fetchRDBMSEnrichment(ctx context.Context, d
 	}
 	data.StorageType = storResp.StorageType
 	data.StorageSize = storResp.StorageSize
+
+	// Try to fetch backup info (may not be available as separate endpoint)
+	var backupResp struct {
+		Header nhnRDSResponseHeader `json:"header"`
+		nhnRDSBackupConfig
+	}
+	if err := handler.getRDS(ctx, "/v3.0/db-instances/"+dbInstanceId+"/backup-info", &backupResp); err == nil {
+		if checkErr := checkRDSResponseHeader(backupResp.Header); checkErr == nil {
+			data.BackupConfig = backupResp.nhnRDSBackupConfig
+			cblogger.Infof("[NHN RDBMS] Backup info from /backup-info - BackupPeriod: %d, BackupSchedules: %d",
+				data.BackupConfig.BackupPeriod, len(data.BackupConfig.BackupSchedules))
+		} else {
+			cblogger.Infof("[NHN RDBMS] /backup-info endpoint exists but returned error: %v", checkErr)
+		}
+	} else {
+		cblogger.Infof("[NHN RDBMS] /backup-info endpoint not available: %v", err)
+	}
 
 	return data, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
@@ -25,9 +25,10 @@ import (
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/limits"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/quotasets"
 	"github.com/gophercloud/gophercloud/v2/openstack/blockstorage/v3/volumetypes"
-	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
+	computeflavors "github.com/gophercloud/gophercloud/v2/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/databases"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/datastores"
+	dbflavors "github.com/gophercloud/gophercloud/v2/openstack/db/v1/flavors"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/instances"
 	"github.com/gophercloud/gophercloud/v2/openstack/db/v1/users"
 	"github.com/gophercloud/gophercloud/v2/pagination"
@@ -78,7 +79,14 @@ func (handler *OpenStackRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMet
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, false, true, true, false, false)
+	instanceSpecOptions, err := handler.fetchInstanceSpecOptions(supportedEngines)
+	if err != nil {
+		cblogger.Error(err)
+		LoggingError(hiscallInfo, err)
+		return irs.RDBMSMetaInfo{}, err
+	}
+
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, false, true, true, false, false, "NA", false, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -200,6 +208,53 @@ func (handler *OpenStackRDBMSHandler) fetchStorageSizeRange() (irs.StorageSizeRa
 	return irs.StorageSizeRange{Min: 1, Max: int64(maxSize)}, nil
 }
 
+// fetchInstanceSpecOptions queries Trove flavors API to retrieve available instance specifications.
+func (handler *OpenStackRDBMSHandler) fetchInstanceSpecOptions(supportedEngines map[string][]string) (map[string][]string, error) {
+	if handler.DBClient == nil {
+		return nil, errors.New("OpenStack Trove DB client is not initialized")
+	}
+
+	allPages, err := dbflavors.List(handler.DBClient).AllPages(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Trove flavors: %w", err)
+	}
+
+	flavorList, err := dbflavors.ExtractFlavors(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract Trove flavors: %w", err)
+	}
+
+	if len(flavorList) == 0 {
+		cblogger.Warn("Trove returned no flavors, using empty list")
+		instanceSpecOptions := make(map[string][]string, len(supportedEngines))
+		for engine := range supportedEngines {
+			instanceSpecOptions[engine] = []string{}
+		}
+		return instanceSpecOptions, nil
+	}
+
+	// Extract flavor names or IDs
+	flavorNames := make([]string, 0, len(flavorList))
+	for _, flavor := range flavorList {
+		if flavor.Name != "" {
+			flavorNames = append(flavorNames, flavor.Name)
+		} else if flavor.StrID != "" {
+			flavorNames = append(flavorNames, flavor.StrID)
+		}
+	}
+	sort.Strings(flavorNames)
+
+	// All engines share the same flavor list in Trove
+	instanceSpecOptions := make(map[string][]string, len(supportedEngines))
+	for engine := range supportedEngines {
+		engineFlavors := make([]string, len(flavorNames))
+		copy(engineFlavors, flavorNames)
+		instanceSpecOptions[engine] = engineFlavors
+	}
+
+	return instanceSpecOptions, nil
+}
+
 // ListIID returns a list of RDBMS instance IIDs.
 func (handler *OpenStackRDBMSHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := GetCallLogScheme(handler.CredentialInfo.IdentityEndpoint, call.RDBMS, "ListIID", "instances.List()")
@@ -314,11 +369,12 @@ func (handler *OpenStackRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (i
 		createOpts.VolumeType = rdbmsReqInfo.StorageType
 	}
 
-	// Network: Trove needs a neutron *network* UUID (= VPC SystemId), not subnet IDs.
-	if rdbmsReqInfo.VpcIID.SystemId != "" {
-		createOpts.Networks = []instances.NetworkOpts{
-			{UUID: rdbmsReqInfo.VpcIID.SystemId},
-		}
+	// Network validation: Trove needs a neutron *network* UUID (= VPC SystemId), not subnet IDs.
+	if rdbmsReqInfo.VpcIID.SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("VPC (VpcIID.SystemId) is required for OpenStack Trove")
+	}
+	createOpts.Networks = []instances.NetworkOpts{
+		{UUID: rdbmsReqInfo.VpcIID.SystemId},
 	}
 
 	// Set availability zone if provided in Region
@@ -376,7 +432,13 @@ func (handler *OpenStackRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (i
 	// Grant global admin privileges to the non-root master user so it can
 	// create/drop databases (Trove's user API only grants db-specific access).
 	if effectiveUser != "root" {
-		if grantErr := grantAdminPrivileges(rdbmsInfo.Endpoint, rdbmsInfo.Port, rootPwd, effectiveUser); grantErr != nil {
+		// Determine default port based on engine type
+		engineType := strings.ToLower(rdbmsReqInfo.DBEngine)
+		defaultPort := "3306"
+		if strings.Contains(engineType, "postgresql") {
+			defaultPort = "5432"
+		}
+		if grantErr := grantAdminPrivileges(rdbmsInfo.Endpoint, defaultPort, rootPwd, effectiveUser); grantErr != nil {
 			cblogger.Warnf("CreateRDBMS: could not grant admin privileges to '%s': %v", effectiveUser, grantErr)
 		} else {
 			cblogger.Infof("CreateRDBMS: granted ALL PRIVILEGES ON *.* to '%s'", effectiveUser)
@@ -500,11 +562,11 @@ func (handler *OpenStackRDBMSHandler) resolveFlavorRef(spec string) (string, err
 	}
 
 	// Look up by name via Nova flavors (same catalog used by Trove in DevStack)
-	allPages, err := flavors.ListDetail(handler.ComputeClient, flavors.ListOpts{}).AllPages(context.TODO())
+	allPages, err := computeflavors.ListDetail(handler.ComputeClient, computeflavors.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 		return "", fmt.Errorf("failed to list flavors for spec resolution: %w", err)
 	}
-	flavorList, err := flavors.ExtractFlavors(allPages)
+	flavorList, err := computeflavors.ExtractFlavors(allPages)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract flavors: %w", err)
 	}
@@ -525,11 +587,11 @@ func (handler *OpenStackRDBMSHandler) resolveFlavorName(flavorID string) (string
 		return "", fmt.Errorf("resolveFlavorName: ComputeClient is not available; cannot resolve flavor ID '%s' to name", flavorID)
 	}
 
-	allPages, err := flavors.ListDetail(handler.ComputeClient, flavors.ListOpts{}).AllPages(context.TODO())
+	allPages, err := computeflavors.ListDetail(handler.ComputeClient, computeflavors.ListOpts{}).AllPages(context.TODO())
 	if err != nil {
 		return "", fmt.Errorf("failed to list flavors for flavor name resolution: %w", err)
 	}
-	flavorList, err := flavors.ExtractFlavors(allPages)
+	flavorList, err := computeflavors.ExtractFlavors(allPages)
 	if err != nil {
 		return "", fmt.Errorf("failed to extract flavors: %w", err)
 	}
@@ -542,7 +604,7 @@ func (handler *OpenStackRDBMSHandler) resolveFlavorName(flavorID string) (string
 }
 
 // joinFlavorNames returns a comma-separated list of flavor names for error messages.
-func joinFlavorNames(fl []flavors.Flavor) string {
+func joinFlavorNames(fl []computeflavors.Flavor) string {
 	names := make([]string, 0, len(fl))
 	for _, f := range fl {
 		names = append(names, f.Name)
@@ -687,16 +749,14 @@ func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances
 		}
 	}
 
-	// Determine default port based on engine type.
-	// Trove API does not expose the actual port in the instance response,
-	// so standard defaults are used as a best-effort value.
+	// Determine default port for endpoint
 	engineType := strings.ToLower(inst.Datastore.Type)
-	port := "NA"
-	switch {
-	case strings.Contains(engineType, "mysql") || strings.Contains(engineType, "mariadb"):
-		port = "3306"
-	case strings.Contains(engineType, "postgresql"):
-		port = "5432"
+	defaultPort := "3306" // MySQL/MariaDB default
+	if strings.Contains(engineType, "postgresql") {
+		defaultPort = "5432"
+	}
+	if endpoint != "NA" {
+		endpoint = fmt.Sprintf("%s:%s", endpoint, defaultPort)
 	}
 
 	return irs.RDBMSInfo{
@@ -709,19 +769,16 @@ func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances
 		DBEngine:        inst.Datastore.Type,
 		DBEngineVersion: inst.Datastore.Version,
 		DBInstanceSpec:  flavorName,
-		DBInstanceType:  "Primary",
+		DBInstanceType:  "NA",
 
 		StorageType: "NA",
 		StorageSize: strconv.Itoa(inst.Volume.Size),
 
-		Port:     port,
 		Endpoint: endpoint,
 
 		MasterUserName: "NA", // populated by caller via queryMasterUserName()
-		DatabaseName:   "NA", // Not exposed in instance info
 
 		HighAvailability: false, // Trove HA is deployment-specific
-		ReplicationType:  "NA",
 
 		BackupRetentionDays: 0,
 		BackupTime:          "NA",

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
@@ -49,7 +49,7 @@ func (handler *TencentRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	supportedEngines, storageTypeOptions, storageSizeRange, err := handler.fetchCDBMetaOptions()
+	supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, err := handler.fetchCDBMetaOptions()
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		cblogger.Error(err)
@@ -57,7 +57,7 @@ func (handler *TencentRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("GetMetaInfo failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, storageTypeOptions, storageSizeRange, true, true, true, false, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "7-1830", true, false)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -68,18 +68,18 @@ func (handler *TencentRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 	return metaInfo, nil
 }
 
-func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, map[string][]string, irs.StorageSizeRange, error) {
+func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, map[string][]string, map[string][]string, irs.StorageSizeRange, error) {
 	if handler.Client == nil {
-		return nil, nil, irs.StorageSizeRange{}, errors.New("CDB client is unavailable")
+		return nil, nil, nil, irs.StorageSizeRange{}, errors.New("CDB client is unavailable")
 	}
 
 	request := cdb.NewDescribeCdbZoneConfigRequest()
 	response, err := handler.Client.DescribeCdbZoneConfig(request)
 	if err != nil {
-		return nil, nil, irs.StorageSizeRange{}, err
+		return nil, nil, nil, irs.StorageSizeRange{}, err
 	}
 	if response.Response == nil || response.Response.DataResult == nil {
-		return nil, nil, irs.StorageSizeRange{}, errors.New("DescribeCdbZoneConfig returned empty response")
+		return nil, nil, nil, irs.StorageSizeRange{}, errors.New("DescribeCdbZoneConfig returned empty response")
 	}
 
 	data := response.Response.DataResult
@@ -94,7 +94,7 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 		configMap[*cfg.Id] = cfg
 	}
 	if len(configMap) == 0 {
-		return nil, nil, irs.StorageSizeRange{}, errors.New("DescribeCdbZoneConfig returned no available CDB sell configs")
+		return nil, nil, nil, irs.StorageSizeRange{}, errors.New("DescribeCdbZoneConfig returned no available CDB sell configs")
 	}
 
 	versionSet := make(map[string]struct{})
@@ -157,22 +157,29 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 	}
 
 	if !matchedZone {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no online zone for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no online zone for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
 	if len(versionSet) == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no MySQL engine versions for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no MySQL engine versions for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
 	if len(selectedConfigIDs) == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no available CDB config IDs for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no available CDB config IDs for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
 	if len(storageTypeSet) == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no storage types for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no storage types for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
 
+	memorySet := make(map[int64]struct{})
 	storageRange := irs.StorageSizeRange{}
 	for cfgID := range selectedConfigIDs {
 		cfg, ok := configMap[cfgID]
-		if !ok || cfg.VolumeMin == nil || cfg.VolumeMax == nil {
+		if !ok {
+			continue
+		}
+		if cfg.Memory != nil && *cfg.Memory > 0 {
+			memorySet[*cfg.Memory] = struct{}{}
+		}
+		if cfg.VolumeMin == nil || cfg.VolumeMax == nil {
 			continue
 		}
 		if storageRange.Min == 0 || *cfg.VolumeMin < storageRange.Min {
@@ -183,11 +190,26 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 		}
 	}
 	if storageRange.Min == 0 || storageRange.Max == 0 {
-		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no storage size range for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no storage size range for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
+	if len(memorySet) == 0 {
+		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no memory options for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
+	}
+
+	memoryList := make([]string, 0, len(memorySet))
+	for memory := range memorySet {
+		memoryList = append(memoryList, strconv.FormatInt(memory, 10))
+	}
+	sort.Slice(memoryList, func(i, j int) bool {
+		mi, _ := strconv.ParseInt(memoryList[i], 10, 64)
+		mj, _ := strconv.ParseInt(memoryList[j], 10, 64)
+		return mi < mj
+	})
 
 	return map[string][]string{
 			"mysql": sortedTencentVersionSet(versionSet),
+		}, map[string][]string{
+			"mysql": memoryList,
 		}, map[string][]string{
 			"mysql": sortedTencentStringSet(storageTypeSet),
 		}, storageRange, nil
@@ -296,7 +318,9 @@ func (handler *TencentRDBMSHandler) ListIID() ([]*irs.IID, error) {
 }
 
 func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDBMSInfo, error) {
-	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsReqInfo.IId.NameId, "CreateDBInstanceHour()")
+	cblogger.Info("Tencent CDB CreateRDBMS() called")
+
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "CreateRDBMS", "CreateDBInstanceHour()")
 	start := call.Start()
 
 	// Validate required fields
@@ -316,10 +340,13 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		return irs.RDBMSInfo{}, fmt.Errorf("Tencent Cloud Database does not support custom MasterUserName: the admin user is always %q. Set MasterUserName to %q or leave it empty", tencentDefaultAdminUser, tencentDefaultAdminUser)
 	}
 
-	// DBInstanceSpec can be memory(MB) or Tencent VM spec name.
-	memory, err := handler.resolveMemoryMBFromSpec(rdbmsReqInfo.DBInstanceSpec)
+	// DBInstanceSpec must be memory(MB) from Tencent CDB DescribeCdbZoneConfig API
+	memory, err := strconv.ParseInt(rdbmsReqInfo.DBInstanceSpec, 10, 64)
 	if err != nil {
-		return irs.RDBMSInfo{}, err
+		return irs.RDBMSInfo{}, fmt.Errorf("DBInstanceSpec must be numeric memory size in MB (e.g., 1000, 2000, 4000). Use GetMetaInfo API to get available memory options. Error: %w", err)
+	}
+	if memory <= 0 {
+		return irs.RDBMSInfo{}, fmt.Errorf("DBInstanceSpec must be positive integer (memory in MB), got %d", memory)
 	}
 
 	// Parse storage size (volume in GB)
@@ -340,25 +367,21 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		request.EngineVersion = &rdbmsReqInfo.DBEngineVersion
 	}
 
+	// VPC and Subnet validation
+	if rdbmsReqInfo.VpcIID.SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("VPC (VpcIID.SystemId) is required for Tencent CDB")
+	}
+	if len(rdbmsReqInfo.SubnetIIDs) == 0 || rdbmsReqInfo.SubnetIIDs[0].SystemId == "" {
+		return irs.RDBMSInfo{}, errors.New("Subnet (SubnetIIDs[0].SystemId) is required for Tencent CDB")
+	}
+
 	// VPC and Subnet
-	if rdbmsReqInfo.VpcIID.SystemId != "" {
-		request.UniqVpcId = &rdbmsReqInfo.VpcIID.SystemId
-	}
-	if len(rdbmsReqInfo.SubnetIIDs) > 0 && rdbmsReqInfo.SubnetIIDs[0].SystemId != "" {
-		request.UniqSubnetId = &rdbmsReqInfo.SubnetIIDs[0].SystemId
-	}
+	request.UniqVpcId = &rdbmsReqInfo.VpcIID.SystemId
+	request.UniqSubnetId = &rdbmsReqInfo.SubnetIIDs[0].SystemId
 
 	// Zone
 	if handler.Region.Zone != "" {
 		request.Zone = &handler.Region.Zone
-	}
-
-	// Port
-	if rdbmsReqInfo.Port != "" {
-		port, portErr := strconv.ParseInt(rdbmsReqInfo.Port, 10, 64)
-		if portErr == nil {
-			request.Port = &port
-		}
 	}
 
 	// HA - ProtectMode: 0=async, 1=semi-sync, 2=strong-sync
@@ -376,6 +399,16 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		}
 		request.SecurityGroup = sgIds
 	}
+
+	// Backup Configuration
+	// Note: Tencent CDB CreateDBInstanceHour API does not support backup settings.
+	// BackupRetentionDays and BackupTime must be configured via ModifyBackupConfig API after instance creation.
+	// TODO: Implement post-creation backup configuration using ModifyBackupConfig API
+	// if rdbmsReqInfo.BackupRetentionDays > 0 || rdbmsReqInfo.BackupTime != "" {
+	//     cblogger.Infof("[Tencent CDB] Backup settings (RetentionDays=%d, Time=%s) will use CSP defaults. "+
+	//         "Post-creation configuration via ModifyBackupConfig is not yet implemented.",
+	//         rdbmsReqInfo.BackupRetentionDays, rdbmsReqInfo.BackupTime)
+	// }
 
 	// Tags
 	if len(rdbmsReqInfo.TagList) > 0 {
@@ -459,6 +492,8 @@ func (handler *TencentRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 
 		for _, inst := range response.Response.Items {
 			rdbmsInfo := handler.convertToRDBMSInfo(inst)
+			// Retrieve backup configuration for each instance
+			handler.enrichBackupInfo(&rdbmsInfo)
 			rdbmsList = append(rdbmsList, &rdbmsInfo)
 		}
 
@@ -498,7 +533,14 @@ func (handler *TencentRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, e
 		return irs.RDBMSInfo{}, fmt.Errorf("DB instance not found: %s", rdbmsIID.SystemId)
 	}
 
-	return handler.convertToRDBMSInfo(response.Response.Items[0]), nil
+	rdbmsInfo := handler.convertToRDBMSInfo(response.Response.Items[0])
+
+	// Retrieve backup configuration
+	if rdbmsInfo.IId.SystemId != "" {
+		handler.enrichBackupInfo(&rdbmsInfo)
+	}
+
+	return rdbmsInfo, nil
 }
 
 func (handler *TencentRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
@@ -558,20 +600,22 @@ func (handler *TencentRDBMSHandler) convertToRDBMSInfo(inst *cdb.InstanceInfo) i
 	if inst.Volume != nil {
 		rdbmsInfo.StorageSize = strconv.FormatInt(*inst.Volume, 10)
 	}
-	rdbmsInfo.StorageType = "NA" // Not directly exposed in InstanceInfo
+	if inst.DeviceType != nil && *inst.DeviceType != "" {
+		rdbmsInfo.StorageType = *inst.DeviceType
+	} else {
+		rdbmsInfo.StorageType = "NA"
+	}
 
 	// Endpoint: prefer public WAN endpoint when public access is enabled.
 	if inst.WanStatus != nil && *inst.WanStatus == 1 && inst.WanDomain != nil && *inst.WanDomain != "" {
 		rdbmsInfo.Endpoint = *inst.WanDomain
 		if inst.WanPort != nil {
 			rdbmsInfo.Endpoint += ":" + strconv.FormatInt(*inst.WanPort, 10)
-			rdbmsInfo.Port = strconv.FormatInt(*inst.WanPort, 10)
 		}
 	} else if inst.Vip != nil {
 		rdbmsInfo.Endpoint = *inst.Vip
 		if inst.Vport != nil {
 			rdbmsInfo.Endpoint += ":" + strconv.FormatInt(*inst.Vport, 10)
-			rdbmsInfo.Port = strconv.FormatInt(*inst.Vport, 10)
 		}
 	}
 
@@ -611,11 +655,12 @@ func (handler *TencentRDBMSHandler) convertToRDBMSInfo(inst *cdb.InstanceInfo) i
 		rdbmsInfo.PublicAccess = (*inst.WanStatus == 1)
 	}
 
-	rdbmsInfo.DatabaseName = "NA"
+	// BackupTime and BackupRetentionDays are retrieved via DescribeBackupConfig in enrichBackupInfo
 	rdbmsInfo.BackupTime = "NA"
-	rdbmsInfo.ReplicationType = "NA"
-	rdbmsInfo.DeletionProtection = false
-	rdbmsInfo.Encryption = false
+	rdbmsInfo.BackupRetentionDays = 0
+	rdbmsInfo.DeletionProtection = false // Tencent CDB does not expose deletion protection status
+	rdbmsInfo.Encryption = false         // Can be retrieved through DescribeDBInstanceConfig API (not implemented)
+	rdbmsInfo.DBInstanceType = "NA"      // Tencent CDB does not provide instance type information
 
 	// KeyValueList
 	rdbmsInfo.KeyValueList = irs.StructToKeyValueList(inst)
@@ -679,6 +724,31 @@ func (handler *TencentRDBMSHandler) waitForWanStatus(instanceId string, targetWa
 		time.Sleep(10 * time.Second)
 	}
 	return fmt.Errorf("timeout waiting for instance %s to reach WAN status %d", instanceId, targetWanStatus)
+}
+
+func (handler *TencentRDBMSHandler) enrichBackupInfo(rdbmsInfo *irs.RDBMSInfo) {
+	if rdbmsInfo.IId.SystemId == "" {
+		return
+	}
+
+	request := cdb.NewDescribeBackupConfigRequest()
+	request.InstanceId = &rdbmsInfo.IId.SystemId
+
+	response, err := handler.Client.DescribeBackupConfig(request)
+	if err != nil {
+		cblogger.Debug("Failed to retrieve backup config: ", err)
+		return
+	}
+
+	if response.Response != nil {
+		if response.Response.BackupExpireDays != nil {
+			rdbmsInfo.BackupRetentionDays = int(*response.Response.BackupExpireDays)
+		}
+		if response.Response.StartTimeMin != nil && response.Response.StartTimeMax != nil {
+			// Tencent returns time as hour integers (0-23)
+			rdbmsInfo.BackupTime = fmt.Sprintf("%02d:00-%02d:00", *response.Response.StartTimeMin, *response.Response.StartTimeMax)
+		}
+	}
 }
 
 func (handler *TencentRDBMSHandler) resolveMemoryMBFromSpec(spec string) (int64, error) {

--- a/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
@@ -33,16 +33,21 @@ const (
 // Use GetMetaInfo() to discover what each CSP supports before creating an RDBMS instance.
 // @description RDBMS Meta Information for CSP-specific capabilities
 type RDBMSMetaInfo struct {
-	DBEngine           string           `json:"DBEngine" example:"mysql"`                           // Requested DB engine name. e.g., mysql, mariadb, postgresql
-	SupportedVersions  []string         `json:"SupportedVersions" example:"8.0,8.4"`                // Supported versions for the requested DB engine
-	StorageTypeOptions []string         `json:"StorageTypeOptions,omitempty" example:"gp2,gp3,io1"` // Available storage types for the requested DB engine
-	StorageSizeRange   StorageSizeRange `json:"StorageSizeRange,omitempty"`                         // Min/Max storage size in GB for the requested DB engine
+	DBEngine              string           `json:"DBEngine" example:"mysql"`                                    // Requested DB engine name. e.g., mysql, mariadb, postgresql
+	SupportedVersions     []string         `json:"SupportedVersions" example:"8.0,8.4"`                         // Supported versions for the requested DB engine
+	DBInstanceSpecOptions []string         `json:"DBInstanceSpecOptions,omitempty" example:"db.t3.medium,1000"` // Available DBInstanceSpec values for the requested DB engine. "NA" if CSP does not provide spec list API.
+	StorageTypeOptions    []string         `json:"StorageTypeOptions,omitempty" example:"gp2,gp3,io1"`          // Available storage types for the requested DB engine
+	StorageSizeRange      StorageSizeRange `json:"StorageSizeRange,omitempty"`                                  // Min/Max storage size in GB for the requested DB engine
 
-	SupportsHighAvailability   bool `json:"SupportsHighAvailability"`   // true if HA/Multi-AZ can be configured
-	SupportsBackup             bool `json:"SupportsBackup"`             // true if managed automatic backup is supported
-	SupportsPublicAccess       bool `json:"SupportsPublicAccess"`       // true if public access can be toggled
-	SupportsDeletionProtection bool `json:"SupportsDeletionProtection"` // true if deletion protection is available
-	SupportsEncryption         bool `json:"SupportsEncryption"`         // true if storage encryption is available
+	SupportsHighAvailability   bool   `json:"SupportsHighAvailability"`       // true if HA/Multi-AZ can be configured
+	SupportsBackup             bool   `json:"SupportsBackup"`                 // true if managed automatic backup is supported
+	BackupRetentionRange       string `json:"BackupRetentionRange,omitempty"` // Backup retention range at creation time (e.g., "1-35", "7-730"). "NA" if not configurable at creation.
+	SupportsPublicAccess       bool   `json:"SupportsPublicAccess"`           // true if public access can be toggled
+	SupportsDeletionProtection bool   `json:"SupportsDeletionProtection"`     // true if deletion protection is available
+	SupportsEncryption         bool   `json:"SupportsEncryption"`             // true if storage encryption is available
+
+	RequiresSubnet        bool `json:"RequiresSubnet"`        // true if SubnetNames is required at creation
+	RequiresSecurityGroup bool `json:"RequiresSecurityGroup"` // true if SecurityGroupNames is required at creation
 }
 
 func NormalizeRDBMSEngine(dbEngine string) (string, error) {
@@ -55,7 +60,7 @@ func NormalizeRDBMSEngine(dbEngine string) (string, error) {
 	}
 }
 
-func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, storageTypeOptions map[string][]string, storageSizeRange StorageSizeRange, supportsHighAvailability, supportsBackup, supportsPublicAccess, supportsDeletionProtection, supportsEncryption bool) (RDBMSMetaInfo, error) {
+func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, dbInstanceSpecOptions map[string][]string, storageTypeOptions map[string][]string, storageSizeRange StorageSizeRange, supportsHighAvailability, supportsBackup, supportsPublicAccess, supportsDeletionProtection, supportsEncryption bool, backupRetentionRange string, requiresSubnet, requiresSecurityGroup bool) (RDBMSMetaInfo, error) {
 	normalizedEngine, err := NormalizeRDBMSEngine(dbEngine)
 	if err != nil {
 		return RDBMSMetaInfo{}, err
@@ -66,17 +71,22 @@ func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, s
 		return RDBMSMetaInfo{}, fmt.Errorf("DBEngine '%s' is not supported", normalizedEngine)
 	}
 
+	instanceSpecs := append([]string(nil), dbInstanceSpecOptions[normalizedEngine]...)
 	storageTypes := append([]string(nil), storageTypeOptions[normalizedEngine]...)
 	return RDBMSMetaInfo{
 		DBEngine:                   normalizedEngine,
 		SupportedVersions:          versions,
+		DBInstanceSpecOptions:      instanceSpecs,
 		StorageTypeOptions:         storageTypes,
 		StorageSizeRange:           storageSizeRange,
 		SupportsHighAvailability:   supportsHighAvailability,
 		SupportsBackup:             supportsBackup,
+		BackupRetentionRange:       backupRetentionRange,
 		SupportsPublicAccess:       supportsPublicAccess,
 		SupportsDeletionProtection: supportsDeletionProtection,
 		SupportsEncryption:         supportsEncryption,
+		RequiresSubnet:             requiresSubnet,
+		RequiresSecurityGroup:      requiresSecurityGroup,
 	}, nil
 }
 
@@ -107,31 +117,26 @@ type RDBMSInfo struct {
 	StorageSize string `json:"StorageSize" validate:"required" example:"100"` // in GB
 
 	// Network
-	SubnetIIDs        []IID  `json:"SubnetIIDs,omitempty"`          // Subnet IIDs for DB placement
-	SecurityGroupIIDs []IID  `json:"SecurityGroupIIDs,omitempty"`   // Associated Security Groups
-	Port              string `json:"Port,omitempty" example:"3306"` // DB listen port
+	SubnetIIDs        []IID `json:"SubnetIIDs,omitempty"`        // Subnet IIDs for DB placement
+	SecurityGroupIIDs []IID `json:"SecurityGroupIIDs,omitempty"` // Associated Security Groups
 
 	// Authentication
 	MasterUserName     string `json:"MasterUserName" validate:"required" example:"admin"` // Master user name
 	MasterUserPassword string `json:"MasterUserPassword,omitempty"`                       // Master user password (for Create request only)
 
-	// Database
-	DatabaseName string `json:"DatabaseName,omitempty" example:"mydb"` // Initial database name
-
-	// High Availability & Replication
-	HighAvailability bool   `json:"HighAvailability,omitempty" default:"false"` // Multi-AZ / HA enabled
-	ReplicationType  string `json:"ReplicationType,omitempty" example:"async"`  // async | semi-sync | sync (for response)
+	// High Availability
+	HighAvailability bool `json:"HighAvailability,omitempty" default:"false"` // Multi-AZ / HA enabled
 
 	// Backup
-	BackupRetentionDays int    `json:"BackupRetentionDays,omitempty" example:"7"` // Automated backup retention period in days
-	BackupTime          string `json:"BackupTime,omitempty" example:"03:00"`      // Preferred backup time (HH:MM in UTC)
+	BackupRetentionDays int    `json:"BackupRetentionDays,omitempty" example:"7"` // Automated backup retention period in days (configurable at creation if CSP supports)
+	BackupTime          string `json:"BackupTime,omitempty" example:"03:00"`      // Preferred backup time (read-only, CSP-managed. Not configurable at creation via Spider.)
 
 	// Access
 	PublicAccess bool   `json:"PublicAccess,omitempty" default:"false"` // Whether publicly accessible
 	Endpoint     string `json:"Endpoint,omitempty"`                     // Connection endpoint (for response)
 
-	// Encryption
-	Encryption bool `json:"Encryption,omitempty" default:"false"` // Storage encryption enabled
+	// Encryption - read-only, CSP-managed. Not configurable at creation via Spider.
+	Encryption bool `json:"Encryption,omitempty" default:"false"` // Storage encryption enabled (CSP default)
 
 	// Protection
 	DeletionProtection bool `json:"DeletionProtection,omitempty" default:"false"` // Deletion protection enabled
@@ -140,7 +145,8 @@ type RDBMSInfo struct {
 	//** (1) Basic setup: If not set by the user, these fields use CSP default values.
 	//** (2) Advanced setup: If set by the user, these fields enable CSP-specific RDBMS features.
 	//**    → Use GetMetaInfo() to discover CSP-supported options before setting advanced fields.
-	//**    Advanced fields: StorageType, HighAvailability, PublicAccess, Encryption, DeletionProtection
+	//**    Advanced fields: StorageType, HighAvailability, PublicAccess, DeletionProtection
+	//**    Read-only fields (CSP-managed): BackupTime, Encryption
 	//**************************************************************************************************
 
 	// Status (for response)

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleserv
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0/go.mod h1:0mKVz3WT8oNjBunT1zD/HPwMleQ72QClMa7Gmsm+6Kc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0 h1:CbHDMVJhcJSmXenq+UDWyIjumzVkZIb5pVUGzsCok5M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v9 v9.0.0/go.mod h1:raqbEXrok4aycS74XoU6p9Hne1dliAFpHLizlp+qJoM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0 h1:67nFqWXpo0x5Nz0XEb1yI7s8D+EHy8NsTinYw9sZnLk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v1.0.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=

--- a/test/rdbms-mysql-test/README.md
+++ b/test/rdbms-mysql-test/README.md
@@ -1,0 +1,222 @@
+# CB-Spider RDBMS API Test
+
+Automated test suite for CB-Spider RDBMS API — creates MySQL instances across 9 CSPs in parallel, waits until each becomes available, then collects and displays a unified result table.
+
+## Prerequisites
+
+### CB-Spider Running
+
+```bash
+cd ./bin; ./start.sh
+```
+
+### CSP Connection Configuration
+
+Before running tests, register connection names for each CSP in CB-Spider.
+
+| CSP | Connection Name |
+|-----|----------------|
+| AWS | `aws-config01` |
+| Azure | `azure-koreacentral-config` |
+| GCP | `gcp-iowa-config` |
+| Alibaba | `alibaba-beijing-config` |
+| Tencent | `tencent-beijing3-config` |
+| IBM | `ibm-us-east-1-config` |
+| OpenStack | `openstack-config01` |
+| NCP | `ncp-korea1-config` |
+| NHN | `nhn-korea-pangyo1-config` |
+
+### Pre-created Network Resources
+
+RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야 합니다.
+
+| CSP | VPC | Subnet | 비고 |
+|-----|-----|--------|------|
+| AWS | `vpc-01` | `subnet-01`, `subnet-02` | 서로 다른 AZ의 서브넷 2개 필수 (SubnetGroup 요건) |
+| Azure | `vpc-01` | `subnet-01` | 서브넷 미사용 |
+| GCP | `vpc-01` | `subnet-01` | 서브넷 미사용 |
+| Alibaba | `vpc-01` | `subnet-01` | |
+| Tencent | `vpc-01` | `subnet-01` | |
+| IBM | `vpc-01` | `subnet-01` | 서브넷 미사용 |
+| OpenStack | `vpc-01` | `subnet-01` | 서브넷 미사용 |
+| NCP | `vpc-01` | `subnet-01` | |
+| NHN | `vpc-01` | `subnet-01` | |
+
+CB-Spider REST API로 생성하는 경우:
+
+```bash
+# VPC 생성 예시 (AWS)
+curl -u admin:***** -sX POST http://localhost:1024/spider/vpc \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "ConnectionName": "aws-config01",
+    "ReqInfo": {
+      "Name": "vpc-01",
+      "IPv4_CIDR": "10.0.0.0/16",
+      "SubnetInfoList": [
+        {"Name": "subnet-01", "IPv4_CIDR": "10.0.1.0/24", "Zone": "<AZ-1>"},
+        {"Name": "subnet-02", "IPv4_CIDR": "10.0.2.0/24", "Zone": "<AZ-2>"}
+      ]
+    }
+  }' | jq .
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## RDBMS Instance Configuration
+
+All CSPs create a MySQL instance named `cb-spider-mysql-test`.
+
+| CSP | Engine Version | Instance Spec | Storage | Subnet Required |
+|-----|---------------|---------------|---------|-----------------|
+| AWS | 8.0 | db.t3.medium | 100GB | ✅ (2개, 다른 AZ) |
+| Azure | 8.0.21 | Standard_B1ms | 20GB | 미사용 |
+| GCP | 8.0 | db-custom-2-8192 | 20GB | 미사용 |
+| Alibaba | 8.0 | mysql.n2e.small.1 | 20GB | ✅ |
+| Tencent | 8.0 | 8000 (MB) | 50GB | ✅ |
+| IBM | 8.4 | multitenant | 30GB | 미사용 |
+| OpenStack | 5.7.29 | m1.small | 20GB | 미사용 |
+| NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | 10GB | ✅ |
+| NHN | MYSQL_V8408 | m2.c2m4 | 20GB | ✅ |
+
+## Configuration
+
+테스트 실행 전에 CB-Spider 접속 정보를 환경변수로 설정하거나, `run-all-csp-rdbms-tests.sh` / `delete-all-csp-rdbms.sh` 파일 내부의 기본값을 직접 수정합니다.
+
+**방법 1) 환경변수 설정**
+```bash
+export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
+export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+```
+
+**방법 2) 스크립트 파일 직접 수정** (`run-all-csp-rdbms-tests.sh`, `delete-all-csp-rdbms.sh`)
+```bash
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:*****}"   # <-- 비밀번호 변경
+```
+
+> `SPIDER_AUTH`의 비밀번호는 CB-Spider 기동 시 설정한 값으로 변경하세요.
+
+## How to Run Tests
+
+### Create: All CSPs in Parallel
+
+```bash
+./run-all-csp-rdbms-tests.sh
+```
+
+- 9개 CSP에 동시 RDBMS 생성 (백그라운드 병렬 실행)
+- 각 CSP별 Available 상태까지 대기 (최대 60분)
+- 완료 후 통합 결과 테이블 출력
+
+**Example output:**
+```
+CSP          | Status      | Engine   | Version      | Spec                     | Storage    | Endpoint                                 | PublicAccess | Elapsed
+---
+AWS          | Available   | mysql    | 8.0.45       | db.t3.medium             | 100GB      | xxx.rds.amazonaws.com:3306               | true         | 8m39s
+AZURE        | Available   | mysql    | 8.0.21       | Standard_B1ms            | 20GB       | xxx.mysql.database.azure.com:3306        | true         | 5m35s
+GCP          | Available   | mysql    | 8.0          | db-custom-2-8192         | 20GB       | xxx.cloudsql.google.com:3306             | true         | 3m58s
+...
+```
+
+### Delete: All CSPs in Parallel
+
+```bash
+./delete-all-csp-rdbms.sh
+```
+
+- 9개 CSP의 RDBMS 인스턴스 동시 삭제
+- 인스턴스 완전 삭제 확인 후 결과 테이블 출력
+
+**Example output:**
+```
+CSP          | Result         | Detail               | Elapsed
+---
+AWS          | DELETED        | ok                   | 1m48s
+AZURE        | DELETED        | ok                   | 33s
+GCP          | DELETED        | ok                   | 2m9s
+...
+```
+
+### Run Individual CSP Test
+
+특정 CSP만 단독 실행:
+
+```bash
+# Create
+./aws-rdbms-test.sh
+./azure-rdbms-test.sh
+./gcp-rdbms-test.sh
+./alibaba-rdbms-test.sh
+./tencent-rdbms-test.sh
+./ibm-rdbms-test.sh
+./openstack-rdbms-test.sh
+./ncp-rdbms-test.sh
+./nhn-rdbms-test.sh
+```
+
+단독 실행 시에는 `RESULT_DIR` 환경변수를 지정하거나 기본값(`/tmp/rdbms_results`)이 사용됩니다.
+
+## Script Structure
+
+```
+.
+├── run-all-csp-rdbms-tests.sh   # Orchestrator: 전체 생성 테스트 (병렬)
+├── delete-all-csp-rdbms.sh      # Orchestrator: 전체 삭제 (병렬)
+├── common-rdbms-test.sh         # Common: Create → Poll Available → Get Info
+├── common-rdbms-delete.sh       # Common: Verify → Delete → Poll Removed
+├── aws-rdbms-test.sh
+├── azure-rdbms-test.sh
+├── gcp-rdbms-test.sh
+├── alibaba-rdbms-test.sh
+├── tencent-rdbms-test.sh
+├── ibm-rdbms-test.sh
+├── openstack-rdbms-test.sh
+├── ncp-rdbms-test.sh
+└── nhn-rdbms-test.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
+| `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per CSP (seconds) |
+| `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
+| `VERBOSE` | `0` | Set to `1` for per-CSP full log dump |
+
+```bash
+# Example: custom Spider URL
+SPIDER_URL=http://10.0.0.1:1024 ./run-all-csp-rdbms-tests.sh
+
+# Example: verbose output
+VERBOSE=1 ./run-all-csp-rdbms-tests.sh
+```
+
+## Logs & Results
+
+각 실행마다 PID 기반 임시 디렉토리에 로그와 결과 파일이 저장됩니다.
+
+```
+/tmp/rdbms_results_<PID>/result_<csp>.txt   # pipe-separated result line
+/tmp/rdbms_logs_<PID>/log_<csp>.txt         # per-CSP full output
+```
+
+실행 중 모니터링:
+
+```bash
+tail -f /tmp/rdbms_logs_<PID>/log_aws.txt
+```
+
+## CSP-Specific Notes
+
+| CSP | Note |
+|-----|------|
+| AWS | SubnetGroup 생성을 위해 **다른 AZ의 서브넷 2개 이상** 필요 |
+| Tencent | `DBInstanceSpec`은 메모리 크기(MB) 지정 (예: `8000` = 8GB) |
+| NCP | StorageSize는 10GB 단위. G3(KVM) generation만 지원. Public 도메인은 생성 후 콘솔에서 별도 신청 필요 |

--- a/test/rdbms-mysql-test/alibaba-rdbms-test.sh
+++ b/test/rdbms-mysql-test/alibaba-rdbms-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Alibaba Cloud RDBMS Test Script
+# Note: Subnet required
+# Author: CB-Spider Team
+
+export CSP_NAME="ALIBABA"
+export CONNECTION_NAME="alibaba-beijing-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_alibaba.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "alibaba-beijing-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "SubnetNames": ["subnet-01"],
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0",
+    "DBInstanceSpec": "mysql.n2e.small.1",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/aws-rdbms-test.sh
+++ b/test/rdbms-mysql-test/aws-rdbms-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# AWS RDBMS Test Script
+# Note: Requires 2+ subnets in different Availability Zones (SubnetGroup requirement)
+# Author: CB-Spider Team
+
+export CSP_NAME="AWS"
+export CONNECTION_NAME="aws-config01"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_aws.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "aws-config01",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0",
+    "DBInstanceSpec": "db.t3.medium",
+    "StorageSize": "100",
+    "SubnetNames": ["subnet-01", "subnet-02"],
+    "SecurityGroupNames": ["sg-01"],
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/azure-rdbms-test.sh
+++ b/test/rdbms-mysql-test/azure-rdbms-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Azure RDBMS Test Script
+# Note: Subnet not required for Azure Flexible Server
+# Author: CB-Spider Team
+
+export CSP_NAME="AZURE"
+export CONNECTION_NAME="azure-koreacentral-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_azure.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "azure-koreacentral-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0.21",
+    "DBInstanceSpec": "Standard_B1ms",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/common-rdbms-delete.sh
+++ b/test/rdbms-mysql-test/common-rdbms-delete.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Common Delete Script
+# Deletes the RDBMS instance and waits until it is fully removed.
+# Author: CB-Spider Team
+#
+# Required env vars (set by caller):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name to delete
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#   MAX_WAIT_SEC    - Max seconds to wait for deletion (default: 1800)
+#   POLL_INTERVAL   - Polling interval in seconds (default: 15)
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Ensure result directory exists
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+echo "[${CSP_NAME}] [${timestamp}] Deleting RDBMS '${RDBMS_NAME}'..."
+
+# ── Verify instance exists before deleting ────────────────────────────────────
+check_resp=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${check_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] Instance not found or error: ${err_msg}"
+    echo "${CSP_NAME}|NOT_FOUND|${err_msg}|-" > "${RESULT_FILE}"
+    exit 0
+fi
+
+# ── Send DELETE request ───────────────────────────────────────────────────────
+# Note: DELETE requires ConnectionName in request body, not query parameter
+del_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+
+del_result=$(echo "${del_resp}" | jq -r '.Result // .result // empty' 2>/dev/null)
+del_err=$(echo "${del_resp}"    | jq -r '.message // empty' 2>/dev/null)
+
+if [[ -n "${del_err}" ]]; then
+    echo "[${CSP_NAME}] DELETE error: ${del_err}"
+    echo "${CSP_NAME}|DELETE_ERROR|${del_err}|-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+echo "[${CSP_NAME}] DELETE accepted (result: ${del_result:-ok}). Waiting for removal..."
+
+# ── Poll until instance is gone ───────────────────────────────────────────────
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    # Instance is gone when the API returns an error/message
+    poll_err=$(echo "${poll_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${poll_err}" ]]; then
+        echo "[${CSP_NAME}] Instance removed (elapsed: ${elapsed}s)"
+        break
+    fi
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // "unknown"' 2>/dev/null)
+    echo "[${CSP_NAME}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}] TIMEOUT waiting for deletion to complete"
+        echo "${CSP_NAME}|DELETE_TIMEOUT||$(format_elapsed ${elapsed})" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+
+echo "[${CSP_NAME}] Deletion complete (total elapsed: ${elapsed_fmt})"
+echo "${CSP_NAME}|DELETED|ok|${elapsed_fmt}" > "${RESULT_FILE}"

--- a/test/rdbms-mysql-test/common-rdbms-test.sh
+++ b/test/rdbms-mysql-test/common-rdbms-test.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Common Test Script
+# Flow: Create RDBMS -> Poll until Available -> Get Info -> Write result file
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name
+#   CREATE_JSON     - JSON body for POST /spider/rdbms
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#   MAX_WAIT_SEC    - Max seconds to wait for available status (default: 3600)
+#   POLL_INTERVAL   - Polling interval in seconds (default: 30)
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${CSP_NAME}] [${timestamp}] Creating RDBMS '${RDBMS_NAME}'..."
+
+# ── Create RDBMS ─────────────────────────────────────────────────────────────
+create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/rdbms" \
+  -H 'Content-Type: application/json' \
+  -d "${CREATE_JSON}" 2>&1)
+
+# Check for API error response
+err_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR on create: ${err_msg}"
+    echo "${CSP_NAME}|CREATE_ERROR|${err_msg}|||||||-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+create_status=$(echo "${create_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+echo "[${CSP_NAME}] Create response status: ${create_status}"
+
+# ── Poll until Available ──────────────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for RDBMS to become available (poll every ${POLL_INTERVAL}s, max ${MAX_WAIT_SEC}s)..."
+
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+    status_lower=$(echo "${cur_status}" | tr '[:upper:]' '[:lower:]')
+
+    echo "[${CSP_NAME}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    # Accept various CSP-specific available status strings
+    case "${status_lower}" in
+        available|ready|runnable|active)
+            echo "[${CSP_NAME}] RDBMS is available!"
+            break
+            ;;
+    esac
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}] TIMEOUT: RDBMS did not become available within ${MAX_WAIT_SEC}s"
+        echo "${CSP_NAME}|TIMEOUT|||||||||" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+
+# ── Get RDBMS Info ────────────────────────────────────────────────────────────
+info=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}")
+
+name=$(echo "${info}"       | jq -r '.IId.NameId       // "N/A"')
+status=$(echo "${info}"     | jq -r '.Status           // "N/A"')
+engine=$(echo "${info}"     | jq -r '.DBEngine         // "N/A"')
+version=$(echo "${info}"    | jq -r '.DBEngineVersion  // "N/A"')
+spec=$(echo "${info}"       | jq -r '.DBInstanceSpec   // "N/A"')
+storage=$(echo "${info}"    | jq -r '.StorageSize      // "N/A"')
+ep_addr=$(echo "${info}"    | jq -r '.Endpoint         // "N/A"')
+ep_port=$(echo "${info}"    | jq -r '.Port             // "N/A"')
+pub_access=$(echo "${info}" | jq -r '.PublicAccess     // "N/A"')
+
+# Build endpoint display: if Port is valid and not already in Endpoint, append it
+if [[ "${ep_port}" != "N/A" && "${ep_port}" != "null" && "${ep_port}" != "" ]]; then
+    endpoint_display="${ep_addr}:${ep_port}"
+else
+    endpoint_display="${ep_addr}"
+fi
+
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+echo "[${CSP_NAME}] Done. Endpoint: ${endpoint_display} (total elapsed: ${elapsed_fmt})"
+
+# Ensure result directory exists
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+# Write pipe-separated result line
+# Format: CSP|Status|Engine|Version|Spec|Storage(GB)|Endpoint|PublicAccess|Elapsed
+echo "${CSP_NAME}|${status}|${engine}|${version}|${spec}|${storage}GB|${endpoint_display}|${pub_access}|${elapsed_fmt}" \
+  > "${RESULT_FILE}"

--- a/test/rdbms-mysql-test/delete-all-csp-rdbms.sh
+++ b/test/rdbms-mysql-test/delete-all-csp-rdbms.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Delete Script for All CSPs
+# Deletes RDBMS instances on all 9 CSPs in parallel and reports results.
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"  # 30 min timeout per CSP
+export POLL_INTERVAL="${POLL_INTERVAL:-15}"  # poll every 15s
+
+RDBMS_NAME="cb-spider-mysql-test"
+
+RESULT_DIR="/tmp/rdbms_del_results_$$"
+LOG_DIR="/tmp/rdbms_del_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── CSP connection config map ─────────────────────────────────────────────────
+csp_connection() {
+    case "$1" in
+        AWS)       echo "aws-config01"                 ;;
+        AZURE)     echo "azure-koreacentral-config"    ;;
+        GCP)       echo "gcp-iowa-config"              ;;
+        ALIBABA)   echo "alibaba-beijing-config"       ;;
+        TENCENT)   echo "tencent-beijing3-config"      ;;
+        IBM)       echo "ibm-us-east-1-config"         ;;
+        OPENSTACK) echo "openstack-config01"           ;;
+        NCP)       echo "ncp-korea1-config"            ;;
+        NHN)       echo "nhn-korea-pangyo1-config"     ;;
+    esac
+}
+
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+print_separator() {
+    echo "------------------------------------------------------------"
+}
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+echo ""
+echo "############################################################"
+echo "#     CB-Spider RDBMS Delete - All CSPs                    #"
+echo "############################################################"
+echo ""
+echo "RDBMS Name   : ${RDBMS_NAME}"
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per CSP"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo ""
+echo "Launching parallel deletion on all CSPs..."
+echo ""
+
+CSP_ORDER="AWS AZURE GCP ALIBABA TENCENT IBM OPENSTACK NCP NHN"
+
+for csp in ${CSP_ORDER}; do
+    conn=$(csp_connection "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    echo "[MAIN] Deleting ${csp} (log: ${log_file})"
+
+    (
+        export CSP_NAME="${csp}"
+        export CONNECTION_NAME="${conn}"
+        export RDBMS_NAME="${RDBMS_NAME}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-rdbms-delete.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All deletions launched. Waiting for completion..."
+echo "[MAIN] Monitor progress: tail -f ${LOG_DIR}/log_<csp_lowercase>.txt"
+echo ""
+
+# ── Wait for all ──────────────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} deletion completed"
+        else
+            echo "[MAIN] ${csp} deletion failed (exit: ${exit_code}, check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All deletions finished. Collecting results..."
+echo ""
+
+# ── Result table ──────────────────────────────────────────────────────────────
+echo "============================================================"
+echo "         RDBMS DELETE SUMMARY - ALL CSPs"
+echo "============================================================"
+echo ""
+printf "%-12s | %-14s | %-20s | %-10s\n" "CSP" "Result" "Detail" "Elapsed"
+print_separator
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_result r_detail r_elapsed < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_result="NO_RESULT"
+        r_detail="-"
+        r_elapsed="-"
+    fi
+
+    printf "%-12s | %-14s | %-20s | %-10s\n" \
+        "${r_csp}" "${r_result}" "${r_detail}" "${r_elapsed}"
+done
+
+print_separator
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "============================================================"
+echo ""
+
+# ── Per-CSP log dump (VERBOSE=1) ─────────────────────────────────────────────
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo "────────────── ${csp} ──────────────"
+        [[ -f "${log_file}" ]] && cat "${log_file}" || echo "(no log)"
+        echo ""
+    done
+fi

--- a/test/rdbms-mysql-test/gcp-rdbms-test.sh
+++ b/test/rdbms-mysql-test/gcp-rdbms-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# GCP RDBMS Test Script
+# Note: Subnet not required. Creation may take several minutes.
+# Author: CB-Spider Team
+
+export CSP_NAME="GCP"
+export CONNECTION_NAME="gcp-iowa-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_gcp.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "gcp-iowa-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0",
+    "DBInstanceSpec": "db-custom-2-8192",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/ibm-rdbms-test.sh
+++ b/test/rdbms-mysql-test/ibm-rdbms-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# IBM Cloud RDBMS Test Script
+# Note: Subnet not required
+# Author: CB-Spider Team
+
+export CSP_NAME="IBM"
+export CONNECTION_NAME="ibm-us-east-1-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_ibm.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "ibm-us-east-1-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.4",
+    "DBInstanceSpec": "multitenant",
+    "StorageType": "standard",
+    "StorageSize": "30",
+    "MasterUserName": "admin",
+    "MasterUserPassword": "Passwordspider123",
+    "PublicAccess": true,
+    "TagList": [
+      {"Key": "env",        "Value": "test"},
+      {"Key": "managed-by", "Value": "cb-spider"}
+    ]
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/ncp-rdbms-test.sh
+++ b/test/rdbms-mysql-test/ncp-rdbms-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# NCP (Naver Cloud Platform) RDBMS Test Script
+# Note: Subnet required. StorageSize must be 10 (default, 10GB increments up to 6000GB).
+#       G3 (KVM) server generation only. Public domain must be requested via console after creation.
+# Author: CB-Spider Team
+
+export CSP_NAME="NCP"
+export CONNECTION_NAME="ncp-korea1-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_ncp.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "ncp-korea1-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "SubnetNames": ["subnet-01"],
+    "DBInstanceSpec": "SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0.36",
+    "StorageSize": "10",
+    "StorageType": "SSD",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/nhn-rdbms-test.sh
+++ b/test/rdbms-mysql-test/nhn-rdbms-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# NHN Cloud RDBMS Test Script
+# Note: Subnet required
+# Author: CB-Spider Team
+
+export CSP_NAME="NHN"
+export CONNECTION_NAME="nhn-korea-pangyo1-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_nhn.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "nhn-korea-pangyo1-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "SubnetNames": ["subnet-01"],
+    "DBEngine": "mysql",
+    "DBEngineVersion": "MYSQL_V8408",
+    "DBInstanceSpec": "m2.c2m4",
+    "StorageType": "General SSD",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/openstack-rdbms-test.sh
+++ b/test/rdbms-mysql-test/openstack-rdbms-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# OpenStack RDBMS Test Script
+# Note: Subnet not required
+# Author: CB-Spider Team
+
+export CSP_NAME="OPENSTACK"
+export CONNECTION_NAME="openstack-config01"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_openstack.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "openstack-config01",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mysql",
+    "DBEngineVersion": "5.7.29",
+    "DBInstanceSpec": "m1.small",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mysql-test/run-all-csp-rdbms-tests.sh
+++ b/test/rdbms-mysql-test/run-all-csp-rdbms-tests.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Test Runner for All CSPs
+# Runs RDBMS creation on all 9 CSPs in parallel, waits for each to become
+# available, then collects and displays a unified result table.
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"   # 60 min timeout per CSP
+export POLL_INTERVAL="${POLL_INTERVAL:-30}"   # poll every 30s
+
+# Temp directories
+export RESULT_DIR="/tmp/rdbms_results_$$"
+LOG_DIR="/tmp/rdbms_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-rdbms-test.sh"       ;;
+        AZURE)     echo "azure-rdbms-test.sh"     ;;
+        GCP)       echo "gcp-rdbms-test.sh"       ;;
+        ALIBABA)   echo "alibaba-rdbms-test.sh"   ;;
+        TENCENT)   echo "tencent-rdbms-test.sh"   ;;
+        IBM)       echo "ibm-rdbms-test.sh"       ;;
+        OPENSTACK) echo "openstack-rdbms-test.sh" ;;
+        NCP)       echo "ncp-rdbms-test.sh"       ;;
+        NHN)       echo "nhn-rdbms-test.sh"       ;;
+    esac
+}
+
+print_separator() {
+    echo "------------------------------------------------------------------------------------------------------------------------------------------------------------"
+}
+
+print_header() {
+    echo ""
+    echo "============================================================================================================================================================"
+    echo "                                              RDBMS CREATE & INFO TEST SUMMARY - ALL CSPs"
+    echo "============================================================================================================================================================"
+    echo ""
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-10s | %-40s | %-12s | %-10s\n" \
+        "CSP" "Status" "Engine" "Version" "Spec" "Storage" "Endpoint" "PublicAccess" "Elapsed"
+    print_separator
+}
+
+# ── Run all CSP tests in parallel ────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#            CB-Spider RDBMS Multi-CSP Test - Starting All CSPs               #"
+echo "################################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per CSP"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Result dir   : ${RESULT_DIR}"
+echo "Log dir      : ${LOG_DIR}"
+echo ""
+echo "Launching RDBMS creation on all CSPs in parallel..."
+echo ""
+
+CSP_ORDER="AWS AZURE GCP ALIBABA TENCENT IBM OPENSTACK NCP NHN"
+
+# Launch all CSP scripts in background; store PIDs in /tmp files (bash 3.2 compatible)
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} test (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP tests launched. Waiting for completion..."
+echo "[MAIN] Monitor progress: tail -f ${LOG_DIR}/log_<csp_lowercase>.txt"
+echo ""
+
+# ── Wait for all background jobs ─────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed successfully"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code} (check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_status r_engine r_version r_spec r_storage r_endpoint r_public r_elapsed \
+            < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_status="NO_RESULT"
+        r_engine="-"
+        r_version="-"
+        r_spec="-"
+        r_storage="-"
+        r_endpoint="-"
+        r_public="-"
+        r_elapsed="-"
+    fi
+
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-10s | %-40s | %-12s | %-10s\n" \
+        "${r_csp}" "${r_status}" "${r_engine}" "${r_version}" \
+        "${r_spec}" "${r_storage}" "${r_endpoint}" "${r_public}" "${r_elapsed}"
+done
+
+print_separator
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "=============================================================================================================================================================="
+echo ""
+
+# ── Per-CSP full log dump (optional, controlled by VERBOSE=1) ────────────────
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                          Per-CSP Detailed Logs                              #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        if [[ -f "${log_file}" ]]; then
+            cat "${log_file}"
+        else
+            echo "(no log)"
+        fi
+    done
+fi

--- a/test/rdbms-mysql-test/tencent-rdbms-test.sh
+++ b/test/rdbms-mysql-test/tencent-rdbms-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Tencent Cloud RDBMS Test Script
+# Note: Subnet required. DBInstanceSpec is memory size in MB (e.g., 8000 = 8GB).
+# Author: CB-Spider Team
+
+export CSP_NAME="TENCENT"
+export CONNECTION_NAME="tencent-beijing3-config"
+export RDBMS_NAME="cb-spider-mysql-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_tencent.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "tencent-beijing3-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mysql-test",
+    "VPCName": "vpc-01",
+    "SubnetNames": ["subnet-01"],
+    "DBEngine": "mysql",
+    "DBEngineVersion": "8.0",
+    "DBInstanceSpec": "8000",
+    "StorageSize": "50",
+    "StorageType": "CLOUD_HSSD",
+    "MasterUserName": "root",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"


### PR DESCRIPTION
## Overview
Enhanced RDBMS driver interfaces, REST API standardization, AdminWeb UI improvements, and automated testing framework for 9 CSPs.

## Key Changes

### API & Driver Standardization
- Remove deprecated fields (Port, DatabaseName, ReplicationType)
- Standardize Endpoint format: "host:port" across all drivers
- Add RequiresSubnet/RequiresSecurityGroup to MetaInfo
- RESTful endpoint: POST /rdbms/:Name/databases

### NCP Driver G3 Optimization
- G3-exclusive support, API-direct storage retrieval
- Auto-fallback: StorageType="SSD", Range: 10-6000GB

### AdminWeb UI
- Menu: "RDBMS" (removed WIP status)
- MetaInfo-driven dropdowns (Version, InstanceSpec, StorageType)
- Multi-select: Subnet/SecurityGroup
- CSP-specific defaults: Master User, Backup Retention semantics
- Auto-select Storage Type for compatibility (Alibaba)

### Test Suite (test/rdbms-mysql-test/)
- Parallel execution framework for 9 CSPs
- Orchestrators with unified result tables
- Configurable timeout/polling

## Known Limitations & Notes

### CSP Support Status
- ❌ **KT Cloud**: RDBMS API not available
- ⚠️ **NCP**: PublicAccess requires manual console setup (API limitation)

### NHN RDS Authentication
Requires separate RDS credentials (console-only):
1. **User/Secret Access Key**: Console → Account → API Security Settings
2. **appKey**: Console → Project Settings → RDS for MySQL → URL & Appkey

### CSP-Specific Constraints
- **Master User**: Tencent='root', IBM='admin' (fixed)
- **Database DDL**: NHN/NCP require API/stored procedure (no CREATE DATABASE permission)
- **AdminWeb**: Currently incomplete - REST API recommended for production

### Documentation
See **[RDBMS Management]** in Swagger UI and test/rdbms-mysql-test/README.md

## Testing & Validation

### Automated Test Results
Parallel execution across 9 CSPs - all successfully validated:

| CSP | Status | Version | Spec | Storage | Elapsed |
|-----|--------|---------|------|---------|---------|
| Alibaba | Available | 8.0 | mysql.n2e.small.1 | 20GB | 3m4s |
| GCP | Available | 8.0 | db-custom-2-8192 | 20GB | 3m58s |
| OpenStack | Available | 5.7.29 | m1.small | 20GB | 4m22s |
| AWS | Available | 8.0.45 | db.t3.medium | 100GB | 4m37s |
| Azure | Available | 8.0.21 | Standard_B1ms | 20GB | 4m36s |
| Tencent | Available | 8.0 | 8000 | 50GB | 4m39s |
| IBM | Available | 8.4 | multitenant | 30GB | 7m14s |
| NHN | Available | 8.4.08 | m2.c2m4 | 20GB | 8m52s |
| NCP | Available | 8.0.36 | SVR.VDBAS...G003 | 10GB | 12m26s |

✅ Endpoint standardization validated (all include port)  
✅ MetaInfo integration, multi-select UI verified

### Work in Progress
- AdminWeb validation/improvements for all CSP options
- Tag functionality validation