### PR TITLE
[Driver/Runtime] Fix: Handle zombie resources that exist only in Spider meta

### DIFF
--- a/api-runtime/common-runtime/NICManager.go
+++ b/api-runtime/common-runtime/NICManager.go
@@ -294,7 +294,14 @@ func DeleteNIC(connectionName string, rsType string, nameID string, force string
 
 	driverIId := getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
 	result, err := handler.DeleteNIC(driverIId)
-	if err != nil { cblog.Error(err); if force != "true" { return false, err } }
+	if err != nil {
+		cblog.Error(err)
+		if checkNotFoundError(err) {
+			force = "true"
+		} else if force != "true" {
+			return false, err
+		}
+	}
 	if force != "true" && !result { return false, nil }
 
 	_, err = infostore.DeleteByConditions(&NICIIDInfo{}, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, nameID)

--- a/api-runtime/common-runtime/PublicIPManager.go
+++ b/api-runtime/common-runtime/PublicIPManager.go
@@ -464,7 +464,10 @@ func DeletePublicIP(connectionName string, rsType string, nameID string, force s
 	result, err := handler.DeletePublicIP(driverIId)
 	if err != nil {
 		cblog.Error(err)
-		if force != "true" {
+		if checkNotFoundError(err) {
+			// if not found in CSP, continue
+			force = "true"
+		} else if force != "true" {
 			return false, err
 		}
 	}

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
@@ -14,6 +14,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -655,6 +656,9 @@ func (securityHandler *GCPSecurityHandler) GetSecurity(securityIID irs.IID) (irs
 	}
 
 	cblogger.Info("securityInfo : ", securityInfo)
+	if securityInfo.IId.SystemId == "" {
+		return irs.SecurityInfo{}, fmt.Errorf("The SecurityGroup [%s] not found", securityGroupTag)
+	}
 	return securityInfo, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
@@ -11,6 +11,7 @@ package resources
 import (
 	"fmt"
 	"strings"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
@@ -36,7 +37,7 @@ func (keyPairHandler *NcpVpcKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error
 
 	keypairReq := vserver.GetLoginKeyListRequest{
 		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
-		KeyName: 	nil,
+		KeyName:    nil,
 	}
 	callLogStart := call.Start()
 	result, err := keyPairHandler.VMClient.V2Api.GetLoginKeyList(&keypairReq)
@@ -83,7 +84,7 @@ func (keyPairHandler *NcpVpcKeyPairHandler) CreateKey(keyPairReqInfo irs.KeyPair
 
 	keypairReq := vserver.CreateLoginKeyRequest{
 		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
-		KeyName: 	ncloud.String(keyPairReqInfo.IId.NameId),
+		KeyName:    ncloud.String(keyPairReqInfo.IId.NameId),
 	}
 	// Creates a new  keypair with the given name
 	callLogStart := call.Start()
@@ -139,15 +140,15 @@ func (keyPairHandler *NcpVpcKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPairI
 	InitLog() // Caution!!
 	callLogInfo := GetCallLogScheme(keyPairHandler.RegionInfo.Zone, call.VMKEYPAIR, keyIID.NameId, "GetKey()")
 
-	var keyNameId string
-	if keyIID.SystemId == "" {
+	keyNameId := keyIID.SystemId
+	if keyNameId == "" {
 		keyNameId = keyIID.NameId
 	}
 
 	// NCP VPC Key does not have SystemId, so the unique NameId value is also applied to the SystemId when create it.
 	keypairReq := vserver.GetLoginKeyListRequest{
 		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
-		KeyName: 	ncloud.String(keyNameId),
+		KeyName:    ncloud.String(keyNameId),
 	}
 	callLogStart := call.Start()
 	result, err := keyPairHandler.VMClient.V2Api.GetLoginKeyList(&keypairReq)
@@ -240,15 +241,15 @@ func mappingKeyPairInfo(ncpKeyPair *vserver.LoginKey) irs.KeyPairInfo {
 	// NCP Key does not have SystemId, so the unique NameId value is also applied to the SystemId
 	keyPairInfo := irs.KeyPairInfo{
 		IId: irs.IID{
-			NameId:   	*ncpKeyPair.KeyName,
-			SystemId: 	*ncpKeyPair.KeyName,
+			NameId:   *ncpKeyPair.KeyName,
+			SystemId: *ncpKeyPair.KeyName,
 		},
-		Fingerprint: 	*ncpKeyPair.Fingerprint,
-		PublicKey:   	"N/A",
+		Fingerprint: *ncpKeyPair.Fingerprint,
+		PublicKey:   "N/A",
 		// PublicKey:  	*NcpKeyPairList.PublicKey, // Creates Error
-		PrivateKey: 	"N/A",
-		VMUserID:   	lnxUserName,
-		KeyValueList:   irs.StructToKeyValueList(ncpKeyPair),
+		PrivateKey:   "N/A",
+		VMUserID:     lnxUserName,
+		KeyValueList: irs.StructToKeyValueList(ncpKeyPair),
 	}
 	return keyPairInfo
 }
@@ -260,7 +261,7 @@ func (keyPairHandler *NcpVpcKeyPairHandler) ListIID() ([]*irs.IID, error) {
 
 	keypairReq := vserver.GetLoginKeyListRequest{
 		RegionCode: ncloud.String(keyPairHandler.RegionInfo.Region),
-		KeyName: 	nil,
+		KeyName:    nil,
 	}
 	callLogStart := call.Start()
 	result, err := keyPairHandler.VMClient.V2Api.GetLoginKeyList(&keypairReq)
@@ -280,7 +281,7 @@ func (keyPairHandler *NcpVpcKeyPairHandler) ListIID() ([]*irs.IID, error) {
 			var iid irs.IID
 			iid.NameId = *keyPair.KeyName
 			iid.SystemId = *keyPair.KeyName
-	
+
 			iidList = append(iidList, &iid)
 		}
 	}

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -343,7 +344,7 @@ func (keyPairHandler *TencentKeyPairHandler) GetKey(keyIID irs.IID) (irs.KeyPair
 		//cblogger.Debug(keyPairInfo)
 		return keyPairInfo, nil
 	} else {
-		return irs.KeyPairInfo{}, errors.New("I couldn't find the information.")
+		return irs.KeyPairInfo{}, fmt.Errorf("The KeyPair [%s] not found", keyIID.SystemId)
 	}
 }
 


### PR DESCRIPTION
### Problem
Resources deleted directly from the CSP (bypassing Spider) remain in Spider meta DB but are not displayed in AdminWeb's management pages, making them impossible to delete via UI. Several drivers and common-runtime components were not handling the "not found" case correctly.

### Changes

**GCP Driver**
- SecurityHandler.go (`GetSecurity`): Return a `"not found"` error when no matching firewall is found in CSP, instead of silently returning an empty `SecurityInfo{}` without error. This was preventing `checkNotFoundError()` in common-runtime from triggering zombie-resource display logic.

**Tencent Driver**
- KeyPairHandler.go (`GetKey`): Replace `errors.New("I couldn't find the information.")` with `fmt.Errorf("The KeyPair [%s] not found", ...)` so the error message matches the `notfound` pattern in `checkNotFoundError()`.

**NCP Driver**
- KeyPairHandler.go (`GetKey`): Fix inverted condition — `if keyIID.SystemId == ""` caused `keyNameId` to remain empty when SystemId was set, resulting in a blank-name NCP API query that returned the first key in the list (wrong key). Fixed to `keyNameId := keyIID.SystemId; if keyNameId == "" { keyNameId = keyIID.NameId }`.

**Common Runtime**
- PublicIPManager.go (`DeletePublicIP`): Add `checkNotFoundError()` check so CSP-absent EIPs (e.g., AWS `InvalidAllocationID.NotFound`) are treated as force-deleted, cleaning up the meta entry.
- NICManager.go (`DeleteNIC`): Same fix — add `checkNotFoundError()` handling that was missing unlike all other Delete operations in common-runtime.

### Effect
Zombie resources (meta-only) now appear in AdminWeb lists with `NotFound` status and can be selected and deleted, cleaning up stale Spider meta entries.