### PR TITLE
[KT Cloud] Update NLB control features according to New KT Cloud LB API

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/kt/README.md
+++ b/cloud-control-manager/cloud-driver/drivers/kt/README.md
@@ -131,7 +131,8 @@ ssh -i /private_key_경로/private_key_파일명(~~.pem) cb-user@VM의_public_ip
 
  O Shared FileSystem (NAS) volume 생성시 아래의 사항을 참고
 
-   - NAS volume 생성시, 기 생성되어있는 하나의 subnet(Tier)이 필수적으로 지정되어야함.
+   - NAS volume 생성시, volume 이름에 underscore(_) 외의 특수문자는 포함할 수 없음.
+   - NAS volume 생성 요청시, 기 생성되어있는 하나의 subnet(Tier) 이름이 필수적으로 지정되어야함.
       - Spider의 'Access Subnet Name' parameter로서 subnet(Tier) name 입력 필요
       - NAS 생성 요청시, 본 driver 내부적으로 그 subnet(Tier) 기준으로 NAS volume 생성에 필요한 shared network이 먼저 생성됨.
    - CB-Spider에서 Shared FileSystem용 protocol은 현재 'NFS' 기준으로 지원함.(CIFS는 미지원)

--- a/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/1.export.env
+++ b/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/1.export.env
@@ -7,9 +7,7 @@ export OS_NETWORK_API="https://api.ucloudbiz.olleh.com/d1/nsm/v1"
 
 export OS_VOLUME_API="https://api.ucloudbiz.olleh.com/d1/volume"
 
-export OS_LB_API="https://api.ucloudbiz.olleh.com/d1/loadbalancer/api"
-# export OS_LB_API="https://api.ucloudbiz.olleh.com/loadbalancer/v1/client/api"
-# API 문서에 안내된 이 LB end-point는 잘못된 것임.
+export OS_LB_API="https://api.ucloudbiz.olleh.com/d1/loadbalancers"
 
 export OS_METRIC_API="https://api.ucloudbiz.olleh.com/d1/watch/v3/metrics"
 

--- a/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/11.list_lb-vm.sh
+++ b/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/11.list_lb-vm.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 source ./1.export.env
 
-echo "### OS_LB_API - LB List"
-echo "curl -v $OS_LB_API?command=listLoadBalancerWebServers&loadbalancerid=38288&response=json"
+echo "### OS_LB_API - LB VM List (New API - Since 20251220)"
+echo "curl -v $OS_LB_API/30540a4f-3c1b-4053-932e-e507f2c3d808/servers"
 
-#curl -v -H "X-Auth-Token: $OS_TOKEN" $OS_LB_API?command=listLoadBalancerWebServers&loadbalancerid=38288&response=json
-# curl -v -H "X-Auth-Token: $OS_TOKEN" $OS_LB_API?command=listLoadBalancerWebServers&loadbalancerid=38288
-#echo -e "\n"
-
-curl -v -H "X-Auth-Token: $OS_TOKEN" $OS_LB_API?command=listLoadBalancerWebServers&loadbalancerid=38288&multi_stack_id=11&response=json
+curl -v -H "X-Auth-Token: $OS_TOKEN" $OS_LB_API/30540a4f-3c1b-4053-932e-e507f2c3d808/servers
 
 echo -e "\n"
 
+# (For old NLB API)
 # 온라인 고객센터로부터 안내된 예: 
-# <GET http://14.63.254.107/openstack4kt/service1/loadbalancer/api?command=listLoadBalancerWebServers&loadbalancerid=38288&multi_stack_id=11&response=json,[x-auth-token:"gAAAAABlvniyWJCSabJ6CIIDyOIUpZzYRLan_TTXoNEQWmNr1rR3arorAxuLKOmftY8C3TimVz-oXQxnc1rcB2rbS8OAc2WwiGlFXpLUxp1ewsPyTq38G659m1UzKis9pOFC43HBIG4-slOlc3V7oftq4Gyf5DZqMuxmh-EG7y9bHjAx0UxRbOY"
+# <GET http://14.63.254.107/openstack4kt/service1/loadbalancer/api?command=listLoadBalancerWebServers&loadbalancerid=38288&multi_stack_id=11&response=json,[x-auth-token:"XXXXXXXXXXXXXXXXXXXX"

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
@@ -40,7 +40,7 @@ type KTVpcNLBHandler struct {
 }
 
 const (
-	DefaultNLBOption      string = "roundrobin" // NLBOption : roundrobin / leastconnection / leastresponse / sourceiphash /
+	DefaultNLBOption      string = "ROUNDROBIN" // NLBOption : ROUNDROBIN | LEASTCONNECTION | LEASTRESPONSE | SOURCEIPHASH | SRCIPSRCPORTHASH
 	DefaultHealthCheckURL string = "abc.kt.com"
 )
 
@@ -109,26 +109,38 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 	*/
 
 	// Get subnet where VMGroup VMs belong
-	vmGroupSubnetId, err := nlbHandler.getSubnetOfVMGroup(ctx, nlbReqInfo.VMGroup)
+	vmGroupTierNetId, err := nlbHandler.getTierNetIdOfVMGroup(ctx, nlbReqInfo.VMGroup)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get VMGroup Subnet ID : %w", err)
 		cblogger.Error(newErr.Error())
 		loggingError(callLogInfo, newErr)
 		return irs.NLBInfo{}, newErr
 	}
-	cblogger.Infof("VMGroup Subnet ID: %s", vmGroupSubnetId)
+	cblogger.Infof("VMGroup Tier Network ID: %s", vmGroupTierNetId)
 
 	cblogger.Info("### Start to Create New NLB!!")
+	servicePort, err := strconv.Atoi(nlbReqInfo.Listener.Port)
+	if err != nil {
+		newErr := fmt.Errorf("Invalid Listener Port : [%w]", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.NLBInfo{}, newErr
+	}
+	
+	healthCheckURL := ""
+	if strings.EqualFold(nlbReqInfo.HealthChecker.Protocol, "HTTP") || strings.EqualFold(nlbReqInfo.HealthChecker.Protocol, "HTTPS") {
+		healthCheckURL = DefaultHealthCheckURL
+	}
+
 	createOpts := ktvpclb.CreateOpts{
-		Name:            nlbReqInfo.IId.NameId,             // Required
-		ZoneID:          nlbHandler.RegionInfo.Zone,        // Required
-		NlbOption:       DefaultNLBOption,                  // Required
-		ServiceIP:       "",                                // Required. KT Cloud Virtual IP. $$$ In case of an empty value(""), it is newly created.
-		ServicePort:     nlbReqInfo.Listener.Port,          // Required
+		Name:            nlbReqInfo.IId.NameId,             // Required. Load Balancer name
+		NlbOption:       DefaultNLBOption,                  // Load Balancer option
+		ServiceIP:       "",                                // KT Cloud Virtual IP. $$$ In case of an empty value(""), it is newly created.
+		ServicePort:     servicePort,                       // Required
 		ServiceType:     nlbReqInfo.Listener.Protocol,      // Required
-		HealthCheckType: nlbReqInfo.HealthChecker.Protocol, // Required
-		HealthCheckURL:  DefaultHealthCheckURL,             // URL when the HealthCheckType (above) is 'http' or 'https'.
-		NetworkID:       vmGroupSubnetId,                   // Required. Caution!!) Not Tier 'ID' but 'NetworkID' of the Tier!!
+		HealthCheckType: nlbReqInfo.HealthChecker.Protocol, // Health Check type
+		HealthCheckURL:  healthCheckURL,                    // URL when the HealthCheckType (above) is 'HTTP' or 'HTTPS'.
+		NetworkID:       vmGroupTierNetId,                  // Required. Caution!!) Not Tier 'ID' but 'NetworkID' of the Tier!!
 	}
 	start := call.Start()
 	resp, err := ktvpclb.Create(nlbHandler.NLBClient, createOpts).ExtractCreate() // Not 'NetworkClient'
@@ -140,39 +152,26 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 	}
 	loggingInfo(callLogInfo, start)
 
