### PR TITLE
[MetaDB] Fix: Support PostgreSQL config via URL or key-value envs, and improve AWS region/zone resilience

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/RegionZoneHandler.go
@@ -14,6 +14,23 @@ import (
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
 
+const regionZoneHTTPTimeout = 10 * time.Second
+
+func newRegionZoneEC2Client(baseClient *ec2.EC2, regionName *string) (*ec2.EC2, error) {
+	httpClient := &http.Client{Timeout: regionZoneHTTPTimeout}
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: baseClient.Config.Credentials,
+		Region:      regionName,
+		HTTPClient:  httpClient,
+		MaxRetries:  aws.Int(0),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return ec2.New(sess), nil
+}
+
 type AwsRegionZoneHandler struct {
 	Region idrv.RegionInfo
 	Client *ec2.EC2
@@ -28,6 +45,7 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 	}
 
 	var errlist []error
+	var errlistMu sync.Mutex
 	chanRegionZoneInfos := make(chan irs.RegionZoneInfo, len(responseRegions.Regions))
 	var wg sync.WaitGroup
 	for _, region := range responseRegions.Regions {
@@ -35,23 +53,19 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 		go func(region *ec2.Region) {
 			defer wg.Done()
 
-			httpClient := &http.Client{Timeout: 10 * time.Second}
-			sess, err := session.NewSession(&aws.Config{
-				Credentials: regionZoneHandler.Client.Config.Credentials,
-				Region:      region.RegionName,
-				HTTPClient:  httpClient,
-				MaxRetries:  aws.Int(0),
-			})
+			tempclient, err := newRegionZoneEC2Client(regionZoneHandler.Client, region.RegionName)
 			if err != nil {
 				cblogger.Error(err)
+				return
 			}
-			tempclient := ec2.New(sess)
 
 			responseZones, err := DescribeAvailabilityZones(tempclient, false)
 			if err != nil {
 				cblogger.Infof("error on [%s]", *region.RegionName)
-				cblogger.Infof(err.Error())
+				cblogger.Info(err.Error())
+				errlistMu.Lock()
 				errlist = append(errlist, err)
+				errlistMu.Unlock()
 			} else {
 				var zoneInfoList []irs.ZoneInfo
 				for _, zone := range responseZones.AvailabilityZones {
@@ -82,8 +96,11 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListRegionZone() ([]*irs.RegionZo
 
 	if len(errlist) > 0 {
 		errlistjoin := errors.Join(errlist...)
-		cblogger.Error("ListRegionZone() error : ", errlistjoin)
-		return regionZoneInfoList, errlistjoin
+		if len(regionZoneInfoList) == 0 {
+			cblogger.Error("ListRegionZone() error : ", errlistjoin)
+			return nil, errlistjoin
+		}
+		cblogger.Warnf("ListRegionZone(): returning partial results with %d region errors: %v", len(errlist), errlistjoin)
 	}
 
 	return regionZoneInfoList, nil
@@ -99,14 +116,11 @@ func (regionZoneHandler *AwsRegionZoneHandler) GetRegionZone(Name string) (irs.R
 	var regionZoneInfo irs.RegionZoneInfo
 	for _, region := range responseRegions.Regions {
 		cblogger.Debug("#################### region.RegionName", region.RegionName)
-		sess, err := session.NewSession(&aws.Config{
-			Credentials: regionZoneHandler.Client.Config.Credentials,
-			Region:      region.RegionName,
-		})
+		tempclient, err := newRegionZoneEC2Client(regionZoneHandler.Client, region.RegionName)
 		if err != nil {
 			cblogger.Error(err)
+			continue
 		}
-		tempclient := ec2.New(sess)
 
 		responseZones, err := DescribeAvailabilityZones(tempclient, false)
 		if err != nil {
@@ -161,23 +175,19 @@ func (regionZoneHandler *AwsRegionZoneHandler) ListOrgZone() (string, error) {
 
 	for _, region := range responseRegions.Regions {
 
-		sess, err := session.NewSession(&aws.Config{
-			Credentials: regionZoneHandler.Client.Config.Credentials,
-			Region:      region.RegionName,
-		})
+		tempclient, err := newRegionZoneEC2Client(regionZoneHandler.Client, region.RegionName)
 		if err != nil {
 			cblogger.Errorf("NewSession err %s", *region.RegionName)
 			cblogger.Error(err)
-		} else {
-			tempclient := ec2.New(sess)
+			continue
+		}
 
-			responseZones, err := DescribeAvailabilityZones(tempclient, false)
-			if err != nil {
-				cblogger.Errorf("DescribeAvailabilityZones err %s", *region.RegionName)
-				cblogger.Error(err)
-			} else {
-				responseZonesList = append(responseZonesList, responseZones)
-			}
+		responseZones, err := DescribeAvailabilityZones(tempclient, false)
+		if err != nil {
+			cblogger.Errorf("DescribeAvailabilityZones err %s", *region.RegionName)
+			cblogger.Error(err)
+		} else {
+			responseZonesList = append(responseZonesList, responseZones)
 
 		}
 	}

--- a/info-store/InfoStore.go
+++ b/info-store/InfoStore.go
@@ -14,7 +14,9 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -76,16 +78,77 @@ func init() {
 
 func resolveMetaDBConfig() (string, string, error) {
 	metaDBURL := strings.TrimSpace(os.Getenv("SPIDER_METADB_URL"))
-	if metaDBURL == "" {
+
+	metaDBUser := strings.TrimSpace(os.Getenv("SPIDER_METADB_USER"))
+	metaDBPassword := strings.TrimSpace(os.Getenv("SPIDER_METADB_PASSWORD"))
+	metaDBEndpoint := strings.TrimSpace(os.Getenv("SPIDER_METADB_ENDPOINT"))
+	metaDBDatabase := strings.TrimSpace(os.Getenv("SPIDER_METADB_DATABASE"))
+	metaDBSSLMode := strings.TrimSpace(os.Getenv("SPIDER_METADB_SSLMODE"))
+	metaDBConnectTimeout := strings.TrimSpace(os.Getenv("SPIDER_METADB_CONNECT_TIMEOUT"))
+
+	hasURLConfig := metaDBURL != ""
+	hasKVConfig := metaDBUser != "" || metaDBPassword != "" || metaDBEndpoint != "" ||
+		metaDBDatabase != "" || metaDBSSLMode != "" || metaDBConnectTimeout != ""
+
+	if hasURLConfig && hasKVConfig {
+		return dbEngineSQLite, "", fmt.Errorf("invalid MetaDB configuration: use only one mode (SPIDER_METADB_URL or SPIDER_METADB_{USER,PASSWORD,ENDPOINT,DATABASE,SSLMODE,CONNECT_TIMEOUT})")
+	}
+
+	if !hasURLConfig && !hasKVConfig {
 		return dbEngineSQLite, "", nil
 	}
 
-	lowerURL := strings.ToLower(metaDBURL)
-	if strings.HasPrefix(lowerURL, "postgres://") || strings.HasPrefix(lowerURL, "postgresql://") {
-		return dbEnginePostgres, metaDBURL, nil
+	if hasURLConfig {
+		lowerURL := strings.ToLower(metaDBURL)
+		if strings.HasPrefix(lowerURL, "postgres://") || strings.HasPrefix(lowerURL, "postgresql://") {
+			return dbEnginePostgres, metaDBURL, nil
+		}
+
+		return dbEngineSQLite, "", fmt.Errorf("invalid SPIDER_METADB_URL format: %q (expected: postgresql://user:pass@host:port/dbname)", metaDBURL)
 	}
 
-	return dbEngineSQLite, "", fmt.Errorf("invalid SPIDER_METADB_URL format: %q (expected: postgresql://user:pass@host:port/dbname)", metaDBURL)
+	missing := []string{}
+	if metaDBUser == "" {
+		missing = append(missing, "SPIDER_METADB_USER")
+	}
+	if metaDBPassword == "" {
+		missing = append(missing, "SPIDER_METADB_PASSWORD")
+	}
+	if metaDBEndpoint == "" {
+		missing = append(missing, "SPIDER_METADB_ENDPOINT")
+	}
+	if metaDBDatabase == "" {
+		missing = append(missing, "SPIDER_METADB_DATABASE")
+	}
+	if len(missing) > 0 {
+		return dbEngineSQLite, "", fmt.Errorf("invalid MetaDB key-value configuration: missing required variable(s): %s", strings.Join(missing, ", "))
+	}
+
+	if metaDBConnectTimeout != "" {
+		if _, err := strconv.Atoi(metaDBConnectTimeout); err != nil {
+			return dbEngineSQLite, "", fmt.Errorf("invalid SPIDER_METADB_CONNECT_TIMEOUT: %q (must be an integer in seconds)", metaDBConnectTimeout)
+		}
+	}
+
+	dbURL := &url.URL{
+		Scheme: "postgresql",
+		User:   url.UserPassword(metaDBUser, metaDBPassword),
+		Host:   metaDBEndpoint,
+		Path:   "/" + metaDBDatabase,
+	}
+
+	query := url.Values{}
+	if metaDBSSLMode != "" {
+		query.Set("sslmode", metaDBSSLMode)
+	}
+	if metaDBConnectTimeout != "" {
+		query.Set("connect_timeout", metaDBConnectTimeout)
+	}
+	if len(query) > 0 {
+		dbURL.RawQuery = query.Encode()
+	}
+
+	return dbEnginePostgres, dbURL.String(), nil
 }
 
 func IsPostgres() bool {

--- a/setup.env
+++ b/setup.env
@@ -36,13 +36,27 @@ export ADMINWEB=ON
 # If empty, MC-Insight features will be disabled
 export MC_INSIGHT_API_TOKEN=c72df1af9b1f0c29
 
-# Meta DB Configuration
-# Default: if SPIDER_METADB_URL is not set, Spider uses embedded SQLite.
+# Meta DB Configuration (Choose one mode only)
+# Default: if neither mode is set, Spider uses embedded SQLite.
 # SQLite(default) file: $CBSPIDER_ROOT/meta_db/cb-spider.db
-# To use PostgreSQL, set SPIDER_METADB_URL as below:
-#export SPIDER_METADB_URL=postgresql://postgres:password123@localhost:5432/cb_spider
-# If SPIDER_METADB_URL is set, Spider treats MetaDB as user-managed PostgreSQL.
-# In this mode, Spider MetaDB backup scheduler is automatically disabled.
+#
+# Option A) URL mode
+#export SPIDER_METADB_URL="postgresql://postgres:password123@localhost:5432/cb_spider"
+#export SPIDER_METADB_URL="postgresql://postgres:password123@localhost:5432/cb_spider?sslmode=disable&connect_timeout=10"
+#
+# Option B) Key-value mode
+#export SPIDER_METADB_USER=postgres
+#export SPIDER_METADB_PASSWORD=password123
+#export SPIDER_METADB_ENDPOINT=localhost:5432
+#export SPIDER_METADB_DATABASE=cb_spider
+# Optional for key-value mode
+#export SPIDER_METADB_SSLMODE=disable
+#export SPIDER_METADB_CONNECT_TIMEOUT=10
+#
+# NOTE:
+# - Use only one mode (URL or key-value), not both.
+# - If PostgreSQL mode is used, Spider treats MetaDB as user-managed.
+# - In PostgreSQL mode, Spider MetaDB backup scheduler is automatically disabled.
 
 # Meta DB Backup Configuration
 # All settings are optional. If not set, defaults are used without errors.


### PR DESCRIPTION
## Problem
CB-Spider MetaDB only supported a single PostgreSQL URL, which could cause encoding and shell parsing issues. This PR resolves [cb-tumblebug PR #2610](https://github.com/cloud-barista/cb-tumblebug/pull/2610) by adding separate environment-variable based configuration.

In addition, AWS region/zone listing could fail entirely when some regions were unreachable, making the result less resilient under partial network failures.

## Changes
- Added PostgreSQL MetaDB config through either URL or separate env vars
- Validated that only one config mode can be used
- Updated setup.env examples for safer configuration
- Improved AWS region/zone fetching to return partial results and fail fast on unreachable regions

## Result
- PostgreSQL config is easier and safer to provide
- Mixed invalid config is rejected early
- SQLite remains the default when no PostgreSQL config is set
- AWS region/zone listing is more resilient and predictable under partial failures