### PR TITLE
fix(monitoring): restore accidentally removed REST routes for Monitoring API

### DIFF
--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -545,6 +545,10 @@ func getRoutes() []route {
 		{"GET", "/filesystem/:Name/accesssubnet", ListAccessSubnet},
 		{"DELETE", "/filesystem/:Name/accesssubnet", RemoveAccessSubnet},
 
+		//----------Monitoring Handler
+		{"GET", "/monitoring/vm/:VMName/:MetricType", GetVMMetricData},
+		{"GET", "/monitoring/clusternode/:ClusterName/:NodeGroupName/:NodeNumber/:MetricType", GetClusterNodeMetricData},
+
 		//----------Destory All Resources in a Connection
 		{"DELETE", "/destroy", Destroy},
 


### PR DESCRIPTION
## Summary

PR #1697(`Azure: Add Monitoring API`)에서 추가했던 Monitoring REST 라우트가 이후의 무관한 RDBMS 작업 도중 실수로 삭제되어, `/monitoring/...` API 엔드포인트가 404를 반환하던 문제를 복구합니다. 핸들러/매니저/인터페이스/Azure 드라이버 코드는 모두 그대로 남아 있었고, 라우트 등록 2줄만 누락된 상태였습니다.

## Root Cause

- 라우트를 추가한 커밋: `638ef5e1` ("Azure: Add Monitoring API", PR #1697)
- 라우트를 삭제한 커밋: `5f93cf59` ("feat: implement RDBMS MetaInfo and control API ...", PR #1734)
- RDBMS 라우트를 추가하면서 `CBSpiderRuntime.go`의 라우트 테이블을 수정하는 과정에서 Monitoring 라우트 2줄이 함께 제거되었습니다. Monitoring과 RDBMS는 서로 무관한 기능이므로 의도치 않은 누락으로 판단됩니다.

## Changes

- `api-runtime/rest-runtime/CBSpiderRuntime.go`에 누락된 Monitoring 라우트 2개를 원래 위치(FileSystem 핸들러 블록 다음)에 복원했습니다.
  - `GET /monitoring/vm/:VMName/:MetricType`
  - `GET /monitoring/clusternode/:ClusterName/:NodeGroupName/:NodeNumber/:MetricType`