### PR TITLE
fix(ncp): bump ncloud-sdk-go-v2 to v1.6.29

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ImageHandler.go
@@ -176,7 +176,7 @@ func mappingImageInfo(serverImage *vserver.ServerImage) irs.ImageInfo {
 	if len(serverImage.BlockStorageMappingList) > 0 {
 		blockStorageMapping := serverImage.BlockStorageMappingList[0]
 		if blockStorageMapping.BlockStorageSize != nil {
-			blockStorageSize = irs.ConvertByteToGBInt64(*blockStorageMapping.BlockStorageSize)
+			blockStorageSize = irs.ConvertByteToGBInt64(int64(*blockStorageMapping.BlockStorageSize))
 		} else {
 			blockStorageSize = "-1"
 		}

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
@@ -212,7 +212,7 @@ func (vmSpecHandler *NcpVpcVMSpecHandler) mappingVMSpecInfo(ImageId string, vmSp
 		Region:     vmSpecHandler.RegionInfo.Region,
 		Name:       *vmSpec.ServerSpecCode,
 		VCpu:       irs.VCpuInfo{Count: String(*vmSpec.CpuCount), ClockGHz: "-1"},
-		MemSizeMiB: irs.ConvertByteToMiBInt64(*vmSpec.MemorySize), // Byte -> MiB
+		MemSizeMiB: irs.ConvertByteToMiBInt64(int64(*vmSpec.MemorySize)), // Byte -> MiB
 		DiskSizeGB: diskSize,
 
 		KeyValueList: irs.StructToKeyValueList(vmSpec),

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/IBM/cloud-databases-go-sdk v0.8.1
 	github.com/IBM/platform-services-go-sdk v0.97.2
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29
 	github.com/alibabacloud-go/cs-20151215/v4 v4.5.8
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.11
 	github.com/alibabacloud-go/ecs-20140526/v4 v4.24.17

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/IBM/vpc-go-sdk v0.82.1/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxRe
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27 h1:lxXZjrSodJdg4IHGWGMFlWTLOHsD7lTZz6VD2XewX9c=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.27/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29 h1:lcV++fHLbdIWHftNTNo72bR4b4/8xOEuAxNv/ZsSQug=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=


### PR DESCRIPTION
## Summary

- Bump NCP VNKS SDK (`ncloud-sdk-go-v2`) from v1.6.27 to v1.6.29 — see upstream changes: https://github.com/NaverCloudPlatform/ncloud-sdk-go-v2/pull/85
- Fix explicit `int64` type cast in NCP `ImageHandler` and `VMSpecHandler` required by the updated SDK
- Verify backward compatibility by running NCP K8s cluster end-to-end test (create / add nodegroup / deploy nginx / validate external access / delete) 
- Note: The updated SDK introduces Regional (multi-zone) cluster support (`IsRegional`, `ZoneCode`/`ZoneNo` fields); cb-spider does not yet support this feature but it may be worth revisiting in the future
