### PR TITLE
[KT Cloud] Update pagination page size to request all records of a resource data

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/9-1.list_FW_rules.sh
+++ b/cloud-control-manager/cloud-driver/drivers/kt/main/REST_API_test/9-1.list_FW_rules.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+source ./1.export.env
+
+echo "curl -s $OS_NETWORK_API/firewall/policy"
+curl -s $OS_NETWORK_API/firewall/policy --header "X-Auth-Token: $OS_TOKEN"
+echo -e "\n"

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/FileSystemHandler.go
@@ -605,6 +605,57 @@ func (filesystemHandler *KTVpcFileSystemHandler) waitForShareDeleted(shareID str
 	return fmt.Errorf("timed out waiting for NAS share %s to be completely deleted", shareID)
 }
 
+func isInternalServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "internal server error")
+}
+
+func (filesystemHandler *KTVpcFileSystemHandler) findShareNetworkByNameAndTier(name, tierID string) (*sharenetworks.ShareNetwork, error) {
+	listOpts := sharenetworks.ListOpts{}
+	allPages, err := sharenetworks.ListDetail(filesystemHandler.NASClient, listOpts).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list share networks: %w", err)
+	}
+
+	shareNetworkList, err := sharenetworks.ExtractShareNetworks(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract share networks: %w", err)
+	}
+
+	for idx := range shareNetworkList {
+		shareNetwork := shareNetworkList[idx]
+		if strings.EqualFold(strings.TrimSpace(shareNetwork.Name), name) &&
+			strings.EqualFold(strings.TrimSpace(shareNetwork.NeutronNetID), tierID) {
+			return &shareNetwork, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (filesystemHandler *KTVpcFileSystemHandler) resolveShareNetworkAfterInternalServerError(name, tierID string) (string, error) {
+	cblogger.Info("KT Cloud Driver: called resolveShareNetworkAfterInternalServerError()")
+	
+	for attempt := 0; attempt < 3; attempt++ {
+		shareNetwork, err := filesystemHandler.findShareNetworkByNameAndTier(name, tierID)
+		if err != nil {
+			return "", err
+		}
+		if shareNetwork != nil && strings.TrimSpace(shareNetwork.ID) != "" {
+			return strings.TrimSpace(shareNetwork.ID), nil
+		}
+
+		if attempt < 2 {
+			time.Sleep(2 * time.Second)
+		}
+	}
+
+	return "", nil
+}
+
 func (filesystemHandler *KTVpcFileSystemHandler) createSharenetwork(subnetNameID string) (string, error) {
 	cblogger.Info("KT Cloud Driver: called createSharenetwork()")
 	
@@ -647,7 +698,33 @@ func (filesystemHandler *KTVpcFileSystemHandler) createSharenetwork(subnetNameID
 
 	createdShareNetwork, err := sharenetworks.Create(filesystemHandler.NASClient, createOpts).Extract()
 	if err != nil {
-		return "", fmt.Errorf("failed to create share network for Subnet NameID %s (Tier ID %s): %w", subnetNameID, tierID, err)
+		if !isInternalServerError(err) {
+			return "", fmt.Errorf("failed to create share network for Subnet NameID %s (Tier ID %s): %w", subnetNameID, tierID, err)
+		}
+
+		cblogger.Warnf("failed to create share network for Subnet NameID %s (Tier ID %s) due to Internal Server Error; retrying once: %v", subnetNameID, tierID, err)
+
+		// Note) When requesting the creation of a shared network on KT Cloud, the shared network is sometimes created successfully, but an Internal Server Error may occur.
+		createdShareNetwork, err = sharenetworks.Create(filesystemHandler.NASClient, createOpts).Extract()
+		if err != nil {
+			if !isInternalServerError(err) {
+				return "", fmt.Errorf("failed to create share network for Subnet NameID %s (Tier ID %s) on retry: %w", subnetNameID, tierID, err)
+			}
+
+			cblogger.Warnf("retry create share network for Subnet NameID %s (Tier ID %s) also returned Internal Server Error; trying to resolve an existing share network instead: %v", subnetNameID, tierID, err)
+
+			shareNetworkID, resolveErr := filesystemHandler.resolveShareNetworkAfterInternalServerError(subnetNameID, tierID)
+			if resolveErr != nil {
+				return "", fmt.Errorf("failed to resolve share network for Subnet NameID %s (Tier ID %s) after repeated Internal Server Error: %w", subnetNameID, tierID, resolveErr)
+			}
+			if shareNetworkID != "" {
+				cblogger.Infof("### Reusing existing share network after Internal Server Error. ID: %s", shareNetworkID)
+				return shareNetworkID, nil
+			}
+
+			cblogger.Warnf("share network creation for Subnet NameID %s (Tier ID %s) returned Internal Server Error twice, but no existing share network was found; skipping error return as requested", subnetNameID, tierID)
+			return "", nil
+		}
 	}
 
 	if createdShareNetwork == nil || createdShareNetwork.ID == "" {
@@ -690,9 +767,9 @@ func (filesystemHandler *KTVpcFileSystemHandler) listKTSubnet() ([]*subnets.Subn
 	}
 
 	listOpts := subnets.ListOpts{
-		Page:        1,
-		Size:        20,
-		NetworkType: "ALL",
+		Page:       	1,
+		Size: 			2000, // Max page size, to list all info in a single page
+		NetworkType: 	"ALL",
 	}
 
 	pager := subnets.List(filesystemHandler.NetworkClient, listOpts)
@@ -722,7 +799,7 @@ func (filesystemHandler *KTVpcFileSystemHandler) listKTVPC() ([]*networks.VPC, e
 
 	listOpts := networks.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all info in a single page
 	}
 
 	pager := networks.List(filesystemHandler.NetworkClient, listOpts)

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
@@ -324,7 +324,7 @@ func (nlbHandler *KTVpcNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	var nlbCount int
 
 	listOpts := ktvpclb.ListOpts{
-		Size: 2000, // Max page size, to list all NLBs in a single page
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	// Paginate through results
 	err := ktvpclb.List(nlbHandler.NLBClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
@@ -1389,7 +1389,7 @@ func (nlbHandler *KTVpcNLBHandler) ListIID() ([]*irs.IID, error) {
 	callLogInfo := getCallLogScheme(nlbHandler.RegionInfo.Zone, "NETWORKLOADBALANCE", "ListIID()", "ListIID()")
 
 	listOpts := ktvpclb.ListOpts{
-		Size: 2000, // Max page size, to list all NLBs in a single page
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
 	firstPage, err := ktvpclb.List(nlbHandler.NLBClient, listOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()'
@@ -1872,7 +1872,7 @@ func (nlbHandler *KTVpcNLBHandler) listKTStaticNat() ([]*nat.StaticNAT, error) {
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := nat.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
 	pager := nat.List(nlbHandler.NetworkClient, listOpts) // NetworkClient

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/PublicIPHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/PublicIPHandler.go
@@ -34,7 +34,10 @@ func (h *KTVpcPublicIPHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := getCallLogScheme(h.RegionInfo.Zone, call.PUBLICIP, "ListIID", "floatingips.List()")
 	start := call.Start()
 
-	listOpts := ips.ListOpts{Page: 1, Size: 100}
+	listOpts := ips.ListOpts{
+		Page: 1, 
+		Size: 2000, // Max page size, to list all data in a single page
+	}	
 	pager := ips.List(h.NetworkClient, listOpts)
 
 	var iidList []*irs.IID
@@ -92,7 +95,10 @@ func (h *KTVpcPublicIPHandler) ListPublicIP() ([]*irs.PublicIPInfo, error) {
 	hiscallInfo := getCallLogScheme(h.RegionInfo.Zone, call.PUBLICIP, "All", "floatingips.List()")
 	start := call.Start()
 
-	listOpts := ips.ListOpts{Page: 1, Size: 100}
+	listOpts := ips.ListOpts{
+		Page: 1,
+		Size: 2000, // Max page size, to list all data in a single page
+	}
 	pager := ips.List(h.NetworkClient, listOpts)
 
 	var infoList []*irs.PublicIPInfo
@@ -142,7 +148,10 @@ func (h *KTVpcPublicIPHandler) GetPublicIP(publicIPIID irs.IID) (irs.PublicIPInf
 		}
 	} else {
 		// Search by listing
-		listOpts := ips.ListOpts{Page: 1, Size: 100}
+		listOpts := ips.ListOpts{
+			Page: 1,
+			Size: 2000, // Max page size, to list all data in a single page
+		}
 		pager := ips.List(h.NetworkClient, listOpts)
 		pager.EachPage(func(page pagination.Page) (bool, error) {
 			fipList, listErr := ips.ExtractFloatingIPs(page)

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -1617,7 +1617,7 @@ func (vmHandler *KTVpcVMHandler) listFirewallRule() ([]rules.FirewallRule, error
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := rules.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	pager := rules.List(vmHandler.NetworkClient, listOpts) // Caution!!) Not VMClient but NetworkClient
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
@@ -1656,7 +1656,7 @@ func (vmHandler *KTVpcVMHandler) listPortForwarding() ([]portforward.PortForward
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := portforward.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	pager := portforward.List(vmHandler.NetworkClient, listOpts)
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
@@ -1884,7 +1884,7 @@ func (vmHandler *KTVpcVMHandler) removePortForwardingRules(publicIp string) (boo
 	// 1. List all port forwarding rules with pagination
 	listOpts := portforward.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	pager := portforward.List(vmHandler.NetworkClient, listOpts)
 
@@ -2405,7 +2405,7 @@ func (vmHandler *KTVpcVMHandler) findPublicIPIDByIP(publicIPAddress string) (str
 	// List all floating IPs with pagination
 	listOpts := ips.ListOpts{
 		Page: 1,
-		Size: 20,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	pager := ips.List(vmHandler.NetworkClient, listOpts)
 

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
@@ -140,7 +140,7 @@ func (vpcHandler *KTVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
     listOpts := networks.ListOpts{
         Page: 1,
-        Size: 20,    
+        Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
     pager := networks.List(vpcHandler.NetworkClient, listOpts)
@@ -291,7 +291,7 @@ func (vpcHandler *KTVpcVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.II
 		loggingError(callLogInfo, newErr)
 		return false, newErr
 	}
-	cblogger.Info("\n### Waiting for Deleting the Subnet!! Subnet NetworkId: %s", *networkId)
+	cblogger.Infof("\n### Waiting for Deleting the Subnet!! Subnet NetworkId: %s", *networkId)
 	vpcHandler.waitForSubnetDeletion(*networkId)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to wait for the subnet creation: %v", err)
@@ -492,7 +492,7 @@ func (vpcHandler *KTVpcVPCHandler) listKTVPC() ([]*networks.VPC, error) {
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
     listOpts := networks.ListOpts{
         Page: 1,
-        Size: 20,    
+        Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
     pager := networks.List(vpcHandler.NetworkClient, listOpts)
@@ -536,8 +536,8 @@ func (vpcHandler *KTVpcVPCHandler) listKTSubnet() ([]*subnets.Subnet, error) {
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
     listOpts := subnets.ListOpts{
         Page: 			1,
-        Size: 			20,
-		NetworkType: 	"ALL", // [Optional] [default: trust] TRUST / UNTRUST / ALL
+        Size: 			2000, 	// Max page size, to list all data in a single page
+		NetworkType: 	"ALL", 	// [Optional] [default: trust] TRUST / UNTRUST / ALL
 	}
 	start := call.Start()
     pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -630,9 +630,9 @@ func (vpcHandler *KTVpcVPCHandler) getTierIdWithNetworkId(networkId string) (*st
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 1,
-		Size: 20,
-		NetworkID: networkId, // Tier NetworkId
+		Page: 		1,
+		Size: 		2000, 		// Max page size, to list all data in a single page
+		NetworkID: 	networkId, 	// Tier NetworkId
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -690,9 +690,9 @@ func (vpcHandler *KTVpcVPCHandler) getNetworkIdWithTierId(tierId string) (*strin
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 1,
-		Size: 20,
-		RefID: tierId, // Tier Id
+		Page: 	1,
+		Size: 	2000, 	// Max page size, to list all data in a single page
+		RefID: 	tierId, // Tier Ref Id
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -825,8 +825,8 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
 		Page: 		1,
-		Size: 		20,
-		NetworkID: 	tierNetworkId, // Tier NetworkID (Not RefID parameter)
+		Size: 		2000, 			// Max page size, to list all data in a single page
+		NetworkID: 	tierNetworkId, 	// Tier NetworkID (Not RefID parameter)
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -888,9 +888,9 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierRefId(tierRefId string) (*str
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 		1,
-		Size: 		20,
-		RefID: 	tierRefId, // Tier RefID (Not NetworkID parameter)
+		Page: 	1,
+		Size: 	2000, 		// Max page size, to list all data in a single page
+		RefID: 	tierRefId, 	// Tier RefID (Not NetworkID parameter)
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
@@ -944,7 +944,7 @@ func (vpcHandler *KTVpcVPCHandler) ListIID() ([]*irs.IID, error) {
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
     listOpts := networks.ListOpts{
         Page: 1,
-        Size: 20,    
+        Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
     pager := networks.List(vpcHandler.NetworkClient, listOpts)


### PR DESCRIPTION
- Update pagination page size to request all records of a resource data
  - Note) If set the default value for 'Size` to '20', only 20 records will be retrieved
  - Related issues
    - https://github.com/cloud-barista/cb-spider/issues/1756
    - https://github.com/cloud-barista/cb-spider/issues/1718
  - Related PR : https://github.com/cloud-barista/cb-spider/pull/1764
- Added test code to query firewall rules using KT Cloud REST API
- Update to resolve an abnormal InternalServerError during FileSystem control
  - Update FileSystemHandler.go