### PR TITLE
[NCP/Cluster] Fix NodeGroup deletion failures and stabilize cluster operations

### DIFF
--- a/api-runtime/common-runtime/ClusterManager.go
+++ b/api-runtime/common-runtime/ClusterManager.go
@@ -14,12 +14,18 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	ccm "github.com/cloud-barista/cb-spider/cloud-control-manager"
 	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	iidm "github.com/cloud-barista/cb-spider/cloud-control-manager/iid-manager"
 	cim "github.com/cloud-barista/cb-spider/cloud-info-manager"
 	infostore "github.com/cloud-barista/cb-spider/info-store"
+)
+
+const (
+	ncpNodeGroupIDPollInterval = 5 * time.Second
+	ncpNodeGroupIDPollMaxTry   = 24
 )
 
 // ====================================================================
@@ -617,6 +623,15 @@ func CreateCluster(connectionName string, rsType string, reqInfo cres.ClusterInf
 		return nil, err
 	}
 
+	if hasNCPTemporaryNodeGroupID(providerName, info.NodeGroupList) {
+		waitInfoList, waitErr := waitForNCPNodeGroupSystemIDs(handler, providerName, info.IId, info.NodeGroupList)
+		if waitErr != nil {
+			cblog.Error(waitErr)
+			return nil, waitErr
+		}
+		info.NodeGroupList = waitInfoList
+	}
+
 	// (4) create spiderIID: {reqNameID, "driverNameID:driverSystemID"}
 	//     ex) spiderIID {"seoul-service", "vm-01-9m4e2mr0ui3e8a215n4g:i-0bc7123b7e5cbf79d"}
 	spiderIId := cres.IID{NameId: reqIId.NameId, SystemId: spUUID + ":" + info.IId.SystemId}
@@ -702,6 +717,75 @@ func getReqNameId(reqIIdList []cres.IID, driverNameId string) string {
 		}
 	}
 	return ""
