### PR TITLE
[RDBMS/MySQL] Feat: Add Storage Type test suite and fixes

### DIFF
--- a/api-runtime/rest-runtime/RDBMSRest.go
+++ b/api-runtime/rest-runtime/RDBMSRest.go
@@ -115,7 +115,13 @@ type RDBMSCreateRequest struct {
 		DBInstanceSpec  string `json:"DBInstanceSpec" validate:"required" example:"db.t3.medium"`
 		StorageSize     string `json:"StorageSize" validate:"required" example:"100"` // in GB
 
+		// StorageType: storage volume type. Use GetMetaInfo() to discover available options per CSP.
+		// OpenStack: configurable at creation time, but Trove API does not return this field in responses (always "NA").
 		StorageType string `json:"StorageType,omitempty" validate:"omitempty" example:"gp2"`
+		// Iops: Provisioned IOPS for the storage volume.
+		// AWS: required for io1/io2 (100-64000).
+		// Other CSPs: not used.
+		Iops string `json:"Iops,omitempty" validate:"omitempty" example:"3000"`
 
 		SubnetNames        []string `json:"SubnetNames,omitempty" validate:"omitempty" example:"subnet-01"`
 		SecurityGroupNames []string `json:"SecurityGroupNames,omitempty" validate:"omitempty" example:"sg-01"`
@@ -181,6 +187,7 @@ func CreateRDBMS(c echo.Context) error {
 		DBInstanceSpec:  req.ReqInfo.DBInstanceSpec,
 		StorageType:     req.ReqInfo.StorageType,
 		StorageSize:     req.ReqInfo.StorageSize,
+		Iops:            req.ReqInfo.Iops,
 
 		SubnetIIDs:        subnetIIDs,
 		SecurityGroupIIDs: sgIIDs,

--- a/api/docs.go
+++ b/api/docs.go
@@ -13452,6 +13452,11 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "Iops": {
+                    "description": "Iops: Provisioned IOPS for the storage volume.\nAWS: required for io1/io2 (100–64000).\nOther CSPs: not used.",
+                    "type": "string",
+                    "example": "3000"
+                },
                 "KeyValueList": {
                     "type": "array",
                     "items": {
@@ -13494,7 +13499,7 @@ const docTemplate = `{
                     "example": "100"
                 },
                 "StorageType": {
-                    "description": "Storage",
+                    "description": "Storage\nStorageType: storage volume type for the RDBMS instance.\ne.g., \"gp2\", \"io1\", \"SSD\", \"cloud_essd\"\nOpenStack: configurable at creation time, but Trove API does not return this field in responses (always \"NA\").",
                     "type": "string",
                     "example": "gp2"
                 },
@@ -13602,6 +13607,14 @@ const docTemplate = `{
                 },
                 "SupportsPublicAccess": {
                     "description": "true if public access can be toggled",
+                    "type": "boolean"
+                },
+                "SupportsStorageSizeConfiguration": {
+                    "description": "true if user can specify StorageSize at creation; false if CSP manages size automatically (e.g., NCP)",
+                    "type": "boolean"
+                },
+                "SupportsStorageTypeSelection": {
+                    "description": "true if user can specify StorageType at creation; false if CSP sets it automatically (e.g., Azure, NCP)",
                     "type": "boolean"
                 }
             }
@@ -16402,6 +16415,11 @@ const docTemplate = `{
                             "type": "boolean",
                             "default": false
                         },
+                        "Iops": {
+                            "description": "Iops: Provisioned IOPS for the storage volume.\nAWS: required for io1/io2 (100-64000).\nOther CSPs: not used.",
+                            "type": "string",
+                            "example": "3000"
+                        },
                         "MasterUserName": {
                             "type": "string",
                             "example": "admin"
@@ -16433,6 +16451,7 @@ const docTemplate = `{
                             "example": "100"
                         },
                         "StorageType": {
+                            "description": "StorageType: storage volume type. Use GetMetaInfo() to discover available options per CSP.\nOpenStack: configurable at creation time, but Trove API does not return this field in responses (always \"NA\").",
                             "type": "string",
                             "example": "gp2"
                         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -13449,6 +13449,11 @@
                         }
                     ]
                 },
+                "Iops": {
+                    "description": "Iops: Provisioned IOPS for the storage volume.\nAWS: required for io1/io2 (100–64000).\nOther CSPs: not used.",
+                    "type": "string",
+                    "example": "3000"
+                },
                 "KeyValueList": {
                     "type": "array",
                     "items": {
@@ -13491,7 +13496,7 @@
                     "example": "100"
                 },
                 "StorageType": {
-                    "description": "Storage",
+                    "description": "Storage\nStorageType: storage volume type for the RDBMS instance.\ne.g., \"gp2\", \"io1\", \"SSD\", \"cloud_essd\"\nOpenStack: configurable at creation time, but Trove API does not return this field in responses (always \"NA\").",
                     "type": "string",
                     "example": "gp2"
                 },
@@ -13599,6 +13604,14 @@
                 },
                 "SupportsPublicAccess": {
                     "description": "true if public access can be toggled",
+                    "type": "boolean"
+                },
+                "SupportsStorageSizeConfiguration": {
+                    "description": "true if user can specify StorageSize at creation; false if CSP manages size automatically (e.g., NCP)",
+                    "type": "boolean"
+                },
+                "SupportsStorageTypeSelection": {
+                    "description": "true if user can specify StorageType at creation; false if CSP sets it automatically (e.g., Azure, NCP)",
                     "type": "boolean"
                 }
             }
@@ -16399,6 +16412,11 @@
                             "type": "boolean",
                             "default": false
                         },
