### PR TITLE
fix(tencent): return a recognizable not-found error so cluster deletion completes

### DIFF
--- a/api-runtime/common-runtime/CommonManager.go
+++ b/api-runtime/common-runtime/CommonManager.go
@@ -211,13 +211,23 @@ func getAWSNLBShortID(inID string) string {
 	return inID
 }
 
+// checkNotFoundError reports whether err means "this resource does not exist in the CSP".
+//
+// CONTRACT FOR DRIVER AUTHORS: when a resource is absent, a driver MUST return an
+// error whose message contains "not found" or "not exist" (spaces and case are
+// ignored here). Delete and List flows in common-runtime depend on it:
+//   - DeleteXXX() polls GetXXX() until the resource is gone from the CSP and ends
+//     the wait on this check. A message it cannot recognize turns a successful
+//     deletion into an error and leaves a stale IID in the meta DB.
+//   - ListXXX() degrades to a stub IID instead of failing the whole listing.
 func checkNotFoundError(err error) bool {
 	msg := err.Error()
 	msg = strings.ReplaceAll(msg, " ", "")
 	msg = strings.ToLower(msg)
 
 	return strings.Contains(msg, "notexist") || strings.Contains(msg, "notfound") ||
-		strings.Contains(msg, "notexist") || strings.Contains(msg, "failedtofind") || strings.Contains(msg, "failedtogetthevm") || strings.Contains(msg, "noresult")
+		strings.Contains(msg, "failedtofind") || strings.Contains(msg, "failedtogetthevm") ||
+		strings.Contains(msg, "noresult")
 }
 
 func getUserIIDList(iidInfoList []*iidm.IIDInfo) []*cres.IID {

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -408,7 +408,12 @@ func getClusterInfo(access_key string, access_secret string, region_id string, c
 	}
 
 	if *res.Response.TotalCount == 0 {
-		err := fmt.Errorf("Failed to Get Cluster: cluster_id: %s", cluster_id)
+		// NOTE: This message must contain a token recognized by common-runtime
+		// checkNotFoundError() ("not found" / "not exist"). DeleteCluster() polls
+		// GetCluster() until the cluster disappears from the CSP and ends the wait
+		// on that check; a message it cannot recognize turns a successful deletion
+		// into an error and leaves a stale ClusterIIDInfo in the meta DB.
+		err := fmt.Errorf("Cluster not found: cluster_id: %s", cluster_id)
 		cblogger.Error(err)
 		return nil, err
 	}


### PR DESCRIPTION

## Problem

- **Symptom** — Deleting a Tencent cluster returns **500** even though the cluster is already gone
  from the CSP, and Spider keeps its `ClusterIIDInfo` row. Later lookups keep returning 500, and
  cb-tumblebug's polling trips its circuit breaker into a zombie loop. An ordinary delete fails the
  same way as the CSP auto-destroy case: TKE deletes asynchronously, and the poll takes the broken
  path the moment the cluster disappears.
- **Cause** — `getClusterInfo()` reports a missing cluster as `Failed to Get Cluster: cluster_id: ...`,
  which normalizes to `failedtogetclusterinfo:failedtogetcluster:...` and matches none of the six
  patterns in `checkNotFoundError()`. The wait loop in `DeleteCluster()` therefore never hits its
  `break`, falls through to `return false, err`, and never reaches the IID cleanup that follows.

## Solution

- **Result** — `DELETE` now returns **200** and the `ClusterIIDInfo` is cleaned up as well.
- **How** — One line: `getClusterInfo()` now reports a missing cluster as
  `Cluster not found: cluster_id: ...`. `checkNotFoundError()` recognizes it, so the wait loop exits
  through `break` and goes on to delete the `NodeGroupIIDInfo` and `ClusterIIDInfo` rows. This aligns
  Tencent with a convention the other drivers already follow; it is not a new rule.