+}
+
+func isNCPTemporaryNodeGroupID(providerName string, systemID string) bool {
+	return strings.EqualFold(providerName, "NCP") && strings.TrimSpace(systemID) == "1"
+}
+
+func hasNCPTemporaryNodeGroupID(providerName string, nodeGroupList []cres.NodeGroupInfo) bool {
+	for _, ngInfo := range nodeGroupList {
+		if isNCPTemporaryNodeGroupID(providerName, ngInfo.IId.SystemId) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitForNCPNodeGroupSystemIDs(handler cres.ClusterHandler, providerName string, clusterDriverIID cres.IID, nodeGroupList []cres.NodeGroupInfo) ([]cres.NodeGroupInfo, error) {
+	if !strings.EqualFold(providerName, "NCP") {
+		return nodeGroupList, nil
+	}
+
+	targetNameIDMap := map[string]struct{}{}
+	for _, ngInfo := range nodeGroupList {
+		if isNCPTemporaryNodeGroupID(providerName, ngInfo.IId.SystemId) {
+			targetNameIDMap[ngInfo.IId.NameId] = struct{}{}
+		}
+	}
+	if len(targetNameIDMap) == 0 {
+		return nodeGroupList, nil
+	}
+
+	updatedList := make([]cres.NodeGroupInfo, len(nodeGroupList))
+	copy(updatedList, nodeGroupList)
+
+	for i := 0; i < ncpNodeGroupIDPollMaxTry; i++ {
+		clusterInfo, err := handler.GetCluster(clusterDriverIID)
+		if err != nil {
+			cblog.Warnf("failed to refresh cluster while waiting NodeGroup instance IDs (try %d/%d): %v", i+1, ncpNodeGroupIDPollMaxTry, err)
+			time.Sleep(ncpNodeGroupIDPollInterval)
+			continue
+		}
+
+		currentByNameID := map[string]cres.NodeGroupInfo{}
+		for _, ngInfo := range clusterInfo.NodeGroupList {
+			currentByNameID[ngInfo.IId.NameId] = ngInfo
+		}
+
+		remaining := 0
+		for idx, ngInfo := range updatedList {
+			if _, ok := targetNameIDMap[ngInfo.IId.NameId]; !ok {
+				continue
+			}
+
+			latestInfo, ok := currentByNameID[ngInfo.IId.NameId]
+			if !ok || isNCPTemporaryNodeGroupID(providerName, latestInfo.IId.SystemId) {
+				remaining++
+				continue
+			}
+
+			updatedList[idx].IId.SystemId = latestInfo.IId.SystemId
+		}
+
+		if remaining == 0 {
+			return updatedList, nil
+		}
+
+		time.Sleep(ncpNodeGroupIDPollInterval)
+	}
+
+	return nil, fmt.Errorf("timed out while waiting for meaningful NodeGroup instance IDs from CSP")
 }
 
 func setResourcesNameId(connectionName string, info *cres.ClusterInfo) error {
@@ -1339,6 +1423,20 @@ func AddNodeGroup(connectionName string, rsType string, clusterName string, reqI
 		return nil, err
 	}
 
+	if isNCPTemporaryNodeGroupID(providerName, ngInfo.IId.SystemId) {
+		waitInfoList, waitErr := waitForNCPNodeGroupSystemIDs(
+			handler,
+			providerName,
+			getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId}),
+			[]cres.NodeGroupInfo{ngInfo},
+		)
+		if waitErr != nil {
+			cblog.Error(waitErr)
+			return nil, waitErr
+		}
+		ngInfo = waitInfoList[0]
+	}
+
 	ngSpiderIId := cres.IID{NameId: nodeGroupNameId, SystemId: nodeGroupUUID + ":" + ngInfo.IId.SystemId}
 	err2 := infostore.Insert(&NodeGroupIIDInfo{ConnectionName: iidInfo.ConnectionName, NameId: ngSpiderIId.NameId, SystemId: ngSpiderIId.SystemId,
 		OwnerClusterName: clusterName})
@@ -1964,7 +2062,7 @@ func DeleteCluster(connectionName string, rsType string, nameID string, force st
 	driverIId := getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
 	result := false
 
-	result, err = handler.(cres.ClusterHandler).DeleteCluster(driverIId)
+	result, err = handler.DeleteCluster(driverIId)
 	if err != nil {
 		cblog.Error(err)
 		if checkNotFoundError(err) {
@@ -1981,8 +2079,35 @@ func DeleteCluster(connectionName string, rsType string, nameID string, force st
 		}
 	}
 
+	// Wait until the cluster is not found in CSP, like VM deletion flow.
+	waiter := NewWaiter(15, 600)
+	for {
+		_, err = handler.GetCluster(driverIId)
+		if err != nil {
+			if checkNotFoundError(err) {
+				break
+			}
+			cblog.Error(err)
+			if force != "true" {
+				return false, err
+			}
+			break
+		}
+
+		if !waiter.Wait() {
+			err = fmt.Errorf("[%s] Failed to delete Cluster %s. (Timeout=%v)", connectionName, driverIId.NameId, waiter.Timeout)
+			cblog.Error(err)
+			if force != "true" {
+				return false, err
+			}
+			break
+		}
+	}
+
 	// (3) delete IID
-	_, err = infostore.DeleteByConditions(&ClusterIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName, NAME_ID_COLUMN, nameID)
+	// delete all nodegroups of target Cluster first
+	_, err = infostore.DeleteByConditions(&NodeGroupIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName,
+		OWNER_CLUSTER_NAME_COLUMN, iidInfo.NameId)
 	if err != nil {
 		cblog.Error(err)
 		if force != "true" {
@@ -1990,13 +2115,13 @@ func DeleteCluster(connectionName string, rsType string, nameID string, force st
 		}
 	}
 
-	// for NodeGroup list
-	// delete all nodegroups of target Cluster
-	_, err = infostore.DeleteByConditions(&NodeGroupIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName,
-		OWNER_CLUSTER_NAME_COLUMN, iidInfo.NameId)
+	// delete cluster IID after nodegroup IIDs
+	_, err = infostore.DeleteByConditions(&ClusterIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName, NAME_ID_COLUMN, nameID)
 	if err != nil {
 		cblog.Error(err)
-		return false, err
+		if force != "true" {
+			return false, err
+		}
 	}
 
 	return result, nil

--- a/api-runtime/rest-runtime/admin-web/html/cluster.html
+++ b/api-runtime/rest-runtime/admin-web/html/cluster.html
@@ -1130,7 +1130,7 @@
             const deletePromises = Array.from(checkboxes).map(checkbox => {
                 const clusterName = checkbox.value;
 
-                return fetchWithProgress(`/spider/cluster/${clusterName}`, {
+                return fetchWithProgress(`/spider/cluster/${clusterName}?force=true`, {
                     method: 'DELETE',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ ConnectionName: "{{.ConnectionConfig}}" })
@@ -1477,7 +1477,7 @@
             button.parentElement.remove();
         }
     
-        function postCluster() {
+        function buildClusterCreateData(versionOverride = null) {
             const connConfig = document.getElementById('connConfig').value;
             const selectedSubnets = Array.from(document.getElementById('subnetSelect').selectedOptions).map(option => option.value);
             const selectedKeyPair = document.getElementById('keyPairSelect').value;
@@ -1515,7 +1515,7 @@
                 ConnectionName: connConfig,
                 ReqInfo: {
                     Name: document.getElementById('clusterName').value,
-                    Version: document.getElementById('clusterVersion').value,
+                    Version: versionOverride !== null ? versionOverride : document.getElementById('clusterVersion').value,
                     VPCName: selectedVPCText,
                     SubnetNames: selectedSubnets,
                     SecurityGroupNames: securityGroupArray,
@@ -1525,7 +1525,11 @@
                 }
             };
 
-            fetchWithProgress('/spider/cluster', {
+            return clusterData;
+        }
+
+        function createCluster(clusterData) {
+            return fetchWithProgress('/spider/cluster', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(clusterData)
@@ -1534,11 +1538,89 @@
                     return response.json().then(error => { throw new Error(error.message); });
                 }
                 return response.json();
-            }).then(() => {
+            });
+        }
+
+        function parseAvailableVersions(errorMessage) {
+            const match = errorMessage.match(/Available\s+version[s]?:\s*([^)]+)/i);
+            if (!match || !match[1]) {
+                return [];
+            }
+
+            return match[1]
+                .split(',')
+                .map(v => v.trim().replace(/[)\]]+$/g, ''))
+                .filter(v => v.length > 0);
+        }
+
+        function escapeHtml(text) {
+            return text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function showVersionSelectionError(errorMessage, versions) {
+            closeError();
+
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'error-message';
+
+            const optionsHtml = versions
+                .map(v => `<option value="${escapeHtml(v)}">${escapeHtml(v)}</option>`)
+                .join('');
+
+            errorDiv.innerHTML = `
+                <p>Cluster Creation Error</p>
+                <p style="margin-bottom:10px;">${escapeHtml(errorMessage)}</p>
+                <p style="margin:8px 0 4px;">Select one of available versions and retry:</p>
+                <select id="availableVersionSelect" style="min-width:220px; font-size:14px; padding:4px;">
+                    ${optionsHtml}
+                </select>
+                <div style="margin-top:16px; display:flex; gap:10px; justify-content:center;">
+                    <button id="retryWithSelectedVersionBtn">Retry</button>
+                    <button id="cancelVersionRetryBtn">Cancel</button>
+                </div>
+            `;
+
+            document.body.appendChild(errorDiv);
+            document.addEventListener('keydown', handleEscError);
+
+            document.getElementById('retryWithSelectedVersionBtn').addEventListener('click', () => {
+                const selectedVersion = document.getElementById('availableVersionSelect').value;
+                if (!selectedVersion) {
+                    return;
+                }
+                document.getElementById('clusterVersion').value = selectedVersion;
+                closeError();
+                postCluster(selectedVersion);
+            });
+
+            document.getElementById('cancelVersionRetryBtn').addEventListener('click', () => {
+                closeError();
+            });
+        }
+
+        function postCluster(versionOverride = null) {
+            const connConfig = document.getElementById('connConfig').value;
+            const clusterData = buildClusterCreateData(versionOverride);
+
+            createCluster(clusterData).then(() => {
                 hideOverlay();
                 location.reload();
             }).catch(error => {
-                showError(`Error adding cluster: ${error.message}`, "Cluster Creation Error");
+                const availableVersions = parseAvailableVersions(error.message || '');
+                getCSPInfo(connConfig).then(providerName => {
+                    if (providerName && providerName.toUpperCase() === 'NCP' && availableVersions.length > 0) {
+                        showVersionSelectionError(error.message, availableVersions);
+                        return;
+                    }
+                    showError(`Error adding cluster: ${error.message}`, "Cluster Creation Error");
+                }).catch(() => {
+                    showError(`Error adding cluster: ${error.message}`, "Cluster Creation Error");
+                });
             });
         }
 
@@ -1908,26 +1990,26 @@
 
                     // Add each row of information from the provided node data
                     const rows = [
-                        { label: "Node Name", value: node.IId.NameId || 'N/A' },
-                        { label: "System ID", value: node.IId.SystemId },
-                        { label: "Start Time", value: node.StartTime },
-                        { label: "Region", value: node.Region.Region },
-                        { label: "Zone", value: node.Region.Zone },
-                        { label: "Image ID", value: node.ImageIId.NameId || node.ImageIId.SystemId },
-                        { label: "VM Spec Name", value: node.VMSpecName },
-                        { label: "VPC ID", value: node.VpcIID.SystemId },
-                        { label: "Subnet ID", value: node.SubnetIID.SystemId },
-                        { label: "Security Groups", value: node.SecurityGroupIIds.map(sg => sg.NameId).join(', ') },
-                        { label: "Key Pair", value: node.KeyPairIId.NameId },
-                        { label: "Root Disk Type", value: node.RootDiskType },
-                        { label: "Root Disk Size (GB)", value: node.RootDiskSize },
-                        { label: "Root Device Name", value: node.RootDeviceName },
-                        { label: "Block Disk", value: node.VMBlockDisk },
-                        { label: "Network Interface", value: node.NetworkInterface },
+                        { label: "Node Name", value: node.IId?.NameId || 'N/A' },
+                        { label: "System ID", value: node.IId?.SystemId || 'N/A' },
+                        { label: "Start Time", value: node.StartTime || 'N/A' },
+                        { label: "Region", value: node.Region?.Region || 'N/A' },
+                        { label: "Zone", value: node.Region?.Zone || 'N/A' },
+                        { label: "Image ID", value: node.ImageIId?.NameId || node.ImageIId?.SystemId || 'N/A' },
+                        { label: "VM Spec Name", value: node.VMSpecName || 'N/A' },
+                        { label: "VPC ID", value: node.VpcIID?.SystemId || 'N/A' },
+                        { label: "Subnet ID", value: node.SubnetIID?.SystemId || 'N/A' },
+                        { label: "Security Groups", value: node.SecurityGroupIIds?.map(sg => sg.NameId || sg.SystemId).join(', ') || 'N/A' },
+                        { label: "Key Pair", value: node.KeyPairIId?.NameId || 'N/A' },
+                        { label: "Root Disk Type", value: node.RootDiskType || 'N/A' },
+                        { label: "Root Disk Size (GB)", value: node.RootDiskSize || 'N/A' },
+                        { label: "Root Device Name", value: node.RootDeviceName || 'N/A' },
+                        { label: "Block Disk", value: node.VMBlockDisk || 'N/A' },
+                        { label: "Network Interface", value: node.NetworkInterface || 'N/A' },
                         { label: "Public IP", value: node.PublicIP || 'N/A' },
-                        { label: "Private IP", value: node.PrivateIP },
+                        { label: "Private IP", value: node.PrivateIP || 'N/A' },
                         { label: "Private DNS", value: node.PrivateDNS || 'N/A' },
-                        { label: "Platform", value: node.Platform },
+                        { label: "Platform", value: node.Platform || 'N/A' },
                         { label: "Access Point", value: node.AccessPoint || 'N/A' },
                     ];
 

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
@@ -705,7 +705,39 @@ func (nvch *NcpVpcClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInf
 		clusterInfo.NodeGroupList = append(clusterInfo.NodeGroupList, nodeGroupInfo)
 	}
 
-	// NCP 정책상 NodeGroup의 실제 노드 목록 및 컨테이너(파드) 목록 반환은 미지원
+	// Fetch all worker nodes for the cluster and group by NodePool InstanceNo
+	workerNodeRes, err := nvch.ClusterClient.V2Api.ClustersUuidNodesGet(nvch.Ctx, ncloud.String(ncloud.StringValue(targetCluster.Uuid)))
+	if err != nil {
+		cblogger.Warnf("failed to get worker nodes for cluster %s: %v (nodes will be empty)", clusterIID.SystemId, err)
+	}
+
+	nodesByPoolId := map[string][]irs.IID{}
+	if workerNodeRes != nil && workerNodeRes.Nodes != nil {
+		for _, wn := range workerNodeRes.Nodes {
+			if wn.NodePoolId == nil {
+				continue
+			}
+			poolKey := fmt.Sprintf("%d", ncloud.Int32Value(wn.NodePoolId))
+			nodeSystemId := strings.TrimPrefix(ncloud.StringValue(wn.ProviderID), "navercloudplatform://")
+			if nodeSystemId == "" {
+				nodeSystemId = ncloud.StringValue(wn.Name)
+			}
+			if nodeSystemId == "" {
+				nodeSystemId = fmt.Sprintf("%d", ncloud.Int32Value(wn.Id))
+			}
+			nodesByPoolId[poolKey] = append(nodesByPoolId[poolKey], irs.IID{
+				NameId:   ncloud.StringValue(wn.Name),
+				SystemId: nodeSystemId,
+			})
+		}
+	}
+
+	for idx := range clusterInfo.NodeGroupList {
+		poolKey := clusterInfo.NodeGroupList[idx].IId.SystemId
+		if nodes, ok := nodesByPoolId[poolKey]; ok {
+			clusterInfo.NodeGroupList[idx].Nodes = nodes
+		}
+	}
 
 	LoggingInfo(hiscallInfo, start)
 	cblogger.Debug(clusterInfo)
@@ -1354,6 +1386,14 @@ func (nvch *NcpVpcClusterHandler) GetNodeGroup(clusterIID irs.IID, nodeGroupIID 
 		return irs.NodeGroupInfo{}, getErr
 	}
 
+	workerNodeRes, err := nvch.ClusterClient.V2Api.ClustersUuidNodesGet(nvch.Ctx, ncloud.String(clusterIID.SystemId))
+	if err != nil {
+		getErr := fmt.Errorf("failed to get worker node list: %w", err)
+		cblogger.Error(getErr)
+		LoggingError(hiscallInfo, getErr)
+		return irs.NodeGroupInfo{}, getErr
+	}
+
 	// Build NodeGroupInfo
 	onAutoScaling := false
 	minNodeSize := 0
@@ -1378,6 +1418,25 @@ func (nvch *NcpVpcClusterHandler) GetNodeGroup(clusterIID irs.IID, nodeGroupIID 
 		)
 	}
 
+	nodeList := []irs.IID{}
+	if workerNodeRes != nil && workerNodeRes.Nodes != nil {
+		for _, workerNode := range workerNodeRes.Nodes {
+			if workerNode.NodePoolId == nil || fmt.Sprintf("%d", ncloud.Int32Value(workerNode.NodePoolId)) != nodeGroupIID.SystemId {
+				continue
+			}
+
+			nodeSystemId := strings.TrimPrefix(ncloud.StringValue(workerNode.ProviderID), "navercloudplatform://")
+			if nodeSystemId == "" {
+				nodeSystemId = ncloud.StringValue(workerNode.Name)
+			}
+			if nodeSystemId == "" {
+				nodeSystemId = fmt.Sprintf("%d", ncloud.Int32Value(workerNode.Id))
+			}
+
+			nodeList = append(nodeList, irs.IID{NameId: ncloud.StringValue(workerNode.Name), SystemId: nodeSystemId})
+		}
+	}
+
 	nodeGroupInfo := irs.NodeGroupInfo{
 		IId: irs.IID{
 			NameId:   ncloud.StringValue(targetNodePool.Name),
@@ -1389,6 +1448,7 @@ func (nvch *NcpVpcClusterHandler) GetNodeGroup(clusterIID irs.IID, nodeGroupIID 
 		KeyPairIID:      irs.IID{NameId: ncloud.StringValue(targetCluster.LoginKeyName)},
 		OnAutoScaling:   onAutoScaling,
 		Status:          convertNCPNodePoolStatus(ncloud.StringValue(targetNodePool.Status)),
+		Nodes:           nodeList,
 		KeyValueList:    nodeGroupKeyValueList,
 	}
 
@@ -1440,51 +1500,27 @@ func (nvch *NcpVpcClusterHandler) ChangeNodeGroupScaling(clusterIID irs.IID, nod
 	DesiredNodeSize int, MinNodeSize int, MaxNodeSize int) (irs.NodeGroupInfo, error) {
 	cblogger.Infof("Cluster SystemId : [%s] / NodeGroup SystemId : [%s] / DesiredNodeSize : [%d] / MinNodeSize : [%d] / MaxNodeSize : [%d]", clusterIID.SystemId, nodeGroupIID.SystemId, DesiredNodeSize, MinNodeSize, MaxNodeSize)
 
-	return irs.NodeGroupInfo{}, nil
-	/*
-		// clusterIID로 cluster 정보를 조회
-		// nodeGroupIID로 nodeGroup 정보를 조회
-		// 		nodeGroup에 AutoScaling 그룹 이름이 있음.
+	if MinNodeSize < 1 || MaxNodeSize < 1 || DesiredNodeSize < 1 {
+		return irs.NodeGroupInfo{}, fmt.Errorf("invalid node group scaling values")
+	}
 
-		// TODO : 공통으로 뺄 것
-		input := &vnks.DescribeNodegroupInput{
-			ClusterName:   ncloud.String(clusterIID.SystemId),   //required
-			NodegroupName: ncloud.String(nodeGroupIID.SystemId), // required
-		}
+	updateBody := &vnks.NodePoolUpdateBody{
+		NodeCount: ncloud.Int32(int32(DesiredNodeSize)),
+		Autoscale: &vnks.AutoscalerUpdate{
+			Enabled: ncloud.Bool(true),
+			Min:     ncloud.Int32(int32(MinNodeSize)),
+			Max:     ncloud.Int32(int32(MaxNodeSize)),
+		},
+	}
 
-		result, err := nvch.ClusterClient.DescribeNodegroup(input)
-		cblogger.Debug(result.Nodegroup)
-		if err != nil {
-			cblogger.Error(err)
-			return irs.NodeGroupInfo{}, err
-		}
+	err := nvch.ClusterClient.V2Api.ClustersUuidNodePoolInstanceNoPatch(nvch.Ctx, updateBody,
+		ncloud.String(clusterIID.SystemId), ncloud.String(nodeGroupIID.SystemId))
+	if err != nil {
+		cblogger.Error(err)
+		return irs.NodeGroupInfo{}, err
+	}
 
-		nodeGroupName := result.Nodegroup.NodegroupName
-		nodeGroupResources := result.Nodegroup.Resources.AutoScalingGroups
-		for _, autoScalingGroup := range nodeGroupResources {
-			input := &vautoscaling.UpdateAutoScalingGroupInput{
-				AutoScalingGroupName: ncloud.String(*autoScalingGroup.Name),
-
-				MaxSize:         ncloud.Int64(int64(MaxNodeSize)),
-				MinSize:         ncloud.Int64(int64(MinNodeSize)),
-				DesiredCapacity: ncloud.Int64(int64(DesiredNodeSize)),
-			}
-
-			updateResult, err := nvch.ASClient.UpdateAutoScalingGroup(input)
-			if err != nil {
-				cblogger.Error(err)
-				return irs.NodeGroupInfo{}, err
-			}
-			cblogger.Debug(updateResult)
-		}
-
-		nodeGroupInfo, err := nvch.GetNodeGroup(clusterIID, irs.IID{SystemId: *nodeGroupName})
-		if err != nil {
-			cblogger.Error(err)
-			return irs.NodeGroupInfo{}, err
-		}
-		return nodeGroupInfo, nil
-	*/
+	return nvch.GetNodeGroup(clusterIID, nodeGroupIID)
 }
 
 func (nvch *NcpVpcClusterHandler) RemoveNodeGroup(clusterIID irs.IID, nodeGroupIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -1063,13 +1063,7 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 		return irs.VMInfo{}, newErr
 	}
 
-	// Caution!!) Because disk info within the NCP VM info is being returned with incorrect value.
-	var rootDiskType string
-	if strings.EqualFold(*NcpInstance.BaseBlockStorageDiskDetailType.CodeName, "CB1") || strings.EqualFold(*NcpInstance.BaseBlockStorageDiskDetailType.CodeName, "CB2") {
-		rootDiskType = "SSD"
-	} else if strings.EqualFold(*NcpInstance.BaseBlockStorageDiskDetailType.CodeName, "SSD") {
-		rootDiskType = "HDD"
-	}
+	
 
 	// PublicIpID : Using for deleting the PublicIP
 	vmInfo := irs.VMInfo{
@@ -1098,7 +1092,6 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 		NetworkInterface: 	*netInterfaceName,
 		PublicIP:         	*publicIp,
 		PrivateIP:        	*privateIp,
-		RootDiskType:     	rootDiskType,
 		SSHAccessPoint:   	*publicIp + ":22",
 		KeyValueList:   	irs.StructToKeyValueList(NcpInstance),
 	}
@@ -1128,18 +1121,14 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 	}
 
 	// Set the VM Image Info
-	imageHandler := NcpVpcImageHandler{
-		RegionInfo: vmHandler.RegionInfo,
-		VMClient:   vmHandler.VMClient,
-	}
 	if !strings.EqualFold(*NcpInstance.ServerImageNo, "") {
-		isPublicImage, err := imageHandler.isPublicImage(*NcpInstance.ServerImageNo) // Caution!! : Not '*NcpInstance.ServerImageProductCode'
+		isPublicImage, known, err := vmHandler.probePublicImageTypeQuiet(*NcpInstance.ServerImageNo) // Caution!! : Not '*NcpInstance.ServerImageProductCode'
 		if err != nil {
-			newErr := fmt.Errorf("Failed to Check Whether the Image is Public Image : [%v]", err)
-			cblogger.Debug(newErr.Error())
-			
+			cblogger.Debugf("Failed to Check Whether the Image is Public Image (quiet mode): %v", err)
 			vmInfo.ImageType = "NA"
-			// return irs.VMInfo{}, newErr // Caution!! Consider what happens when an image that was supported in the past is no longer available.
+		} else if !known {
+			// Managed/ephemeral image may not be returned by image list API.
+			vmInfo.ImageType = "NA"
 		} else if isPublicImage {
 			vmInfo.ImageType = irs.PublicImage
 		} else {
@@ -1147,11 +1136,14 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 		}
 	}
 
-	_, storageSize, deviceName, err := vmHandler.getVmRootDiskInfo(NcpInstance.ServerInstanceNo)
+	_, diskTypeFromBS, storageSize, deviceName, err := vmHandler.getVmRootDiskInfo(NcpInstance.ServerInstanceNo)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get BlockStorage Info : [%v]", err)
 		cblogger.Error(newErr.Error())
 		return irs.VMInfo{}, newErr
+	}
+	if diskTypeFromBS != nil && !strings.EqualFold(*diskTypeFromBS, "") {
+		vmInfo.RootDiskType = *diskTypeFromBS
 	}
 	if !strings.EqualFold(*storageSize, "") {
 		vmInfo.RootDiskSize = *storageSize
@@ -1180,6 +1172,34 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 	}
 
 	return vmInfo, nil
+}
+
+// probePublicImageTypeQuiet checks image visibility/type without emitting error logs for expected "not found" cases.
+func (vmHandler *NcpVpcVMHandler) probePublicImageTypeQuiet(imageNo string) (bool, bool, error) {
+	if strings.EqualFold(imageNo, "") {
+		return false, false, nil
+	}
+
+	imageReq := vserver.GetServerImageListRequest{
+		RegionCode:        ncloud.String(vmHandler.RegionInfo.Region),
+		ServerImageNoList: []*string{ncloud.String(imageNo)},
+	}
+
+	result, err := vmHandler.VMClient.V2Api.GetServerImageList(&imageReq)
+	if err != nil {
+		return false, false, err
+	}
+
+	if len(result.ServerImageList) < 1 {
+		return false, false, nil
+	}
+
+	image := result.ServerImageList[0]
+	if image == nil || image.ServerImageType == nil || image.ServerImageType.Code == nil {
+		return false, false, nil
+	}
+
+	return strings.EqualFold(ncloud.StringValue(image.ServerImageType.Code), "NCP"), true, nil
 }
 
 func (vmHandler *NcpVpcVMHandler) createLinuxInitScript(imageIID irs.IID, keyPairId string) (*string, error) {
@@ -1501,7 +1521,7 @@ func (vmHandler *NcpVpcVMHandler) waitForDiskAttach(vmIID irs.IID) (irs.DiskStat
 	maxRetryCnt := 100
 
 	for {
-		storageNo, _, _, err := vmHandler.getVmRootDiskInfo(&vmIID.SystemId)
+		storageNo, _, _, _, err := vmHandler.getVmRootDiskInfo(&vmIID.SystemId)
 		if err != nil {
 			newErr := fmt.Errorf("Failed to Get BlockStorage Info : [%v]", err)
 			cblogger.Error(newErr.Error())
@@ -1574,13 +1594,13 @@ func (vmHandler *NcpVpcVMHandler) DeletePublicIP(vmInfo irs.VMInfo) (irs.VMStatu
 	return irs.VMStatus("Terminating"), nil
 }
 
-func (vmHandler *NcpVpcVMHandler) getVmRootDiskInfo(vmId *string) (*string, *string, *string, error) {
+func (vmHandler *NcpVpcVMHandler) getVmRootDiskInfo(vmId *string) (*string, *string, *string, *string, error) {
 	cblogger.Info("NCP VPC Cloud driver: called getVmRootDiskInfo()!!")
 
 	if strings.EqualFold(*vmId, "") {
 		newErr := fmt.Errorf("Invalid VM ID!!")
 		cblogger.Error(newErr.Error())
-		return nil, nil, nil, newErr
+		return nil, nil, nil, nil, newErr
 	}
 
 	storageReq := vserver.GetBlockStorageInstanceListRequest{
@@ -1591,7 +1611,7 @@ func (vmHandler *NcpVpcVMHandler) getVmRootDiskInfo(vmId *string) (*string, *str
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get Block Storage List!! : [%v]", err)
 		cblogger.Error(newErr.Error())
-		return nil, nil, nil, newErr
+		return nil, nil, nil, nil, newErr
 	}
 
 	if len(storageResult.BlockStorageInstanceList) < 1 {
@@ -1599,18 +1619,26 @@ func (vmHandler *NcpVpcVMHandler) getVmRootDiskInfo(vmId *string) (*string, *str
 	}
 
 	var storageInstanceNo *string
+	var diskType string
 	var storageSize string
 	var deviceName *string
 	for _, disk := range storageResult.BlockStorageInstanceList {
 		if strings.EqualFold(*disk.ServerInstanceNo, *vmId) && strings.EqualFold(*disk.BlockStorageType.Code, "BASIC") {
-
 			storageInstanceNo = disk.BlockStorageInstanceNo
 			storageSize 	  = strconv.FormatFloat(float64(*disk.BlockStorageSize)/(1024*1024*1024), 'f', 0, 64)
 			deviceName 		  = disk.DeviceName
+			if disk.BlockStorageDiskDetailType != nil {
+				codeName := ncloud.StringValue(disk.BlockStorageDiskDetailType.CodeName)
+				if strings.EqualFold(codeName, "SSD") || strings.EqualFold(codeName, "CB1") || strings.EqualFold(codeName, "CB2") {
+					diskType = "SSD"
+				} else {
+					diskType = "HDD"
+				}
+			}
 			break
 		}
 	}
-	return storageInstanceNo, &storageSize, deviceName, nil
+	return storageInstanceNo, &diskType, &storageSize, deviceName, nil
 }
 
 func (vmHandler *NcpVpcVMHandler) getVmDataDiskList(vmId *string) ([]irs.IID, error) {


### PR DESCRIPTION

- During asynchronous NodeGroup creation, the temporary ID `1` was stored in the meta DB.
  - Deletion later used that `1` value, which caused failures. 
  - Now, NodeGroup metadata is stored only after the official ID is available.
- Populate nodegroup node lists from NCP worker node API during cluster/nodegroup retrieval.
- Normalize node SystemId by stripping provider prefix so node click resolves VM details correctly.
- Correct root disk type reporting by deriving disk type from block storage detail metadata.
