### PR TITLE
fix(k8s): handle ACK image_type aliases in Alibaba ClusterHandler

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -546,11 +546,33 @@ func (ach *AlibabaClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqI
 	// Image: Alibaba uses ImageId as SystemId
 	imageId := nodeGroupReqInfo.ImageIID.SystemId
 
+	// ACK image_type aliases - these must be passed as image_type, not image_id.
+	// Actual ECS image IDs start with "m-"; anything else that matches a known
+	// ACK image_type value should be routed accordingly.
+	ackImageTypeAliases := map[string]bool{
+		"AliyunLinux":                    true,
+		"AliyunLinux3":                   true,
+		"AliyunLinux3ContainerOptimized": true,
+		"AliyunLinux3Arm64":              true,
+		"AliyunLinuxSecurity":            true,
+		"AliyunLinuxUEFI":                true,
+		"ContainerOS":                    true,
+		"CentOS":                         true,
+		"Ubuntu":                         true,
+		"Windows":                        true,
+		"WindowsCore":                    true,
+	}
+
 	imageType := ""
 	if strings.EqualFold(imageId, "") || strings.EqualFold(imageId, "default") {
 		imageId = ""
 		imageType = defaultNodePoolImageType
 		cblogger.Debugf("Using default image type: %s", imageType)
+	} else if ackImageTypeAliases[imageId] {
+		// imageId is an ACK image_type alias, not an actual ECS image ID
+		imageType = imageId
+		imageId = ""
+		cblogger.Debugf("Routing ACK image_type alias as image_type: %s", imageType)
 	} else {
 		cblogger.Debugf("Using specified image ID: %s", imageId)
 	}


### PR DESCRIPTION
## Changes
- Fix ACK node image routing: correctly pass known image_type aliases (e.g. `AliyunLinux3ContainerOptimized`, `Ubuntu`) as `image_type` instead of `image_id` in Alibaba ClusterHandler

## Future Plan
- Default image handling (selecting an appropriate node image when `imageId` is empty or `"default"`) will be moved to the cb-tumblebug layer so that CSP-specific logic is centralized and drivers remain thin