### PR TITLE
[NCP] Fix: Bump ncloud-sdk-go-v2 to v1.6.30 to resolve Image/VMSpec list failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/IBM/cloud-databases-go-sdk v0.8.1
 	github.com/IBM/platform-services-go-sdk v0.97.2
-	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29
+	github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.30
 	github.com/alibabacloud-go/cs-20151215/v4 v4.5.8
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.11
 	github.com/alibabacloud-go/ecs-20140526/v4 v4.24.17

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/IBM/vpc-go-sdk v0.82.1/go.mod h1:85bJ/0FS7vYAifHdZvlnXypf8pQSmuf9kxRe
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29 h1:lcV++fHLbdIWHftNTNo72bR4b4/8xOEuAxNv/ZsSQug=
-github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.29/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.30 h1:Q6gdZKpdTIrPUIfOL4n0LPa6pCjIbWPfCOdh5gVci4I=
+github.com/NaverCloudPlatform/ncloud-sdk-go-v2 v1.6.30/go.mod h1:jRp8KZ64MUevBWNqehghhG2oF5/JU3Dmt/Cu7dp1mQE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=


### PR DESCRIPTION
## Problem
After upgrading `ncloud-sdk-go-v2` to v1.6.29 (PR #1750), `ListImage()` and `ListVMSpec()` fail with the following error:

```
json: cannot unmarshal number into Go struct field
BlockStorageMapping.serverImageList.blockStorageMappingList.blockStorageSnapshotInstanceNo of type string
```

## Root Cause
v1.6.29 incorrectly changed `BlockStorageMapping.BlockStorageSnapshotInstanceNo` from `*int32` to `*string`, while the NCP API still returns this field as a JSON number. Go's `json.Unmarshal` cannot decode a JSON number into a `*string`, causing all `GetServerImageList` calls to fail.

| Version | Type | Status |
|---|---|---|
| v1.6.27 | `*int32` | OK |
| v1.6.29 | `*string` | **Bug** — JSON unmarshal failure |
| **v1.6.30** | **`*int32`** | **Fixed** |

## Changes
- Bump `github.com/NaverCloudPlatform/ncloud-sdk-go-v2` from `v1.6.29` → `v1.6.30` in go.mod

## Verification
- `ListImage()` and `ListVMSpec()` confirmed working after upgrade
- Full build passes with no errors