### PR TITLE
[S3/Swagger] Feat: Add Object Storage Management APIs and Fix allxxxinfo Swagger Docs

### DIFF
--- a/api-runtime/common-runtime/S3Manager.go
+++ b/api-runtime/common-runtime/S3Manager.go
@@ -19,6 +19,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	ccm "github.com/cloud-barista/cb-spider/cloud-control-manager"
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	ccim "github.com/cloud-barista/cb-spider/cloud-info-manager/connection-config-info-manager"
 	cim "github.com/cloud-barista/cb-spider/cloud-info-manager/credential-info-manager"
 	rim "github.com/cloud-barista/cb-spider/cloud-info-manager/region-info-manager"
@@ -3570,4 +3571,461 @@ func CountS3BucketsByConnection(connectionName string) (int64, error) {
 	}
 
 	return count, nil
+}
+
+// ============================================================================
+// CB-Spider Special Features: Register/Unregister/ListAll/CountAll/DeleteCSP
+// ============================================================================
+
+// AllS3BucketList is the response structure for listing all S3 buckets with categorization.
+type AllS3BucketList struct {
+	AllList struct {
+		MappedList     []*cres.IID `json:"MappedList"`
+		OnlySpiderList []*cres.IID `json:"OnlySpiderList"`
+		OnlyCSPList    []*cres.IID `json:"OnlyCSPList"`
+	}
+}
+
+// AllS3BucketInfoList is the response structure for listing all S3 bucket info with categorization.
+type AllS3BucketInfoList struct {
+	ResourceType string `json:"ResourceType"`
+	AllListInfo  struct {
+		MappedInfoList  []*S3BucketWithIID `json:"MappedInfoList"`
+		OnlySpiderList  []*cres.IID        `json:"OnlySpiderList"`
+		OnlyCSPInfoList []*S3BucketWithIID `json:"OnlyCSPInfoList"`
+	}
+}
+
+// RegisterS3Bucket registers an existing CSP S3 bucket into CB-Spider metadata.
+// UserIID{NameId=user-name, SystemId=CSP-bucket-name}
+func RegisterS3Bucket(connectionName string, userIID cres.IID) (*S3BucketWithIID, error) {
+	cblog.Info("call RegisterS3Bucket()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	// Check if already registered
+	exist, err := infostore.HasByConditions(&S3BucketIIDInfo{}, "connection_name", connectionName, "name_id", userIID.NameId)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+	if exist {
+		return nil, fmt.Errorf("S3 Bucket '%s' already exists in connection '%s'", userIID.NameId, connectionName)
+	}
+
+	connInfo, err := GetS3ConnectionInfo(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	var creationDate time.Time
+	if connInfo.ProviderName == "AZURE" {
+		bucketInfo, err := getAzureBucket(connInfo, &S3BucketIIDInfo{
+			ConnectionName: connectionName,
+			NameId:         userIID.NameId,
+			SystemId:       userIID.SystemId,
+			Region:         connInfo.Region,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("S3 Bucket '%s' not found in CSP: %v", userIID.SystemId, err)
+		}
+		creationDate = bucketInfo.CreationDate
+	} else {
+		client, err := NewS3Client(connInfo)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		exists, err := client.BucketExists(ctx, userIID.SystemId)
+		if err != nil {
+			cblog.Error(err)
+			return nil, err
+		}
+		if !exists {
+			return nil, fmt.Errorf("S3 Bucket '%s' not found in CSP for connection '%s'", userIID.SystemId, connectionName)
+		}
+		buckets, err := client.ListBuckets(ctx)
+		if err == nil {
+			for _, b := range buckets {
+				if b.Name == userIID.SystemId {
+					creationDate = b.CreationDate
+					break
+				}
+			}
+		}
+	}
+
+	iidInfo := S3BucketIIDInfo{
+		ConnectionName: connectionName,
+		NameId:         userIID.NameId,
+		SystemId:       userIID.SystemId,
+		Region:         connInfo.Region,
+	}
+	err = infostore.Insert(&iidInfo)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+
+	return &S3BucketWithIID{
+		NameId:       userIID.NameId,
+		SystemId:     userIID.SystemId,
+		CreationDate: creationDate,
+	}, nil
+}
+
+// UnregisterS3Bucket removes a bucket mapping from CB-Spider metadata without deleting from CSP.
+func UnregisterS3Bucket(connectionName string, nameId string) (bool, error) {
+	cblog.Info("call UnregisterS3Bucket()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	nameId, err = EmptyCheckAndTrim("nameId", nameId)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	exist, err := infostore.HasByConditions(&S3BucketIIDInfo{}, "connection_name", connectionName, "name_id", nameId)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+	if !exist {
+		return false, fmt.Errorf("S3 Bucket '%s' does not exist in connection '%s'", nameId, connectionName)
+	}
+
+	_, err = infostore.DeleteByConditions(&S3BucketIIDInfo{}, "connection_name", connectionName, "name_id", nameId)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	return true, nil
+}
+
+// listAllCSPS3Buckets fetches all bucket system IDs from CSP for a given connection.
+func listAllCSPS3Buckets(connInfo *S3ConnectionInfo) ([]string, error) {
+	if connInfo.ProviderName == "AZURE" {
+		client, _, err := newAzureBlobClient(connInfo)
+		if err != nil {
+			return nil, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		var names []string
+		pager := client.NewListContainersPager(nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list Azure containers: %w", err)
+			}
+			for _, item := range page.ContainerItems {
+				if item.Name != nil {
+					names = append(names, *item.Name)
+				}
+			}
+		}
+		return names, nil
+	}
+
+	client, err := NewS3Client(connInfo)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	buckets, err := client.ListBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, b := range buckets {
+		names = append(names, b.Name)
+	}
+	return names, nil
+}
+
+// ListAllS3Buckets lists all S3 buckets for a connection, categorized into
+// MappedList (in both SP and CSP), OnlySpiderList (only in SP), OnlyCSPList (only in CSP).
+func ListAllS3Buckets(connectionName string) (AllS3BucketList, error) {
+	cblog.Info("call ListAllS3Buckets()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketList{}, err
+	}
+
+	var iidInfoList []*S3BucketIIDInfo
+	err = infostore.ListByCondition(&iidInfoList, "connection_name", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketList{}, err
+	}
+
+	connInfo, err := GetS3ConnectionInfo(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketList{}, err
+	}
+
+	cspNames, err := listAllCSPS3Buckets(connInfo)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketList{}, err
+	}
+
+	var allResult AllS3BucketList
+	emptyList := []*cres.IID{}
+
+	spList := make([]*cres.IID, 0, len(iidInfoList))
+	for _, info := range iidInfoList {
+		spList = append(spList, &cres.IID{NameId: info.NameId, SystemId: info.SystemId})
+	}
+
+	if len(spList) == 0 && len(cspNames) == 0 {
+		allResult.AllList.MappedList = emptyList
+		allResult.AllList.OnlySpiderList = emptyList
+		allResult.AllList.OnlyCSPList = emptyList
+		return allResult, nil
+	}
+
+	if len(cspNames) == 0 {
+		allResult.AllList.MappedList = emptyList
+		allResult.AllList.OnlyCSPList = emptyList
+		allResult.AllList.OnlySpiderList = spList
+		return allResult, nil
+	}
+
+	if len(spList) == 0 {
+		onlyCSP := make([]*cres.IID, 0, len(cspNames))
+		for _, name := range cspNames {
+			onlyCSP = append(onlyCSP, &cres.IID{NameId: name, SystemId: name})
+		}
+		allResult.AllList.MappedList = emptyList
+		allResult.AllList.OnlySpiderList = emptyList
+		allResult.AllList.OnlyCSPList = onlyCSP
+		return allResult, nil
+	}
+
+	mappedList := []*cres.IID{}
+	onlySpiderList := []*cres.IID{}
+	for _, spIID := range spList {
+		found := false
+		for _, cspName := range cspNames {
+			if spIID.SystemId == cspName {
+				mappedList = append(mappedList, spIID)
+				found = true
+				break
+			}
+		}
+		if !found {
+			onlySpiderList = append(onlySpiderList, spIID)
+		}
+	}
+
+	onlyCSPList := []*cres.IID{}
+	for _, cspName := range cspNames {
+		isMapped := false
+		for _, mapped := range mappedList {
+			if cspName == mapped.SystemId {
+				isMapped = true
+				break
+			}
+		}
+		if !isMapped {
+			onlyCSPList = append(onlyCSPList, &cres.IID{NameId: cspName, SystemId: cspName})
+		}
+	}
+
+	allResult.AllList.MappedList = mappedList
+	allResult.AllList.OnlySpiderList = onlySpiderList
+	allResult.AllList.OnlyCSPList = onlyCSPList
+
+	return allResult, nil
+}
+
+// ListAllS3BucketInfo lists detailed S3 bucket info for a connection, categorized into
+// MappedInfoList, OnlySpiderList, and OnlyCSPInfoList.
+func ListAllS3BucketInfo(connectionName string) (AllS3BucketInfoList, error) {
+	cblog.Info("call ListAllS3BucketInfo()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketInfoList{}, err
+	}
+
+	var iidInfoList []*S3BucketIIDInfo
+	err = infostore.ListByCondition(&iidInfoList, "connection_name", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketInfoList{}, err
+	}
+
+	connInfo, err := GetS3ConnectionInfo(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return AllS3BucketInfoList{}, err
+	}
+
+	// Get all CSP buckets with creation dates
+	type cspBucketEntry struct {
+		Name         string
+		CreationDate time.Time
+	}
+	var cspEntries []cspBucketEntry
+
+	if connInfo.ProviderName == "AZURE" {
+		client, _, err := newAzureBlobClient(connInfo)
+		if err != nil {
+			return AllS3BucketInfoList{}, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		pager := client.NewListContainersPager(nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return AllS3BucketInfoList{}, fmt.Errorf("failed to list Azure containers: %w", err)
+			}
+			for _, item := range page.ContainerItems {
+				if item.Name != nil {
+					lastModified := time.Time{}
+					if item.Properties != nil && item.Properties.LastModified != nil {
+						lastModified = *item.Properties.LastModified
+					}
+					cspEntries = append(cspEntries, cspBucketEntry{Name: *item.Name, CreationDate: lastModified})
+				}
+			}
+		}
+	} else {
+		client, err := NewS3Client(connInfo)
+		if err != nil {
+			return AllS3BucketInfoList{}, err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		buckets, err := client.ListBuckets(ctx)
+		if err != nil {
+			return AllS3BucketInfoList{}, err
+		}
+		for _, b := range buckets {
+			cspEntries = append(cspEntries, cspBucketEntry{Name: b.Name, CreationDate: b.CreationDate})
+		}
+	}
+
+	var allResult AllS3BucketInfoList
+	allResult.ResourceType = "s3bucket"
+
+	mappedInfoList := []*S3BucketWithIID{}
+	onlySpiderList := []*cres.IID{}
+	for _, spInfo := range iidInfoList {
+		found := false
+		for _, csp := range cspEntries {
+			if spInfo.SystemId == csp.Name {
+				mappedInfoList = append(mappedInfoList, &S3BucketWithIID{
+					NameId:       spInfo.NameId,
+					SystemId:     spInfo.SystemId,
+					CreationDate: csp.CreationDate,
+				})
+				found = true
+				break
+			}
+		}
+		if !found {
+			onlySpiderList = append(onlySpiderList, &cres.IID{NameId: spInfo.NameId, SystemId: spInfo.SystemId})
+		}
+	}
+
+	onlyCSPInfoList := []*S3BucketWithIID{}
+	for _, csp := range cspEntries {
+		isMapped := false
+		for _, mapped := range mappedInfoList {
+			if csp.Name == mapped.SystemId {
+				isMapped = true
+				break
+			}
+		}
+		if !isMapped {
+			onlyCSPInfoList = append(onlyCSPInfoList, &S3BucketWithIID{
+				NameId:       csp.Name,
+				SystemId:     csp.Name,
+				CreationDate: csp.CreationDate,
+			})
+		}
+	}
+
+	allResult.AllListInfo.MappedInfoList = mappedInfoList
+	allResult.AllListInfo.OnlySpiderList = onlySpiderList
+	allResult.AllListInfo.OnlyCSPInfoList = onlyCSPInfoList
+
+	return allResult, nil
+}
+
+// CountAllS3Buckets counts all S3 buckets across all connections.
+func CountAllS3Buckets() (int64, error) {
+	var info S3BucketIIDInfo
+	count, err := infostore.CountAllNameIDs(&info)
+	if err != nil {
+		cblog.Error(err)
+		return count, err
+	}
+	return count, nil
+}
+
+// DeleteCSPS3Bucket deletes an S3 bucket directly from CSP by system ID without affecting CB-Spider metadata.
+func DeleteCSPS3Bucket(connectionName string, systemId string) (bool, error) {
+	cblog.Info("call DeleteCSPS3Bucket()")
+
+	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	connInfo, err := GetS3ConnectionInfo(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	if connInfo.ProviderName == "AZURE" {
+		err := deleteAzureBucket(connInfo, systemId)
+		if err != nil {
+			cblog.Error(err)
+			return false, err
+		}
+		return true, nil
+	}
+
+	client, err := NewS3Client(connInfo)
+	if err != nil {
+		cblog.Error(err)
+		return false, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = client.RemoveBucket(ctx, systemId)
+	if err != nil {
+		cblog.Error(err)
+		return false, fmt.Errorf("failed to delete CSP S3 bucket '%s': %v", systemId, err)
+	}
+
+	return true, nil
 }

--- a/api-runtime/rest-runtime/CBSpiderRuntime.go
+++ b/api-runtime/rest-runtime/CBSpiderRuntime.go
@@ -639,6 +639,14 @@ func getRoutes() []route {
 
 		//-- for dashboard
 		{"GET", "/counts3/:ConnectionName", CountS3BucketsByConnection},
+
+		// CB-Spider Special Features for S3 Object Storage Management
+		{"POST", "/regs3", RegisterS3Bucket},
+		{"DELETE", "/regs3/:Name", UnregisterS3Bucket},
+		{"GET", "/alls3", ListAllS3Buckets},
+		{"GET", "/alls3info", ListAllS3BucketInfo},
+		{"GET", "/counts3", CountAllS3Buckets},
+		{"DELETE", "/csps3/:Id", DeleteCSPS3Bucket},
 	}
 
 	// Add AdminWeb and Swagger routes conditionally

--- a/api-runtime/rest-runtime/DiskRest.go
+++ b/api-runtime/rest-runtime/DiskRest.go
@@ -239,11 +239,14 @@ func ListAllDisk(c echo.Context) error {
 // listAllDiskInfo godoc
 // @ID list-all-disk-info
 // @Summary List All Disk Info
-// @Description Retrieve a list of all Disk information associated with all connections.
+// @Description Retrieve a comprehensive list of all Disk information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
 // @Tags [Disk Management]
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} AllResourceListResponse "List of all Disk information across all connections"
+// @Param ConnectionName query string true "The name of the Connection to list Disk information for"
+// @Success 200 {object} AllResourceInfoListResponse "List of all Disk information within the specified connection, including Disks in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
 // @Router /alldiskinfo [get]
 func ListAllDiskInfo(c echo.Context) error { return listAllResourceInfo(c, cres.DISK) }

--- a/api-runtime/rest-runtime/KeyPairRest.go
+++ b/api-runtime/rest-runtime/KeyPairRest.go
@@ -230,11 +230,14 @@ func ListAllKey(c echo.Context) error {
 // listAllKeyPairInfo godoc
 // @ID list-all-keypair-info
 // @Summary List All KeyPair Info
-// @Description Retrieve a list of KeyPair information associated with all connections.
+// @Description Retrieve a comprehensive list of all KeyPair information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
 // @Tags [KeyPair Management]
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} AllResourceInfoListResponse "List of KeyPair information associated with all connections"
+// @Param ConnectionName query string true "The name of the Connection to list KeyPair information for"
+// @Success 200 {object} AllResourceInfoListResponse "List of all KeyPair information within the specified connection, including KeyPairs in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
 // @Router /allkeypairinfo [get]
 func ListAllKeyPairInfo(c echo.Context) error { return listAllResourceInfo(c, cres.KEY) }

--- a/api-runtime/rest-runtime/RDBMSRest.go
+++ b/api-runtime/rest-runtime/RDBMSRest.go
@@ -299,11 +299,14 @@ func ListAllRDBMS(c echo.Context) error {
 // listAllRDBMSInfo godoc
 // @ID list-all-rdbms-info
 // @Summary List All RDBMS Info
-// @Description Retrieve a list of all RDBMS information associated with all connections.
+// @Description Retrieve a comprehensive list of all RDBMS information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
 // @Tags [RDBMS Management]
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} AllResourceListResponse "List of all RDBMS information across all connections"
+// @Param ConnectionName query string true "The name of the Connection to list RDBMS information for"
+// @Success 200 {object} AllResourceInfoListResponse "List of all RDBMS information within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
 // @Router /allrdbmsinfo [get]
 func ListAllRDBMSInfo(c echo.Context) error { return listAllResourceInfo(c, cres.RDBMS) }

--- a/api-runtime/rest-runtime/S3Rest.go
+++ b/api-runtime/rest-runtime/S3Rest.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	cmrt "github.com/cloud-barista/cb-spider/api-runtime/common-runtime"
+	cres "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 	"github.com/labstack/echo/v4"
 	"github.com/minio/minio-go/v7"
 )
@@ -3537,4 +3538,206 @@ func CountS3BucketsByConnection(c echo.Context) error {
 	jsonResult.Count = int(count)
 
 	return c.JSON(http.StatusOK, jsonResult)
+}
+
+// ============================================================================
+// CB-Spider Special Features: Register/Unregister/ListAll/CountAll/DeleteCSP
+// ============================================================================
+
+// S3BucketRegisterRequest represents the request body for registering an S3 Bucket.
+type S3BucketRegisterRequest struct {
+	ConnectionName string `json:"ConnectionName" validate:"required" example:"aws-connection"`
+	ReqInfo        struct {
+		Name  string `json:"Name" validate:"required" example:"my-bucket"`
+		CSPId string `json:"CSPId" validate:"required" example:"my-csp-bucket-name"`
+	} `json:"ReqInfo" validate:"required"`
+}
+
+// S3BucketWithIIDResponse is the REST response wrapper for S3BucketWithIID.
+type S3BucketWithIIDResponse struct {
+	NameId       string    `json:"NameId" validate:"required" example:"my-bucket"`
+	SystemId     string    `json:"SystemId" validate:"required" example:"my-csp-bucket-name"`
+	CreationDate time.Time `json:"CreationDate"`
+}
+
+// registerS3Bucket godoc
+// @ID register-s3-bucket
+// @Summary Register S3 Bucket
+// @Description Register an existing CSP S3 bucket into CB-Spider metadata with a user-defined name. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Accept  json
+// @Produce  json
+// @Param S3BucketRegisterRequest body restruntime.S3BucketRegisterRequest true "Request body for registering an S3 Bucket"
+// @Success 200 {object} S3BucketWithIIDResponse "Details of the registered S3 Bucket"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /regs3 [post]
+func RegisterS3Bucket(c echo.Context) error {
+	cblog.Info("call RegisterS3Bucket()")
+
+	req := S3BucketRegisterRequest{}
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	userIId := cres.IID{NameId: req.ReqInfo.Name, SystemId: req.ReqInfo.CSPId}
+
+	result, err := cmrt.RegisterS3Bucket(req.ConnectionName, userIId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// unregisterS3Bucket godoc
+// @ID unregister-s3-bucket
+// @Summary Unregister S3 Bucket
+// @Description Remove an S3 bucket mapping from CB-Spider metadata without deleting it from the CSP. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionRequest body restruntime.ConnectionRequest true "Request body for unregistering an S3 Bucket"
+// @Param Name path string true "The name of the S3 Bucket to unregister"
+// @Success 200 {object} BooleanInfo "Result of the unregister operation"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /regs3/{Name} [delete]
+func UnregisterS3Bucket(c echo.Context) error {
+	cblog.Info("call UnregisterS3Bucket()")
+
+	var req ConnectionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	result, err := cmrt.UnregisterS3Bucket(req.ConnectionName, c.Param("Name"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resultInfo := BooleanInfo{
+		Result: strconv.FormatBool(result),
+	}
+	return c.JSON(http.StatusOK, &resultInfo)
+}
+
+// listAllS3Buckets godoc
+// @ID list-all-s3-bucket
+// @Summary List All S3 Buckets in a Connection
+// @Description Retrieve a comprehensive list of all S3 Buckets associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to list S3 Buckets for"
+// @Success 200 {object} AllResourceListResponse "List of all S3 Buckets within the specified connection, including Buckets in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /alls3 [get]
+func ListAllS3Buckets(c echo.Context) error {
+	cblog.Info("call ListAllS3Buckets()")
+
+	var req ConnectionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if req.ConnectionName == "" {
+		req.ConnectionName = c.QueryParam("ConnectionName")
+	}
+
+	allBucketList, err := cmrt.ListAllS3Buckets(req.ConnectionName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, &allBucketList)
+}
+
+// listAllS3BucketInfo godoc
+// @ID list-all-s3-bucket-info
+// @Summary List All S3 Bucket Info
+// @Description Retrieve detailed info of all S3 Buckets associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionName query string true "The name of the Connection to list S3 Bucket info for"
+// @Success 200 {object} cmrt.AllS3BucketInfoList "Detailed info of all S3 Buckets within the specified connection"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /alls3info [get]
+func ListAllS3BucketInfo(c echo.Context) error {
+	cblog.Info("call ListAllS3BucketInfo()")
+
+	var req ConnectionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if req.ConnectionName == "" {
+		req.ConnectionName = c.QueryParam("ConnectionName")
+	}
+
+	allBucketInfoList, err := cmrt.ListAllS3BucketInfo(req.ConnectionName)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, &allBucketInfoList)
+}
+
+// countAllS3Buckets godoc
+// @ID count-all-s3-bucket
+// @Summary Count All S3 Buckets
+// @Description Get the total number of S3 Buckets registered across all connections. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Produce  json
+// @Success 200 {object} CountResponse "Total count of S3 Buckets"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /counts3 [get]
+func CountAllS3Buckets(c echo.Context) error {
+	cblog.Info("call CountAllS3Buckets()")
+
+	count, err := cmrt.CountAllS3Buckets()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	jsonResult := CountResponse{
+		Count: int(count),
+	}
+	return c.JSON(http.StatusOK, jsonResult)
+}
+
+// deleteCSPS3Bucket godoc
+// @ID delete-csp-s3-bucket
+// @Summary Delete CSP S3 Bucket
+// @Description Delete a specified CSP S3 Bucket directly from the CSP without affecting CB-Spider metadata. (CB-Spider special feature)
+// @Tags [S3 Object Storage Management]
+// @Accept  json
+// @Produce  json
+// @Param ConnectionRequest body restruntime.ConnectionRequest true "Request body for deleting a CSP S3 Bucket"
+// @Param Id path string true "The CSP S3 Bucket ID (system name) to delete"
+// @Success 200 {object} BooleanInfo "Result of the delete operation"
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid JSON structure or missing fields"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
+// @Failure 500 {object} SimpleMsg "Internal Server Error"
+// @Router /csps3/{Id} [delete]
+func DeleteCSPS3Bucket(c echo.Context) error {
+	cblog.Info("call DeleteCSPS3Bucket()")
+
+	var req ConnectionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	result, err := cmrt.DeleteCSPS3Bucket(req.ConnectionName, c.Param("Id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	resultInfo := BooleanInfo{
+		Result: strconv.FormatBool(result),
+	}
+	return c.JSON(http.StatusOK, &resultInfo)
 }

--- a/api-runtime/rest-runtime/SecurityGroupRest.go
+++ b/api-runtime/rest-runtime/SecurityGroupRest.go
@@ -284,11 +284,14 @@ func ListVpcSecurity(c echo.Context) error {
 // listAllSecurityGroupInfo godoc
 // @ID list-all-securitygroup-info
 // @Summary List All SecurityGroup Info
-// @Description Retrieve a list of Security Group information associated with all connections.
+// @Description Retrieve a comprehensive list of all Security Group information associated with a specific connection, <br> including those mapped between CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing in the CSP.
 // @Tags [SecurityGroup Management]
 // @Accept  json
 // @Produce  json
-// @Success 200 {object} AllResourceInfoListResponse "List of all Security Group information"
+// @Param ConnectionName query string true "The name of the Connection to list Security Group information for"
+// @Success 200 {object} AllResourceInfoListResponse "List of all Security Group information within the specified connection, including Security Groups in CB-Spider only, CSP only, and mapped between both."
+// @Failure 400 {object} SimpleMsg "Bad Request, possibly due to invalid query parameter"
+// @Failure 404 {object} SimpleMsg "Resource Not Found"
 // @Failure 500 {object} SimpleMsg "Internal Server Error"
 // @Router /allsecuritygroupinfo [get]
 func ListAllSecurityGroupInfo(c echo.Context) error { return listAllResourceInfo(c, cres.SG) }

--- a/api/docs.go
+++ b/api/docs.go
@@ -178,7 +178,7 @@ const docTemplate = `{
         },
         "/alldiskinfo": {
             "get": {
-                "description": "Retrieve a list of all Disk information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all Disk information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -190,11 +190,32 @@ const docTemplate = `{
                 ],
                 "summary": "List All Disk Info",
                 "operationId": "list-all-disk-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list Disk information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all Disk information across all connections",
+                        "description": "List of all Disk information within the specified connection, including Disks in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
-                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                            "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -259,7 +280,7 @@ const docTemplate = `{
         },
         "/allkeypairinfo": {
             "get": {
-                "description": "Retrieve a list of KeyPair information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all KeyPair information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -271,11 +292,32 @@ const docTemplate = `{
                 ],
                 "summary": "List All KeyPair Info",
                 "operationId": "list-all-keypair-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list KeyPair information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of KeyPair information associated with all connections",
+                        "description": "List of all KeyPair information within the specified connection, including KeyPairs in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -544,7 +586,7 @@ const docTemplate = `{
         },
         "/allrdbmsinfo": {
             "get": {
-                "description": "Retrieve a list of all RDBMS information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all RDBMS information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -556,11 +598,122 @@ const docTemplate = `{
                 ],
                 "summary": "List All RDBMS Info",
                 "operationId": "list-all-rdbms-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all RDBMS information across all connections",
+                        "description": "List of all RDBMS information within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both.",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/alls3": {
+            "get": {
+                "description": "Retrieve a comprehensive list of all S3 Buckets associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "List All S3 Buckets in a Connection",
+                "operationId": "list-all-s3-bucket",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list S3 Buckets for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of all S3 Buckets within the specified connection, including Buckets in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/alls3info": {
+            "get": {
+                "description": "Retrieve detailed info of all S3 Buckets associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "List All S3 Bucket Info",
+                "operationId": "list-all-s3-bucket-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list S3 Bucket info for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Detailed info of all S3 Buckets within the specified connection",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllS3BucketInfoList"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -625,7 +778,7 @@ const docTemplate = `{
         },
         "/allsecuritygroupinfo": {
             "get": {
-                "description": "Retrieve a list of Security Group information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all Security Group information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -637,11 +790,32 @@ const docTemplate = `{
                 ],
                 "summary": "List All SecurityGroup Info",
                 "operationId": "list-all-securitygroup-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list Security Group information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all Security Group information",
+                        "description": "List of all Security Group information within the specified connection, including Security Groups in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -2486,6 +2660,33 @@ const docTemplate = `{
                 }
             }
         },
+        "/counts3": {
+            "get": {
+                "description": "Get the total number of S3 Buckets registered across all connections. (CB-Spider special feature)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Count All S3 Buckets",
+                "operationId": "count-all-s3-bucket",
+                "responses": {
+                    "200": {
+                        "description": "Total count of S3 Buckets",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/counts3/{ConnectionName}": {
             "get": {
                 "description": "Get the total number of S3 buckets for a specific connection.",
@@ -3263,6 +3464,66 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "description": "The CSP RDBMS ID to delete",
+                        "name": "Id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/csps3/{Id}": {
+            "delete": {
+                "description": "Delete a specified CSP S3 Bucket directly from the CSP without affecting CB-Spider metadata. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Delete CSP S3 Bucket",
+                "operationId": "delete-csp-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting a CSP S3 Bucket",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP S3 Bucket ID (system name) to delete",
                         "name": "Id",
                         "in": "path",
                         "required": true
@@ -9095,6 +9356,119 @@ const docTemplate = `{
                 }
             }
         },
+        "/regs3": {
+            "post": {
+                "description": "Register an existing CSP S3 bucket into CB-Spider metadata with a user-defined name. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Register S3 Bucket",
+                "operationId": "register-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for registering an S3 Bucket",
+                        "name": "S3BucketRegisterRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.S3BucketRegisterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the registered S3 Bucket",
+                        "schema": {
+                            "$ref": "#/definitions/spider.S3BucketWithIIDResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regs3/{Name}": {
+            "delete": {
+                "description": "Remove an S3 bucket mapping from CB-Spider metadata without deleting it from the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Unregister S3 Bucket",
+                "operationId": "unregister-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for unregistering an S3 Bucket",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the S3 Bucket to unregister",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the unregister operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/regsecuritygroup": {
             "post": {
                 "description": "Register a new Security Group with the specified name and CSP ID.",
@@ -12976,6 +13350,37 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "spider.AllS3BucketInfoList": {
+            "type": "object",
+            "properties": {
+                "ResourceType": {
+                    "type": "string"
+                },
+                "allListInfo": {
+                    "type": "object",
+                    "properties": {
+                        "MappedInfoList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.S3BucketWithIID"
+                            }
+                        },
+                        "OnlyCSPInfoList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.S3BucketWithIID"
+                            }
+                        },
+                        "OnlySpiderList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.IID"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "spider.DeletedResourceInfoList": {
             "type": "object",
             "required": [
@@ -13133,6 +13538,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "systemNetSent": {
+                    "type": "string"
+                }
+            }
+        },
+        "spider.S3BucketWithIID": {
+            "type": "object",
+            "properties": {
+                "creationDate": {
+                    "type": "string"
+                },
+                "nameId": {
+                    "type": "string"
+                },
+                "systemId": {
                     "type": "string"
                 }
             }
@@ -18421,6 +18840,56 @@ const docTemplate = `{
                             }
                         }
                     }
+                }
+            }
+        },
+        "spider.S3BucketRegisterRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "CSPId",
+                        "Name"
+                    ],
+                    "properties": {
+                        "CSPId": {
+                            "type": "string",
+                            "example": "my-csp-bucket-name"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "my-bucket"
+                        }
+                    }
+                }
+            }
+        },
+        "spider.S3BucketWithIIDResponse": {
+            "type": "object",
+            "required": [
+                "NameId",
+                "SystemId"
+            ],
+            "properties": {
+                "CreationDate": {
+                    "type": "string"
+                },
+                "NameId": {
+                    "type": "string",
+                    "example": "my-bucket"
+                },
+                "SystemId": {
+                    "type": "string",
+                    "example": "my-csp-bucket-name"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -175,7 +175,7 @@
         },
         "/alldiskinfo": {
             "get": {
-                "description": "Retrieve a list of all Disk information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all Disk information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -187,11 +187,32 @@
                 ],
                 "summary": "List All Disk Info",
                 "operationId": "list-all-disk-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list Disk information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all Disk information across all connections",
+                        "description": "List of all Disk information within the specified connection, including Disks in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
-                            "$ref": "#/definitions/spider.AllResourceListResponse"
+                            "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -256,7 +277,7 @@
         },
         "/allkeypairinfo": {
             "get": {
-                "description": "Retrieve a list of KeyPair information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all KeyPair information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -268,11 +289,32 @@
                 ],
                 "summary": "List All KeyPair Info",
                 "operationId": "list-all-keypair-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list KeyPair information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of KeyPair information associated with all connections",
+                        "description": "List of all KeyPair information within the specified connection, including KeyPairs in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -541,7 +583,7 @@
         },
         "/allrdbmsinfo": {
             "get": {
-                "description": "Retrieve a list of all RDBMS information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all RDBMS information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -553,11 +595,122 @@
                 ],
                 "summary": "List All RDBMS Info",
                 "operationId": "list-all-rdbms-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list RDBMS information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all RDBMS information across all connections",
+                        "description": "List of all RDBMS information within the specified connection, including RDBMS in CB-Spider only, CSP only, and mapped between both.",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/alls3": {
+            "get": {
+                "description": "Retrieve a comprehensive list of all S3 Buckets associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "List All S3 Buckets in a Connection",
+                "operationId": "list-all-s3-bucket",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list S3 Buckets for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of all S3 Buckets within the specified connection, including Buckets in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/alls3info": {
+            "get": {
+                "description": "Retrieve detailed info of all S3 Buckets associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "List All S3 Bucket Info",
+                "operationId": "list-all-s3-bucket-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list S3 Bucket info for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Detailed info of all S3 Buckets within the specified connection",
+                        "schema": {
+                            "$ref": "#/definitions/spider.AllS3BucketInfoList"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -622,7 +775,7 @@
         },
         "/allsecuritygroupinfo": {
             "get": {
-                "description": "Retrieve a list of Security Group information associated with all connections.",
+                "description": "Retrieve a comprehensive list of all Security Group information associated with a specific connection, \u003cbr\u003e including those mapped between CB-Spider and the CSP, \u003cbr\u003e only registered in CB-Spider's metadata, \u003cbr\u003e and only existing in the CSP.",
                 "consumes": [
                     "application/json"
                 ],
@@ -634,11 +787,32 @@
                 ],
                 "summary": "List All SecurityGroup Info",
                 "operationId": "list-all-securitygroup-info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The name of the Connection to list Security Group information for",
+                        "name": "ConnectionName",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "List of all Security Group information",
+                        "description": "List of all Security Group information within the specified connection, including Security Groups in CB-Spider only, CSP only, and mapped between both.",
                         "schema": {
                             "$ref": "#/definitions/spider.AllResourceInfoListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid query parameter",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
                         }
                     },
                     "500": {
@@ -2483,6 +2657,33 @@
                 }
             }
         },
+        "/counts3": {
+            "get": {
+                "description": "Get the total number of S3 Buckets registered across all connections. (CB-Spider special feature)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Count All S3 Buckets",
+                "operationId": "count-all-s3-bucket",
+                "responses": {
+                    "200": {
+                        "description": "Total count of S3 Buckets",
+                        "schema": {
+                            "$ref": "#/definitions/spider.CountResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/counts3/{ConnectionName}": {
             "get": {
                 "description": "Get the total number of S3 buckets for a specific connection.",
@@ -3260,6 +3461,66 @@
                     {
                         "type": "string",
                         "description": "The CSP RDBMS ID to delete",
+                        "name": "Id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the delete operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/csps3/{Id}": {
+            "delete": {
+                "description": "Delete a specified CSP S3 Bucket directly from the CSP without affecting CB-Spider metadata. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Delete CSP S3 Bucket",
+                "operationId": "delete-csp-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for deleting a CSP S3 Bucket",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The CSP S3 Bucket ID (system name) to delete",
                         "name": "Id",
                         "in": "path",
                         "required": true
@@ -9092,6 +9353,119 @@
                 }
             }
         },
+        "/regs3": {
+            "post": {
+                "description": "Register an existing CSP S3 bucket into CB-Spider metadata with a user-defined name. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Register S3 Bucket",
+                "operationId": "register-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for registering an S3 Bucket",
+                        "name": "S3BucketRegisterRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.S3BucketRegisterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Details of the registered S3 Bucket",
+                        "schema": {
+                            "$ref": "#/definitions/spider.S3BucketWithIIDResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/regs3/{Name}": {
+            "delete": {
+                "description": "Remove an S3 bucket mapping from CB-Spider metadata without deleting it from the CSP. (CB-Spider special feature)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[S3 Object Storage Management]"
+                ],
+                "summary": "Unregister S3 Bucket",
+                "operationId": "unregister-s3-bucket",
+                "parameters": [
+                    {
+                        "description": "Request body for unregistering an S3 Bucket",
+                        "name": "ConnectionRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/spider.ConnectionRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "The name of the S3 Bucket to unregister",
+                        "name": "Name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Result of the unregister operation",
+                        "schema": {
+                            "$ref": "#/definitions/spider.BooleanInfo"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, possibly due to invalid JSON structure or missing fields",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Resource Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/spider.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/regsecuritygroup": {
             "post": {
                 "description": "Register a new Security Group with the specified name and CSP ID.",
@@ -12973,6 +13347,37 @@
         }
     },
     "definitions": {
+        "spider.AllS3BucketInfoList": {
+            "type": "object",
+            "properties": {
+                "ResourceType": {
+                    "type": "string"
+                },
+                "allListInfo": {
+                    "type": "object",
+                    "properties": {
+                        "MappedInfoList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.S3BucketWithIID"
+                            }
+                        },
+                        "OnlyCSPInfoList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.S3BucketWithIID"
+                            }
+                        },
+                        "OnlySpiderList": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/spider.IID"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "spider.DeletedResourceInfoList": {
             "type": "object",
             "required": [
@@ -13130,6 +13535,20 @@
                     "type": "string"
                 },
                 "systemNetSent": {
+                    "type": "string"
+                }
+            }
+        },
+        "spider.S3BucketWithIID": {
+            "type": "object",
+            "properties": {
+                "creationDate": {
+                    "type": "string"
+                },
+                "nameId": {
+                    "type": "string"
+                },
+                "systemId": {
                     "type": "string"
                 }
             }
@@ -18418,6 +18837,56 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "spider.S3BucketRegisterRequest": {
+            "type": "object",
+            "required": [
+                "ConnectionName",
+                "ReqInfo"
+            ],
+            "properties": {
+                "ConnectionName": {
+                    "type": "string",
+                    "example": "aws-connection"
+                },
+                "ReqInfo": {
+                    "type": "object",
+                    "required": [
+                        "CSPId",
+                        "Name"
+                    ],
+                    "properties": {
+                        "CSPId": {
+                            "type": "string",
+                            "example": "my-csp-bucket-name"
+                        },
+                        "Name": {
+                            "type": "string",
+                            "example": "my-bucket"
+                        }
+                    }
+                }
+            }
+        },
+        "spider.S3BucketWithIIDResponse": {
+            "type": "object",
+            "required": [
+                "NameId",
+                "SystemId"
+            ],
+            "properties": {
+                "CreationDate": {
+                    "type": "string"
+                },
+                "NameId": {
+                    "type": "string",
+                    "example": "my-bucket"
+                },
+                "SystemId": {
+                    "type": "string",
+                    "example": "my-csp-bucket-name"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1,5 +1,25 @@
 basePath: /spider
 definitions:
+  spider.AllS3BucketInfoList:
+    properties:
+      ResourceType:
+        type: string
+      allListInfo:
+        properties:
+          MappedInfoList:
+            items:
+              $ref: '#/definitions/spider.S3BucketWithIID'
+            type: array
+          OnlyCSPInfoList:
+            items:
+              $ref: '#/definitions/spider.S3BucketWithIID'
+            type: array
+          OnlySpiderList:
+            items:
+              $ref: '#/definitions/spider.IID'
+            type: array
+        type: object
+    type: object
   spider.DeletedResourceInfoList:
     properties:
       DeletedIIDList:
@@ -113,6 +133,15 @@ definitions:
       systemNetReceived:
         type: string
       systemNetSent:
+        type: string
+    type: object
+  spider.S3BucketWithIID:
+    properties:
+      creationDate:
+        type: string
+      nameId:
+        type: string
+      systemId:
         type: string
     type: object
   spider.SystemInfo:
@@ -3915,6 +3944,41 @@ definitions:
     - ConnectionName
     - ReqInfo
     type: object
+  spider.S3BucketRegisterRequest:
+    properties:
+      ConnectionName:
+        example: aws-connection
+        type: string
+      ReqInfo:
+        properties:
+          CSPId:
+            example: my-csp-bucket-name
+            type: string
+          Name:
+            example: my-bucket
+            type: string
+        required:
+        - CSPId
+        - Name
+        type: object
+    required:
+    - ConnectionName
+    - ReqInfo
+    type: object
+  spider.S3BucketWithIIDResponse:
+    properties:
+      CreationDate:
+        type: string
+      NameId:
+        example: my-bucket
+        type: string
+      SystemId:
+        example: my-csp-bucket-name
+        type: string
+    required:
+    - NameId
+    - SystemId
+    type: object
   spider.S3Error:
     properties:
       Code:
@@ -4656,15 +4720,33 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of all Disk information associated with all connections.
+      description: Retrieve a comprehensive list of all Disk information associated
+        with a specific connection, <br> including those mapped between CB-Spider
+        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
+        in the CSP.
       operationId: list-all-disk-info
+      parameters:
+      - description: The name of the Connection to list Disk information for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: List of all Disk information across all connections
+          description: List of all Disk information within the specified connection,
+            including Disks in CB-Spider only, CSP only, and mapped between both.
           schema:
-            $ref: '#/definitions/spider.AllResourceListResponse'
+            $ref: '#/definitions/spider.AllResourceInfoListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
         "500":
           description: Internal Server Error
           schema:
@@ -4714,15 +4796,33 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of KeyPair information associated with all connections.
+      description: Retrieve a comprehensive list of all KeyPair information associated
+        with a specific connection, <br> including those mapped between CB-Spider
+        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
+        in the CSP.
       operationId: list-all-keypair-info
+      parameters:
+      - description: The name of the Connection to list KeyPair information for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: List of KeyPair information associated with all connections
+          description: List of all KeyPair information within the specified connection,
+            including KeyPairs in CB-Spider only, CSP only, and mapped between both.
           schema:
             $ref: '#/definitions/spider.AllResourceInfoListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
         "500":
           description: Internal Server Error
           schema:
@@ -4930,15 +5030,33 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of all RDBMS information associated with all connections.
+      description: Retrieve a comprehensive list of all RDBMS information associated
+        with a specific connection, <br> including those mapped between CB-Spider
+        and the CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
+        in the CSP.
       operationId: list-all-rdbms-info
+      parameters:
+      - description: The name of the Connection to list RDBMS information for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: List of all RDBMS information across all connections
+          description: List of all RDBMS information within the specified connection,
+            including RDBMS in CB-Spider only, CSP only, and mapped between both.
           schema:
-            $ref: '#/definitions/spider.AllResourceListResponse'
+            $ref: '#/definitions/spider.AllResourceInfoListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
         "500":
           description: Internal Server Error
           schema:
@@ -4946,6 +5064,73 @@ paths:
       summary: List All RDBMS Info
       tags:
       - '[RDBMS Management]'
+  /alls3:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a comprehensive list of all S3 Buckets associated with
+        a specific connection, <br> including those mapped between CB-Spider and the
+        CSP, <br> only registered in CB-Spider's metadata, <br> and only existing
+        in the CSP. (CB-Spider special feature)
+      operationId: list-all-s3-bucket
+      parameters:
+      - description: The name of the Connection to list S3 Buckets for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of all S3 Buckets within the specified connection, including
+            Buckets in CB-Spider only, CSP only, and mapped between both.
+          schema:
+            $ref: '#/definitions/spider.AllResourceListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: List All S3 Buckets in a Connection
+      tags:
+      - '[S3 Object Storage Management]'
+  /alls3info:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve detailed info of all S3 Buckets associated with a specific
+        connection, <br> including those mapped between CB-Spider and the CSP, <br>
+        only registered in CB-Spider's metadata, <br> and only existing in the CSP.
+        (CB-Spider special feature)
+      operationId: list-all-s3-bucket-info
+      parameters:
+      - description: The name of the Connection to list S3 Bucket info for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Detailed info of all S3 Buckets within the specified connection
+          schema:
+            $ref: '#/definitions/spider.AllS3BucketInfoList'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: List All S3 Bucket Info
+      tags:
+      - '[S3 Object Storage Management]'
   /allsecuritygroup:
     get:
       consumes:
@@ -4990,16 +5175,35 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of Security Group information associated with all
-        connections.
+      description: Retrieve a comprehensive list of all Security Group information
+        associated with a specific connection, <br> including those mapped between
+        CB-Spider and the CSP, <br> only registered in CB-Spider's metadata, <br>
+        and only existing in the CSP.
       operationId: list-all-securitygroup-info
+      parameters:
+      - description: The name of the Connection to list Security Group information
+          for
+        in: query
+        name: ConnectionName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: List of all Security Group information
+          description: List of all Security Group information within the specified
+            connection, including Security Groups in CB-Spider only, CSP only, and
+            mapped between both.
           schema:
             $ref: '#/definitions/spider.AllResourceInfoListResponse'
+        "400":
+          description: Bad Request, possibly due to invalid query parameter
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
         "500":
           description: Internal Server Error
           schema:
@@ -6278,6 +6482,25 @@ paths:
       summary: Count RDBMS by Connection
       tags:
       - '[RDBMS Management]'
+  /counts3:
+    get:
+      description: Get the total number of S3 Buckets registered across all connections.
+        (CB-Spider special feature)
+      operationId: count-all-s3-bucket
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Total count of S3 Buckets
+          schema:
+            $ref: '#/definitions/spider.CountResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Count All S3 Buckets
+      tags:
+      - '[S3 Object Storage Management]'
   /counts3/{ConnectionName}:
     get:
       description: Get the total number of S3 buckets for a specific connection.
@@ -6825,6 +7048,48 @@ paths:
       summary: Delete CSP RDBMS
       tags:
       - '[RDBMS Management]'
+  /csps3/{Id}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a specified CSP S3 Bucket directly from the CSP without
+        affecting CB-Spider metadata. (CB-Spider special feature)
+      operationId: delete-csp-s3-bucket
+      parameters:
+      - description: Request body for deleting a CSP S3 Bucket
+        in: body
+        name: ConnectionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.ConnectionRequest'
+      - description: The CSP S3 Bucket ID (system name) to delete
+        in: path
+        name: Id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result of the delete operation
+          schema:
+            $ref: '#/definitions/spider.BooleanInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Delete CSP S3 Bucket
+      tags:
+      - '[S3 Object Storage Management]'
   /cspsecuritygroup/{Id}:
     delete:
       consumes:
@@ -10784,6 +11049,85 @@ paths:
       summary: Unregister RDBMS
       tags:
       - '[RDBMS Management]'
+  /regs3:
+    post:
+      consumes:
+      - application/json
+      description: Register an existing CSP S3 bucket into CB-Spider metadata with
+        a user-defined name. (CB-Spider special feature)
+      operationId: register-s3-bucket
+      parameters:
+      - description: Request body for registering an S3 Bucket
+        in: body
+        name: S3BucketRegisterRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.S3BucketRegisterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Details of the registered S3 Bucket
+          schema:
+            $ref: '#/definitions/spider.S3BucketWithIIDResponse'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Register S3 Bucket
+      tags:
+      - '[S3 Object Storage Management]'
+  /regs3/{Name}:
+    delete:
+      consumes:
+      - application/json
+      description: Remove an S3 bucket mapping from CB-Spider metadata without deleting
+        it from the CSP. (CB-Spider special feature)
+      operationId: unregister-s3-bucket
+      parameters:
+      - description: Request body for unregistering an S3 Bucket
+        in: body
+        name: ConnectionRequest
+        required: true
+        schema:
+          $ref: '#/definitions/spider.ConnectionRequest'
+      - description: The name of the S3 Bucket to unregister
+        in: path
+        name: Name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Result of the unregister operation
+          schema:
+            $ref: '#/definitions/spider.BooleanInfo'
+        "400":
+          description: Bad Request, possibly due to invalid JSON structure or missing
+            fields
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "404":
+          description: Resource Not Found
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/spider.SimpleMsg'
+      summary: Unregister S3 Bucket
+      tags:
+      - '[S3 Object Storage Management]'
   /regsecuritygroup:
     post:
       consumes:


### PR DESCRIPTION
## Changes

### 1. Add Register/Unregister/ListAll/CountAll/DeleteCSP APIs for Object Storage
Object Storage (S3) lacked resource lifecycle management APIs
available for other resource types such as Disk Management.

- `S3Manager.go`: add `AllS3BucketList`, `AllS3BucketInfoList` types
  and 6 new common-runtime functions:
  - `RegisterS3Bucket()`: register existing CSP bucket into CB-Spider metadata
  - `UnregisterS3Bucket()`: remove bucket from CB-Spider metadata without CSP deletion
  - `ListAllS3Buckets()`: list all buckets with MappedList/OnlySpiderList/OnlyCSPList
  - `ListAllS3BucketInfo()`: list detailed bucket info with categorization
  - `CountAllS3Buckets()`: count all buckets across all connections
  - `DeleteCSPS3Bucket()`: delete bucket directly from CSP without affecting metadata
- `S3Rest.go`: add 6 REST handler functions with full Swagger docs
- `CBSpiderRuntime.go`: register 6 new routes
  - `POST /regs3`, `DELETE /regs3/:Name`
  - `GET /alls3`, `GET /alls3info`
  - `GET /counts3`, `DELETE /csps3/:Id`

### 2. Fix missing ConnectionName param and wrong response type in allxxxinfo Swagger docs
Four `allxxxinfo` APIs had incorrect Swagger documentation:
missing the required `ConnectionName` query parameter, incorrect
descriptions claiming "all connections", and two had the wrong
response type.

- `DiskRest.go` (`/alldiskinfo`): add `ConnectionName` param, fix description,
  fix response type `AllResourceListResponse` → `AllResourceInfoListResponse`
- `KeyPairRest.go` (`/allkeypairinfo`): add `ConnectionName` param, fix description
- `RDBMSRest.go` (`/allrdbmsinfo`): add `ConnectionName` param, fix description,
  fix response type `AllResourceListResponse` → `AllResourceInfoListResponse`
- `SecurityGroupRest.go` (`/allsecuritygroupinfo`): add `ConnectionName` param, fix description
- All 4 APIs: add missing `@Failure 400` and `@Failure 404` annotations



**[Before] Incorrect Swagger definitions for some allxxxinfo APIs**

| API | @Param ConnectionName | Description | Response Type |
|---|---|---|---|
| /alldiskinfo | ❌ missing | ❌ "all connections" | ❌ `AllResourceListResponse` |
| /allkeypairinfo | ❌ missing | ❌ "all connections" | ✅ |
| /allrdbmsinfo | ❌ missing | ❌ "all connections" | ❌ `AllResourceListResponse` |
| /allsecuritygroupinfo | ❌ missing | ❌ "all connections" | ✅ |
| /allclusterinfo | ✅ | ✅ | ✅ |
| /allmyimageinfo | ✅ | ✅ | ✅ |
| /allnlbinfo | ✅ | ✅ | ✅ |
| /allvminfo | ✅ | ✅ | ✅ |
| /allvpcinfo | ✅ | ✅ | ✅ |
| /alls3info | ✅ | ✅ | ✅ |

**[After]**

| File | API | @Param ConnectionName | Description | Response Type |
|---|---|---|---|---|
| DiskRest.go | /alldiskinfo | ✅ added | ✅ fixed | ✅ changed to `AllResourceInfoListResponse` |
| KeyPairRest.go | /allkeypairinfo | ✅ added | ✅ fixed | (already correct) |
| RDBMSRest.go | /allrdbmsinfo | ✅ added | ✅ fixed | ✅ changed to `AllResourceInfoListResponse` |
| SecurityGroupRest.go | /allsecuritygroupinfo | ✅ added | ✅ fixed | (already correct) |
