### PR TITLE
Enhance IBM API call efficiency

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ibm/IBMCloudDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/IBMCloudDriver.go
@@ -3,6 +3,7 @@ package ibmcloudvpc
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/IBM/cloud-databases-go-sdk/clouddatabasesv5"
@@ -24,6 +25,29 @@ type IbmCloudDriver struct{}
 
 const (
 	cspTimeout time.Duration = 6000
+)
+
+// iamAuthCache shares one IamAuthenticator (and its cached IAM token) per ApiKey.
+var (
+	iamAuthCache   = map[string]*core.IamAuthenticator{}
+	iamAuthCacheMu sync.Mutex
+)
+
+func getIamAuthenticator(apiKey string) *core.IamAuthenticator {
+	iamAuthCacheMu.Lock()
+	defer iamAuthCacheMu.Unlock()
+	if auth, ok := iamAuthCache[apiKey]; ok {
+		return auth
+	}
+	auth := &core.IamAuthenticator{ApiKey: apiKey}
+	iamAuthCache[apiKey] = auth
+	return auth
+}
+
+// regionEndpointCache caches the VPC endpoint per validated (region, zone) pair.
+var (
+	regionEndpointCache   = map[string]string{}
+	regionEndpointCacheMu sync.Mutex
 )
 
 func (IbmCloudDriver) GetDriverVersion() string {
@@ -69,78 +93,73 @@ func (driver *IbmCloudDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (
 	}
 	ctx, _ := context.WithTimeout(context.Background(), cspTimeout*time.Second)
 
-	// Region & Zone Check
-	initVpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	var endPoint string
-	getRegionOptions := &vpcv1.GetRegionOptions{}
-	getRegionOptions.SetName(connectionInfo.RegionInfo.Region)
-	region, _, err := initVpcService.GetRegionWithContext(ctx, getRegionOptions)
-	if err != nil {
-		return nil, err
-	} else {
+	auth := getIamAuthenticator(connectionInfo.CredentialInfo.ApiKey)
+
+	// Region & Zone Check (cached per region/zone pair)
+	endpointCacheKey := connectionInfo.RegionInfo.Region + "/" + connectionInfo.RegionInfo.Zone
+	regionEndpointCacheMu.Lock()
+	endPoint, cached := regionEndpointCache[endpointCacheKey]
+	regionEndpointCacheMu.Unlock()
+	if !cached {
+		initVpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
+			Authenticator: auth,
+		})
+		if err != nil {
+			return nil, err
+		}
+		getRegionOptions := &vpcv1.GetRegionOptions{}
+		getRegionOptions.SetName(connectionInfo.RegionInfo.Region)
+		region, _, err := initVpcService.GetRegionWithContext(ctx, getRegionOptions)
+		if err != nil {
+			return nil, err
+		}
 		getZoneOptions := &vpcv1.GetRegionZoneOptions{}
 		getZoneOptions.SetRegionName(*region.Name)
 		getZoneOptions.SetName(connectionInfo.RegionInfo.Zone)
-		_, _, err := initVpcService.GetRegionZoneWithContext(ctx, getZoneOptions)
+		_, _, err = initVpcService.GetRegionZoneWithContext(ctx, getZoneOptions)
 		if err != nil {
 			return nil, err
 		}
 		endPoint = *region.Endpoint + "/v1"
+		regionEndpointCacheMu.Lock()
+		regionEndpointCache[endpointCacheKey] = endPoint
+		regionEndpointCacheMu.Unlock()
 	}
 	vpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
-		URL: endPoint,
+		Authenticator: auth,
+		URL:           endPoint,
 	})
 	if err != nil {
 		return nil, err
 	}
 	clusterService, err := kubernetesserviceapiv1.NewKubernetesServiceApiV1(&kubernetesserviceapiv1.KubernetesServiceApiV1Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
+		Authenticator: auth,
 	})
 	if err != nil {
 		return nil, err
 	}
 	taggingService, err := globaltaggingv1.NewGlobalTaggingV1(&globaltaggingv1.GlobalTaggingV1Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
+		Authenticator: auth,
 	})
 	if err != nil {
 		return nil, err
 	}
 	searchService, err := globalsearchv2.NewGlobalSearchV2(&globalsearchv2.GlobalSearchV2Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
+		Authenticator: auth,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	resourceControllerService, err := resourcecontrollerv2.NewResourceControllerV2(&resourcecontrollerv2.ResourceControllerV2Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
+		Authenticator: auth,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	cloudDBService, err := clouddatabasesv5.NewCloudDatabasesV5(&clouddatabasesv5.CloudDatabasesV5Options{
-		Authenticator: &core.IamAuthenticator{
-			ApiKey: connectionInfo.CredentialInfo.ApiKey,
-		},
+		Authenticator: auth,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
현재 IBM 드라이버에는 API 호출 성능 측면에서 큰 비효율이 있는 것으로 판단됩니다.
본 PR은, API 호출 효율을 높이는 개선을 제공합니다. To support, https://github.com/cloud-barista/cb-tumblebug/issues/2461


### 기존 비효율
spider는 IBM REST 요청을 처리할 때마다 ConnectCloud를 호출하는데, 이 함수가:

1) 서비스 7개(VPC, Cluster, Tagging, Search, ResourceController, CloudDB 등)마다 IamAuthenticator를 새로 생성: IBM SDK의 토큰 캐시는 authenticator 인스턴스 단위라서, 연결마다 iam.cloud.ibm.com과 IAM 토큰 교환을 새로 함 (keypair 조회 기준 2회)
2) 매 연결마다 GetRegion + GetRegionZone API 왕복 2회: 리전 엔드포인트를 알아내는 용도인데, 결과는 정적

결과적으로 키 목록 조회 1건 = 네트워크 왕복 5회(토큰 2 + 리전 2 + 실제 조회 1)이고, 
IAM 토큰은 약 1시간 유효한데도 같은 크레덴셜의 리전 13개를 검증하면 토큰 교환만 26회가 발생함.

특히, CB-Tumblebug 에서 전리전에 대한 호출 패턴을 고려하면,
IBM은 활용이 어려울 정도로 성능이 낮아집니다.

### 개선 내용
ApiKey당 IamAuthenticator 1개를 패키지 레벨에 캐시하여 서비스 7개와 모든 연결이 공유하여, 1회 호출로 처리할 수 있도록 개선
- 호출당 CSP API 왕복 횟수 5회 → 1회로 감소 효과
- 약 2 ~ 3배의 응답속도 개선 효과가 있는 것으로 보임. (특히 cb-tb 에서 csp 검증용으로 활용하는 allkeypair 에서는)