### PR TITLE
fix(alibaba): fix AddNodeGroup to correctly route ACK image_type aliases

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -543,8 +543,15 @@ func (ach *AlibabaClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqI
 	// KeyPair: Alibaba uses KeyPairName as both NameId and SystemId, so use SystemId
 	keyPair := nodeGroupReqInfo.KeyPairIID.SystemId
 
-	// Image: Alibaba uses ImageId as SystemId
-	imageId := nodeGroupReqInfo.ImageIID.SystemId
+	// Image: prefer NameId (user-specified ACK image_type alias) over SystemId (resolved ECS image ID).
+	// TB resolves ACK aliases (e.g. "AliyunLinux3") to ECS image IDs before calling Spider, but
+	// ACK rejects ECS IDs on AddNodeGroup with "does not support cgroup v2". Using NameId keeps
+	// the alias intact so the ackImageTypeAliases check below can route it correctly, consistent
+	// with how CreateCluster's buildNodepoolsForCreateCluster uses ImageIID.NameId.
+	imageId := nodeGroupReqInfo.ImageIID.NameId
+	if imageId == "" {
+		imageId = nodeGroupReqInfo.ImageIID.SystemId
+	}
 
 	// ACK image_type aliases - these must be passed as image_type, not image_id.
 	// Actual ECS image IDs start with "m-"; anything else that matches a known


### PR DESCRIPTION
## Summary

- Fix Alibaba ACK `AddNodeGroup` to use `ImageIID.NameId` over `SystemId` when selecting node pool image, so ACK image_type aliases (e.g. `AliyunLinux3ContainerOptimized`, `Ubuntu`) are routed correctly via `image_type` parameter instead of being passed as an ECS image ID
- This change corresponds to CB-Tumblebug's Alibaba ACK image_type support PR: [cloud-barista/cb-tumblebug#2553](https://github.com/cloud-barista/cb-tumblebug/pull/2553)