-	nlbIdStr := strconv.Itoa(resp.Createnlbresponse.NLBId)
+	nlbIdStr := resp.Data.LoadBalancerID
 	cblogger.Infof("# ID of the NLB being created : %s", nlbIdStr)
 	cblogger.Infof("# Full API Response: %+v", resp)
 
-	// Check if API returned an error (check ErrorCode, ErrorText, or DisplayText)
-	if resp.Createnlbresponse.ErrorCode != "" || resp.Createnlbresponse.ErrorText != "" ||
-		(resp.Createnlbresponse.DisplayText != "" && resp.Createnlbresponse.NLBId == 0) {
-		// DisplayText often contains error messages like "internal server error"
-		newErr := fmt.Errorf("KT Cloud NLB creation failed - ErrorCode: %s, ErrorText: %s, DisplayText: %s",
-			resp.Createnlbresponse.ErrorCode,
-			resp.Createnlbresponse.ErrorText,
-			resp.Createnlbresponse.DisplayText)
-		cblogger.Error(newErr.Error())
-		loggingError(callLogInfo, newErr)
-		return irs.NLBInfo{}, newErr
-	}
-
-	// Check if NLB creation was successful
-	if resp.Createnlbresponse.NLBId == 0 {
-		// NLB ID 0 usually indicates creation failure
-		cblogger.Warn("Received NLB ID 0 from KT Cloud (no explicit error in response).")
+	// Check if NLB creation was successful. The new API returns the new LB id in 'data.loadbalancerId'.
+	if strings.EqualFold(nlbIdStr, "") {
+		// An empty ID usually indicates creation failure
+		cblogger.Warn("Received an empty NLB ID from KT Cloud (no explicit error in response).")
 
 		// Check if VMs were provided
 		hasVMs := nlbReqInfo.VMGroup.VMs != nil && len(*nlbReqInfo.VMGroup.VMs) > 0
 		if !hasVMs {
-			newErr := fmt.Errorf("KT Cloud NLB creation returned ID 0. KT Cloud may require at least one VM to create NLB. Please add VMs to the NLB request and try again")
+			newErr := fmt.Errorf("KT Cloud NLB creation returned an empty ID. KT Cloud may require at least one VM to create NLB. Please add VMs to the NLB request and try again")
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
 			return irs.NLBInfo{}, newErr
 		}
 
-		// If VMs were provided but still got ID 0, wait and try to find by name
-		cblogger.Warn("VMs were provided but received ID 0. Waiting and searching by name...")
+		// If VMs were provided but still got an empty ID, wait and try to find by name
+		cblogger.Warn("VMs were provided but received an empty ID. Waiting and searching by name...")
 		time.Sleep(time.Second * 15)
 
 		foundNLB, findErr := nlbHandler.getKtNlbWithName(nlbReqInfo.IId.NameId)
@@ -183,7 +182,7 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 			return irs.NLBInfo{}, newErr
 		}
 
-		nlbIdStr = strconv.Itoa(foundNLB.NlbID)
+		nlbIdStr = foundNLB.NlbID
 		cblogger.Infof("Found NLB by name with ID: %s", nlbIdStr)
 	} else {
 		// # Note) KtNlbInfo.State is info. related to VMGroup HealthInfo. (not related to the operational status.)
@@ -313,11 +312,17 @@ func (nlbHandler *KTVpcNLBHandler) createVMGroup(nlbId string, nlbReqInfo irs.NL
 	}
 
 	for _, vm := range vmInfoList {
+		serviceType := ""
+		if strings.EqualFold(nlbReqInfo.Listener.Protocol, "HTTP") || strings.EqualFold(nlbReqInfo.Listener.Protocol, "HTTPS") {
+			serviceType = nlbReqInfo.Listener.Protocol
+		}
+
 		addOpts := ktvpclb.AddServerOpts{
-			NlbID:      nlbId,                   // Required
-			VMID:       vm.VmID,                 // Required
-			IPAddress:  vm.PrivateIP,            // Required
-			PublicPort: nlbReqInfo.VMGroup.Port, // Required
+			NlbID:       nlbId,                   // Required
+			VMID:        vm.VmID,                 // Required
+			IPAddress:   vm.PrivateIP,            // Required
+			PublicPort:  nlbReqInfo.VMGroup.Port, // Required
+			ServiceType: serviceType,             // HTTP | HTTPS only
 		}
 		start := call.Start()
 		_, err := ktvpclb.AddServer(nlbHandler.NLBClient, addOpts).Extract() // Not 'NetworkClient'
@@ -350,7 +355,7 @@ func (nlbHandler *KTVpcNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	var nlbCount int
 
 	listOpts := ktvpclb.ListOpts{
-		ZoneID: nlbHandler.RegionInfo.Zone,
+		Size: 2000, // Max page size, to list all NLBs in a single page
 	}
 	// Paginate through results
 	err := ktvpclb.List(nlbHandler.NLBClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
@@ -657,14 +662,14 @@ func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 			}
 
 			// Get tier ID from tier name
-			tierId, getNetErr := vpcHandler.getTierIdWithTierName(subnetName)
+			tierRefId, getNetErr := vpcHandler.getTierRefIdWithTierName(subnetName)
 			if getNetErr != nil {
 				newErr := fmt.Errorf("Failed to Get tier ID with name [%s]: %w", subnetName, getNetErr)
 				cblogger.Error(newErr.Error())
 				loggingError(callLogInfo, newErr)
 				return irs.VMGroupInfo{}, newErr
 			}
-			vmInfo.SubnetID = *tierId
+			vmInfo.SubnetID = *tierRefId
 
 			// Validate VM is in the same subnet as NLB
 			if vmInfo.SubnetID != nlbSubnetId {
@@ -697,11 +702,17 @@ func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 	vmGroupPort := vmGroupInfo.Port
 
 	for _, vm := range vmInfoList {
+		serviceType := ""
+		if strings.EqualFold(ktNLB.ServiceType, "HTTP") || strings.EqualFold(ktNLB.ServiceType, "HTTPS") {
+			serviceType = ktNLB.ServiceType
+		}
+
 		addOpts := ktvpclb.AddServerOpts{
-			NlbID:      nlbIID.SystemId, // Required
-			VMID:       vm.VmID,         // Required
-			IPAddress:  vm.PrivateIP,    // Required
-			PublicPort: vmGroupPort,     // Required
+			NlbID:       nlbIID.SystemId, // Required
+			VMID:        vm.VmID,         // Required
+			IPAddress:   vm.PrivateIP,    // Required
+			PublicPort:  vmGroupPort,     // Required
+			ServiceType: serviceType,     // HTTP | HTTPS only
 		}
 		start := call.Start()
 		_, err := ktvpclb.AddServer(nlbHandler.NLBClient, addOpts).Extract() // Not 'NetworkClient'
@@ -803,7 +814,8 @@ func (nlbHandler *KTVpcNLBHandler) RemoveVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) 
 		}
 
 		removeOpts := ktvpclb.RemoveServerOpts{
-			ServiceID: serviceId, // Required. Not VMID
+			NlbID:     nlbIID.SystemId, // Required
+			ServiceID: serviceId,       // Required. Not VMID
 		}
 		start := call.Start()
 		_, rmErr := ktvpclb.RemoveServer(nlbHandler.NLBClient, removeOpts).Extract() // Not 'NetworkClient'
@@ -866,7 +878,7 @@ func (nlbHandler *KTVpcNLBHandler) GetVMGroupHealthInfo(nlbIID irs.IID) (irs.Hea
 
 		allVMs = append(allVMs, irs.IID{NameId: vmName, SystemId: vm.VmID})
 
-		if strings.EqualFold(vm.VmState, "UP") {
+		if strings.EqualFold(vm.MonitorState, "UP") {
 			// cblogger.Infof("\n### [%s] is Healthy VM.", vm.Name)
 			healthVMs = append(healthVMs, irs.IID{NameId: vmName, SystemId: vm.VmID})
 		} else {
@@ -890,7 +902,7 @@ func (nlbHandler *KTVpcNLBHandler) ChangeHealthCheckerInfo(nlbIID irs.IID, healt
 func (nlbHandler *KTVpcNLBHandler) getListenerInfo(nlb *ktvpclb.LoadBalancer) (irs.ListenerInfo, error) {
 	cblogger.Info("KT Cloud VPC Driver: called getListenerInfo()")
 
-	nlbId := strconv.Itoa(nlb.NlbID)
+	nlbId := nlb.NlbID
 	InitLog()
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "getListenerInfo()")
 
@@ -904,7 +916,7 @@ func (nlbHandler *KTVpcNLBHandler) getListenerInfo(nlb *ktvpclb.LoadBalancer) (i
 	listenerInfo := irs.ListenerInfo{
 		Protocol: nlb.ServiceType,
 		IP:       nlb.ServiceIP,
-		Port:     nlb.ServicePort,
+		Port:     strconv.Itoa(nlb.ServicePort),
 		// DNSName:		"NA",
 		// CspID: 		"NA",
 		// KeyValueList:   irs.StructToKeyValueList(nlb),
@@ -915,7 +927,7 @@ func (nlbHandler *KTVpcNLBHandler) getListenerInfo(nlb *ktvpclb.LoadBalancer) (i
 func (nlbHandler *KTVpcNLBHandler) getHealthCheckerInfo(nlb *ktvpclb.LoadBalancer) (irs.HealthCheckerInfo, error) {
 	cblogger.Info("KT Cloud VPC Driver: called getHealthCheckerInfo()")
 
-	nlbId := strconv.Itoa(nlb.NlbID)
+	nlbId := nlb.NlbID
 	InitLog()
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Region, "NETWORKLOADBALANCE", nlbId, "getHealthCheckerInfo()")
 
@@ -928,7 +940,7 @@ func (nlbHandler *KTVpcNLBHandler) getHealthCheckerInfo(nlb *ktvpclb.LoadBalance
 
 	healthCheckerInfo := irs.HealthCheckerInfo{
 		Protocol: nlb.HealthCheckType,
-		Port:     nlb.ServicePort,
+		Port:     strconv.Itoa(nlb.ServicePort),
 		// CspID: 		"NA",
 	}
 	return healthCheckerInfo, nil
@@ -968,15 +980,15 @@ func (nlbHandler *KTVpcNLBHandler) getVMGroupInfo(nlbId string) (irs.VMGroupInfo
 		// Return VMGroupInfo with basic protocol and port info from NLB, even when no VMs exist
 		vmGroupInfo := irs.VMGroupInfo{
 			Protocol: ktNLB.ServiceType,
-			Port:     ktNLB.ServicePort,
+			Port:     strconv.Itoa(ktNLB.ServicePort),
 			VMs:      &[]irs.IID{}, // Empty VM list
 		}
 		return vmGroupInfo, nil
 	}
 
 	vmGroupInfo := irs.VMGroupInfo{
-		Protocol: ktNLB.ServiceType,       // Caution!!
-		Port:     nlbVmList[0].PublicPort, // In case, Any VM exists
+		Protocol: ktNLB.ServiceType,                    // Caution!!
+		Port:     strconv.Itoa(nlbVmList[0].PublicPort), // In case, Any VM exists
 		// CspID:    	"NA",
 		KeyValueList: irs.StructToKeyValueList(nlbVmList[0]),
 	}
@@ -1002,7 +1014,7 @@ func (nlbHandler *KTVpcNLBHandler) getVMGroupInfo(nlbId string) (irs.VMGroupInfo
 
 		keyValue := irs.KeyValue{
 			Key:   vmName + "_ServiceId",
-			Value: strconv.Itoa(vm.ServiceID),
+			Value: vm.ServiceID,
 		}
 		vmGroupInfo.KeyValueList = append(vmGroupInfo.KeyValueList, keyValue)
 
@@ -1048,7 +1060,7 @@ func (nlbHandler *KTVpcNLBHandler) getNlbServiceIdWithVMId(nlbId string, vmId st
 	var serviceID string
 	for _, vm := range nlbVmList {
 		if strings.EqualFold(vm.VmID, vmId) {
-			serviceID = strconv.Itoa(vm.ServiceID)
+			serviceID = vm.ServiceID
 			break
 		}
 	}
@@ -1065,12 +1077,17 @@ func (nlbHandler *KTVpcNLBHandler) getNlbServiceIdWithVMId(nlbId string, vmId st
 func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (irs.NLBInfo, error) {
 	cblogger.Info("KT Cloud VPC Driver: called mappingNlbInfo()")
 
+	if strings.EqualFold(nlb.NetworkID, "") {
+		newErr := fmt.Errorf("Invalid nlb.NetworkID!!")
+		cblogger.Error(newErr.Error())		
+		return irs.NLBInfo{}, newErr
+	}
+
 	vpcHandler := KTVpcVPCHandler{
 		RegionInfo:    nlbHandler.RegionInfo,
 		NetworkClient: nlbHandler.NetworkClient,
 	}
-
-	vpcId, err := vpcHandler.getVPCIdWithTierId(nlb.NetworkID)
+	vpcId, err := vpcHandler.getVPCIdWithTierNetId(nlb.NetworkID)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get VPC ID with the Tier ID : [%w]", err)
 		cblogger.Error(newErr.Error())
@@ -1080,7 +1097,7 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 	nlbInfo := irs.NLBInfo{
 		IId: irs.IID{
 			NameId:   nlb.Name,
-			SystemId: strconv.Itoa(nlb.NlbID),
+			SystemId: nlb.NlbID,
 		},
 		VpcIID: irs.IID{
 			// NameId:   "N/A", // Cauton!!) 'NameId: "N/A"' makes an Error on CB-Spider
@@ -1102,7 +1119,7 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 	}
 
 	// Get NLB info from DB
-	nlbDbInfo, getSGErr := nim.GetNlb(strconv.Itoa(nlb.NlbID))
+	nlbDbInfo, getSGErr := nim.GetNlb(nlb.NlbID)
 	if getSGErr != nil {
 		cblogger.Debug(getSGErr)
 		// return irs.VMInfo{}, getSGErr
@@ -1129,7 +1146,7 @@ func (nlbHandler *KTVpcNLBHandler) mappingNlbInfo(nlb *ktvpclb.LoadBalancer) (ir
 		nlbInfo.HealthChecker = healthCheckerInfo
 	}
 
-	vmGroupInfo, err := nlbHandler.getVMGroupInfo(strconv.Itoa(nlb.NlbID))
+	vmGroupInfo, err := nlbHandler.getVMGroupInfo(nlb.NlbID)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get VMGroup Info with the NLB ID : [%w]", err)
 		cblogger.Error(newErr.Error())
@@ -1152,8 +1169,7 @@ func (nlbHandler *KTVpcNLBHandler) getKtNlbInfo(nlbId string) (*ktvpclb.LoadBala
 
 	var nlbList []ktvpclb.LoadBalancer
 	listOpts := ktvpclb.ListOpts{
-		ZoneID: nlbHandler.RegionInfo.Zone,
-		NlbID:  nlbId,
+		NlbID: nlbId,
 	}
 	// Paginate through results
 	err := ktvpclb.List(nlbHandler.NLBClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
@@ -1197,8 +1213,7 @@ func (nlbHandler *KTVpcNLBHandler) getKtNlbWithName(nlbName string) (*ktvpclb.Lo
 	}
 
 	listOpts := ktvpclb.ListOpts{
-		ZoneID: nlbHandler.RegionInfo.Zone,
-		Name:   nlbName,
+		Name: nlbName,
 	}
 	start := call.Start()
 	firstPage, err := ktvpclb.List(nlbHandler.NLBClient, listOpts).FirstPage() // Not '~.AllPages()'
@@ -1333,7 +1348,7 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatForNLB(ktNLB *ktvpclb.LoadBala
 
 	// Register NLB info to DB
 	providerName := "KTVPC"
-	nlbDbInfo, regErr := nim.RegisterNlb(strconv.Itoa(ktNLB.NlbID), providerName, keyValueList)
+	nlbDbInfo, regErr := nim.RegisterNlb(ktNLB.NlbID, providerName, keyValueList)
 	if regErr != nil {
 		cblogger.Error(regErr)
 		return regErr
@@ -1407,7 +1422,7 @@ func (nlbHandler *KTVpcNLBHandler) ListIID() ([]*irs.IID, error) {
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", "ListIID()", "ListIID()")
 
 	listOpts := ktvpclb.ListOpts{
-		ZoneID: nlbHandler.RegionInfo.Zone,
+		Size: 2000, // Max page size, to list all NLBs in a single page
 	}
 	start := call.Start()
 	firstPage, err := ktvpclb.List(nlbHandler.NLBClient, listOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()'
@@ -1434,7 +1449,7 @@ func (nlbHandler *KTVpcNLBHandler) ListIID() ([]*irs.IID, error) {
 	for _, nlb := range nlbList {
 		iid := &irs.IID{
 			NameId:   nlb.Name,
-			SystemId: strconv.Itoa(nlb.NlbID),
+			SystemId: nlb.NlbID,
 		}
 		iidList = append(iidList, iid)
 	}
@@ -1444,9 +1459,9 @@ func (nlbHandler *KTVpcNLBHandler) ListIID() ([]*irs.IID, error) {
 // getSubnetOfVMGroup finds the subnet (tier) where VMs in the VMGroup belong
 // Returns the subnet ID after validating all VMs are in the same subnet
 // KT Cloud NLB requires at least one VM and all VMs must be in the same subnet
-func (nlbHandler *KTVpcNLBHandler) getSubnetOfVMGroup(ctx context.Context, vmGroup irs.VMGroupInfo) (string, error) {
-	cblogger.Info("KT Cloud VPC Driver: called getSubnetOfVMGroup()")
-	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", "VMGroup", "getSubnetOfVMGroup()")
+func (nlbHandler *KTVpcNLBHandler) getTierNetIdOfVMGroup(ctx context.Context, vmGroup irs.VMGroupInfo) (string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called getTierNetIdOfVMGroup()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", "VMGroup", "getTierNetIdOfVMGroup()")
 
 	// KT Cloud NLB requires at least one VM because NLB operates at subnet level
 	if vmGroup.VMs == nil || len(*vmGroup.VMs) == 0 {
@@ -1479,7 +1494,7 @@ func (nlbHandler *KTVpcNLBHandler) getSubnetOfVMGroup(ctx context.Context, vmGro
 
 	// Validate all VMs and collect their subnet IDs
 	vms := *vmGroup.VMs
-	var subnetIds []string
+	var tierNetIds []string
 	var vmNames []string
 
 	cblogger.Infof("Validating %d VMs for subnet consistency", len(vms))
@@ -1530,8 +1545,8 @@ func (nlbHandler *KTVpcNLBHandler) getSubnetOfVMGroup(ctx context.Context, vmGro
 			return "", newErr
 		}
 
-		// Get tier ID from tier name
-		tierId, getNetErr := vpcHandler.getTierIdWithTierName(subnetName)
+		// Get tier Network ID from tier name
+		tierNetId, getNetErr := vpcHandler.getTierNetIdWithTierName(subnetName)
 		if getNetErr != nil {
 			newErr := fmt.Errorf("Failed to Get tier ID with name [%s]: %w", subnetName, getNetErr)
 			cblogger.Error(newErr.Error())
@@ -1539,40 +1554,40 @@ func (nlbHandler *KTVpcNLBHandler) getSubnetOfVMGroup(ctx context.Context, vmGro
 			return "", newErr
 		}
 
-		subnetIds = append(subnetIds, *tierId)
-		vmNames = append(vmNames, vmIID.NameId)
+		tierNetIds 	= append(tierNetIds, *tierNetId)
+		vmNames		= append(vmNames, vmIID.NameId)
 
-		cblogger.Infof("VM %s (ID: %s) is in subnet %s (tier name: %s)", vmIID.NameId, vmId, *tierId, subnetName)
+		cblogger.Infof("VM %s (ID: %s) is in subnet %s (tier name: %s)", vmIID.NameId, vmId, *tierNetId, subnetName)
 	}
 
 	// Validate all VMs are in the same subnet
-	if len(subnetIds) == 0 {
+	if len(tierNetIds) == 0 {
 		newErr := fmt.Errorf("No valid VMs found in VMGroup")
 		cblogger.Error(newErr.Error())
 		loggingError(callLogInfo, newErr)
 		return "", newErr
 	}
 
-	firstSubnetId := subnetIds[0]
-	for i := 1; i < len(subnetIds); i++ {
-		if subnetIds[i] != firstSubnetId {
+	firstTierNetId := tierNetIds[0]
+	for i := 1; i < len(tierNetIds); i++ {
+		if tierNetIds[i] != firstTierNetId {
 			newErr := fmt.Errorf("KT Cloud NLB requires all VMs to be in the same subnet. VM '%s' is in subnet '%s', but VM '%s' is in subnet '%s'. Please ensure all VMs in the VMGroup are in the same subnet",
-				vmNames[0], firstSubnetId, vmNames[i], subnetIds[i])
+				vmNames[0], firstTierNetId, vmNames[i], tierNetIds[i])
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
 			return "", newErr
 		}
 	}
 
-	cblogger.Infof("All %d VMs validated - all are in subnet %s", len(vms), firstSubnetId)
-	return firstSubnetId, nil
+	cblogger.Infof("All %d VMs validated - all are in subnet %s", len(vms), firstTierNetId)
+	return firstTierNetId, nil
 }
 
 // createFirewallRulesForNLB creates inbound and outbound firewall rules for NLB
 // Supports TCP, UDP, and ICMP protocols with proper error handling and logging
 func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.LoadBalancer, publicIP, staticNatId string) error {
 	cblogger.Info("KT Cloud VPC Driver: called createFirewallRulesForNLB()")
-	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", strconv.Itoa(ktNLB.NlbID), "createFirewallRulesForNLB()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", ktNLB.NlbID, "createFirewallRulesForNLB()")
 
 	if ktNLB == nil {
 		newErr := fmt.Errorf("Invalid NLB info")
@@ -1663,7 +1678,7 @@ func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.Load
 // ### createInboundFirewallRule creates an inbound firewall rule for the specified protocol 'fot StaticNAT'
 func (nlbHandler *KTVpcNLBHandler) createStaticNatInboundFirewallRule(ktNLB *ktvpclb.LoadBalancer, publicIP, staticNatId, protocol, extNetId, networkId string) error {
 	cblogger.Info("KT Cloud VPC Driver: called createInboundFirewallRule()")
-	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", strconv.Itoa(ktNLB.NlbID), "createInboundFirewallRule()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", ktNLB.NlbID, "createInboundFirewallRule()")
 
 	cblogger.Infof("Start to create firewall inbound rule for protocol: [%s]", protocol)
 
@@ -1697,12 +1712,12 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatInboundFirewallRule(ktNLB *ktv
 		}
 	} else {
 		// TCP and UDP with port forwarding
-		comment := "Allow inbound - " + protocol + " - " + ktNLB.ServicePort + " to " + ktNLB.ServicePort
+		comment := "Allow inbound - " + protocol + " - " + strconv.Itoa(ktNLB.ServicePort) + " to " + strconv.Itoa(ktNLB.ServicePort)
 		inboundFWOpts = &rules.CreateOpts{
 			Action:      true, // accept
 			Protocol:    protocol,
-			StartPort:   ktNLB.ServicePort,
-			EndPort:     ktNLB.ServicePort,
+			StartPort:   strconv.Itoa(ktNLB.ServicePort),
+			EndPort:     strconv.Itoa(ktNLB.ServicePort),
 			SrcNetwork:  []string{extNetId},
 			StaticNatId: staticNatId, // Caution!!
 			SrcAddress:  []string{srcIPAdds},
@@ -1746,7 +1761,7 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatInboundFirewallRule(ktNLB *ktv
 // createOutboundFirewallRule creates an outbound firewall rule for the specified protocol
 func (nlbHandler *KTVpcNLBHandler) createStaticNatOutboundFirewallRule(ktNLB *ktvpclb.LoadBalancer, protocol, extNetId, networkId string) error {
 	cblogger.Info("KT Cloud VPC Driver: called createOutboundFirewallRule()")
-	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", strconv.Itoa(ktNLB.NlbID), "createOutboundFirewallRule()")
+	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", ktNLB.NlbID, "createOutboundFirewallRule()")
 
 	cblogger.Infof("Start to create firewall outbound rule for protocol: [%s]", protocol)
 
@@ -1780,12 +1795,12 @@ func (nlbHandler *KTVpcNLBHandler) createStaticNatOutboundFirewallRule(ktNLB *kt
 		}
 	} else {
 		// TCP and UDP with ports
-		comment := "Allow outbound - " + protocol + " - " + ktNLB.ServicePort + " to " + ktNLB.ServicePort
+		comment := "Allow outbound - " + protocol + " - " + strconv.Itoa(ktNLB.ServicePort) + " to " + strconv.Itoa(ktNLB.ServicePort)
 		outboundFWOpts = &rules.CreateOpts{
 			Action:     true, // accept
 			Protocol:   protocol,
-			StartPort:  ktNLB.ServicePort,
-			EndPort:    ktNLB.ServicePort,
+			StartPort:  strconv.Itoa(ktNLB.ServicePort),
+			EndPort:    strconv.Itoa(ktNLB.ServicePort),
 			SrcNetwork: []string{networkId},
 			DstNetwork: []string{extNetId},
 			SrcAddress: []string{srcCIDR},
@@ -1849,8 +1864,7 @@ func (nlbHandler *KTVpcNLBHandler) checkNLBExists(ctx context.Context, nlbName s
 	}
 
 	listOpts := ktvpclb.ListOpts{
-		Name:   nlbName,
-		ZoneID: nlbHandler.RegionInfo.Zone,
+		Name: nlbName,
 	}
 
 	var nlbExists bool
@@ -1871,7 +1885,7 @@ func (nlbHandler *KTVpcNLBHandler) checkNLBExists(ctx context.Context, nlbName s
 
 		if len(loadBalancers) > 0 {
 			nlbExists = true
-			cblogger.Infof("NLB with name [%s] already exists (ID: %d)", nlbName, loadBalancers[0].NlbID)
+			cblogger.Infof("NLB with name [%s] already exists (ID: %s)", nlbName, loadBalancers[0].NlbID)
 			return false, nil // Stop pagination
 		}
 
@@ -2036,16 +2050,17 @@ func (nlbHandler *KTVpcNLBHandler) deleteAllVMsFromNLB(nlbIID irs.IID) (int, err
 	var removeErrors []string
 
 	for _, vm := range nlbVmList {
-		cblogger.Infof("Removing VM [%s] (ServiceID: %d) from NLB", vm.VmID, vm.ServiceID)
+		cblogger.Infof("Removing VM [%s] (ServiceID: %s) from NLB", vm.VmID, vm.ServiceID)
 
 		removeOpts := ktvpclb.RemoveServerOpts{
-			ServiceID: strconv.Itoa(vm.ServiceID),
+			NlbID:     nlbIID.SystemId,
+			ServiceID: vm.ServiceID,
 		}
 
 		start := call.Start()
 		_, rmErr := ktvpclb.RemoveServer(nlbHandler.NLBClient, removeOpts).Extract()
 		if rmErr != nil {
-			errMsg := fmt.Sprintf("Failed to Remove VM [%s] (ServiceID: %d): %v", vm.VmID, vm.ServiceID, rmErr)
+			errMsg := fmt.Sprintf("Failed to Remove VM [%s] (ServiceID: %s): %v", vm.VmID, vm.ServiceID, rmErr)
 			cblogger.Error(errMsg)
 			removeErrors = append(removeErrors, errMsg)
 			loggingError(callLogInfo, rmErr)

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
@@ -8,6 +8,7 @@
 //
 // by ETRI Team, 2024.02.
 // Updated by ETRI Team, 2025.11.
+// Updated by ETRI Team, 2026.07.
 
 package resources
 
@@ -18,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
 	// "github.com/davecgh/go-spew/spew"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
@@ -93,22 +93,7 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 		return irs.NLBInfo{}, newErr
 	}
 
-	/*
-		vpcHandler := KTVpcVPCHandler{
-			RegionInfo:    nlbHandler.RegionInfo,
-			NetworkClient: nlbHandler.NetworkClient, // Required!!
-		}
-		tierId, getError := vpcHandler.getTierIdWithTierName(NlbSubnetName)
-		if getError != nil {
-			newErr := fmt.Errorf("Failed to Get the Tier ID of the 'NLB-Subnet' : [%v]", getError)
-			cblogger.Error(newErr.Error())
-			return irs.NLBInfo{}, newErr
-		} else {
-			cblogger.Infof("# Tier ID of NLB-SUBNET : %s", *tierId)
-		}
-	*/
-
-	// Get subnet where VMGroup VMs belong
+	// Get Tier Network ID where VMGroup VMs belong
 	vmGroupTierNetId, err := nlbHandler.getTierNetIdOfVMGroup(ctx, nlbReqInfo.VMGroup)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get VMGroup Subnet ID : %w", err)
@@ -220,22 +205,6 @@ func (nlbHandler *KTVpcNLBHandler) CreateNLB(nlbReqInfo irs.NLBInfo) (createNLB 
 		loggingError(callLogInfo, newErr)
 		return irs.NLBInfo{}, newErr
 	}
-
-	// createTagOpts := ktvpclb.CreateTagOpts{
-	// 	NlbID:           	strconv.Itoa(ktNLB.NlbID),  			// Required
-	// 	Tag:         		publicIp, 								// Required
-	// }
-	// _, tagErr := ktvpclb.CreateTag(nlbHandler.NLBClient, createTagOpts).Extract() // Not 'NetworkClient'
-	// if tagErr != nil {
-	// 	newErr := fmt.Errorf("Failed to Create the Tag : [%v]", tagErr.Error())
-	// 	cblogger.Error(newErr.Error())
-	// 	loggingError(callLogInfo, newErr)
-	// 	return irs.NLBInfo{}, newErr
-	// }
-	// loggingInfo(callLogInfo, start)
-
-	// cblogger.Info("\n### Creating New Tag!!")
-	// time.Sleep(time.Second * 3)
 
 	nlbIID := irs.IID{SystemId: nlbIdStr}
 	nlbInfo, getErr := nlbHandler.GetNLB(nlbIID)
@@ -444,16 +413,6 @@ func (nlbHandler *KTVpcNLBHandler) DeleteNLB(nlbIID irs.IID) (bool, error) {
 		return false, newErr
 	}
 
-	/*
-		ktNLB, err := nlbHandler.getKtNlbInfo(nlbIID.SystemId)
-		if err != nil {
-			newErr := fmt.Errorf("Failed to Get KT Cloud NLB info!! [%v]", err)
-			cblogger.Error(newErr.Error())
-			loggingError(callLogInfo, newErr)
-			return false, newErr
-		}
-	*/
-
 	// Delete FirewallRules
 	dellVmErr := nlbHandler.deleteAllVMs(nlbIID)
 	if dellVmErr != nil {
@@ -504,8 +463,8 @@ func (nlbHandler *KTVpcNLBHandler) DeleteNLB(nlbIID irs.IID) (bool, error) {
 	// Caution) Before deleting the StaticNAT, must first delete the firewall settings.
 	// Delete FirewallRules, Static NAT and Public IP
 	if !strings.EqualFold(publicIp, "") {
-
 		// Delete FirewallRules
+		cblogger.Info("### Deleting Firewall Rules of the StaticNAT!!")
 		_, dellFwErr := vmHandler.removeFirewallRules(publicIp)
 		if dellFwErr != nil {
 			cblogger.Error(dellFwErr.Error())
@@ -603,15 +562,7 @@ func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 		loggingError(callLogInfo, newErr)
 		return irs.VMGroupInfo{}, newErr
 	}
-	nlbSubnetId := ktNLB.NetworkID
-	cblogger.Infof("NLB is in subnet (tier): %s", nlbSubnetId)
-
-	type VMInfo struct {
-		VmID      string
-		PrivateIP string
-		SubnetID  string
-		VMName    string
-	}
+	nlbTierNetworkId := ktNLB.NetworkID
 
 	vmHandler := KTVpcVMHandler{
 		RegionInfo:    nlbHandler.RegionInfo,
@@ -622,6 +573,22 @@ func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 	vpcHandler := KTVpcVPCHandler{
 		RegionInfo:    nlbHandler.RegionInfo,
 		NetworkClient: nlbHandler.NetworkClient,
+	}
+
+	nlbTierRefId, getTierErr := vpcHandler.getTierIdWithNetworkId(nlbTierNetworkId)
+	if getTierErr != nil {
+		newErr := fmt.Errorf("Failed to Get TierRefId with NLB Tier Network ID [%s]: %w", nlbTierNetworkId, getTierErr)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.VMGroupInfo{}, newErr
+	}
+	cblogger.Infof("NLB is in Subnet(tier): %s", *nlbTierRefId)
+
+	type VMInfo struct {
+		VmID      string
+		PrivateIP string
+		SubnetID  string
+		VMName    string
 	}
 
 	var vmInfo VMInfo
@@ -661,20 +628,20 @@ func (nlbHandler *KTVpcNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 				return irs.VMGroupInfo{}, newErr
 			}
 
-			// Get tier ID from tier name
-			tierRefId, getNetErr := vpcHandler.getTierRefIdWithTierName(subnetName)
+			// Get tier Network ID from tier name
+			vmTierRefId, getNetErr := vpcHandler.getTierRefIdWithTierName(subnetName)
 			if getNetErr != nil {
 				newErr := fmt.Errorf("Failed to Get tier ID with name [%s]: %w", subnetName, getNetErr)
 				cblogger.Error(newErr.Error())
 				loggingError(callLogInfo, newErr)
 				return irs.VMGroupInfo{}, newErr
 			}
-			vmInfo.SubnetID = *tierRefId
+			vmInfo.SubnetID = *vmTierRefId
 
 			// Validate VM is in the same subnet as NLB
-			if vmInfo.SubnetID != nlbSubnetId {
+			if *nlbTierRefId != vmInfo.SubnetID {
 				newErr := fmt.Errorf("KT Cloud NLB requires all VMs to be in the same subnet as the NLB. NLB is in subnet '%s', but VM '%s' is in subnet '%s'. Please ensure the VM is in the same subnet as the NLB",
-					nlbSubnetId, vmIID.NameId, vmInfo.SubnetID)
+					*nlbTierRefId, vmIID.NameId, vmInfo.SubnetID)
 				cblogger.Error(newErr.Error())
 				loggingError(callLogInfo, newErr)
 				return irs.VMGroupInfo{}, newErr
@@ -1066,7 +1033,7 @@ func (nlbHandler *KTVpcNLBHandler) getNlbServiceIdWithVMId(nlbId string, vmId st
 	}
 
 	if strings.EqualFold(serviceID, "") {
-		newErr := fmt.Errorf("Failed to Find the Service ID with the VM ID!!")
+		newErr := fmt.Errorf("Failed to Find the Service ID with the VM ID(%s)!!", vmId)
 		cblogger.Error(newErr.Error())
 		return "", newErr
 	}
@@ -1624,16 +1591,6 @@ func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.Load
 	}
 	cblogger.Infof("External network ID: %s", *extNetId)
 
-	// Get tier network ID
-	networkId, err := vpcHandler.getNetworkIdWithTierId(ktNLB.NetworkID)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Get Tier Network ID: %w", err)
-		cblogger.Error(newErr.Error())
-		loggingError(callLogInfo, newErr)
-		return newErr
-	}
-	cblogger.Infof("Tier network ID: %s", *networkId)
-
 	// Convert service type to protocol
 	protocol := ktNLB.ServiceType
 	var protocols []string
@@ -1656,7 +1613,7 @@ func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.Load
 		cblogger.Infof("Creating firewall rules for protocol: %s", curProtocol)
 
 		// Create inbound firewall rule
-		if err := nlbHandler.createStaticNatInboundFirewallRule(ktNLB, publicIP, staticNatId, curProtocol, *extNetId, *networkId); err != nil {
+		if err := nlbHandler.createStaticNatInboundFirewallRule(ktNLB, publicIP, staticNatId, curProtocol, *extNetId); err != nil {
 			newErr := fmt.Errorf("Failed to create inbound firewall rule for %s: %w", curProtocol, err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
@@ -1664,7 +1621,7 @@ func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.Load
 		}
 
 		// Create outbound firewall rule
-		if err := nlbHandler.createStaticNatOutboundFirewallRule(ktNLB, curProtocol, *extNetId, *networkId); err != nil {
+		if err := nlbHandler.createStaticNatOutboundFirewallRule(ktNLB, curProtocol, *extNetId, ktNLB.NetworkID); err != nil {
 			newErr := fmt.Errorf("Failed to create outbound firewall rule for %s: %w", curProtocol, err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
@@ -1676,7 +1633,7 @@ func (nlbHandler *KTVpcNLBHandler) createFirewallRulesForNLB(ktNLB *ktvpclb.Load
 }
 
 // ### createInboundFirewallRule creates an inbound firewall rule for the specified protocol 'fot StaticNAT'
-func (nlbHandler *KTVpcNLBHandler) createStaticNatInboundFirewallRule(ktNLB *ktvpclb.LoadBalancer, publicIP, staticNatId, protocol, extNetId, networkId string) error {
+func (nlbHandler *KTVpcNLBHandler) createStaticNatInboundFirewallRule(ktNLB *ktvpclb.LoadBalancer, publicIP, staticNatId, protocol, extNetId string) error {
 	cblogger.Info("KT Cloud VPC Driver: called createInboundFirewallRule()")
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", ktNLB.NlbID, "createInboundFirewallRule()")
 

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -9,6 +9,7 @@
 // by ETRI, 2022.12.
 // Updated by ETRI 2024.01.
 // Updated by ETRI 2025.11.
+// Updated by ETRI 2026.07.
 
 package resources
 
@@ -1328,15 +1329,18 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 			}
 		}
 	}
-
-	netInfo, err := vmHandler.getNetIDsWithPrivateIP(vmInfo.PrivateIP)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Get PortForwarding Info. [%v]", err)
-		cblogger.Debug(newErr.Error())
-		// return irs.VMInfo{}, nil
-		// return irs.VMInfo{}, newErr
+	
+	var netInfo *NetworkInfo
+	if !strings.EqualFold(vmInfo.PrivateIP, "") {
+		var getNetErr error
+		netInfo, getNetErr = vmHandler.getNetIDsWithPrivateIP(vmInfo.PrivateIP)
+		if getNetErr != nil {
+			newErr := fmt.Errorf("Failed to Get PortForwarding Info. [%v]", getNetErr)
+			cblogger.Debug(newErr.Error())
+			// return irs.VMInfo{}, nil
+			// return irs.VMInfo{}, newErr
+		}
 	}
-
 	// cblogger.Info("\n\n### netInfo : ")
 	// spew.Dump(netInfo)
 	// cblogger.Info("\n")
@@ -1358,17 +1362,17 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 	// 	cblogger.Infof("# OsNetwork ID : %s", OsNetId)
 	// }
 
-	tierId, getNetErr := vpcHandler.getTierIdWithTierName(vmInfo.SubnetIID.NameId)
+	tierRefId, getNetErr := vpcHandler.getTierRefIdWithTierName(vmInfo.SubnetIID.NameId)
 	if getNetErr != nil {
 		newErr := fmt.Errorf("Failed to Get the OsNetwork ID with the Tier Name : [%v]", getNetErr)
 		cblogger.Error(newErr.Error())
 		return irs.VMInfo{}, newErr
 	}
-	if tierId != nil {
-		vmInfo.SubnetIID.SystemId = *tierId // Caution!!) Not Tier 'NetworkId' but 'TierId' to Create VM through REST API!!
+	if tierRefId != nil {
+		vmInfo.SubnetIID.SystemId = *tierRefId // Caution!!) Not Tier 'NetworkId' but 'tierRefId' to Create VM through REST API!!
 	}
 
-	vpcId, err := vpcHandler.getVPCIdWithTierId(*tierId)
+	vpcId, err := vpcHandler.getVPCIdWithTierRefId(*tierRefId)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the VPC ID with teh OsNetwork ID. [%v]", err)
 		cblogger.Error(newErr.Error())
@@ -2226,7 +2230,7 @@ func (vmHandler *KTVpcVMHandler) getVmPrivateIpAndNetIdWithVMId(vmId string) (st
 		RegionInfo:    vmHandler.RegionInfo,
 		NetworkClient: vmHandler.NetworkClient, // Required!!
 	}
-	tierId, getOsNetErr := vpcHandler.getTierIdWithTierName(subnetName)
+	tierId, getOsNetErr := vpcHandler.getTierRefIdWithTierName(subnetName)
 	if getOsNetErr != nil {
 		newErr := fmt.Errorf("Failed to Get the OsNetwork ID with the Tier Name : [%v]", getOsNetErr)
 		cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -1242,7 +1242,7 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 		cblogger.Debug(getSGErr)
 		// return irs.VMInfo{}, getSGErr
 	}
-	if countSgKvList(*sgInfo) > 0 {
+	if sgInfo != nil && countSgKvList(*sgInfo) > 0 {
 		// Since S/G is managed as a file, the systemID is the same as the name ID.
 		var sgIIDs []irs.IID
 		for _, kv := range sgInfo.KeyValueInfoList {
@@ -1822,7 +1822,7 @@ func (vmHandler *KTVpcVMHandler) removeFirewallRules(ip string) (bool, error) {
 		return false, newErr
 	}
 
-	cblogger.Info("Cloud driver: called listFirewallRule()!!")
+	cblogger.Info("listFirewallRule()!!")
 	fwRuleList, err := vmHandler.listFirewallRule()
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get Firewall Rule List. [%v]", err)
@@ -1834,6 +1834,8 @@ func (vmHandler *KTVpcVMHandler) removeFirewallRules(ip string) (bool, error) {
 		cblogger.Debug(newErr.Error())
 		return true, nil // Not false, newErr
 	}
+	// cblogger.Infof("/n＃ fwRuleList :")
+	// spew.Dump(fwRuleList)
 
 	policyIDs, err := vmHandler.findFirewallPolicyIDsByIP(fwRuleList, ip)
 	if err != nil {
@@ -1850,6 +1852,7 @@ func (vmHandler *KTVpcVMHandler) removeFirewallRules(ip string) (bool, error) {
 
 	// Deletes all firewall rules matching the given policyIDs.
 	for _, policyID := range policyIDs {
+		cblogger.Infof("＃ PolicyID: %s", policyID)
 		result := rules.Delete(vmHandler.NetworkClient, policyID)
 		if result.Err != nil {
 			errMsg := result.Err.Error()

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
@@ -736,9 +736,10 @@ func (vpcHandler *KTVpcVPCHandler) getNetworkIdWithTierId(tierId string) (*strin
 	return &subnetAdrsList[0].NetworkID, nil
 }
 
-func (vpcHandler *KTVpcVPCHandler) getTierIdWithTierName(tierName string) (*string, error) {
-	cblogger.Info("KT Cloud VPC Driver: called getTierIdWithTierName()!")
-	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierName, "getTierIdWithTierName()")
+
+func (vpcHandler *KTVpcVPCHandler) getTierNetIdWithTierName(tierName string) (*string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called getTierNetIdWithTierName()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierName, "getTierNetIdWithTierName()")
 
 	if strings.EqualFold(tierName, "") {
 		newErr := fmt.Errorf("Invalid Subnet(Tier) Name!!")
@@ -757,38 +758,75 @@ func (vpcHandler *KTVpcVPCHandler) getTierIdWithTierName(tierName string) (*stri
 	}
 	loggingInfo(callLogInfo, start)
 
-	var tierId string
+	var tierNetId string
 	for _, subnet := range subnets {
 		if strings.EqualFold(subnet.RefName, tierName) {
-			tierId = subnet.RefID
+			tierNetId = subnet.NetworkID // Not RefId but NetworkID
 			break
 		}
 	}
-	if strings.EqualFold(tierId, "") {
+	if strings.EqualFold(tierNetId, "") {
 		newErr := fmt.Errorf("Failed to Find the Subnet(Tier) ID!!")
 		cblogger.Error(newErr.Error())
 		return nil, newErr
 	}
-	return &tierId, nil
+	return &tierNetId, nil
 }
 
-func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierId(tierId string) (*string, error) {
-	cblogger.Info("KT Cloud VPC Driver: called getVPCIdWithTierId()!")
-	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierId, "getVPCIdWithTierId()")
+func (vpcHandler *KTVpcVPCHandler) getTierRefIdWithTierName(tierName string) (*string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called getTierRefIdWithTierName()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierName, "getTierRefIdWithTierName()")
 
-	if strings.EqualFold(tierId, "") {
-		newErr := fmt.Errorf("Invalid Subnet(Tier) ID!!")
+	if strings.EqualFold(tierName, "") {
+		newErr := fmt.Errorf("Invalid Subnet(Tier) Name!!")
 		cblogger.Error(newErr.Error())
 		loggingError(callLogInfo, newErr)
 		return nil, newErr
 	}
-	// cblogger.Infof("# Subnet(Tier) ID to Find Network ID : %s", tierId)
+
+	// Get Subnet list
+	start := call.Start()
+	subnets, err := vpcHandler.listKTSubnet() // ALL Subnet : TRUST and UNTRUST
+	if err != nil {
+		newErr := fmt.Errorf("Failed to Get Subnet list!! : [%v] ", err)
+		cblogger.Error(newErr.Error())
+		return nil, newErr
+	}
+	loggingInfo(callLogInfo, start)
+
+	var tierRefId string
+	for _, subnet := range subnets {
+		if strings.EqualFold(subnet.RefName, tierName) {
+			tierRefId = subnet.RefID // Not NetworkID but RefID
+			break
+		}
+	}
+	if strings.EqualFold(tierRefId, "") {
+		newErr := fmt.Errorf("Failed to Find the Subnet(Tier) ID!!")
+		cblogger.Error(newErr.Error())
+		return nil, newErr
+	}
+	return &tierRefId, nil
+}
+
+// Get VPC ID with Tier 'NetworkID'
+func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (*string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called getVPCIdWithTierNetId()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierNetworkId, "getVPCIdWithTierNetId()")
+
+	if strings.EqualFold(tierNetworkId, "") {
+		newErr := fmt.Errorf("Invalid Subnet(Tier) NetworkID!!")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+	cblogger.Infof("# Subnet(Tier) Network ID to Find Network ID : %s", tierNetworkId)
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 	1,
-		Size: 	20,
-		RefID: 	tierId, // Tier Id
+		Page: 		1,
+		Size: 		20,
+		NetworkID: 	tierNetworkId, // Tier NetworkID (Not RefID parameter)
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -821,10 +859,77 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierId(tierId string) (*string, e
 			return nil, newErr
 		}
 	}
+	if !strings.EqualFold(subnetAdrsList[0].VpcID, "") {
+		cblogger.Infof("# VPC ID : [%s]", subnetAdrsList[0].VpcID)
+	}	
 
 	// Caution!!
 	if len(subnetAdrsList) == 0 || strings.EqualFold(subnetAdrsList[0].VpcID, "") {
-		newErr := fmt.Errorf("No NetworkId found with the TierId")
+		newErr := fmt.Errorf("No NetworkId found with the Tier NetworkId")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+	return &subnetAdrsList[0].VpcID, nil
+}
+
+// Get VPC ID with Tier 'RefID'
+func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierRefId(tierRefId string) (*string, error) {
+	cblogger.Info("KT Cloud VPC Driver: called getVPCIdWithTierRefId()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, tierRefId, "getVPCIdWithTierRefId()")
+
+	if strings.EqualFold(tierRefId, "") {
+		newErr := fmt.Errorf("Invalid Subnet(Tier) RefID!!")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+	cblogger.Infof("# Subnet(Tier) Network ID to Find Network ID : %s", tierRefId)
+
+	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
+	listOpts := subnets.ListOpts{
+		Page: 		1,
+		Size: 		20,
+		RefID: 	tierRefId, // Tier RefID (Not NetworkID parameter)
+	}
+	start := call.Start()
+	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
+	loggingInfo(callLogInfo, start)
+	
+	var subnetAdrsList []*subnets.Subnet
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		subnetlist, err := subnets.ExtractSubnets(page)
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Extract Subnet list : [%v]", err)
+			cblogger.Error(newErr.Error())
+			return false, newErr
+		}
+		if len(subnetlist) < 1 {
+			newErr := fmt.Errorf("Failed to Get Any Subnet Info.")
+			cblogger.Infof("No Subent found : %v", newErr)
+			return false, newErr
+		}
+		for _, subnet := range subnetlist {
+			subnetAdrsList = append(subnetAdrsList, &subnet)
+		}
+	
+		return true, nil
+	})
+	if err != nil {
+		if err != nil {
+			newErr := fmt.Errorf("Failed to Get Subnet list : [%v]", err)
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return nil, newErr
+		}
+	}
+	if !strings.EqualFold(subnetAdrsList[0].VpcID, "") {
+		cblogger.Infof("# VPC ID : [%s]", subnetAdrsList[0].VpcID)
+	}	
+
+	// Caution!!
+	if len(subnetAdrsList) == 0 || strings.EqualFold(subnetAdrsList[0].VpcID, "") {
+		newErr := fmt.Errorf("No NetworkId found with the Tier NetworkId")
 		cblogger.Error(newErr.Error())
 		loggingError(callLogInfo, newErr)
 		return nil, newErr
@@ -1032,7 +1137,7 @@ func (vpcHandler *KTVpcVPCHandler) getSubnet(subnetIID irs.IID) (irs.SubnetInfo,
         cblogger.Infof("Using provided SystemId (TierId): %s", tierId)
     } else {
         // Get tier ID from tier name
-        tierIdPtr, getErr := vpcHandler.getTierIdWithTierName(subnetIID.NameId)
+        tierIdPtr, getErr := vpcHandler.getTierRefIdWithTierName(subnetIID.NameId)
         if getErr != nil {
             newErr := fmt.Errorf("failed to get tier ID with name [%s]: %w", subnetIID.NameId, getErr)
             cblogger.Error(newErr.Error())

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/info_manager/security_group_info_manager/SecurityGroupInfoManager.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/info_manager/security_group_info_manager/SecurityGroupInfoManager.go
@@ -97,7 +97,6 @@ func GetSecurityGroup(vmID string) (*SecurityGroupInfo, error) {
 	err := infostore.Get(&sgInfo, KEY_COLUMN_NAME, vmID)
 	if err != nil {
 		cblogger.Debug(err)
-		// return nil, err
 	}
 
 	return &sgInfo, err

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/alibabacloud-go/tea v1.3.11
 	github.com/alibabacloud-go/vpc-20160428/v6 v6.4.0
 	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb
-	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260414095107-3f44f8d184a6
+	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863
 	github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -64,13 +64,14 @@ require (
 	github.com/alibabacloud-go/tea v1.3.11
 	github.com/alibabacloud-go/vpc-20160428/v6 v6.4.0
 	github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb
-	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863
+	github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260713072217-58ff4a0ab139
 	github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251
 	github.com/glebarez/go-sqlite v1.21.2
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-openapi/strfmt v0.25.0
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/goccy/go-json v0.10.5
+	github.com/gophercloud/gophercloud v1.14.1
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/itchyny/gojq v0.12.17

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb h1:
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb/go.mod h1:lgLL364ot3Z0Sa0xZjJQqT7LSaQzSug0YnwmQnTwzEg=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260414095107-3f44f8d184a6 h1:UtZnpQ6SAuOLaEKd8VA2R+od8Cy/noD7ir25Iq5oTFA=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260414095107-3f44f8d184a6/go.mod h1:KTct9zIiho4yDWKGVDz1Wde20bqXkH51o8EKfLzoyG8=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863 h1:MNltRVqxmxODou3Kz/fnGTReqI9Dew2PaK3GTl8/Kxs=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863/go.mod h1:KTct9zIiho4yDWKGVDz1Wde20bqXkH51o8EKfLzoyG8=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251 h1:C0X6xvE6xgZPA2h0AmUoBDjSSyND7c1IRx/SRSe2ThM=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251/go.mod h1:J+VrbCRKFXfUpGLFOTjNht6/7y0gZEYd9reNEPZ23Z8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -230,10 +230,10 @@ github.com/cloud-barista/cb-log v0.12.0 h1:pNu4zkEf5Itv3L1J4Az0N2C3BuexBCTTBY9Bf
 github.com/cloud-barista/cb-log v0.12.0/go.mod h1:R3qwPv6oIyhDxtmBHOFfIVYn/Un7eRKj711uRnyGrGI=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb h1:WEDtnjKYd8JkvvlXP6vV+V43nMdadRCU2JjfevbwXzY=
 github.com/cloud-barista/ktcloud-sdk-go v0.2.1-0.20251103105234-6cbc5279b7fb/go.mod h1:lgLL364ot3Z0Sa0xZjJQqT7LSaQzSug0YnwmQnTwzEg=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260414095107-3f44f8d184a6 h1:UtZnpQ6SAuOLaEKd8VA2R+od8Cy/noD7ir25Iq5oTFA=
-github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260414095107-3f44f8d184a6/go.mod h1:KTct9zIiho4yDWKGVDz1Wde20bqXkH51o8EKfLzoyG8=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863 h1:MNltRVqxmxODou3Kz/fnGTReqI9Dew2PaK3GTl8/Kxs=
 github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260712154229-92f96cb02863/go.mod h1:KTct9zIiho4yDWKGVDz1Wde20bqXkH51o8EKfLzoyG8=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260713072217-58ff4a0ab139 h1:4vZeAomyjMJKUVzseDoUaLkrQIXwN1eeqDSq3dhacWE=
+github.com/cloud-barista/ktcloudvpc-sdk-go v0.0.0-20260713072217-58ff4a0ab139/go.mod h1:KTct9zIiho4yDWKGVDz1Wde20bqXkH51o8EKfLzoyG8=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251 h1:C0X6xvE6xgZPA2h0AmUoBDjSSyND7c1IRx/SRSe2ThM=
 github.com/cloud-barista/nhncloud-sdk-go v0.0.2-0.20260522111605-48d0ba7e7251/go.mod h1:J+VrbCRKFXfUpGLFOTjNht6/7y0gZEYd9reNEPZ23Z8=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -436,6 +436,8 @@ github.com/googleapis/gax-go/v2 v2.18.0/go.mod h1:uSzZN4a356eRG985CzJ3WfbFSpqkLT
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/gophercloud/gophercloud v1.14.1 h1:DTCNaTVGl8/cFu58O1JwWgis9gtISAFONqpMKNg/Vpw=
+github.com/gophercloud/gophercloud v1.14.1/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/gophercloud/gophercloud/v2 v2.12.0 h1:Gxmc/Bog1UDKkxTcQW7MSPTDviJXpLeEgVeN5KrxoCo=
 github.com/gophercloud/gophercloud/v2 v2.12.0/go.mod h1:H7TTOxbLy8RIaHSNhI2GCrWIzw4Xpw8Xn2mBhCUT5kA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -793,6 +795,7 @@ golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
@@ -893,6 +896,7 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=


### PR DESCRIPTION
- Update NLB control features according to New KT Cloud LB API
- Update helper fuctions of KT Cloud Tier info
- Update README.md
- Update go.mod/go.sum (Update ktcloudvpc-sdk-go version)
- Update NLB REST API test codes
- Related PRs : 
  - https://github.com/cloud-barista/ktcloudvpc-sdk-go/pull/53
  - https://github.com/cloud-barista/ktcloudvpc-sdk-go/pull/54
- Related issue : https://github.com/cloud-barista/cb-spider/issues/1718
- Note) The current version of NLBHandler, as described in this PR, encounters an error during the firewall rule deletion phase when an NLB is deleted.
This issue has the same root cause as the case described below regarding the KT Cloud VM: the return values when querying the KT Cloud firewall rule list have changed, making it impossible to delete certain rules properly. (Scheduled to be fixed in a future update)
  - KT Cloud VM deletion issue : https://github.com/cloud-barista/cb-spider/issues/1756