### PR TITLE
[Go/SpiderWatch] Chore: Upgrade Go 1.25.0 → 1.26.2 and add missing spiderwatch 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Note: --platform=$BUILDPLATFORM runs the builder natively on the host (e.g., amd64),
 # avoiding slow QEMU emulation. Cross-compilation is handled via TARGETOS/TARGETARCH.
-FROM --platform=$BUILDPLATFORM golang:1.25.0 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloud-barista/cb-spider/cli
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloud-barista/cb-spider
 
-go 1.25.0
+go 1.26.2
 
 replace github.com/alibabacloud-go/ecs-20140526/v4 => github.com/alibabacloud-go/ecs-20140526/v4 v4.0.1
 

--- a/spiderwatch/.gitignore
+++ b/spiderwatch/.gitignore
@@ -1,6 +1,5 @@
 # Binaries
 bin/
-spiderwatch
 
 # PID file and log (created by 'make run')
 .spiderwatch.pid

--- a/spiderwatch/cmd/spiderwatch/main.go
+++ b/spiderwatch/cmd/spiderwatch/main.go
@@ -1,0 +1,104 @@
+// SpiderWatch - CB-Spider Status Board
+// Periodically tests all CSP resources via CB-Spider and serves results on the web.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/cloud-barista/cb-spider/spiderwatch/internal/config"
+	"github.com/cloud-barista/cb-spider/spiderwatch/internal/runner"
+	"github.com/cloud-barista/cb-spider/spiderwatch/internal/store"
+	"github.com/cloud-barista/cb-spider/spiderwatch/internal/web"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.New()
+
+func main() {
+	cfgPath := flag.String("config", "conf/spiderwatch.yaml", "path to configuration file")
+	flag.Parse()
+
+	// Scheduler and store are created after config load; the hot-reload callback
+	// references sched, so we declare it before calling config.Load.
+	var sched *runner.Scheduler
+
+	cfg, err := config.Load(*cfgPath, func(newCfg *config.Config) {
+		setupLogger(newCfg)
+		if sched != nil {
+			sched.Reconfigure(newCfg)
+		}
+		log.Info("configuration hot-reloaded")
+	})
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+	setupLogger(cfg)
+	log.Infof("SpiderWatch starting - port=%d cron=%q", cfg.Server.Port, cfg.Scheduler.Cron)
+
+	// Data store
+	st, err := store.New("data/results")
+	if err != nil {
+		log.Fatalf("failed to init store: %v", err)
+	}
+
+	// Runner + Scheduler
+	r := runner.New()
+	sched = runner.NewScheduler(r, st, nil)
+
+	// Web server
+	renderer, err := web.NewRenderer("web/templates/*.html")
+	if err != nil {
+		log.Fatalf("failed to load templates: %v", err)
+	}
+	srv := web.New(st, sched, r, renderer, *cfgPath)
+
+	// Start scheduler
+	sched.Start(cfg)
+
+	// Start HTTP server
+	addr := fmt.Sprintf("%s:%d", cfg.Server.Address, cfg.Server.Port)
+	go func() {
+		log.Infof("SpiderWatch listening on http://%s", addr)
+		if err := srv.Start(addr); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	// Graceful shutdown
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	<-quit
+	log.Info("shutting down SpiderWatch...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Echo().Shutdown(ctx); err != nil {
+		log.WithError(err).Error("server shutdown error")
+	}
+	log.Info("SpiderWatch stopped")
+}
+
+func setupLogger(cfg *config.Config) {
+	lvl, err := logrus.ParseLevel(cfg.Log.Level)
+	if err != nil {
+		lvl = logrus.InfoLevel
+	}
+	log.SetLevel(lvl)
+	logrus.SetLevel(lvl)
+	if cfg.Log.File != "" {
+		if mkErr := os.MkdirAll(filepath.Dir(cfg.Log.File), 0o755); mkErr == nil {
+			f, fErr := os.OpenFile(cfg.Log.File, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+			if fErr == nil {
+				log.SetOutput(f)
+			}
+		}
+	}
+}

--- a/spiderwatch/go.mod
+++ b/spiderwatch/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloud-barista/cb-spider/spiderwatch
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/fsnotify/fsnotify v1.10.0


### PR DESCRIPTION
## Changes
- `go.mod`: bump Go from 1.25.0 to 1.26.2
- `spiderwatch/cmd/spiderwatch/main.go`: add missing entry point
  (was excluded by `.gitignore`, causing `make build` to fail)