### PR TITLE
Fix alibaba incomplete information retrival

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -675,6 +675,9 @@ func (vmHandler *TencentVMHandler) ExtractDescribeInstances(curVm *cvm.Instance)
 		VMUserId:   "cb-user",
 		//KeyPairIId: irs.IID{SystemId: *curVm.},
 	}
+	if curVm.InstanceName != nil {
+		vmInfo.IId.NameId = *curVm.InstanceName
+	}
 
 	if !reflect.ValueOf(curVm.ImageId).IsNil() {
 		imageIID := irs.IID{SystemId: *curVm.ImageId}


### PR DESCRIPTION
Alibaba driver does not provide vmInfo.IId.NameId for the allvm request.
This bug limits cb-tb reconciling action.

This PR fix the issue.