+                        "Iops": {
+                            "description": "Iops: Provisioned IOPS for the storage volume.\nAWS: required for io1/io2 (100-64000).\nOther CSPs: not used.",
+                            "type": "string",
+                            "example": "3000"
+                        },
                         "MasterUserName": {
                             "type": "string",
                             "example": "admin"
@@ -16430,6 +16448,7 @@
                             "example": "100"
                         },
                         "StorageType": {
+                            "description": "StorageType: storage volume type. Use GetMetaInfo() to discover available options per CSP.\nOpenStack: configurable at creation time, but Trove API does not return this field in responses (always \"NA\").",
                             "type": "string",
                             "example": "gp2"
                         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1204,6 +1204,13 @@ definitions:
         allOf:
         - $ref: '#/definitions/spider.IID'
         description: '{NameId, SystemId}'
+      Iops:
+        description: |-
+          Iops: Provisioned IOPS for the storage volume.
+          AWS: required for io1/io2 (100–64000).
+          Other CSPs: not used.
+        example: "3000"
+        type: string
       KeyValueList:
         items:
           $ref: '#/definitions/spider.KeyValue'
@@ -1234,7 +1241,11 @@ definitions:
         example: "100"
         type: string
       StorageType:
-        description: Storage
+        description: |-
+          Storage
+          StorageType: storage volume type for the RDBMS instance.
+          e.g., "gp2", "io1", "SSD", "cloud_essd"
+          OpenStack: configurable at creation time, but Trove API does not return this field in responses (always "NA").
         example: gp2
         type: string
       SubnetIIDs:
@@ -1321,6 +1332,14 @@ definitions:
         type: boolean
       SupportsPublicAccess:
         description: true if public access can be toggled
+        type: boolean
+      SupportsStorageSizeConfiguration:
+        description: true if user can specify StorageSize at creation; false if CSP
+          manages size automatically (e.g., NCP)
+        type: boolean
+      SupportsStorageTypeSelection:
+        description: true if user can specify StorageType at creation; false if CSP
+          sets it automatically (e.g., Azure, NCP)
         type: boolean
     type: object
   spider.RDBMSStatus:
@@ -3308,6 +3327,13 @@ definitions:
           HighAvailability:
             default: false
             type: boolean
+          Iops:
+            description: |-
+              Iops: Provisioned IOPS for the storage volume.
+              AWS: required for io1/io2 (100-64000).
+              Other CSPs: not used.
+            example: "3000"
+            type: string
           MasterUserName:
             example: admin
             type: string
@@ -3331,6 +3357,9 @@ definitions:
             example: "100"
             type: string
           StorageType:
+            description: |-
+              StorageType: storage volume type. Use GetMetaInfo() to discover available options per CSP.
+              OpenStack: configurable at creation time, but Trove API does not return this field in responses (always "NA").
             example: gp2
             type: string
           SubnetNames:

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
@@ -59,7 +59,7 @@ func (handler *AlibabaRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "7-730", true, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "7-730", true, false, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -513,19 +513,36 @@ func (handler *AlibabaRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		}
 	}
 
-	// Create master user account
+	// Create master user account with retry for IncorrectDBInstanceState.
+	// The instance may still be initializing after public connection allocation.
 	if rdbmsReqInfo.MasterUserName != "" {
-		acctReq := rds.CreateCreateAccountRequest()
-		acctReq.DBInstanceId = dbInstanceId
-		acctReq.AccountName = rdbmsReqInfo.MasterUserName
-		acctReq.AccountPassword = rdbmsReqInfo.MasterUserPassword
-		acctReq.AccountType = "Super"
-		_, acctErr := handler.Client.CreateAccount(acctReq)
-		if acctErr != nil {
-			cblogger.Errorf("Failed to create master account [%s] for [%s]: %v", rdbmsReqInfo.MasterUserName, dbInstanceId, acctErr)
+		const acctRetryInterval = 15
+		const acctRetryTimeout = 180
+		acctAttempts := 0
+		for {
+			acctReq := rds.CreateCreateAccountRequest()
+			acctReq.DBInstanceId = dbInstanceId
+			acctReq.AccountName = rdbmsReqInfo.MasterUserName
+			acctReq.AccountPassword = rdbmsReqInfo.MasterUserPassword
+			acctReq.AccountType = "Super"
+			_, acctErr := handler.Client.CreateAccount(acctReq)
+			if acctErr == nil {
+				cblogger.Infof("Master account [%s] created for [%s]", rdbmsReqInfo.MasterUserName, dbInstanceId)
+				break
+			}
+			if strings.Contains(acctErr.Error(), "IncorrectDBInstanceState") {
+				elapsed := acctAttempts * acctRetryInterval
+				if elapsed >= acctRetryTimeout {
+					return irs.RDBMSInfo{}, fmt.Errorf("failed to create master account after %ds: %w", acctRetryTimeout, acctErr)
+				}
+				cblogger.Warnf("[Alibaba] IncorrectDBInstanceState on account create attempt %d – retrying in %ds: %v",
+					acctAttempts+1, acctRetryInterval, acctErr)
+				time.Sleep(time.Duration(acctRetryInterval) * time.Second)
+				acctAttempts++
+				continue
+			}
 			return irs.RDBMSInfo{}, fmt.Errorf("failed to create master account: %w", acctErr)
 		}
-		cblogger.Infof("Master account [%s] created for [%s]", rdbmsReqInfo.MasterUserName, dbInstanceId)
 	}
 
 	// Set deletion protection if requested

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RDBMSHandler.go
@@ -137,7 +137,7 @@ func (handler *AwsRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("DescribeOrderableDBInstanceOptions failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "0-35", true, true)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "0-35", true, true, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -368,10 +368,23 @@ func (handler *AwsRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 	}
 
 	// Storage Type (Advanced - default: gp2)
+	// io1/io2: Iops is required. gp3: Iops is optional (default 3000).
 	if rdbmsReqInfo.StorageType != "" {
 		input.StorageType = aws.String(rdbmsReqInfo.StorageType)
 	}
-
+	st := rdbmsReqInfo.StorageType
+	if st == "io1" || st == "io2" {
+		if rdbmsReqInfo.Iops == "" {
+			return irs.RDBMSInfo{}, fmt.Errorf("Iops is required for StorageType %q (AWS RDS)", st)
+		}
+	}
+	if rdbmsReqInfo.Iops != "" {
+		iops, err := strconv.ParseInt(rdbmsReqInfo.Iops, 10, 64)
+		if err != nil {
+			return irs.RDBMSInfo{}, fmt.Errorf("invalid Iops value: %s", rdbmsReqInfo.Iops)
+		}
+		input.Iops = aws.Int64(iops)
+	}
 	// High Availability (Multi-AZ)
 	input.MultiAZ = aws.Bool(rdbmsReqInfo.HighAvailability)
 
@@ -668,7 +681,9 @@ func (handler *AwsRDBMSHandler) convertDBInstanceToRDBMSInfo(dbInstance *rds.DBI
 	if dbInstance.AllocatedStorage != nil {
 		rdbmsInfo.StorageSize = strconv.FormatInt(aws.Int64Value(dbInstance.AllocatedStorage), 10)
 	}
-
+	if dbInstance.Iops != nil {
+		rdbmsInfo.Iops = strconv.FormatInt(aws.Int64Value(dbInstance.Iops), 10)
+	}
 	// Security Groups
 	for _, sg := range dbInstance.VpcSecurityGroups {
 		rdbmsInfo.SecurityGroupIIDs = append(rdbmsInfo.SecurityGroupIIDs, irs.IID{

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RDBMSHandler.go
@@ -44,13 +44,8 @@ type AzureRDBMSHandler struct {
 	BackupsClient            *armmysqlfs.BackupsClient
 }
 
-var azureMySQLFallbackVersions = []string{"5.7", "8.0.21", "8.4", "9.5"}
-
-var azureMySQLFallbackStorageTypeOptions = map[string][]string{
-	"mysql": {"Burstable", "GeneralPurpose", "MemoryOptimized"},
-}
-
-var azureMySQLFallbackStorageSizeRange = irs.StorageSizeRange{Min: 20, Max: 32768}
+// Azure MySQL Flexible Server storage type (storageSku) is read-only and set automatically by Azure.
+// StorageTypeOptions returns ["NA"] to indicate it is not user-selectable.
 
 // GetMetaInfo returns metadata about Azure Database for MySQL Flexible Server capabilities.
 // Supported engine versions are fetched dynamically via the Azure REST API (api-version 2023-12-30).
@@ -64,7 +59,7 @@ func (handler *AzureRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInf
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	versions, skus, storageTypeOptions, storageSizeRange, err := handler.fetchMySQLMetaOptions(handler.Region.Region)
+	versions, skus, storageSizeRange, err := handler.fetchMySQLMetaOptions(handler.Region.Region)
 	if err != nil {
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 		LoggingError(hiscallInfo, err)
@@ -75,8 +70,10 @@ func (handler *AzureRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInf
 	instanceSpecOptions := map[string][]string{
 		"mysql": skus,
 	}
+	// Azure storageSku is read-only and set automatically; not user-selectable
+	storageTypeOptions := map[string][]string{"mysql": {"NA"}}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, map[string][]string{"mysql": versions}, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "1-35", false, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, map[string][]string{"mysql": versions}, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "1-35", false, false, false, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -88,9 +85,9 @@ func (handler *AzureRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInf
 }
 
 // fetchMySQLMetaOptions queries the Azure LocationBasedCapabilitySet_Get endpoint
-// (api-version 2023-12-30) to get supported MySQL versions, SKUs, and storage options for the given location.
-// This endpoint supersedes the legacy /capabilities endpoint and is stable across all regions.
-func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]string, []string, map[string][]string, irs.StorageSizeRange, error) {
+// (api-version 2023-12-30) to get supported MySQL versions, SKUs, and storage size range for the given location.
+// StorageType is not returned because Azure sets storageSku automatically (read-only).
+func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]string, []string, irs.StorageSizeRange, error) {
 	cred, err := azidentity.NewClientSecretCredential(
 		handler.CredentialInfo.TenantId,
 		handler.CredentialInfo.ClientId,
@@ -98,55 +95,50 @@ func (handler *AzureRDBMSHandler) fetchMySQLMetaOptions(location string) ([]stri
 		nil,
 	)
 	if err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to create Azure credential: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
 	token, err := cred.GetToken(handler.Ctx, policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},
 	})
 	if err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to get Azure token: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to get Azure token: %w", err)
 	}
 
 	apiURL := fmt.Sprintf(
 		"https://management.azure.com/subscriptions/%s/providers/Microsoft.DBforMySQL/locations/%s/capabilitySets/default?api-version=2023-12-30",
 		handler.CredentialInfo.SubscriptionId, location,
 	)
-	versions, skus, storageTypeOptions, storageSizeRange, err := handler.doCapabilitySetRequest(apiURL, token.Token)
+	versions, skus, storageSizeRange, err := handler.doCapabilitySetRequest(apiURL, token.Token)
 	if err != nil {
-		fallbackVersions := append([]string(nil), azureMySQLFallbackVersions...)
-		fallbackStorageTypeOptions := map[string][]string{
-			"mysql": append([]string(nil), azureMySQLFallbackStorageTypeOptions["mysql"]...),
-		}
-		cblogger.Infof("Azure MySQL capabilitySets API failed for location %s. Using fallback: versions=%v, storage=%v/%+v: %v", location, fallbackVersions, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, err)
-		return fallbackVersions, []string{}, fallbackStorageTypeOptions, azureMySQLFallbackStorageSizeRange, nil
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets API failed for location %s: %w", location, err)
 	}
-	return versions, skus, storageTypeOptions, storageSizeRange, nil
+	return versions, skus, storageSizeRange, nil
 }
 
 // doCapabilitySetRequest calls the Azure LocationBasedCapabilitySet_Get endpoint.
 // URL: GET .../capabilitySets/default?api-version=2023-12-30
 // Response: { "properties": { "supportedServerVersions": [{"name":"..."}], "supportedFlexibleServerEditions": [...] } }
-func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken string) ([]string, []string, map[string][]string, irs.StorageSizeRange, error) {
+func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken string) ([]string, []string, irs.StorageSizeRange, error) {
 	req, err := http.NewRequestWithContext(handler.Ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to build capabilitySets request: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to build capabilitySets request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+bearerToken)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets request failed: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to read capabilitySets response: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to read capabilitySets response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets API returned status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var result struct {
@@ -168,7 +160,7 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 		} `json:"properties"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to parse capabilitySets response: %w", err)
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("failed to parse capabilitySets response: %w", err)
 	}
 
 	versionSet := map[string]bool{}
@@ -199,13 +191,9 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 	}
 	sort.Strings(skus)
 
-	storageTypeSet := map[string]bool{}
 	var minStorageGB int64
 	var maxStorageGB int64
 	for _, edition := range result.Properties.SupportedFlexibleServerEditions {
-		if edition.Name != "" {
-			storageTypeSet[edition.Name] = true
-		}
 		for _, storageEdition := range edition.SupportedStorageEditions {
 			if storageEdition.MinStorageSize > 0 {
 				minGB := azureStorageMBToGB(storageEdition.MinStorageSize)
@@ -221,18 +209,12 @@ func (handler *AzureRDBMSHandler) doCapabilitySetRequest(apiURL, bearerToken str
 			}
 		}
 	}
-	storageTypes := make([]string, 0, len(storageTypeSet))
-	for storageType := range storageTypeSet {
-		storageTypes = append(storageTypes, storageType)
-	}
-	sort.Strings(storageTypes)
-	if len(storageTypes) == 0 || minStorageGB == 0 || maxStorageGB == 0 {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets response did not include storage options")
+	if minStorageGB == 0 || maxStorageGB == 0 {
+		return nil, nil, irs.StorageSizeRange{}, fmt.Errorf("capabilitySets response did not include storage size options")
 	}
 
-	storageTypeOptions := map[string][]string{"mysql": storageTypes}
 	storageSizeRange := irs.StorageSizeRange{Min: minStorageGB, Max: maxStorageGB}
-	return versions, skus, storageTypeOptions, storageSizeRange, nil
+	return versions, skus, storageSizeRange, nil
 }
 
 func azureStorageMBToGB(storageMB int64) int64 {
@@ -292,6 +274,9 @@ func (handler *AzureRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.R
 	}
 	if rdbmsReqInfo.StorageSize == "" {
 		return irs.RDBMSInfo{}, errors.New("StorageSize is required")
+	}
+	if rdbmsReqInfo.StorageType != "" {
+		return irs.RDBMSInfo{}, errors.New("StorageType is not supported for Azure: storage type is set automatically by the CSP. See SupportsStorageTypeSelection in GetMetaInfo")
 	}
 
 	// Validate PublicAccess and VPC combination

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
@@ -58,7 +58,7 @@ func (handler *GCPRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("fetch Cloud SQL instance options failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "1-7", false, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "1-7", false, false, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -331,6 +331,52 @@ func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 		return irs.RDBMSInfo{}, fmt.Errorf("invalid StorageSize: %s", rdbmsReqInfo.StorageSize)
 	}
 
+	// Validate StorageType against machine series.
+	// Each machine series has a fixed storage type that cannot be changed:
+	//
+	//   StorageType         | Machine Series          | Edition
+	//   --------------------|-------------------------|----------------
+	//   PD_SSD (fixed)      | db-perf-optimized-N-*   | Enterprise Plus
+	//   PD_SSD or PD_HDD    | db-custom-*, db-f1-micro, db-g1-small | Enterprise
+	//   HYPERDISK_BALANCED  | db-c4a-highmem-*        | Enterprise Plus
+	//   HYPERDISK_BALANCED  | db-custom-N4-*          | Enterprise
+	if rdbmsReqInfo.StorageType != "" {
+		spec := rdbmsReqInfo.DBInstanceSpec
+		st := rdbmsReqInfo.StorageType
+		const storageMapping = "\n\n  StorageType mapping:\n" +
+			"    PD_SSD (fixed)     : db-perf-optimized-N-* (Enterprise Plus)\n" +
+			"    PD_SSD or PD_HDD   : db-custom-*, db-f1-micro, db-g1-small (Enterprise)\n" +
+			"    HYPERDISK_BALANCED : db-c4a-highmem-* (Enterprise Plus)\n" +
+			"    HYPERDISK_BALANCED : db-custom-N4-* (Enterprise)"
+		switch {
+		case strings.HasPrefix(spec, "db-perf-optimized"):
+			if st != "PD_SSD" {
+				return irs.RDBMSInfo{}, fmt.Errorf(
+					"StorageType %q is not supported for machine series db-perf-optimized-N-* (fixed: PD_SSD)%s",
+					st, storageMapping)
+			}
+		case strings.HasPrefix(spec, "db-c4a"):
+			if st != "HYPERDISK_BALANCED" {
+				return irs.RDBMSInfo{}, fmt.Errorf(
+					"StorageType %q is not supported for machine series db-c4a-highmem-* (fixed: HYPERDISK_BALANCED)%s",
+					st, storageMapping)
+			}
+		case strings.HasPrefix(spec, "db-custom-N4-"):
+			if st != "HYPERDISK_BALANCED" {
+				return irs.RDBMSInfo{}, fmt.Errorf(
+					"StorageType %q is not supported for machine series db-custom-N4-* (fixed: HYPERDISK_BALANCED)%s",
+					st, storageMapping)
+			}
+		default:
+			// Shared/Dedicated core: PD_SSD and PD_HDD only
+			if st != "PD_SSD" && st != "PD_HDD" {
+				return irs.RDBMSInfo{}, fmt.Errorf(
+					"StorageType %q is not supported for machine series db-custom-*/db-f1-micro/db-g1-small (selectable: PD_SSD, PD_HDD)%s",
+					st, storageMapping)
+			}
+		}
+	}
+
 	projectId := handler.getProjectId()
 
 	// Map engine to GCP database version format
@@ -342,8 +388,20 @@ func (handler *GCPRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs.RDB
 		DataDiskSizeGb: storageSizeGB,
 	}
 
-	// Storage Type
-	if rdbmsReqInfo.StorageType != "" {
+	// Edition: N2 (db-perf-optimized-N-*) and C4A (db-c4a-highmem-*) require ENTERPRISE_PLUS.
+	// N4 (db-custom-N4-*) and Shared/Dedicated core (db-custom-*) use ENTERPRISE (default).
+	if strings.HasPrefix(rdbmsReqInfo.DBInstanceSpec, "db-perf-optimized") ||
+		strings.HasPrefix(rdbmsReqInfo.DBInstanceSpec, "db-c4a") {
+		settings.Edition = "ENTERPRISE_PLUS"
+	}
+
+	// Storage Type:
+	// - N2 (db-perf-optimized-N-*): PD_SSD is fixed by machine series; do not set DataDiskType.
+	// - HYPERDISK_BALANCED: auto-assigned for C4A and N4 machine series; do not set DataDiskType.
+	// - Shared/Dedicated core (db-custom-*): PD_SSD or PD_HDD can be selected; set DataDiskType.
+	if rdbmsReqInfo.StorageType != "" &&
+		!strings.HasPrefix(rdbmsReqInfo.DBInstanceSpec, "db-perf-optimized") &&
+		rdbmsReqInfo.StorageType != "HYPERDISK_BALANCED" {
 		settings.DataDiskType = rdbmsReqInfo.StorageType
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
@@ -94,7 +94,7 @@ func (handler *IbmRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo,
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "NA", false, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, true, "NA", false, false, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -555,10 +555,20 @@ func (handler *IbmRDBMSHandler) getDefaultMemberScalingGroup(dbEngine string, ho
 // apply admin_password passed as a provisioning parameter; the explicit UpdateUser call
 // (matching the IBM Terraform Provider approach) is required to actually set the password.
 func (handler *IbmRDBMSHandler) setAdminPassword(deploymentID, password string) error {
-	deployment, _, err := handler.CloudDBService.GetDeploymentInfoWithContext(
-		handler.getContext(),
-		handler.CloudDBService.NewGetDeploymentInfoOptions(deploymentID),
-	)
+	const retryInterval = 15
+	const retryTimeout = 180
+	var deployment *clouddatabasesv5.GetDeploymentInfoResponse
+	var err error
+	for elapsed := 0; elapsed < retryTimeout; elapsed += retryInterval {
+		deployment, _, err = handler.CloudDBService.GetDeploymentInfoWithContext(
+			handler.getContext(),
+			handler.CloudDBService.NewGetDeploymentInfoOptions(deploymentID),
+		)
+		if err == nil && deployment != nil && deployment.Deployment != nil {
+			break
+		}
+		time.Sleep(retryInterval * time.Second)
+	}
 	if err != nil || deployment == nil || deployment.Deployment == nil {
 		return fmt.Errorf("failed to get deployment info for setting admin password: %w", err)
 	}

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/RDBMSHandler.go
@@ -112,21 +112,23 @@ func (handler *NcpVpcRDBMSHandler) getMysqlMetaInfo() (irs.RDBMSMetaInfo, error)
 		}
 	}
 
-	// StorageTypeOptions: G3 generation uses SSD automatically.
-	// StorageSizeRange: NCP G3 supports 10GB default, 10GB increments up to 6000GB.
+	// StorageTypeOptions: NCP G3 generation sets SSD automatically; not user-selectable.
+	// StorageSizeRange: shown for reference only. NCP G3 starts at 10GB and auto-scales by 10GB increments up to 6000GB.
 	return irs.RDBMSMetaInfo{
-		DBEngine:                   "mysql",
-		SupportedVersions:          versions,
-		DBInstanceSpecOptions:      instanceSpecs,
-		StorageTypeOptions:         []string{"SSD"},
-		StorageSizeRange:           irs.StorageSizeRange{Min: 10, Max: 6000},
-		SupportsHighAvailability:   true,
-		SupportsBackup:             true,
-		SupportsPublicAccess:       false, // NCP does not expose a public domain assignment API; must be done manually via NCP Console
-		SupportsDeletionProtection: true,
-		SupportsEncryption:         false, // 2024년 10월 21일부터 신규 서비스 암호화 미제공 (Rocky 8.10)
-		RequiresSubnet:             true,
-		RequiresSecurityGroup:      false,
+		DBEngine:                         "mysql",
+		SupportedVersions:                versions,
+		DBInstanceSpecOptions:            instanceSpecs,
+		StorageTypeOptions:               []string{"NA"},
+		StorageSizeRange:                 irs.StorageSizeRange{Min: 10, Max: 6000},
+		SupportsHighAvailability:         true,
+		SupportsBackup:                   true,
+		SupportsPublicAccess:             false, // NCP does not expose a public domain assignment API; must be done manually via NCP Console
+		SupportsDeletionProtection:       true,
+		SupportsEncryption:               false, // 2024년 10월 21일부터 신규 서비스 암호화 미제공 (Rocky 8.10)
+		SupportsStorageTypeSelection:     false,
+		SupportsStorageSizeConfiguration: false,
+		RequiresSubnet:                   true,
+		RequiresSecurityGroup:            false,
 	}, nil
 }
 
@@ -198,21 +200,23 @@ func (handler *NcpVpcRDBMSHandler) getPostgresqlMetaInfo() (irs.RDBMSMetaInfo, e
 		}
 	}
 
-	// StorageTypeOptions: per NCP documentation, PostgreSQL (G3) uses SSD automatically.
-	// StorageSizeRange: NCP G3 supports 10GB default, 10GB increments up to 6000GB.
+	// StorageTypeOptions: NCP G3 generation sets SSD automatically; not user-selectable.
+	// StorageSizeRange: shown for reference only. NCP G3 starts at 10GB and auto-scales by 10GB increments up to 6000GB.
 	return irs.RDBMSMetaInfo{
-		DBEngine:                   "postgresql",
-		SupportedVersions:          versions,
-		DBInstanceSpecOptions:      instanceSpecs,
-		StorageTypeOptions:         []string{"SSD"},
-		StorageSizeRange:           irs.StorageSizeRange{Min: 10, Max: 6000},
-		SupportsHighAvailability:   true,
-		SupportsBackup:             true,
-		SupportsPublicAccess:       false,
-		SupportsDeletionProtection: false,
-		SupportsEncryption:         true,
-		RequiresSubnet:             true,
-		RequiresSecurityGroup:      false,
+		DBEngine:                         "postgresql",
+		SupportedVersions:                versions,
+		DBInstanceSpecOptions:            instanceSpecs,
+		StorageTypeOptions:               []string{"NA"},
+		StorageSizeRange:                 irs.StorageSizeRange{Min: 10, Max: 6000},
+		SupportsHighAvailability:         true,
+		SupportsBackup:                   true,
+		SupportsPublicAccess:             false,
+		SupportsDeletionProtection:       false,
+		SupportsEncryption:               true,
+		SupportsStorageTypeSelection:     false,
+		SupportsStorageSizeConfiguration: false,
+		RequiresSubnet:                   true,
+		RequiresSecurityGroup:            false,
 	}, nil
 }
 
@@ -362,17 +366,12 @@ func (handler *NcpVpcRDBMSHandler) createMysqlInstance(reqInfo irs.RDBMSInfo, hi
 
 	// StorageSize: NCP G3 always starts with 10GB and automatically scales up by 10GB as data increases (up to 6000GB).
 	// Storage size cannot be specified at creation time.
-	if reqInfo.StorageSize != "" && reqInfo.StorageSize != "10" {
-		return irs.RDBMSInfo{}, fmt.Errorf("NCP MySQL G3 does not support custom StorageSize at creation. Default is 10GB, automatically scaled up by 10GB as data increases (up to 6000GB). Requested: %s GB", reqInfo.StorageSize)
+	if reqInfo.StorageSize != "" {
+		return irs.RDBMSInfo{}, fmt.Errorf("StorageSize is not configurable for NCP: NCP G3 starts at 10GB and auto-scales by 10GB increments up to 6000GB. See SupportsStorageSizeConfiguration in GetMetaInfo. Requested: %s GB", reqInfo.StorageSize)
 	}
 
 	if reqInfo.StorageType != "" {
-		// G3 generation automatically uses SSD; DataStorageTypeCode must NOT be specified
-		if strings.ToUpper(reqInfo.StorageType) != "SSD" {
-			return irs.RDBMSInfo{}, fmt.Errorf("NCP MySQL G3 only supports SSD storage type, requested: %s", reqInfo.StorageType)
-		}
-		// Do not set DataStorageTypeCode for G3 (SSD is automatic)
-		cblogger.Infof("NCP MySQL G3: SSD storage type is applied automatically (not set explicitly)")
+		return irs.RDBMSInfo{}, errors.New("StorageType is not supported for NCP: storage type is set automatically by the CSP. See SupportsStorageTypeSelection in GetMetaInfo")
 	}
 	// Encryption is not configurable at creation via Spider (NCP uses default encryption settings)
 	if reqInfo.DeletionProtection {
@@ -469,17 +468,12 @@ func (handler *NcpVpcRDBMSHandler) createPostgresqlInstance(reqInfo irs.RDBMSInf
 
 	// StorageSize: NCP G3 always starts with 10GB and automatically scales up by 10GB as data increases (up to 6000GB).
 	// Storage size cannot be specified at creation time.
-	if reqInfo.StorageSize != "" && reqInfo.StorageSize != "10" {
-		return irs.RDBMSInfo{}, fmt.Errorf("NCP PostgreSQL G3 does not support custom StorageSize at creation. Default is 10GB, automatically scaled up by 10GB as data increases (up to 6000GB). Requested: %s GB", reqInfo.StorageSize)
+	if reqInfo.StorageSize != "" {
+		return irs.RDBMSInfo{}, fmt.Errorf("StorageSize is not configurable for NCP: NCP G3 starts at 10GB and auto-scales by 10GB increments up to 6000GB. See SupportsStorageSizeConfiguration in GetMetaInfo. Requested: %s GB", reqInfo.StorageSize)
 	}
 
 	if reqInfo.StorageType != "" {
-		// G3 generation automatically uses SSD; DataStorageTypeCode must NOT be specified
-		if strings.ToUpper(reqInfo.StorageType) != "SSD" {
-			return irs.RDBMSInfo{}, fmt.Errorf("NCP PostgreSQL G3 only supports SSD storage type, requested: %s", reqInfo.StorageType)
-		}
-		// Do not set DataStorageTypeCode for G3 (SSD is automatic)
-		cblogger.Infof("NCP PostgreSQL G3: SSD storage type is applied automatically (not set explicitly)")
+		return irs.RDBMSInfo{}, errors.New("StorageType is not supported for NCP: storage type is set automatically by the CSP. See SupportsStorageTypeSelection in GetMetaInfo")
 	}
 	// Encryption is not configurable at creation via Spider (NCP uses default encryption settings)
 	backupPeriod := reqInfo.BackupRetentionDays

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -328,7 +328,7 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 
 	storageSizeRange := irs.StorageSizeRange{Min: 20, Max: 2048}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, false, "1-730", true, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, true, false, "1-730", true, false, true, true)
 	if err != nil {
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err

--- a/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/openstack/resources/RDBMSHandler.go
@@ -86,7 +86,7 @@ func (handler *OpenStackRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMet
 		return irs.RDBMSMetaInfo{}, err
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, false, true, true, false, false, "NA", false, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, false, true, true, false, false, "NA", false, false, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -415,13 +415,15 @@ func (handler *OpenStackRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (i
 	LoggingInfo(hiscallInfo, start)
 
 	// Re-fetch to get the latest status/endpoint after ACTIVE
-	freshInst, err := instances.Get(context.TODO(), handler.DBClient, instanceID).Extract()
+	freshResult := instances.Get(context.TODO(), handler.DBClient, instanceID)
+	freshInst, err := freshResult.Extract()
 	if err != nil {
 		cblogger.Warnf("failed to re-fetch instance %s after creation: %v", instanceID, err)
 		freshInst = createdInstance
 	}
+	freshVolumeType := extractVolumeTypeFromBody(freshResult.Body)
 
-	rdbmsInfo, err := handler.convertInstanceToRDBMSInfo(freshInst)
+	rdbmsInfo, err := handler.convertInstanceToRDBMSInfo(freshInst, freshVolumeType)
 	if err != nil {
 		cblogger.Error(err)
 		LoggingError(hiscallInfo, err)
@@ -460,8 +462,9 @@ func (handler *OpenStackRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 		if err != nil {
 			return false, err
 		}
+		volumeTypes := extractVolumeTypesFromPageBody(page.GetBody())
 		for _, inst := range instanceList {
-			info, err := handler.convertInstanceToRDBMSInfo(&inst)
+			info, err := handler.convertInstanceToRDBMSInfo(&inst, volumeTypes[inst.ID])
 			if err != nil {
 				return false, err
 			}
@@ -511,7 +514,7 @@ func (handler *OpenStackRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo,
 
 	LoggingInfo(hiscallInfo, start)
 
-	rdbmsInfo, err := handler.convertInstanceToRDBMSInfo(inst)
+	rdbmsInfo, err := handler.convertInstanceToRDBMSInfo(inst, extractVolumeTypeFromBody(result.Body))
 	if err != nil {
 		cblogger.Error(err)
 		LoggingError(hiscallInfo, err)
@@ -722,8 +725,61 @@ func (handler *OpenStackRDBMSHandler) findInstanceIDByName(name string) (string,
 	return foundID, nil
 }
 
+// extractVolumeTypeFromBody extracts volume.type from a Trove single-instance raw response body.
+// gophercloud's Volume struct does not include the Type field, so we parse it from the raw JSON.
+// Note: Trove API does not return volume.type or volume.id in instance detail responses in many
+// deployments. StorageType will be "NA" if the Trove API omits volume.type.
+func extractVolumeTypeFromBody(body interface{}) string {
+	raw, ok := body.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	rawInst, ok := raw["instance"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	rawVol, ok := rawInst["volume"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	vt, _ := rawVol["type"].(string)
+	return vt
+}
+
+// extractVolumeTypesFromPageBody extracts volume.type for each instance in a list page body.
+// Returns a map of instanceID -> volumeType.
+func extractVolumeTypesFromPageBody(body interface{}) map[string]string {
+	result := map[string]string{}
+	raw, ok := body.(map[string]interface{})
+	if !ok {
+		return result
+	}
+	rawInsts, ok := raw["instances"].([]interface{})
+	if !ok {
+		return result
+	}
+	for _, ri := range rawInsts {
+		rawInst, ok := ri.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := rawInst["id"].(string)
+		if id == "" {
+			continue
+		}
+		rawVol, ok := rawInst["volume"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		vt, _ := rawVol["type"].(string)
+		result[id] = vt
+	}
+	return result
+}
+
 // convertInstanceToRDBMSInfo converts a Trove Instance to RDBMSInfo.
-func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances.Instance) (irs.RDBMSInfo, error) {
+// volumeType is passed explicitly because gophercloud's Volume struct omits the Type field.
+func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances.Instance, volumeType string) (irs.RDBMSInfo, error) {
 	flavorName, err := handler.resolveFlavorName(inst.Flavor.ID)
 	if err != nil {
 		return irs.RDBMSInfo{}, err
@@ -771,7 +827,12 @@ func (handler *OpenStackRDBMSHandler) convertInstanceToRDBMSInfo(inst *instances
 		DBInstanceSpec:  flavorName,
 		DBInstanceType:  "NA",
 
-		StorageType: "NA",
+		StorageType: func() string {
+			if volumeType != "" {
+				return volumeType
+			}
+			return "NA"
+		}(),
 		StorageSize: strconv.Itoa(inst.Volume.Size),
 
 		Endpoint: endpoint,

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
@@ -57,7 +57,7 @@ func (handler *TencentRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaI
 		return irs.RDBMSMetaInfo{}, fmt.Errorf("GetMetaInfo failed: %w", err)
 	}
 
-	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "7-1830", true, false)
+	metaInfo, err := irs.BuildRDBMSMetaInfo(requestedEngine, supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, true, true, true, false, true, "7-1830", true, false, true, true)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -101,6 +101,17 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 	storageTypeSet := make(map[string]struct{})
 	selectedConfigIDs := make(map[int64]struct{})
 
+	// DeviceTypes supported in the matched zone, derived from SellType ConfigIds.
+	// Used to filter DiskTypeConf: cloud disk types are only included when the zone
+	// actually has CLOUD_NATIVE_CLUSTER configs available.
+	zoneDeviceTypes := make(map[string]struct{})
+
+	// Device types that use cloud disk storage (CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM).
+	cloudNativeDeviceTypes := map[string]bool{
+		"CLOUD_NATIVE_CLUSTER":           true,
+		"CLOUD_NATIVE_CLUSTER_EXCLUSIVE": true,
+	}
+
 	matchedZone := false
 	for _, regionConf := range data.Regions {
 		if regionConf == nil || regionConf.Region == nil {
@@ -135,16 +146,30 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 					if cfgID == nil {
 						continue
 					}
-					_, ok := configMap[*cfgID]
+					cfg, ok := configMap[*cfgID]
 					if !ok {
 						continue
 					}
 					selectedConfigIDs[*cfgID] = struct{}{}
+					// Track device types actually available in this zone
+					if cfg.DeviceType != nil && *cfg.DeviceType != "" {
+						zoneDeviceTypes[*cfg.DeviceType] = struct{}{}
+					}
 				}
 			}
 
+			// Include cloud disk storage types only if the zone supports CLOUD_NATIVE_CLUSTER.
+			// DiskTypeConf items carry a DeviceType field; we match it against zoneDeviceTypes
+			// so that zones without cloud-native configs (e.g., Beijing-3) do not expose
+			// CLOUD_HSSD/CLOUD_SSD/CLOUD_PREMIUM as usable options.
 			for _, diskTypeConf := range zoneConf.DiskTypeConf {
-				if diskTypeConf == nil {
+				if diskTypeConf == nil || diskTypeConf.DeviceType == nil {
+					continue
+				}
+				if !cloudNativeDeviceTypes[*diskTypeConf.DeviceType] {
+					continue
+				}
+				if _, supported := zoneDeviceTypes[*diskTypeConf.DeviceType]; !supported {
 					continue
 				}
 				for _, diskType := range diskTypeConf.DiskType {
@@ -165,9 +190,8 @@ func (handler *TencentRDBMSHandler) fetchCDBMetaOptions() (map[string][]string, 
 	if len(selectedConfigIDs) == 0 {
 		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no available CDB config IDs for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
 	}
-	if len(storageTypeSet) == 0 {
-		return nil, nil, nil, irs.StorageSizeRange{}, fmt.Errorf("DescribeCdbZoneConfig returned no storage types for region [%s], zone [%s]", handler.Region.Region, handler.Region.Zone)
-	}
+	// UNIVERSAL (local SSD) is always available; add it regardless of cloud disk support.
+	storageTypeSet["local_ssd"] = struct{}{}
 
 	memorySet := make(map[int64]struct{})
 	storageRange := irs.StorageSizeRange{}
@@ -379,11 +403,6 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 	request.UniqVpcId = &rdbmsReqInfo.VpcIID.SystemId
 	request.UniqSubnetId = &rdbmsReqInfo.SubnetIIDs[0].SystemId
 
-	// Zone
-	if handler.Region.Zone != "" {
-		request.Zone = &handler.Region.Zone
-	}
-
 	// HA - ProtectMode: 0=async, 1=semi-sync, 2=strong-sync
 	if rdbmsReqInfo.HighAvailability {
 		protectMode := int64(1) // semi-sync for HA
@@ -424,7 +443,77 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 		request.ResourceTags = tags
 	}
 
-	response, err := handler.Client.CreateDBInstanceHour(request)
+	// StorageType handling:
+	//   "local_ssd"    → UNIVERSAL device type (default, no DeviceType/Zone needed)
+	//   cloud disk types → DeviceType=CLOUD_NATIVE_CLUSTER required; Zone must NOT be set
+	//                      (CLOUD_NATIVE_CLUSTER derives zone from VPC/Subnet automatically)
+	tencentCloudDiskTypes := map[string]bool{
+		"CLOUD_HSSD":    true,
+		"CLOUD_SSD":     true,
+		"CLOUD_PREMIUM": true,
+	}
+	switch {
+	case rdbmsReqInfo.StorageType == "local_ssd" || rdbmsReqInfo.StorageType == "":
+		// UNIVERSAL instance (local SSD): apply zone from connection config
+		if handler.Region.Zone != "" {
+			request.Zone = &handler.Region.Zone
+		}
+	case tencentCloudDiskTypes[rdbmsReqInfo.StorageType]:
+		// Cloud disk instance: DeviceType=CLOUD_NATIVE_CLUSTER + DiskType specifies the disk technology.
+		// Zone/SlaveZone must NOT be set for cloud disk edition;
+		// node availability zones are configured via ClusterTopology instead.
+		deviceType := "CLOUD_NATIVE_CLUSTER"
+		request.DeviceType = &deviceType
+
+		diskType := rdbmsReqInfo.StorageType // CLOUD_HSSD, CLOUD_SSD, or CLOUD_PREMIUM
+		request.DiskType = &diskType
+
+		// ClusterTopology: RW node in the configured zone; RO node auto-assigned.
+		rwZone := handler.Region.Zone
+		isRandomZone := "YES"
+		request.ClusterTopology = &cdb.ClusterTopology{
+			ReadWriteNode: &cdb.ReadWriteNode{
+				Zone: &rwZone,
+			},
+			ReadOnlyNodes: []*cdb.ReadonlyNode{
+				{IsRandomZone: &isRandomZone},
+			},
+		}
+	default:
+		return irs.RDBMSInfo{}, fmt.Errorf("unsupported StorageType '%s' for Tencent CDB; valid values: local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM", rdbmsReqInfo.StorageType)
+	}
+
+	// CreateDBInstanceHour with retry for OperationDenied.OtherOderInProcess.
+	// Tencent rejects concurrent orders while another order is being placed.
+	// Retry with backoff until the order slot is free or timeout is reached.
+	const orderRetryIntervalSec = 10
+	const orderRetryTimeoutSec = 300 // 5 minutes
+	var response *cdb.CreateDBInstanceHourResponse
+	orderAttempts := 0
+	for {
+		orderAttempts++
+		response, err = handler.Client.CreateDBInstanceHour(request)
+		if err == nil {
+			break
+		}
+		if strings.Contains(err.Error(), "OtherOderInProcess") {
+			elapsed := orderAttempts * orderRetryIntervalSec
+			if elapsed >= orderRetryTimeoutSec {
+				hiscallInfo.ElapsedTime = call.Elapsed(start)
+				finalErr := fmt.Errorf("CreateDBInstanceHour failed after %d attempt(s) over %ds timeout: %w",
+					orderAttempts, orderRetryTimeoutSec, err)
+				cblogger.Error(finalErr)
+				LoggingError(hiscallInfo, finalErr)
+				return irs.RDBMSInfo{}, finalErr
+			}
+			cblogger.Warnf("[Tencent] OtherOderInProcess on attempt %d – retrying in %ds (elapsed %d/%ds): %v",
+				orderAttempts, orderRetryIntervalSec, elapsed, orderRetryTimeoutSec, err)
+			time.Sleep(time.Duration(orderRetryIntervalSec) * time.Second)
+			continue
+		}
+		// Non-retryable error
+		break
+	}
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		err = handler.enrichUnsupportedSpecError(err, rdbmsReqInfo.DBEngineVersion)
@@ -434,11 +523,21 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 	}
 	calllogger.Info(call.String(hiscallInfo))
 
-	if response.Response == nil || len(response.Response.InstanceIds) == 0 {
-		return irs.RDBMSInfo{}, errors.New("no instance ID returned from CreateDBInstanceHour")
+	// Tencent may return an empty InstanceIds list even on success when concurrent
+	// orders are in flight (OtherOderInProcess scenario). Fall back to a name-based
+	// lookup so the instance is not lost.
+	var instanceId string
+	if response.Response != nil && len(response.Response.InstanceIds) > 0 {
+		instanceId = *response.Response.InstanceIds[0]
+	} else {
+		cblogger.Warnf("[Tencent] CreateDBInstanceHour returned no InstanceIds for '%s'; looking up by name...", rdbmsReqInfo.IId.NameId)
+		var lookupErr error
+		instanceId, lookupErr = handler.findInstanceIdByName(rdbmsReqInfo.IId.NameId, 60)
+		if lookupErr != nil {
+			return irs.RDBMSInfo{}, fmt.Errorf("CreateDBInstanceHour returned no InstanceIds and name lookup failed: %w", lookupErr)
+		}
+		cblogger.Infof("[Tencent] Found instance '%s' by name: %s", rdbmsReqInfo.IId.NameId, instanceId)
 	}
-
-	instanceId := *response.Response.InstanceIds[0]
 
 	// Wait for instance to be running (status=1)
 	err = handler.waitForInstanceStatus(instanceId, 1, 600)
@@ -547,7 +646,7 @@ func (handler *TencentRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) 
 	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "IsolateDBInstance()")
 	start := call.Start()
 
-	// Step 1: Isolate the instance
+	// Step 1: Isolate the instance (moves to recycle bin, status → 4:isolating → 5:isolated)
 	isolateReq := cdb.NewIsolateDBInstanceRequest()
 	isolateReq.InstanceId = &rdbmsIID.SystemId
 
@@ -560,15 +659,21 @@ func (handler *TencentRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) 
 	}
 	calllogger.Info(call.String(hiscallInfo))
 
-	// Step 2: Offline the isolated instance (permanent delete)
+	// Step 2: Wait for isolated status (5) before calling Offline.
+	// OfflineIsolatedInstances fails if the instance is still in isolating state (4).
+	const isolatedStatus int64 = 5
+	if waitErr := handler.waitForInstanceStatus(rdbmsIID.SystemId, isolatedStatus, 300); waitErr != nil {
+		cblogger.Warnf("[Tencent] Timeout waiting for instance %s to reach isolated status; attempting Offline anyway: %v",
+			rdbmsIID.SystemId, waitErr)
+	}
+
+	// Step 3: Permanently delete (Eliminate Now)
 	offlineReq := cdb.NewOfflineIsolatedInstancesRequest()
 	offlineReq.InstanceIds = []*string{&rdbmsIID.SystemId}
 
 	_, err = handler.Client.OfflineIsolatedInstances(offlineReq)
 	if err != nil {
-		cblogger.Warn("Isolate succeeded but Offline failed (instance will be in recycle bin): ", err)
-		// Still return true since isolate succeeded
-		return true, nil
+		return false, fmt.Errorf("instance isolated but permanent delete (OfflineIsolatedInstances) failed: %w", err)
 	}
 
 	return true, nil
@@ -600,8 +705,15 @@ func (handler *TencentRDBMSHandler) convertToRDBMSInfo(inst *cdb.InstanceInfo) i
 	if inst.Volume != nil {
 		rdbmsInfo.StorageSize = strconv.FormatInt(*inst.Volume, 10)
 	}
-	if inst.DeviceType != nil && *inst.DeviceType != "" {
-		rdbmsInfo.StorageType = *inst.DeviceType
+	// DiskType: actual storage disk type (CLOUD_HSSD, CLOUD_SSD).
+	// Only returned for cloud disk instances; empty for local SSD instances.
+	// DeviceType: hardware instance category (UNIVERSAL, EXCLUSIVE, etc.) - NOT the storage type.
+	// When DiskType is empty and DeviceType is UNIVERSAL/EXCLUSIVE, the instance uses local SSD.
+	if inst.DiskType != nil && *inst.DiskType != "" {
+		rdbmsInfo.StorageType = *inst.DiskType
+	} else if inst.DeviceType != nil &&
+		(*inst.DeviceType == "UNIVERSAL" || *inst.DeviceType == "EXCLUSIVE") {
+		rdbmsInfo.StorageType = "local_ssd"
 	} else {
 		rdbmsInfo.StorageType = "NA"
 	}
@@ -681,6 +793,28 @@ func convertTencentStatusToRDBMSStatus(status int64) irs.RDBMSStatus {
 	default:
 		return irs.RDBMSError
 	}
+}
+
+// findInstanceIdByName looks up the CDB instance ID by InstanceName.
+// Tencent may return empty InstanceIds in CreateDBInstanceHour when concurrent
+// orders are processed; this resolves the ID via DescribeDBInstances.
+// It polls for up to timeoutSec seconds (5s interval) to handle propagation delay.
+func (handler *TencentRDBMSHandler) findInstanceIdByName(name string, timeoutSec int) (string, error) {
+	for elapsed := 0; elapsed < timeoutSec; elapsed += 5 {
+		req := cdb.NewDescribeDBInstancesRequest()
+		req.InstanceNames = []*string{&name}
+		resp, err := handler.Client.DescribeDBInstances(req)
+		if err == nil && resp.Response != nil {
+			for _, inst := range resp.Response.Items {
+				if inst.InstanceName != nil && *inst.InstanceName == name &&
+					inst.InstanceId != nil && *inst.InstanceId != "" {
+					return *inst.InstanceId, nil
+				}
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return "", fmt.Errorf("instance with name '%s' not found within %ds", name, timeoutSec)
 }
 
 func (handler *TencentRDBMSHandler) waitForInstanceStatus(instanceId string, targetStatus int64, timeoutSec int) error {

--- a/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
@@ -46,6 +46,9 @@ type RDBMSMetaInfo struct {
 	SupportsDeletionProtection bool   `json:"SupportsDeletionProtection"`     // true if deletion protection is available
 	SupportsEncryption         bool   `json:"SupportsEncryption"`             // true if storage encryption is available
 
+	SupportsStorageTypeSelection    bool `json:"SupportsStorageTypeSelection"`    // true if user can specify StorageType at creation; false if CSP sets it automatically (e.g., Azure, NCP)
+	SupportsStorageSizeConfiguration bool `json:"SupportsStorageSizeConfiguration"` // true if user can specify StorageSize at creation; false if CSP manages size automatically (e.g., NCP)
+
 	RequiresSubnet        bool `json:"RequiresSubnet"`        // true if SubnetNames is required at creation
 	RequiresSecurityGroup bool `json:"RequiresSecurityGroup"` // true if SecurityGroupNames is required at creation
 }
@@ -60,7 +63,7 @@ func NormalizeRDBMSEngine(dbEngine string) (string, error) {
 	}
 }
 
-func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, dbInstanceSpecOptions map[string][]string, storageTypeOptions map[string][]string, storageSizeRange StorageSizeRange, supportsHighAvailability, supportsBackup, supportsPublicAccess, supportsDeletionProtection, supportsEncryption bool, backupRetentionRange string, requiresSubnet, requiresSecurityGroup bool) (RDBMSMetaInfo, error) {
+func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, dbInstanceSpecOptions map[string][]string, storageTypeOptions map[string][]string, storageSizeRange StorageSizeRange, supportsHighAvailability, supportsBackup, supportsPublicAccess, supportsDeletionProtection, supportsEncryption bool, backupRetentionRange string, requiresSubnet, requiresSecurityGroup, supportsStorageTypeSelection, supportsStorageSizeConfiguration bool) (RDBMSMetaInfo, error) {
 	normalizedEngine, err := NormalizeRDBMSEngine(dbEngine)
 	if err != nil {
 		return RDBMSMetaInfo{}, err
@@ -85,6 +88,8 @@ func BuildRDBMSMetaInfo(dbEngine string, supportedEngines map[string][]string, d
 		SupportsPublicAccess:       supportsPublicAccess,
 		SupportsDeletionProtection: supportsDeletionProtection,
 		SupportsEncryption:         supportsEncryption,
+		SupportsStorageTypeSelection:    supportsStorageTypeSelection,
+		SupportsStorageSizeConfiguration: supportsStorageSizeConfiguration,
 		RequiresSubnet:             requiresSubnet,
 		RequiresSecurityGroup:      requiresSecurityGroup,
 	}, nil
@@ -113,8 +118,15 @@ type RDBMSInfo struct {
 	DBInstanceType string `json:"DBInstanceType,omitempty" example:"Primary"`                // Primary | ReadReplica (for response)
 
 	// Storage
-	StorageType string `json:"StorageType,omitempty" example:"gp2"`           // e.g., "gp2", "io1", "SSD", "cloud_essd"
+	// StorageType: storage volume type for the RDBMS instance.
+	// e.g., "gp2", "io1", "SSD", "cloud_essd"
+	// OpenStack: configurable at creation time, but Trove API does not return this field in responses (always "NA").
+	StorageType string `json:"StorageType,omitempty" example:"gp2"`
 	StorageSize string `json:"StorageSize" validate:"required" example:"100"` // in GB
+	// Iops: Provisioned IOPS for the storage volume.
+	// AWS: required for io1/io2 (100–64000).
+	// Other CSPs: not used.
+	Iops string `json:"Iops,omitempty" example:"3000"`
 
 	// Network
 	SubnetIIDs        []IID `json:"SubnetIIDs,omitempty"`        // Subnet IIDs for DB placement

--- a/test/rdbms-mysql-test/README.md
+++ b/test/rdbms-mysql-test/README.md
@@ -14,17 +14,17 @@ cd ./bin; ./start.sh
 
 Before running tests, register connection names for each CSP in CB-Spider.
 
-| CSP | Connection Name |
-|-----|----------------|
-| AWS | `aws-config01` |
-| Azure | `azure-koreacentral-config` |
-| GCP | `gcp-iowa-config` |
-| Alibaba | `alibaba-beijing-config` |
-| Tencent | `tencent-beijing3-config` |
-| IBM | `ibm-us-east-1-config` |
-| OpenStack | `openstack-config01` |
-| NCP | `ncp-korea1-config` |
-| NHN | `nhn-korea-pangyo1-config` |
+| CSP | Connection Name | Region | Zone |
+|-----|----------------|--------|------|
+| AWS | `aws-config01` | `ap-southeast-2` | `ap-southeast-2a` |
+| Azure | `azure-koreacentral-config` | `koreacentral` | `1` |
+| GCP | `gcp-iowa-config` | `us-central1` | `us-central1-a` |
+| Alibaba | `alibaba-beijing-config` | `cn-beijing` | `cn-beijing-f` |
+| Tencent | `tencent-beijing6-config` | `ap-beijing` | `ap-beijing-6` |
+| IBM | `ibm-us-east-1-config` | `us-east` | `us-east-1` |
+| OpenStack | `openstack-config01` | `RegionOne` | `nova` |
+| NCP | `ncp-korea1-config` | `KR` | `KR-1` |
+| NHN | `nhn-korea-pangyo1-config` | `KR1` | `kr-pub-a` |
 
 ### Pre-created Network Resources
 
@@ -71,16 +71,18 @@ curl -u admin:***** -sX POST http://localhost:1024/spider/vpc \
 
 All CSPs create a MySQL instance named `cb-spider-mysql-test`.
 
+StorageType은 지정하지 않으며, CSP 기본값으로 생성됩니다. 결과 테이블의 Storage 컬럼에 `크기|타입` 형태로 표시됩니다 (예: `100GB|gp2`).
+
 | CSP | Engine Version | Instance Spec | Storage | Subnet Required |
 |-----|---------------|---------------|---------|-----------------|
 | AWS | 8.0 | db.t3.medium | 100GB | ✅ (2개, 다른 AZ) |
 | Azure | 8.0.21 | Standard_B1ms | 20GB | 미사용 |
 | GCP | 8.0 | db-custom-2-8192 | 20GB | 미사용 |
-| Alibaba | 8.0 | mysql.n2e.small.1 | 20GB | ✅ |
+| Alibaba | 8.0 | mysql.n4.large.1 | 20GB | ✅ |
 | Tencent | 8.0 | 8000 (MB) | 50GB | ✅ |
 | IBM | 8.4 | multitenant | 30GB | 미사용 |
 | OpenStack | 5.7.29 | m1.small | 20GB | 미사용 |
-| NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | 10GB | ✅ |
+| NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | CSP 관리 | ✅ |
 | NHN | MYSQL_V8408 | m2.c2m4 | 20GB | ✅ |
 
 ## Configuration
@@ -115,11 +117,11 @@ export SPIDER_AUTH="${SPIDER_AUTH:-admin:*****}"   # <-- 비밀번호 변경
 
 **Example output:**
 ```
-CSP          | Status      | Engine   | Version      | Spec                     | Storage    | Endpoint                                 | PublicAccess | Elapsed
+CSP          | Status      | Engine   | Version      | Spec                     | Storage                  | Endpoint                                 | PublicAccess | Elapsed
 ---
-AWS          | Available   | mysql    | 8.0.45       | db.t3.medium             | 100GB      | xxx.rds.amazonaws.com:3306               | true         | 8m39s
-AZURE        | Available   | mysql    | 8.0.21       | Standard_B1ms            | 20GB       | xxx.mysql.database.azure.com:3306        | true         | 5m35s
-GCP          | Available   | mysql    | 8.0          | db-custom-2-8192         | 20GB       | xxx.cloudsql.google.com:3306             | true         | 3m58s
+AWS          | Available   | mysql    | 8.0.45       | db.t3.medium             | 100GB|gp2                | xxx.rds.amazonaws.com:3306               | true         | 8m39s
+AZURE        | Available   | mysql    | 8.0.21       | Standard_B1ms            | 20GB|N/A                 | xxx.mysql.database.azure.com:3306        | true         | 5m35s
+GCP          | Available   | mysql    | 8.0          | db-custom-2-8192         | 20GB|PD_SSD              | xxx.cloudsql.google.com:3306             | true         | 3m58s
 ...
 ```
 
@@ -219,4 +221,27 @@ tail -f /tmp/rdbms_logs_<PID>/log_aws.txt
 |-----|------|
 | AWS | SubnetGroup 생성을 위해 **다른 AZ의 서브넷 2개 이상** 필요 |
 | Tencent | `DBInstanceSpec`은 메모리 크기(MB) 지정 (예: `8000` = 8GB) |
-| NCP | StorageSize는 10GB 단위. G3(KVM) generation만 지원. Public 도메인은 생성 후 콘솔에서 별도 신청 필요 |
+| NCP | StorageSize/StorageType 지정 불가 (CSP 자동 관리). G3(KVM) generation만 지원. Public 도메인은 생성 후 콘솔에서 별도 신청 필요 |
+
+## 시험 결과
+
+### 2026-06-12
+
+```
+=================================================================================================================================================================================
+                                              RDBMS CREATE & INFO TEST SUMMARY - ALL CSPs
+=================================================================================================================================================================================
+CSP          | Status      | Engine   | Version      | Spec                     | Storage                  | Endpoint                                 | PublicAccess | Elapsed
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AWS          | Available   | mysql    | 8.0.45       | db.t3.medium             | 100GB|gp2                | cb-spider-mysql-test-***.ap-southeast-2.rds.amazonaws.com:3306          | true         | 4m36s
+AZURE        | Available   | mysql    | 8.0.21       | Standard_B1ms            | 20GB|Premium_LRS         | cb-spider-mysql-test-***.mysql.database.azure.com:3306                  | true         | 5m37s
+GCP          | Available   | mysql    | 8.0          | db-custom-2-8192         | 20GB|PD_SSD              | *.*.*.*:3306                             | true         | 3m56s
+ALIBABA      | Available   | mysql    | 8.0          | mysql.n4.large.1         | 20GB|cloud_essd          | *.*.*.*:3306                             | true         | 2m52s
+TENCENT      | Available   | mysql    | 8.0          | 8000                     | 50GB|local_ssd           | bj-cdb-***.sql.tencentcdb.com:24740      | true         | 5m14s
+IBM          | Available   | mysql    | 8.4          | multitenant              | 30GB|standard            | ***.databases.appdomain.cloud:31172      | true         | 6m34s
+OPENSTACK    | Available   | mysql    | 5.7.29       | m1.small                 | 20GB|NA                  | *.*.*.*:3306                             | true         | 4m28s
+NCP          | Available   | mysql    | MYSQL8.0.36  | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | 10GB|SSD                 | db-***.vpc-cdb.ntruss.com:3306           | N/A          | 12m27s
+NHN          | Available   | mysql    | MYSQL_V8408  | m2.c2m4                  | 20GB|General SSD         | ***.external.kr1.mysql.rds.nhncloudservice.com:3306                     | true         | 8m36s
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Total: 9  PASS: 9  FAIL: 0
+```

--- a/test/rdbms-mysql-test/alibaba-rdbms-test.sh
+++ b/test/rdbms-mysql-test/alibaba-rdbms-test.sh
@@ -17,7 +17,7 @@ export CREATE_JSON='{
     "SubnetNames": ["subnet-01"],
     "DBEngine": "mysql",
     "DBEngineVersion": "8.0",
-    "DBInstanceSpec": "mysql.n2e.small.1",
+    "DBInstanceSpec": "mysql.n4.large.1",
     "StorageSize": "20",
     "MasterUserName": "myadmin",
     "MasterUserPassword": "Password123!",

--- a/test/rdbms-mysql-test/common-rdbms-test.sh
+++ b/test/rdbms-mysql-test/common-rdbms-test.sh
@@ -45,7 +45,7 @@ create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/rdbms" \
 err_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
 if [[ -n "${err_msg}" ]]; then
     echo "[${CSP_NAME}] ERROR on create: ${err_msg}"
-    echo "${CSP_NAME}|CREATE_ERROR|${err_msg}|||||||-" > "${RESULT_FILE}"
+    echo "${CSP_NAME}|CREATE_ERROR|${err_msg}||||||||-" > "${RESULT_FILE}"
     exit 1
 fi
 
@@ -78,7 +78,7 @@ while true; do
 
     if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
         echo "[${CSP_NAME}] TIMEOUT: RDBMS did not become available within ${MAX_WAIT_SEC}s"
-        echo "${CSP_NAME}|TIMEOUT|||||||||" > "${RESULT_FILE}"
+        echo "${CSP_NAME}|TIMEOUT||||||||||" > "${RESULT_FILE}"
         exit 1
     fi
 done
@@ -95,8 +95,9 @@ status=$(echo "${info}"     | jq -r '.Status           // "N/A"')
 engine=$(echo "${info}"     | jq -r '.DBEngine         // "N/A"')
 version=$(echo "${info}"    | jq -r '.DBEngineVersion  // "N/A"')
 spec=$(echo "${info}"       | jq -r '.DBInstanceSpec   // "N/A"')
-storage=$(echo "${info}"    | jq -r '.StorageSize      // "N/A"')
-ep_addr=$(echo "${info}"    | jq -r '.Endpoint         // "N/A"')
+storage=$(echo "${info}"      | jq -r '.StorageSize  // "N/A"')
+storage_type=$(echo "${info}" | jq -r '.StorageType  // "N/A"')
+ep_addr=$(echo "${info}"      | jq -r '.Endpoint     // "N/A"')
 ep_port=$(echo "${info}"    | jq -r '.Port             // "N/A"')
 pub_access=$(echo "${info}" | jq -r '.PublicAccess     // "N/A"')
 
@@ -114,6 +115,6 @@ echo "[${CSP_NAME}] Done. Endpoint: ${endpoint_display} (total elapsed: ${elapse
 mkdir -p "$(dirname "${RESULT_FILE}")"
 
 # Write pipe-separated result line
-# Format: CSP|Status|Engine|Version|Spec|Storage(GB)|Endpoint|PublicAccess|Elapsed
-echo "${CSP_NAME}|${status}|${engine}|${version}|${spec}|${storage}GB|${endpoint_display}|${pub_access}|${elapsed_fmt}" \
+# Format: CSP|Status|Engine|Version|Spec|Storage(GB)|StorageType|Endpoint|PublicAccess|Elapsed
+echo "${CSP_NAME}|${status}|${engine}|${version}|${spec}|${storage}GB|${storage_type}|${endpoint_display}|${pub_access}|${elapsed_fmt}" \
   > "${RESULT_FILE}"

--- a/test/rdbms-mysql-test/delete-all-csp-rdbms.sh
+++ b/test/rdbms-mysql-test/delete-all-csp-rdbms.sh
@@ -26,7 +26,7 @@ csp_connection() {
         AZURE)     echo "azure-koreacentral-config"    ;;
         GCP)       echo "gcp-iowa-config"              ;;
         ALIBABA)   echo "alibaba-beijing-config"       ;;
-        TENCENT)   echo "tencent-beijing3-config"      ;;
+        TENCENT)   echo "tencent-beijing6-config"      ;;
         IBM)       echo "ibm-us-east-1-config"         ;;
         OPENSTACK) echo "openstack-config01"           ;;
         NCP)       echo "ncp-korea1-config"            ;;

--- a/test/rdbms-mysql-test/ibm-rdbms-test.sh
+++ b/test/rdbms-mysql-test/ibm-rdbms-test.sh
@@ -17,7 +17,6 @@ export CREATE_JSON='{
     "DBEngine": "mysql",
     "DBEngineVersion": "8.4",
     "DBInstanceSpec": "multitenant",
-    "StorageType": "standard",
     "StorageSize": "30",
     "MasterUserName": "admin",
     "MasterUserPassword": "Passwordspider123",

--- a/test/rdbms-mysql-test/ncp-rdbms-test.sh
+++ b/test/rdbms-mysql-test/ncp-rdbms-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # NCP (Naver Cloud Platform) RDBMS Test Script
-# Note: Subnet required. StorageSize must be 10 (default, 10GB increments up to 6000GB).
+# Note: Subnet required. StorageSize and StorageType are not configurable (SupportsStorageSizeConfiguration=false, SupportsStorageTypeSelection=false).
 #       G3 (KVM) server generation only. Public domain must be requested via console after creation.
 # Author: CB-Spider Team
 
@@ -19,8 +19,6 @@ export CREATE_JSON='{
     "DBInstanceSpec": "SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003",
     "DBEngine": "mysql",
     "DBEngineVersion": "8.0.36",
-    "StorageSize": "10",
-    "StorageType": "SSD",
     "MasterUserName": "myadmin",
     "MasterUserPassword": "Password123!",
     "PublicAccess": true

--- a/test/rdbms-mysql-test/nhn-rdbms-test.sh
+++ b/test/rdbms-mysql-test/nhn-rdbms-test.sh
@@ -18,7 +18,6 @@ export CREATE_JSON='{
     "DBEngine": "mysql",
     "DBEngineVersion": "MYSQL_V8408",
     "DBInstanceSpec": "m2.c2m4",
-    "StorageType": "General SSD",
     "StorageSize": "20",
     "MasterUserName": "myadmin",
     "MasterUserPassword": "Password123!",

--- a/test/rdbms-mysql-test/run-all-csp-rdbms-tests.sh
+++ b/test/rdbms-mysql-test/run-all-csp-rdbms-tests.sh
@@ -37,16 +37,16 @@ csp_script() {
 }
 
 print_separator() {
-    echo "------------------------------------------------------------------------------------------------------------------------------------------------------------"
+    printf '%177s\n' '' | tr ' ' '-'
 }
 
 print_header() {
     echo ""
-    echo "============================================================================================================================================================"
+    printf '%177s\n' '' | tr ' ' '='
     echo "                                              RDBMS CREATE & INFO TEST SUMMARY - ALL CSPs"
-    echo "============================================================================================================================================================"
+    printf '%177s\n' '' | tr ' ' '='
     echo ""
-    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-10s | %-40s | %-12s | %-10s\n" \
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-24s | %-40s | %-12s | %-10s\n" \
         "CSP" "Status" "Engine" "Version" "Spec" "Storage" "Endpoint" "PublicAccess" "Elapsed"
     print_separator
 }
@@ -107,7 +107,7 @@ for csp in ${CSP_ORDER}; do
     result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
 
     if [[ -f "${result_file}" ]]; then
-        IFS='|' read -r r_csp r_status r_engine r_version r_spec r_storage r_endpoint r_public r_elapsed \
+        IFS='|' read -r r_csp r_status r_engine r_version r_spec r_storage r_storage_type r_endpoint r_public r_elapsed \
             < "${result_file}"
     else
         r_csp="${csp}"
@@ -116,14 +116,16 @@ for csp in ${CSP_ORDER}; do
         r_version="-"
         r_spec="-"
         r_storage="-"
+        r_storage_type="-"
         r_endpoint="-"
         r_public="-"
         r_elapsed="-"
     fi
 
-    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-10s | %-40s | %-12s | %-10s\n" \
+    r_storage_display="${r_storage}|${r_storage_type}"
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-24s | %-40s | %-12s | %-10s\n" \
         "${r_csp}" "${r_status}" "${r_engine}" "${r_version}" \
-        "${r_spec}" "${r_storage}" "${r_endpoint}" "${r_public}" "${r_elapsed}"
+        "${r_spec}" "${r_storage_display}" "${r_endpoint}" "${r_public}" "${r_elapsed}"
 done
 
 print_separator
@@ -131,7 +133,7 @@ echo ""
 echo "Logs   : ${LOG_DIR}/"
 echo "Results: ${RESULT_DIR}/"
 echo ""
-echo "=============================================================================================================================================================="
+printf '%177s\n' '' | tr ' ' '='
 echo ""
 
 # ── Per-CSP full log dump (optional, controlled by VERBOSE=1) ────────────────

--- a/test/rdbms-mysql-test/storage-type-test/README.md
+++ b/test/rdbms-mysql-test/storage-type-test/README.md
@@ -1,0 +1,245 @@
+# CB-Spider RDBMS StorageType Test
+
+각 CSP의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트.
+
+## 실행
+
+```bash
+# 전체 CSP 병렬 실행
+./run-all-csp-storage-type-tests.sh
+
+# CSP별 단독 실행
+./aws-storage-type-test.sh
+./gcp-storage-type-test.sh
+# ...
+
+# 전체 삭제
+./delete-all-csp-storage-type-rdbms.sh
+```
+
+## 스크립트 구조
+
+```
+.
+├── run-all-csp-storage-type-tests.sh   # 전체 CSP 병렬 실행
+├── delete-all-csp-storage-type-rdbms.sh # 전체 CSP 병렬 삭제
+├── common-storage-type-test.sh          # 공통: Create → Poll Available → Get Info
+├── aws-storage-type-test.sh
+├── gcp-storage-type-test.sh
+├── alibaba-storage-type-test.sh
+├── tencent-storage-type-test.sh
+├── ibm-storage-type-test.sh
+├── nhn-storage-type-test.sh
+├── openstack-storage-type-test.sh
+├── azure-storage-type-test.sh           # SKIP (StorageType 선택 불가)
+└── ncp-storage-type-test.sh             # SKIP (StorageType 선택 불가)
+```
+
+---
+
+## CSP별 시험 설정
+
+### AWS
+
+| StorageType | DBInstanceSpec | StorageSize | Iops |
+|-------------|---------------|-------------|------|
+| gp2 | db.t3.medium | 100 GB | - |
+| gp3 | db.t3.medium | 100 GB | - |
+| io1 | db.t3.medium | 100 GB | **3000 (필수)** |
+| io2 | db.t3.medium | 100 GB | **3000 (필수)** |
+| standard | db.t3.medium | 100 GB | - |
+
+- StorageTypeOptions: metainfo API에서 동적으로 조회
+- Connection: `aws-config01`
+- Region: `ap-southeast-2` / Zone: `ap-southeast-2a`
+- SubnetNames: `subnet-01`, `subnet-02` (서로 다른 AZ, SubnetGroup 생성 필수)
+- SecurityGroupNames: `sg-01`
+
+**특이사항**
+- io1/io2: `Iops` 필드 필수(Iops:AWS io1/io2 전용)
+- StorageSize: io1/io2는 최소 100 GB
+
+---
+
+### GCP
+
+GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 직접 지정.
+
+| StorageType | DBInstanceSpec | StorageSize | Edition | Machine Series |
+|-------------|---------------|-------------|---------|---------------|
+| PD_SSD | db-perf-optimized-N-4 | 10 GB | Enterprise Plus | N2 |
+| PD_SSD | db-custom-2-8192 | 10 GB | Enterprise | Shared/Dedicated core |
+| PD_HDD | db-custom-2-8192 | 10 GB | Enterprise | Shared/Dedicated core |
+| HYPERDISK_BALANCED | db-c4a-highmem-4 | 20 GB | Enterprise Plus | C4A |
+| HYPERDISK_BALANCED | db-custom-N4-2-4096 | 20 GB | Enterprise | N4 |
+
+- Connection: `gcp-iowa-config`
+- Region: `us-central1` / Zone: `us-central1-a`
+- VPCName: `vpc-01`
+
+**특이사항**
+- 머신 시리즈 ↔ StorageType 불일치 시 Spider 드라이버에서 에러 반환 (e.g. N2에 HYPERDISK_BALANCED 요청시 에러)
+- N2/C4A 머신 타입은 Edition=ENTERPRISE_PLUS 자동 설정 (드라이버 내부 처리)
+- N2(`db-perf-optimized-N-*`), C4A(`db-c4a-highmem-*`), N4(`db-custom-N4-*`): StorageType은 API에 전달하지 않음 (머신 시리즈에 의해 자동 결정)
+- GCP metainfo StorageTypeOptions에 HYPERDISK_BALANCED가 포함되나, 직접 지정이 아닌 머신 시리즈 선택으로 결정됨
+- HYPERDISK_BALANCED 최소 StorageSize: 20 GB
+
+---
+
+### Alibaba
+
+| StorageType | DBInstanceSpec | StorageSize | 비고 |
+|-------------|---------------|-------------|------|
+| cloud_auto | mysql.n4.large.1 | 20 GB | |
+| cloud_essd | mysql.n4.large.1 | 20 GB | ESSD PL1 |
+| cloud_essd2 | mysql.n2.small.2c | **500 GB** | ESSD PL2, 최소 500 GB |
+| cloud_essd3 | mysql.n2.small.2c | **1500 GB** | ESSD PL3, 최소 1500 GB |
+| local_ssd | rds.mysql.t1.small | 20 GB | Premium Local SSD, rds.mysql.* 계열 전용 |
+
+- StorageTypeOptions: metainfo API에서 동적으로 조회
+- Connection: `alibaba-beijing-config`
+- Region: `cn-beijing` / Zone: `cn-beijing-f`
+- SubnetNames: `subnet-01`
+
+**특이사항**
+- cloud_essd2/3는 mysql.n4.* 계열과 호환되지 않음 → mysql.n2.small.2c 사용
+- local_ssd는 rds.mysql.* 계열 전용 (mysql.n4.* 사용 시 InvalidInstanceLevel.DiskType 에러)
+
+---
+
+### Tencent
+
+| StorageType | DBInstanceSpec | StorageSize |
+|-------------|---------------|-------------|
+| local_ssd | 8000 (MB) | 50 GB |
+| CLOUD_HSSD | 8000 (MB) | 50 GB |
+| CLOUD_SSD | 8000 (MB) | 50 GB |
+| CLOUD_PREMIUM | 8000 (MB) | 50 GB |
+
+- StorageTypeOptions: metainfo API에서 동적으로 조회
+- Connection: `tencent-beijing6-config`
+- Region: `ap-beijing` / Zone: `ap-beijing-6`
+- SubnetNames: `subnet-01`
+- DBInstanceSpec: 메모리 크기 MB 단위 지정 (8000 = 8 GB)
+
+**특이사항**
+- 동시 주문 거부 발생 가능 (OperationDenied.OtherOderInProcess) → 드라이버 자동 재시도 처리
+
+---
+
+### IBM
+
+| StorageType | DBInstanceSpec | StorageSize |
+|-------------|---------------|-------------|
+| standard | multitenant | 30 GB |
+
+- Connection: `ibm-us-east-1-config`
+- Region: `us-east` / Zone: `us-east-1`
+- DBEngineVersion: `8.4`
+
+---
+
+### OpenStack
+
+| StorageType | DBInstanceSpec | StorageSize |
+|-------------|---------------|-------------|
+| __DEFAULT__ | m1.small | 20 GB |
+| RBD | m1.small | 20 GB |
+
+- Connection: `openstack-config01`
+- Region: `RegionOne` / Zone: `nova`
+- DBEngineVersion: `5.7.29`
+
+---
+
+### NHN
+
+| StorageType | DBInstanceSpec | StorageSize |
+|-------------|---------------|-------------|
+| General HDD | m2.c2m4 | 20 GB |
+| General SSD | m2.c2m4 | 20 GB |
+
+- StorageTypeOptions: NHN Cloud RDS API에서 동적으로 조회
+- Connection: `nhn-korea-pangyo1-config`
+- Region: `KR1` / Zone: `kr-pub-a`
+- SubnetNames: `subnet-01`
+
+---
+
+### Azure — SKIP
+
+- SupportsStorageTypeSelection=false
+- Connection: `azure-koreacentral-config`
+- Region: `koreacentral` / Zone: `1`
+- Azure MySQL Flexible Server의 storageSku는 read-only, Azure가 자동 설정
+- 테스트 스크립트 실행 시 즉시 SKIP 처리
+
+---
+
+### NCP — SKIP
+
+- SupportsStorageTypeSelection=false
+- Connection: `ncp-korea1-config`
+- Region: `KR` / Zone: `KR-1`
+- NCP MySQL G3은 SSD 자동 적용, DataStorageTypeCode 지정 불가
+- 테스트 스크립트 실행 시 즉시 SKIP 처리
+
+---
+
+## StorageType 선택 가능 여부 요약
+
+| CSP | SupportsStorageTypeSelection | 비고 |
+|-----|------------------------------|------|
+| AWS | ✅ | gp2, gp3, io1, io2, standard |
+| GCP | ✅ | 머신 시리즈에 따라 자동 결정 (직접 선택 아님) |
+| Alibaba | ✅ | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd |
+| Tencent | ✅ | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM |
+| IBM | ✅ | standard |
+| OpenStack | ✅ | __DEFAULT__, RBD  |
+| NHN | ✅ | General HDD, General SSD |
+| Azure | ❌ | SKIP |
+| NCP | ❌ | SKIP |
+
+---
+
+## 시험 결과
+
+### 2026-06-12
+
+```
+================================================================================================================================
+                                RDBMS StorageType Test Summary - All CSPs
+================================================================================================================================
+CSP          | StorageType(Req)     | StorageType(Ret)   | Result | DB Status      | Elapsed    | Reason
+--------------------------------------------------------------------------------------------------------------------------------
+ [*] cloud_auto: Alibaba auto-select type - CSP picks the optimal cloud storage type at provisioning time
+--------------------------------------------------------------------------------------------------------------------------------
+AWS          | gp2                  | gp2                | PASS   | Available      | 4m35s      | -
+AWS          | gp3                  | gp3                | PASS   | Available      | 4m36s      | -
+AWS          | io1                  | io1                | PASS   | Available      | 4m36s      | -
+AWS          | io2                  | io2                | PASS   | Available      | 4m36s      | -
+AWS          | standard             | standard           | PASS   | Available      | 6m7s       | -
+AZURE        | N/A                  | N/A                | SKIP   | NOT_APPLICABLE | -          | SupportsStorageTypeSelection=false: storageSku is read-only, set automatically by Azure
+GCP          | HYPERDISK_BALANCED   | HYPERDISK_BALANCED | PASS   | Available      | 3m40s      | -
+GCP          | HYPERDISK_BALANCED   | HYPERDISK_BALANCED | PASS   | Available      | 4m26s      | -
+GCP          | PD_HDD               | PD_HDD             | PASS   | Available      | 4m10s      | -
+GCP          | PD_SSD               | PD_SSD             | PASS   | Available      | 3m55s      | -
+GCP          | PD_SSD               | PD_SSD             | PASS   | Available      | 3m40s      | -
+ALIBABA      | cloud_auto[*]        | general_essd       | PASS   | Available      | 3m0s       | cloud_auto: auto-select type, CSP chose 'general_essd'
+ALIBABA      | cloud_essd           | cloud_essd         | PASS   | Available      | 3m2s       | -
+ALIBABA      | cloud_essd2          | cloud_essd2        | PASS   | Available      | 3m18s      | -
+ALIBABA      | cloud_essd3          | cloud_essd3        | PASS   | Available      | 3m36s      | -
+ALIBABA      | local_ssd            | local_ssd          | PASS   | Available      | 4m54s      | -
+TENCENT      | CLOUD_HSSD           | CLOUD_HSSD         | PASS   | Available      | 9m14s      | -
+TENCENT      | CLOUD_PREMIUM        | CLOUD_PREMIUM      | PASS   | Available      | 9m22s      | -
+TENCENT      | CLOUD_SSD            | CLOUD_SSD          | PASS   | Available      | 9m15s      | -
+TENCENT      | local_ssd            | local_ssd          | PASS   | Available      | 6m15s      | -
+IBM          | standard             | standard           | PASS   | Available      | 39m6s      | -
+OPENSTACK    | __DEFAULT__          | NA                 | PASS   | Available      | 4m57s      | OpenStack Trove does not expose StorageType post-creation; Available=PASS
+OPENSTACK    | RBD                  | NA                 | PASS   | Available      | 4m59s      | OpenStack Trove does not expose StorageType post-creation; Available=PASS
+NCP          | N/A                  | N/A                | SKIP   | NOT_APPLICABLE | -          | SupportsStorageTypeSelection=false: NCP G3 applies SSD automatically, StorageType cannot be specified
+NHN          | General HDD          | General HDD        | PASS   | Available      | 12m5s      | -
+NHN          | General SSD          | General SSD        | PASS   | Available      | 12m35s     | -
+--------------------------------------------------------------------------------------------------------------------------------
+Total: 26  PASS: 24  FAIL: 0  SKIP: 2
+```

--- a/test/rdbms-mysql-test/storage-type-test/alibaba-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/alibaba-storage-type-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Alibaba Cloud RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: Subnet required.
+
+CSP_NAME="ALIBABA"
+CONNECTION_NAME="alibaba-beijing-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_alibaba_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_alibaba_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_alibaba_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_alibaba_${st_safe}.txt"
+
+    # Alibaba per-StorageType configuration:
+    #   cloud_essd2 (ESSD PL2): mysql.n2.small.2c, min 500 GB
+    #   cloud_essd3 (ESSD PL3): mysql.n2.small.2c, min 1500 GB
+    #   local_ssd (Premium Local SSD): rds.mysql.* family
+    case "${storage_type}" in
+        cloud_essd2) db_instance_spec="mysql.n2.small.2c";  db_storage_size="500"  ;;
+        cloud_essd3) db_instance_spec="mysql.n2.small.2c";  db_storage_size="1500" ;;
+        local_ssd)   db_instance_spec="rds.mysql.t1.small"; db_storage_size="20"   ;;
+        *)           db_instance_spec="mysql.n4.large.1";   db_storage_size="20"   ;;
+    esac
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"8.0\",
+    \"DBInstanceSpec\": \"${db_instance_spec}\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"${db_storage_size}\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_alibaba_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_alibaba_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/aws-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/aws-storage-type-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# AWS RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: io1/io2 require StorageSize >= 100. SubnetGroup requires 2+ subnets in different AZs.
+
+CSP_NAME="AWS"
+CONNECTION_NAME="aws-config01"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_aws_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_aws_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_aws_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_aws_${st_safe}.txt"
+
+    # AWS per-StorageType configuration:
+    #   io1/io2: Iops required (100-64000); StorageSize >= 100
+    #   gp3:     Iops not specified (AWS applies default 3000 IOPS automatically)
+    #   others:  no extra params
+    case "${storage_type}" in
+        io1|io2) iops_field="\"Iops\": \"3000\"," ; storage_size="100" ;;
+        *)       iops_field=""                    ; storage_size="100" ;;
+    esac
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"8.0\",
+    \"DBInstanceSpec\": \"db.t3.medium\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"${storage_size}\",
+    ${iops_field}
+    \"SubnetNames\": [\"subnet-01\", \"subnet-02\"],
+    \"SecurityGroupNames\": [\"sg-01\"],
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_aws_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_aws_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/azure-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/azure-storage-type-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Azure RDBMS StorageType Test Script
+# SKIP: Azure MySQL Flexible Server does not support user-selectable StorageType.
+#       storageSku is read-only and set automatically by Azure (always Premium_LRS).
+#       SupportsStorageTypeSelection=false in GetMetaInfo.
+
+CSP_NAME="AZURE"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+mkdir -p "${RESULT_DIR}"
+
+SKIP_REASON="SupportsStorageTypeSelection=false: storageSku is read-only, set automatically by Azure"
+
+echo "[${CSP_NAME}] SKIP - ${SKIP_REASON}"
+
+# Format: CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+echo "${CSP_NAME}|N/A|N/A|SKIP|NOT_APPLICABLE|-|${SKIP_REASON}" \
+    > "${RESULT_DIR}/result_azure_skip.txt"

--- a/test/rdbms-mysql-test/storage-type-test/common-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/common-storage-type-test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Common Test Script
+# Flow: Create RDBMS with specific StorageType -> Poll until Available ->
+#       Get Info -> Verify StorageType matches requested -> Write result ->
+#       Delete instance (if AUTO_DELETE=true)
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name
+#   STORAGE_TYPE    - StorageType value being tested (e.g., "gp2")
+#   CREATE_JSON     - Full JSON body for POST /spider/rdbms
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - default: http://localhost:1024
+#   SPIDER_AUTH     - default: admin:****
+#   MAX_WAIT_SEC    - default: 3600
+#   POLL_INTERVAL   - default: 30
+#   AUTO_DELETE     - delete instance after test (default: false)
+#
+# Result file format (7 fields):
+#   CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+AUTO_DELETE="${AUTO_DELETE:-false}"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${CSP_NAME}/${STORAGE_TYPE}] [${timestamp}] Creating RDBMS '${RDBMS_NAME}'..."
+
+# ── Create RDBMS ─────────────────────────────────────────────────────────────
+create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/rdbms" \
+    -H 'Content-Type: application/json' \
+    -d "${CREATE_JSON}" 2>&1)
+
+err_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] ERROR on create: ${err_msg}"
+    mkdir -p "$(dirname "${RESULT_FILE}")"
+    elapsed_fmt=$(format_elapsed $(($(date +%s) - start_time)))
+    echo "${CSP_NAME}|${STORAGE_TYPE}|N/A|FAIL|CREATE_ERROR|${elapsed_fmt}|-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+create_status=$(echo "${create_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Create response status: ${create_status}"
+
+# ── Poll until Available ──────────────────────────────────────────────────────
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Waiting for RDBMS (poll every ${POLL_INTERVAL}s, max ${MAX_WAIT_SEC}s)..."
+
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+        "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+    status_lower=$(echo "${cur_status}" | tr '[:upper:]' '[:lower:]')
+
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    case "${status_lower}" in
+        available|ready|runnable|active)
+            echo "[${CSP_NAME}/${STORAGE_TYPE}] RDBMS is available!"
+            break
+            ;;
+    esac
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] TIMEOUT: did not become available within ${MAX_WAIT_SEC}s"
+        mkdir -p "$(dirname "${RESULT_FILE}")"
+        echo "${CSP_NAME}|${STORAGE_TYPE}|N/A|FAIL|TIMEOUT|$(format_elapsed ${elapsed})|-" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+
+# ── Get RDBMS Info ────────────────────────────────────────────────────────────
+info=$(curl -u "${SPIDER_AUTH}" -s \
+    "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}")
+
+db_status=$(echo "${info}"      | jq -r '.Status       // "N/A"')
+returned_type=$(echo "${info}"  | jq -r '.StorageType  // "N/A"')
+
+# ── Verify StorageType ────────────────────────────────────────────────────────
+req_lower=$(echo "${STORAGE_TYPE}"   | tr '[:upper:]' '[:lower:]')
+ret_lower=$(echo "${returned_type}"  | tr '[:upper:]' '[:lower:]')
+
+reason="-"
+
+if [[ "${CSP_NAME}" == "OPENSTACK" ]]; then
+    # OpenStack Trove API does not return volume.type in instance detail responses.
+    # Accept Available status as PASS since StorageType cannot be verified post-creation.
+    if [[ "${ret_lower}" == "n/a" || "${ret_lower}" == "na" || -z "${ret_lower}" ]]; then
+        pass_fail="PASS"
+        reason="OpenStack Trove does not expose StorageType post-creation; Available=PASS"
+    elif [[ "${ret_lower}" == "${req_lower}" ]]; then
+        pass_fail="PASS"
+    else
+        pass_fail="FAIL"
+    fi
+elif [[ "${req_lower}" == "cloud_auto" ]]; then
+    # cloud_auto is Alibaba's auto-select storage type.
+    # Alibaba automatically picks the best cloud storage type at provisioning time.
+    # Accept any cloud-based type (cloud_*/general_essd); reject local_ssd or N/A.
+    if [[ "${ret_lower}" == "n/a" || "${ret_lower}" == "na" || \
+          "${ret_lower}" == "local_ssd" || -z "${ret_lower}" ]]; then
+        pass_fail="FAIL"
+        reason="cloud_auto: auto-select, unexpected returned type '${returned_type}'"
+    else
+        pass_fail="PASS"
+        reason="cloud_auto: auto-select type, CSP chose '${returned_type}'"
+    fi
+elif [[ "${ret_lower}" == "${req_lower}" ]]; then
+    pass_fail="PASS"
+else
+    pass_fail="FAIL"
+fi
+
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Requested=${STORAGE_TYPE}, Returned=${returned_type} => ${pass_fail} (${elapsed_fmt})"
+[[ "${reason}" != "-" ]] && echo "[${CSP_NAME}/${STORAGE_TYPE}] Note: ${reason}"
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+# Format: CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+echo "${CSP_NAME}|${STORAGE_TYPE}|${returned_type}|${pass_fail}|${db_status}|${elapsed_fmt}|${reason}" \
+    > "${RESULT_FILE}"
+
+# ── Auto Delete ───────────────────────────────────────────────────────────────
+if [[ "${AUTO_DELETE}" == "true" ]]; then
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] Sending delete request for '${RDBMS_NAME}'..."
+    del_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+        "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}" \
+        -H 'Content-Type: application/json' \
+        -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+    del_err=$(echo "${del_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${del_err}" ]]; then
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] Delete warning: ${del_err}"
+    else
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] Delete request accepted."
+    fi
+fi

--- a/test/rdbms-mysql-test/storage-type-test/delete-all-csp-storage-type-rdbms.sh
+++ b/test/rdbms-mysql-test/storage-type-test/delete-all-csp-storage-type-rdbms.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Test - Delete All Instances
+# For each CSP, fetches StorageTypeOptions from rdbmsmetainfo, derives the
+# RDBMS names used during StorageType testing (cb-mysql-st-<type>), and deletes
+# them in parallel. All CSPs run concurrently.
+#
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DELETE="${SCRIPT_DIR}/../common-rdbms-delete.sh"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"
+export POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+BASE_DIR="/tmp/st_del_$$"
+RESULT_DIR="${BASE_DIR}/results"
+LOG_DIR="${BASE_DIR}/logs"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── CSP connection config map ─────────────────────────────────────────────────
+csp_connection() {
+    case "$1" in
+        AWS)       echo "aws-config01"                 ;;
+        AZURE)     echo "azure-koreacentral-config"    ;;
+        GCP)       echo "gcp-iowa-config"              ;;
+        ALIBABA)   echo "alibaba-beijing-config"       ;;
+        TENCENT)   echo "tencent-beijing6-config"      ;;
+        IBM)       echo "ibm-us-east-1-config"         ;;
+        OPENSTACK) echo "openstack-config01"           ;;
+        NCP)       echo "ncp-korea1-config"            ;;
+        NHN)       echo "nhn-korea-pangyo1-config"     ;;
+    esac
+}
+
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# Derive safe name (same logic as in per-CSP test scripts)
+st_safe_name() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15
+}
+
+print_separator() {
+    echo "----------------------------------------------------------------------"
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+echo ""
+echo "########################################################################"
+echo "#      CB-Spider RDBMS StorageType Test - Delete All Instances         #"
+echo "########################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per instance"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Base dir     : ${BASE_DIR}"
+echo ""
+
+CSP_ORDER="AWS AZURE GCP ALIBABA TENCENT IBM OPENSTACK NCP NHN"
+
+# ── GCP fixed instance suffixes (matches gcp-storage-type-test.sh TEST_CASES) ─
+GCP_SUFFIXES="pdssd-n2 pdssd-ent pdhdd-ent hdb-c4a hdb-n4"
+
+# ── Per-CSP delete function (runs in background subshell) ─────────────────────
+run_csp_delete() {
+    local csp="$1"
+    local conn="$2"
+    local csp_lower
+    csp_lower=$(to_lower "${csp}")
+
+    # GCP uses fixed instance names (not derived from metainfo StorageTypeOptions)
+    if [[ "${csp}" == "GCP" ]]; then
+        echo "[${csp}] Using fixed instance list for deletion..."
+        for suffix in ${GCP_SUFFIXES}; do
+            local rdbms_name="cb-mysql-st-${suffix}"
+            local result_file="${RESULT_DIR}/result_${csp_lower}_${suffix}.txt"
+            local log_file="${LOG_DIR}/log_${csp_lower}_${suffix}.txt"
+
+            echo "[${csp}] Deleting '${rdbms_name}'..."
+            (
+                export CSP_NAME="${csp}"
+                export CONNECTION_NAME="${conn}"
+                export RDBMS_NAME="${rdbms_name}"
+                export RESULT_FILE="${result_file}"
+                exec "${COMMON_DELETE}"
+            ) > "${log_file}" 2>&1 &
+
+            echo $! > "${LOG_DIR}/pid_${csp_lower}_${suffix}.txt"
+        done
+
+        for pid_file in "${LOG_DIR}"/pid_${csp_lower}_*.txt; do
+            [[ -f "${pid_file}" ]] || continue
+            pid=$(cat "${pid_file}")
+            wait "${pid}"
+        done
+        echo "[${csp}] All delete jobs completed."
+        return 0
+    fi
+
+    echo "[${csp}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+    meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+        "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${conn}" 2>&1)
+
+    err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${err_msg}" ]]; then
+        echo "[${csp}] ERROR fetching metainfo: ${err_msg}"
+        echo "${csp}|META_ERROR|${err_msg}|-" \
+            > "${RESULT_DIR}/result_${csp_lower}_meta_error.txt"
+        return 1
+    fi
+
+    storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+    if [[ -z "${storage_types}" ]]; then
+        echo "[${csp}] No StorageTypeOptions - nothing to delete"
+        echo "${csp}|SKIP|no StorageTypeOptions|-" \
+            > "${RESULT_DIR}/result_${csp_lower}_skip.txt"
+        return 0
+    fi
+
+    echo "[${csp}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+
+    # Launch one delete job per StorageType in parallel
+    while IFS= read -r storage_type; do
+        [[ -z "${storage_type}" ]] && continue
+
+        st_safe=$(st_safe_name "${storage_type}")
+        rdbms_name="cb-mysql-st-${st_safe}"
+        result_file="${RESULT_DIR}/result_${csp_lower}_${st_safe}.txt"
+        log_file="${LOG_DIR}/log_${csp_lower}_${st_safe}.txt"
+
+        echo "[${csp}] Deleting '${rdbms_name}' (StorageType=${storage_type})..."
+        (
+            export CSP_NAME="${csp}"
+            export CONNECTION_NAME="${conn}"
+            export RDBMS_NAME="${rdbms_name}"
+            export RESULT_FILE="${result_file}"
+            exec "${COMMON_DELETE}"
+        ) > "${log_file}" 2>&1 &
+
+        echo $! > "${LOG_DIR}/pid_${csp_lower}_${st_safe}.txt"
+    done <<< "${storage_types}"
+
+    # Wait for all delete jobs for this CSP
+    for pid_file in "${LOG_DIR}"/pid_${csp_lower}_*.txt; do
+        [[ -f "${pid_file}" ]] || continue
+        pid=$(cat "${pid_file}")
+        wait "${pid}"
+    done
+    echo "[${csp}] All delete jobs completed."
+}
+
+# ── Launch per-CSP delete in parallel ─────────────────────────────────────────
+echo "Launching parallel deletion on all CSPs..."
+echo ""
+
+for csp in ${CSP_ORDER}; do
+    conn=$(csp_connection "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} delete (log: ${log_file})"
+    run_csp_delete "${csp}" "${conn}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_csp_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP delete jobs launched. Waiting for completion..."
+echo "[MAIN] Monitor: tail -f ${LOG_DIR}/log_<csp>.txt"
+echo ""
+
+# ── Wait for all CSP jobs ─────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_csp_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} delete completed"
+        else
+            echo "[MAIN] ${csp} delete finished with exit code ${exit_code}"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP delete jobs finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+echo "========================================================================"
+echo "         RDBMS StorageType Test - DELETE SUMMARY - All CSPs"
+echo "========================================================================"
+echo ""
+printf "%-12s | %-18s | %-14s | %-20s | %-10s\n" \
+    "CSP" "RDBMS Name" "Result" "Detail" "Elapsed"
+print_separator
+
+total=0
+deleted_count=0
+skipped_count=0
+error_count=0
+
+for csp in ${CSP_ORDER}; do
+    csp_lower=$(to_lower "${csp}")
+    csp_results=$(ls "${RESULT_DIR}"/result_${csp_lower}_*.txt 2>/dev/null | sort)
+
+    if [[ -z "${csp_results}" ]]; then
+        printf "%-12s | %-18s | %-14s | %-20s | %-10s\n" \
+            "${csp}" "-" "NO_RESULT" "-" "-"
+        continue
+    fi
+
+    while IFS= read -r result_file; do
+        [[ -f "${result_file}" ]] || continue
+        IFS='|' read -r r_csp r_result r_detail r_elapsed < "${result_file}"
+
+        # Derive RDBMS name from filename (result_<csp>_<st_safe>.txt)
+        fname=$(basename "${result_file}" .txt)
+        # Remove "result_<csp_lower>_" prefix to get st_safe
+        st_safe="${fname#result_${csp_lower}_}"
+        rdbms_name="cb-mysql-st-${st_safe}"
+        [[ "${st_safe}" == "skip" || "${st_safe}" == "meta_error" ]] && rdbms_name="-"
+
+        printf "%-12s | %-18s | %-14s | %-20s | %-10s\n" \
+            "${r_csp}" "${rdbms_name}" "${r_result}" "${r_detail}" "${r_elapsed}"
+
+        total=$((total + 1))
+        case "${r_result}" in
+            DELETED) deleted_count=$((deleted_count + 1)) ;;
+            SKIP|NOT_FOUND) skipped_count=$((skipped_count + 1)) ;;
+            *) error_count=$((error_count + 1)) ;;
+        esac
+    done <<< "${csp_results}"
+done
+
+print_separator
+echo ""
+echo "Total: ${total}  DELETED: ${deleted_count}  SKIPPED: ${skipped_count}  ERROR: ${error_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "========================================================================"
+echo ""
+
+# ── Per-CSP detailed logs (VERBOSE=1) ─────────────────────────────────────────
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "########################################################################"
+    echo "#                       Per-CSP Detailed Logs                         #"
+    echo "########################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        [[ -f "${log_file}" ]] && cat "${log_file}" || echo "(no log)"
+    done
+fi

--- a/test/rdbms-mysql-test/storage-type-test/gcp-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/gcp-storage-type-test.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# GCP RDBMS StorageType Test Script
+# Tests 5 fixed combinations of Storage Option, Edition, and Machine Series:
+#
+#   Storage Option     | Edition        | Machine Series
+#   -------------------|----------------|-----------------------------
+#   PD_SSD             | Enterprise Plus| N2  (db-perf-optimized-N-4)
+#   PD_SSD             | Enterprise     | Dedicated core (db-custom-2-8192)
+#   PD_HDD             | Enterprise     | Dedicated core (db-custom-2-8192)
+#   HYPERDISK_BALANCED | Enterprise Plus| C4A (db-c4a-highmem-4)
+#   HYPERDISK_BALANCED | Enterprise     | N4  (db-custom-N4-2-4096)
+
+CSP_NAME="GCP"
+CONNECTION_NAME="gcp-iowa-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Test cases: storage_type|db_instance_spec|storage_size_gb|rdbms_suffix ──
+# rdbms_suffix is used as part of the instance name: cb-mysql-st-<suffix>
+TEST_CASES=(
+    "PD_SSD|db-perf-optimized-N-4|10|pdssd-n2"
+    "PD_SSD|db-custom-2-8192|10|pdssd-ent"
+    "PD_HDD|db-custom-2-8192|10|pdhdd-ent"
+    "HYPERDISK_BALANCED|db-c4a-highmem-4|20|hdb-c4a"
+    "HYPERDISK_BALANCED|db-custom-N4-2-4096|20|hdb-n4"
+)
+
+echo "[${CSP_NAME}] Launching ${#TEST_CASES[@]} StorageType tests in parallel..."
+
+for test_case in "${TEST_CASES[@]}"; do
+    IFS='|' read -r storage_type db_instance_spec db_storage_size rdbms_suffix <<< "${test_case}"
+
+    rdbms_name="cb-mysql-st-${rdbms_suffix}"
+    result_file="${RESULT_DIR}/result_gcp_${rdbms_suffix}.txt"
+    log_file="${LOG_DIR}/log_gcp_${rdbms_suffix}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"8.0\",
+    \"DBInstanceSpec\": \"${db_instance_spec}\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"${db_storage_size}\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching: StorageType='${storage_type}' Spec='${db_instance_spec}' Size=${db_storage_size}GB (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_gcp_${rdbms_suffix}.txt"
+done
+
+# ── Wait for all tests ────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_gcp_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/ibm-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/ibm-storage-type-test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# IBM Cloud RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+
+CSP_NAME="IBM"
+CONNECTION_NAME="ibm-us-east-1-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_ibm_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_ibm_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_ibm_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_ibm_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"8.4\",
+    \"DBInstanceSpec\": \"multitenant\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"30\",
+    \"MasterUserName\": \"admin\",
+    \"MasterUserPassword\": \"Passwordspider123\",
+    \"PublicAccess\": true,
+    \"TagList\": [
+      {\"Key\": \"env\",        \"Value\": \"test\"},
+      {\"Key\": \"managed-by\", \"Value\": \"cb-spider\"}
+    ]
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_ibm_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_ibm_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/ncp-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/ncp-storage-type-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# NCP RDBMS StorageType Test Script
+# SKIP: NCP MySQL G3 does not support user-selectable StorageType.
+#       SSD is applied automatically; DataStorageTypeCode must NOT be specified.
+#       SupportsStorageTypeSelection=false in GetMetaInfo.
+
+CSP_NAME="NCP"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+mkdir -p "${RESULT_DIR}"
+
+SKIP_REASON="SupportsStorageTypeSelection=false: NCP G3 applies SSD automatically, StorageType cannot be specified"
+
+echo "[${CSP_NAME}] SKIP - ${SKIP_REASON}"
+
+# Format: CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+echo "${CSP_NAME}|N/A|N/A|SKIP|NOT_APPLICABLE|-|${SKIP_REASON}" \
+    > "${RESULT_DIR}/result_ncp_skip.txt"

--- a/test/rdbms-mysql-test/storage-type-test/nhn-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/nhn-storage-type-test.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# NHN Cloud RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: Subnet required.
+
+CSP_NAME="NHN"
+CONNECTION_NAME="nhn-korea-pangyo1-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_nhn_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_nhn_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_nhn_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_nhn_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"MYSQL_V8408\",
+    \"DBInstanceSpec\": \"m2.c2m4\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"20\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_nhn_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_nhn_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/openstack-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/openstack-storage-type-test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# OpenStack RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+
+CSP_NAME="OPENSTACK"
+CONNECTION_NAME="openstack-config01"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_openstack_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_openstack_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_openstack_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_openstack_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"5.7.29\",
+    \"DBInstanceSpec\": \"m1.small\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"20\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_openstack_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_openstack_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/storage-type-test/run-all-csp-storage-type-tests.sh
+++ b/test/rdbms-mysql-test/storage-type-test/run-all-csp-storage-type-tests.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Test Runner - All CSPs
+# For each CSP:
+#   1. Fetches StorageTypeOptions via rdbmsmetainfo API
+#   2. Creates one RDBMS per StorageType option (in parallel within each CSP)
+#   3. Verifies returned StorageType matches requested
+#   4. Deletes test instances after verification
+# CSPs with SupportsStorageTypeSelection=false (Azure, NCP) are skipped automatically.
+# All CSPs run concurrently. A unified result table is shown at the end.
+#
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+export POLL_INTERVAL="${POLL_INTERVAL:-30}"
+export AUTO_DELETE="${AUTO_DELETE:-false}"
+
+BASE_DIR="/tmp/st_test_$$"
+export RESULT_DIR="${BASE_DIR}/results"
+export LOG_DIR="${BASE_DIR}/logs"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-storage-type-test.sh"       ;;
+        AZURE)     echo "azure-storage-type-test.sh"     ;;
+        GCP)       echo "gcp-storage-type-test.sh"       ;;
+        ALIBABA)   echo "alibaba-storage-type-test.sh"   ;;
+        TENCENT)   echo "tencent-storage-type-test.sh"   ;;
+        IBM)       echo "ibm-storage-type-test.sh"       ;;
+        OPENSTACK) echo "openstack-storage-type-test.sh" ;;
+        NCP)       echo "ncp-storage-type-test.sh"       ;;
+        NHN)       echo "nhn-storage-type-test.sh"       ;;
+    esac
+}
+
+print_separator() {
+    echo "--------------------------------------------------------------------------------------------------------------------------------"
+}
+
+print_header() {
+    echo ""
+    echo "================================================================================================================================"
+    echo "                                RDBMS StorageType Test Summary - All CSPs"
+    echo "================================================================================================================================"
+    echo ""
+    printf "%-12s | %-20s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+        "CSP" "StorageType(Req)" "StorageType(Ret)" "Result" "DB Status" "Elapsed" "Reason"
+    print_separator
+    echo " [*] cloud_auto: Alibaba auto-select type - CSP picks the optimal cloud storage type at provisioning time"
+    print_separator
+}
+
+# ── Banner ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#        CB-Spider RDBMS StorageType Test - Starting All CSPs                 #"
+echo "################################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per instance"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Auto delete  : ${AUTO_DELETE}"
+echo "Base dir     : ${BASE_DIR}"
+echo ""
+echo "Note: Azure, NCP are skipped (SupportsStorageTypeSelection=false)"
+echo ""
+echo "Launching all CSP StorageType tests in parallel..."
+echo ""
+
+CSP_ORDER="AWS AZURE GCP ALIBABA TENCENT IBM OPENSTACK NCP NHN"
+
+# ── Launch all CSP scripts in background ─────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_csp_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP tests launched. Waiting for completion..."
+echo "[MAIN] Monitor: tail -f ${LOG_DIR}/log_<csp>.txt"
+echo ""
+
+# ── Wait for all CSP background jobs ─────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_csp_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code}"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+total=0
+pass_count=0
+fail_count=0
+skip_count=0
+
+for csp in ${CSP_ORDER}; do
+    csp_lower=$(to_lower "${csp}")
+    csp_results=$(ls "${RESULT_DIR}"/result_${csp_lower}_*.txt 2>/dev/null | sort)
+
+    if [[ -z "${csp_results}" ]]; then
+        printf "%-12s | %-18s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+            "${csp}" "-" "-" "N/A" "NO_RESULT" "-" "-"
+        continue
+    fi
+
+    while IFS= read -r result_file; do
+        [[ -f "${result_file}" ]] || continue
+        IFS='|' read -r r_csp r_req r_ret r_pass r_status r_elapsed r_reason \
+            < "${result_file}"
+
+        # Mark cloud_auto entries with [*] in the StorageType(Req) column
+        r_req_display="${r_req}"
+        if [[ "$(echo "${r_req}" | tr '[:upper:]' '[:lower:]')" == "cloud_auto" ]]; then
+            r_req_display="${r_req}[*]"
+        fi
+
+        printf "%-12s | %-20s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+            "${r_csp}" "${r_req_display}" "${r_ret}" "${r_pass}" "${r_status}" "${r_elapsed}" "${r_reason}"
+
+        total=$((total + 1))
+        case "${r_pass}" in
+            PASS) pass_count=$((pass_count + 1)) ;;
+            FAIL) fail_count=$((fail_count + 1)) ;;
+            SKIP) skip_count=$((skip_count + 1)) ;;
+        esac
+    done <<< "${csp_results}"
+done
+
+print_separator
+echo ""
+echo "Total: ${total}  PASS: ${pass_count}  FAIL: ${fail_count}  SKIP: ${skip_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "================================================================================================================================"
+echo ""
+
+# ── Per-CSP detailed logs (VERBOSE=1) ────────────────────────────────────────
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                         Per-CSP Detailed Logs                               #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        if [[ -f "${log_file}" ]]; then
+            cat "${log_file}"
+        else
+            echo "(no log)"
+        fi
+    done
+fi

--- a/test/rdbms-mysql-test/storage-type-test/tencent-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/tencent-storage-type-test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Tencent Cloud RDBMS StorageType Test Script
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: Subnet required. DBInstanceSpec is memory size in MB.
+# Note: Tencent may reject concurrent orders (OperationDenied.OtherOderInProcess).
+#       The driver handles this with automatic retry logic, so parallel execution is safe.
+
+CSP_NAME="TENCENT"
+CONNECTION_NAME="tencent-beijing6-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_tencent_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_tencent_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType in parallel ───────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mysql-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_tencent_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_tencent_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mysql\",
+    \"DBEngineVersion\": \"8.0\",
+    \"DBInstanceSpec\": \"8000\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"50\",
+    \"MasterUserName\": \"root\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_tencent_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_tencent_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mysql-test/tencent-rdbms-test.sh
+++ b/test/rdbms-mysql-test/tencent-rdbms-test.sh
@@ -5,12 +5,12 @@
 # Author: CB-Spider Team
 
 export CSP_NAME="TENCENT"
-export CONNECTION_NAME="tencent-beijing3-config"
+export CONNECTION_NAME="tencent-beijing6-config"
 export RDBMS_NAME="cb-spider-mysql-test"
 export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_tencent.txt"
 
 export CREATE_JSON='{
-  "ConnectionName": "tencent-beijing3-config",
+  "ConnectionName": "tencent-beijing6-config",
   "ReqInfo": {
     "Name": "cb-spider-mysql-test",
     "VPCName": "vpc-01",
@@ -19,7 +19,6 @@ export CREATE_JSON='{
     "DBEngineVersion": "8.0",
     "DBInstanceSpec": "8000",
     "StorageSize": "50",
-    "StorageType": "CLOUD_HSSD",
     "MasterUserName": "root",
     "MasterUserPassword": "Password123!",
     "PublicAccess": true


### PR DESCRIPTION
- Add storage-type-test suite for 7 CSPs in parallel (Azure/NCP skipped: SupportsStorageTypeSelection=false)
- Add SupportsStorageTypeSelection/SupportsStorageSizeConfiguration to RDBMSMetaInfo
- Add Iops field to RDBMSInfo/RDBMSCreateRequest (Swagger); remove Throughput (AWS SDK v1.39.4 unsupported)
- OpenStack: document Trove API limitation (StorageType always "NA")
- Alibaba: add retry for IncorrectDBInstanceState on CreateAccount (15s/180s)
- IBM: add retry for Bad Gateway on GetDeploymentInfoWithContext in setAdminPassword (15s/180s)
- Remove StorageType from basic RDBMS test scripts (IBM/NHN/Tencent); show default StorageType in result table (format: 100GB|gp2)
- Update READMEs with test config and verified results (9 CSPs all PASS)

For details, see ./test/rdbms-mysql-test/storage-type-test/README.md

## Testing & Validation
### Automated StorageType Test Results
Parallel execution across 9 CSPs (26 cases) - all successfully validated:

| CSP | Tested StorageTypes | Result | Notes |
|-----|---------------------|--------|-------|
| AWS | gp2, gp3, io1, io2, standard | ✅ PASS (5/5) | |
| GCP | PD_SSD ×2, PD_HDD, HYPERDISK_BALANCED ×2 | ✅ PASS (5/5) | Determined by machine series |
| Alibaba | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd | ✅ PASS (5/5) | cloud_auto → CSP chose `general_essd` |
| Tencent | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM | ✅ PASS (4/4) | |
| IBM | standard | ✅ PASS (1/1) | |
| OpenStack | \_\_DEFAULT\_\_, RBD | ✅ PASS (2/2) | Trove API does not expose StorageType post-creation |
| NHN | General HDD, General SSD | ✅ PASS (2/2) | |
| Azure | N/A | ⏭ SKIP | `SupportsStorageTypeSelection=false` |
| NCP | N/A | ⏭ SKIP | `SupportsStorageTypeSelection=false` |

**Total: 26 cases — PASS: 24, SKIP: 2, FAIL: 0**


### Work in Progress

- Storage Size Test
- AdminWeb validation/improvements for all CSP options
- Tag functionality validation