### PR TITLE
[Azure/Alibaba/KT/NCP] Fix: Multi-CSP bug patches for NLB, VM, Cluster, and KeyPair

### DIFF
--- a/api-runtime/common-runtime/VMManager.go
+++ b/api-runtime/common-runtime/VMManager.go
@@ -1730,18 +1730,32 @@ func getSetNameId(ConnectionName string, vmInfo *cres.VMInfo) error {
 			err = infostore.GetByConditionsAndContain(&iidInfo, CONNECTION_NAME_COLUMN, vpcIIDInfo.ConnectionName,
 				OWNER_VPC_NAME_COLUMN, vmInfo.VpcIID.NameId, SYSTEM_ID_COLUMN, vmInfo.SubnetIID.SystemId)
 			if err != nil {
-				cblog.Error(err)
-				return err
+				// Subnet may not be registered in Spider's metadb (e.g. pre-existing subnet,
+				// or stale metadb after subnet re-creation). Log and continue gracefully.
+				if checkNotFoundError(err) {
+					cblog.Info(err)
+				} else {
+					cblog.Error(err)
+					return err
+				}
 			}
 		} else {
 			err := infostore.GetByConditionsAndContain(&iidInfo, CONNECTION_NAME_COLUMN, ConnectionName,
 				OWNER_VPC_NAME_COLUMN, vmInfo.VpcIID.NameId, SYSTEM_ID_COLUMN, vmInfo.SubnetIID.SystemId)
 			if err != nil {
-				cblog.Error(err)
-				return err
+				// Subnet may not be registered in Spider's metadb (e.g. pre-existing subnet,
+				// or stale metadb after subnet re-creation). Log and continue gracefully.
+				if checkNotFoundError(err) {
+					cblog.Info(err)
+				} else {
+					cblog.Error(err)
+					return err
+				}
 			}
 		}
-		vmInfo.SubnetIID.NameId = iidInfo.NameId
+		if iidInfo.NameId != "" {
+			vmInfo.SubnetIID.NameId = iidInfo.NameId
+		}
 	}
 
 	// set SecurityGroups NameId

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -866,10 +866,25 @@ func (ach *AlibabaClusterHandler) getClusterInfoWithoutNodeGroupList(regionId, c
 		return nil, err
 	}
 
-	secGroupAttr, err := aliDescribeSecurityGroupAttribute(ach.EcsClient, regionId, tea.StringValue(cluster.SecurityGroupId))
-	if err != nil {
-		err = fmt.Errorf("failed to get ClusterInfo: %v", err)
-		return nil, err
+	var secGroupAttr *ecs2014.DescribeSecurityGroupAttributeResponseBody
+	{
+		const maxSGRetries = 10
+		const sgRetryInterval = 10 * time.Second
+		var sgErr error
+		for attempt := 1; attempt <= maxSGRetries; attempt++ {
+			secGroupAttr, sgErr = aliDescribeSecurityGroupAttribute(ach.EcsClient, regionId, tea.StringValue(cluster.SecurityGroupId))
+			if sgErr == nil {
+				break
+			}
+			cblogger.Warnf("getClusterInfoWithoutNodeGroupList: SG attribute attempt %d/%d failed: %v", attempt, maxSGRetries, sgErr)
+			if attempt < maxSGRetries {
+				time.Sleep(sgRetryInterval)
+			}
+		}
+		if sgErr != nil {
+			err = fmt.Errorf("failed to get ClusterInfo: %v", sgErr)
+			return nil, err
+		}
 	}
 
 	clusterInfo := &irs.ClusterInfo{

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -26,12 +26,12 @@ type AlibabaNLBHandler struct {
 }
 
 type AlibabaNLBBackendServer struct {
-	ServerId    string
-	Port        int
-	Weight      int
-	Description string
-	Type        string
-	ServerIp    string
+	ServerId    string `json:"ServerId"`
+	Port        int    `json:"Port,omitempty"`
+	Weight      int    `json:"Weight"`
+	Description string `json:"Description,omitempty"`
+	Type        string `json:"Type"`
+	ServerIp    string `json:"ServerIp,omitempty"`
 }
 
 const (
@@ -321,33 +321,14 @@ func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error)
 	vms := make([]irs.IID, 0)
 	backendServerList := lbAttributeResponse.BackendServers.BackendServer
 	for _, backendServer := range backendServerList {
-		// vm 이름 때문에 조회 해야하나...
-		vmHandler := AlibabaVMHandler{Client: NLBHandler.VMClient}
-		vmIID := irs.IID{SystemId: backendServer.ServerId}
-		vmInfo, err := vmHandler.GetVM(vmIID)
-		if err != nil {
-			cblogger.Error(err.Error())
-			// vm 정보 조회 실패
-			// var inKeyValueList []irs.KeyValue
-			// keyValue := irs.KeyValue{"reason", err.Error()}
-			// inKeyValueList = append(inKeyValueList, keyValue)
-			// vmGroup.KeyValueList = inKeyValueList
-			vmGroup.KeyValueList = irs.StructToKeyValueList(err)
-		} else {
-			vmIID = vmInfo.IId
-			nlbInfo.VpcIID = vmInfo.VpcIID
-		}
-
-		vms = append(vms, vmIID)
+		// Return the ECS instance ID as SystemId; NLBManager resolves NameId from meta_db.
+		vms = append(vms, irs.IID{SystemId: backendServer.ServerId})
 	}
 
-	//VpcIID : vm 조회하면서 set함.
-	//vpcHandler := AlibabaVPCHandler{Client: NLBHandler.VpcClient}
-	//vpcInfo, err := vpcHandler.GetVPC(nlbInfo.VpcIID)
-	//if err != nil {
-	//
-	//}
-	//nlbInfo.VpcIID = vpcInfo.IId
+	// VpcIID: obtained directly from the CLB attribute response (no VM lookup needed).
+	if lbAttributeResponse.VpcId != "" {
+		nlbInfo.VpcIID = irs.IID{SystemId: lbAttributeResponse.VpcId}
+	}
 
 	// VMGroup
 	vmGroup.VMs = &vms
@@ -936,7 +917,11 @@ func (NLBHandler *AlibabaNLBHandler) addVMGroupInfo(nlbIID irs.IID, nlbReqInfo i
 	vmGroupRequest.LoadBalancerId = nlbIID.SystemId
 	vmGroupRequest.VServerGroupName = nlbIID.NameId // LB와 똑같은 이름 상관없음
 
-	vmHandler := AlibabaVMHandler{Client: NLBHandler.VMClient}
+	vmHandler := AlibabaVMHandler{
+		Client:    NLBHandler.VMClient,
+		VpcClient: NLBHandler.VpcClient,
+		Region:    NLBHandler.Region,
+	}
 
 	maxVmCount := 20
 	vmCount := len(*vmGroup.VMs)
@@ -1035,8 +1020,6 @@ func (NLBHandler *AlibabaNLBHandler) addBackendServer(nlbIID irs.IID, nlbReqInfo
 	backendServersRequest := slb.CreateAddBackendServersRequest()
 	backendServersRequest.LoadBalancerId = nlbIID.SystemId
 
-	vmHandler := AlibabaVMHandler{Client: NLBHandler.VMClient}
-
 	maxVmCount := 20
 	vmCount := len(*vmGroup.VMs)
 	if maxVmCount < vmCount {
@@ -1052,18 +1035,6 @@ func (NLBHandler *AlibabaNLBHandler) addBackendServer(nlbIID irs.IID, nlbReqInfo
 
 		backendServer := AlibabaNLBBackendServer{ServerId: vmIId.SystemId}
 
-		// vm 정보 조회해서 backendServer정보 set
-		vmInfo, err := vmHandler.GetVM(vmIId)
-		if err != nil {
-			return irs.VMGroupInfo{}, err
-		}
-		printToJson(vmInfo)
-		// IP
-		backendServer.ServerIp = vmInfo.PublicIP
-
-		// Port
-		backendServer.Port, _ = strconv.Atoi(vmGroup.Port)
-
 		// Weight
 		if vmIndex == vmCount-1 {
 			backendServer.Weight = remainingWeight
@@ -1072,7 +1043,9 @@ func (NLBHandler *AlibabaNLBHandler) addBackendServer(nlbIID irs.IID, nlbReqInfo
 			remainingWeight -= weight
 		}
 
-		// type( ecs : elastic compute service instance / eni : elastic network interface / eci : elastic container instance )
+		// Type: ecs (elastic compute service instance)
+		// ServerIp and Port are optional for ecs-type CLB backends and are omitted
+		// to avoid validation errors (empty/zero values rejected by the Alibaba API).
 		backendServer.Type = "ecs"
 
 		backendServerJson, err := json.Marshal(backendServer)
@@ -1082,10 +1055,7 @@ func (NLBHandler *AlibabaNLBHandler) addBackendServer(nlbIID irs.IID, nlbReqInfo
 		vms = append(vms, string(backendServerJson))
 
 		// vmGroup 정보 갱신
-		returnVms = append(returnVms, vmInfo.IId)
-		printToJson(vmInfo.IId)
-		printToJson(returnVms)
-		//vmIId.NameId = vmInfo.IId.NameId
+		returnVms = append(returnVms, vmIId)
 	}
 	backendServersRequest.BackendServers = "[" + strings.Join(vms, ",") + "]"
 	cblogger.Debug("backendServersRequest---")

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
@@ -1592,9 +1592,14 @@ func applySecurityGroupList(sourceSecurity armnetwork.SecurityGroup, targetSecur
 			update := inboundsgRule
 			update.Properties.Priority = inboundsgRule.Properties.Priority
 			if *update.Properties.Priority >= 500 {
-				// AKS baseRule 회피
-				priority := *inboundsgRule.Properties.Priority + 100
-				update.Properties.Priority = &priority
+				// AKS baseRule 회피: +100 offset to avoid conflicts with AKS default rules.
+				// Skip rules whose adjusted priority would exceed Azure's 4096 limit.
+				adjusted := *inboundsgRule.Properties.Priority + 100
+				if adjusted > 4096 {
+					cblogger.Warnf("applySecurityGroupList: skipping rule %q — adjusted priority %d exceeds Azure max 4096", *inboundsgRule.Name, adjusted)
+					continue
+				}
+				update.Properties.Priority = &adjusted
 			}
 			poller, err := SecurityRulesClient.BeginCreateOrUpdate(ctx, sgresourceGroup, *targetsg.Name, *inboundsgRule.Name, *update, nil)
 			if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/NLBHandler.go
@@ -590,15 +590,26 @@ func (nlbHandler *AzureNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 	}
 
 	if len(nlb.Properties.BackendAddressPools) > 0 && len(*vmIIDs) > 0 {
-		backendPools := nlb.Properties.BackendAddressPools
-		cbOnlyOneBackendPool := backendPools[0]
+		backendPoolName := *nlb.Properties.BackendAddressPools[0].Name
 
-		// Get VPC ID: if backend pool has existing VMs, use their VPC; otherwise get from first VM to add
+		// NLBClient.Get does NOT inline LoadBalancerBackendAddresses; fetch the
+		// actual backend pool first so that existCheck and VPC ID resolution are
+		// based on real data (not an always-empty slice).
+		resp, err := nlbHandler.NLBBackendAddressPoolsClient.Get(
+			nlbHandler.Ctx, nlbHandler.Region.Region, nlbIID.NameId, backendPoolName, nil)
+		if err != nil {
+			addErr := errors.New(fmt.Sprintf("Failed to AddVMs NLB. err = %s", err.Error()))
+			cblogger.Error(addErr.Error())
+			LoggingError(hiscallInfo, addErr)
+			return irs.VMGroupInfo{}, addErr
+		}
+
+		// Derive VPC ID from existing backend addresses, or fall back to the first VM.
 		var vpcID string
-		if cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses != nil && len(cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses) > 0 {
-			vpcID = *cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses[0].Properties.VirtualNetwork.ID
+		if resp.BackendAddressPool.Properties != nil &&
+			len(resp.BackendAddressPool.Properties.LoadBalancerBackendAddresses) > 0 {
+			vpcID = *resp.BackendAddressPool.Properties.LoadBalancerBackendAddresses[0].Properties.VirtualNetwork.ID
 		} else {
-			// No existing VMs in NLB, get VPC from the first VM to add
 			firstVMIID := (*vmIIDs)[0]
 			vpcID, err = nlbHandler.getVPCIDFromVM(firstVMIID)
 			if err != nil {
@@ -609,7 +620,12 @@ func (nlbHandler *AzureNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 			}
 		}
 
-		nlbCurrentVMIIds, err := nlbHandler.getVMIIDsByLoadBalancerBackendAddresses(vpcID, cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses)
+		// Check for already-existing VMs using the actual backend pool data.
+		var actualAddresses []*armnetwork.LoadBalancerBackendAddress
+		if resp.BackendAddressPool.Properties != nil {
+			actualAddresses = resp.BackendAddressPool.Properties.LoadBalancerBackendAddresses
+		}
+		nlbCurrentVMIIds, err := nlbHandler.getVMIIDsByLoadBalancerBackendAddresses(vpcID, actualAddresses)
 		existCheck := false
 		for _, currentVMIId := range nlbCurrentVMIIds {
 			for _, addVmIId := range *vmIIDs {
@@ -630,7 +646,6 @@ func (nlbHandler *AzureNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 			return irs.VMGroupInfo{}, addErr
 		}
 
-		backendPoolName := *cbOnlyOneBackendPool.Name
 		var privateIPs []string
 		for _, vmIID := range *vmIIDs {
 			convertedIID, err := ConvertVMIID(vmIID, nlbHandler.CredentialInfo, nlbHandler.Region)
@@ -649,14 +664,6 @@ func (nlbHandler *AzureNLBHandler) AddVMs(nlbIID irs.IID, vmIIDs *[]irs.IID) (ir
 				return irs.VMGroupInfo{}, addErr
 			}
 			privateIPs = append(privateIPs, ip)
-		}
-
-		resp, err := nlbHandler.NLBBackendAddressPoolsClient.Get(nlbHandler.Ctx, nlbHandler.Region.Region, nlbIID.NameId, backendPoolName, nil)
-		if err != nil {
-			addErr := errors.New(fmt.Sprintf("Failed to AddVMs NLB. err = %s", err.Error()))
-			cblogger.Error(addErr.Error())
-			LoggingError(hiscallInfo, addErr)
-			return irs.VMGroupInfo{}, addErr
 		}
 
 		for _, ip := range privateIPs {
@@ -1349,24 +1356,12 @@ func (nlbHandler *AzureNLBHandler) getVMIIDsByLoadBalancerBackendAddresses(vpcID
 		return vmIIds, nil
 	}
 
-	var nlbVPC *armnetwork.VirtualNetwork
-	pager := nlbHandler.VPCClient.NewListPager(nlbHandler.Region.Region, nil)
-	for pager.More() {
-		page, err := pager.NextPage(nlbHandler.Ctx)
-		if err != nil {
-			return nil, errors.New(fmt.Sprintf("failed to list VPC list: %s", err.Error()))
+	// Collect the private IPs registered in the backend pool.
+	ipSet := make(map[string]struct{})
+	for _, addr := range address {
+		if addr.Properties != nil && addr.Properties.IPAddress != nil {
+			ipSet[*addr.Properties.IPAddress] = struct{}{}
 		}
-
-		for _, vpc := range page.Value {
-			if *vpc.ID == vpcID {
-				nlbVPC = vpc
-				break
-			}
-		}
-	}
-
-	if nlbVPC == nil {
-		return nil, errors.New("failed to get NLB VPC")
 	}
 
 	vmHandler := AzureVMHandler{
@@ -1383,40 +1378,17 @@ func (nlbHandler *AzureNLBHandler) getVMIIDsByLoadBalancerBackendAddresses(vpcID
 
 	vmList, err := vmHandler.ListVM()
 	if err != nil {
-		err = errors.New(fmt.Sprintf("Failed to get VMs. err = %s", err))
-		cblogger.Error(err)
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Failed to get VMs. err = %s", err))
 	}
 
-	var ips []*string
-	for _, addr := range address {
-		if addr.Properties.IPAddress != nil {
-			ips = append(ips, addr.Properties.IPAddress)
-		}
-	}
-
-	vNICNames := getVNICNames(nlbVPC)
+	// Match each VM by private IP — no NIC/subnet expansion needed.
 	for _, vm := range vmList {
-		vmFound := false
-
-		for _, vNICName := range vNICNames {
-			if strings.ToLower(*vNICName) == strings.ToLower((func() string { if len(vm.NICs) > 0 { return vm.NICs[0].IId.SystemId }; return "" })()) {
-				for _, ip := range ips {
-					if vm.PrivateIP == *ip {
-						vmIIds = append(vmIIds, vm.IId)
-						vmFound = true
-						break
-					}
-				}
-			}
-
-			if vmFound {
-				continue
-			}
+		if _, ok := ipSet[vm.PrivateIP]; ok {
+			vmIIds = append(vmIIds, vm.IId)
 		}
 	}
 
-	return vmIIds, err
+	return vmIIds, nil
 }
 
 func (nlbHandler *AzureNLBHandler) getRawNLB(nlbIId irs.IID) (*armnetwork.LoadBalancer, error) {
@@ -1502,12 +1474,20 @@ func (nlbHandler *AzureNLBHandler) getLoadBalancingRuleInfoByNLB(nlb *armnetwork
 	backendPools := nlb.Properties.BackendAddressPools
 	cbOnlyOneBackendPool := backendPools[0]
 
-	// VMs are optional - if no backend addresses, use empty list
+	// VMs are optional.
+	// NLBClient.Get does NOT inline LoadBalancerBackendAddresses; fetch the backend
+	// pool separately via NLBBackendAddressPoolsClient.Get to get the actual VM list.
 	vmIIds := make([]irs.IID, 0)
-	if len(cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses) > 0 {
-		vpcID := *cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses[0].Properties.VirtualNetwork.ID
+	backendPoolName := *cbOnlyOneBackendPool.Name
+	poolResp, poolErr := nlbHandler.NLBBackendAddressPoolsClient.Get(
+		nlbHandler.Ctx, nlbHandler.Region.Region, *nlb.Name, backendPoolName, nil)
+	if poolErr == nil &&
+		poolResp.BackendAddressPool.Properties != nil &&
+		len(poolResp.BackendAddressPool.Properties.LoadBalancerBackendAddresses) > 0 {
+		vpcID := *poolResp.BackendAddressPool.Properties.LoadBalancerBackendAddresses[0].Properties.VirtualNetwork.ID
 		var err error
-		vmIIds, err = nlbHandler.getVMIIDsByLoadBalancerBackendAddresses(vpcID, cbOnlyOneBackendPool.Properties.LoadBalancerBackendAddresses)
+		vmIIds, err = nlbHandler.getVMIIDsByLoadBalancerBackendAddresses(
+			vpcID, poolResp.BackendAddressPool.Properties.LoadBalancerBackendAddresses)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/NICHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/NICHandler.go
@@ -338,7 +338,7 @@ func (nicHandler *KTVpcNICHandler) mappingNICInfo(port *ports.Port) (irs.NICInfo
 
 		subnet, err := getSubnetWithId(nicHandler.NetworkClient, subnetID)
 		if err == nil {
-			nicInfo.SubnetIID.NameId = subnet.NetworkName // KT subnet name = tier name
+			nicInfo.SubnetIID.NameId = subnet.NetworkName // KT subnet name = tier name (for NIC display)
 			nicInfo.VpcIID = irs.IID{SystemId: subnet.NetworkID}
 			if net, netErr := networks.Get(nicHandler.NetworkClient, subnet.NetworkID).ExtractVPC(); netErr == nil {
 				nicInfo.VpcIID.NameId = net.Name
@@ -385,7 +385,6 @@ func (nicHandler *KTVpcNICHandler) mappingNICInfo(port *ports.Port) (irs.NICInfo
 	nicInfo.CreatedTime = time.Now()
 	return nicInfo, nil
 }
-
 
 // AddPrivateIP adds a secondary private IP to a KT Cloud VPC NIC (port) using ports.Update.
 func (h *KTVpcNICHandler) AddPrivateIP(nicIID irs.IID, privateIP string) (irs.NICInfo, error) {

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -1288,11 +1288,10 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 						nicInfo.SubnetIID = irs.IID{SystemId: subnetID}
 						sub, subErr := ktsubnets.Get(vmHandler.NetworkClient, subnetID).ExtractSubnet()
 						if subErr == nil && sub != nil {
-							nicInfo.SubnetIID.NameId = sub.NetworkName // KT Cloud uses NetworkName (tier name)
+							nicInfo.SubnetIID.NameId = sub.NetworkName // zone subnet name for NIC display
 						}
-						if idx == 0 {
-							vmInfo.SubnetIID = nicInfo.SubnetIID
-						}
+						// Note: vmInfo.SubnetIID is set from vm.Addresses key below (not from NIC loop),
+						// which gives the tier name directly (old approach, more reliable for KT Cloud).
 					}
 					// Build FloatingIP map (fixedIP → publicIP)
 					fipMap := map[string]string{}
@@ -1329,7 +1328,7 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 			}
 		}
 	}
-	
+
 	var netInfo *NetworkInfo
 	if !strings.EqualFold(vmInfo.PrivateIP, "") {
 		var getNetErr error
@@ -1362,6 +1361,9 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 	// 	cblogger.Infof("# OsNetwork ID : %s", OsNetId)
 	// }
 
+	// Find the correct KT tier by name.
+	// vm.Addresses map key = tier name (e.g. "spider-watch") — this is set above and matches
+	// the RefName stored in Spider metadb via mappingSubnetInfo, so getTierRefIdWithTierName works correctly.
 	tierRefId, getNetErr := vpcHandler.getTierRefIdWithTierName(vmInfo.SubnetIID.NameId)
 	if getNetErr != nil {
 		newErr := fmt.Errorf("Failed to Get the OsNetwork ID with the Tier Name : [%v]", getNetErr)
@@ -1372,9 +1374,9 @@ func (vmHandler *KTVpcVMHandler) mappingVMInfo(vm servers.Server) (irs.VMInfo, e
 		vmInfo.SubnetIID.SystemId = *tierRefId // Caution!!) Not Tier 'NetworkId' but 'tierRefId' to Create VM through REST API!!
 	}
 
-	vpcId, err := vpcHandler.getVPCIdWithTierRefId(*tierRefId)
+	vpcId, err := vpcHandler.getVPCIdWithTierRefId(vmInfo.SubnetIID.SystemId)
 	if err != nil {
-		newErr := fmt.Errorf("Failed to Get the VPC ID with teh OsNetwork ID. [%v]", err)
+		newErr := fmt.Errorf("Failed to Get the VPC ID with the OsNetwork ID. [%v]", err)
 		cblogger.Error(newErr.Error())
 		return irs.VMInfo{}, newErr
 	}

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
@@ -16,8 +16,10 @@ package resources
 import (
 	// "errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	ktvpcsdk "github.com/cloud-barista/ktcloudvpc-sdk-go"
@@ -32,7 +34,7 @@ import (
 )
 
 const (
-	DefaultVpcCIDR	string = "172.25.0.0/12" // CIDR of KT Cloud D Platform default VPC
+	DefaultVpcCIDR string = "172.25.0.0/12" // CIDR of KT Cloud D Platform default VPC
 )
 
 type KTVpcVPCHandler struct {
@@ -116,12 +118,12 @@ func (vpcHandler *KTVpcVPCHandler) GetVPC(vpcIID irs.IID) (irs.VPCInfo, error) {
 		return irs.VPCInfo{}, newErr
 	}
 
-    vpc, err := networks.Get(vpcHandler.NetworkClient, vpcIID.SystemId).ExtractVPC()
-    if err != nil {
+	vpc, err := networks.Get(vpcHandler.NetworkClient, vpcIID.SystemId).ExtractVPC()
+	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the VPC info.")
 		cblogger.Error(newErr.Error())
-        return irs.VPCInfo{}, newErr
-    }
+		return irs.VPCInfo{}, newErr
+	}
 
 	vpcInfo, mapErr := vpcHandler.mappingVpcInfo(vpc)
 	if mapErr != nil {
@@ -138,21 +140,21 @@ func (vpcHandler *KTVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, "ListVPC()", "ListVPC()")
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
-    listOpts := networks.ListOpts{
-        Page: 1,
-        Size: 2000, // Max page size, to list all data in a single page
+	listOpts := networks.ListOpts{
+		Page: 1,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
-    pager := networks.List(vpcHandler.NetworkClient, listOpts)
-    loggingInfo(callLogInfo, start)
+	pager := networks.List(vpcHandler.NetworkClient, listOpts)
+	loggingInfo(callLogInfo, start)
 
 	var vpcInfoList []*irs.VPCInfo
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-        vpcs, err := networks.ExtractVPCs(page)
-        if err != nil {
+		vpcs, err := networks.ExtractVPCs(page)
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Extract VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
-		    return false, newErr
+			return false, newErr
 		}
 
 		if len(vpcs) < 1 {
@@ -160,8 +162,8 @@ func (vpcHandler *KTVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 			cblogger.Infof("No VPC found : %v", newErr)
 			return false, newErr
 		}
-    
-        for _, vpc := range vpcs {
+
+		for _, vpc := range vpcs {
 			vpcInfo, err := vpcHandler.mappingVpcInfo(&vpc)
 			if err != nil {
 				newErr := fmt.Errorf("Failed to Map the VPC Info : [%v]", err)
@@ -171,17 +173,17 @@ func (vpcHandler *KTVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 			}
 			vpcInfoList = append(vpcInfoList, vpcInfo)
 		}
- 		return true, nil
+		return true, nil
 	})
-    if err != nil {
-        if err != nil {
+	if err != nil {
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Get VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
-		    return nil, newErr
+			return nil, newErr
 		}
-    }    
- 	return vpcInfoList, nil
+	}
+	return vpcInfoList, nil
 }
 
 // Note) KT Cloud (D platform) supports only one VPC that has been created.
@@ -274,7 +276,7 @@ func (vpcHandler *KTVpcVPCHandler) RemoveSubnet(vpcIID irs.IID, subnetIID irs.II
 		return false, newErr
 	}
 	cblogger.Infof("\n# Subnet Id(TierId) to Remove : %s", subnetIID.SystemId)
-	
+
 	networkId, err := vpcHandler.getNetworkIdWithTierId(subnetIID.SystemId)
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the Network ID!!")
@@ -317,11 +319,11 @@ func (vpcHandler *KTVpcVPCHandler) mappingVpcInfo(nvpc *networks.VPC) (*irs.VPCI
 	// Mapping VPC info.
 	vpcInfo := irs.VPCInfo{
 		IId: irs.IID{
-			NameId:   	nvpc.Name,
-			SystemId: 	nvpc.VpcID,
+			NameId:   nvpc.Name,
+			SystemId: nvpc.VpcID,
 		},
-		IPv4_CIDR: 		DefaultVpcCIDR, // CIDR of KT Cloud D Platform default VPC
-		KeyValueList:   irs.StructToKeyValueList(nvpc),
+		IPv4_CIDR:    DefaultVpcCIDR, // CIDR of KT Cloud D Platform default VPC
+		KeyValueList: irs.StructToKeyValueList(nvpc),
 	}
 
 	// Get Subnet list
@@ -337,8 +339,8 @@ func (vpcHandler *KTVpcVPCHandler) mappingVpcInfo(nvpc *networks.VPC) (*irs.VPCI
 	for _, subnet := range subnets {
 		// if !strings.EqualFold(subnet.RefName, "Private") && !strings.EqualFold(subnet.RefName, "DMZ") && !strings.EqualFold(subnet.RefName, "external") {
 		// $$$ When apply filtering
-			subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
-			subnetInfoList = append(subnetInfoList, *subnetInfo)
+		subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
+		subnetInfoList = append(subnetInfoList, *subnetInfo)
 		// }
 	}
 	vpcInfo.SubnetInfoList = subnetInfoList
@@ -350,12 +352,12 @@ func (vpcHandler *KTVpcVPCHandler) mappingSubnetInfo(subnet subnets.Subnet) *irs
 
 	subnetInfo := irs.SubnetInfo{
 		IId: irs.IID{
-			NameId:   	subnet.RefName,
-			SystemId: 	subnet.RefID, // Caution!! Not 'subnet.NetworkID(Tier UUID)' but 'Tier ID based on OpenStack Neutron' to Create VM!!
+			NameId:   subnet.RefName,
+			SystemId: subnet.RefID, // Caution!! Not 'subnet.NetworkID(Tier UUID)' but 'Tier ID based on OpenStack Neutron' to Create VM!!
 		},
-		Zone:      		subnet.ZoneID,
-		IPv4_CIDR: 		subnet.CIDR,
-		KeyValueList:   irs.StructToKeyValueList(subnet),
+		Zone:         subnet.ZoneID,
+		IPv4_CIDR:    subnet.CIDR,
+		KeyValueList: irs.StructToKeyValueList(subnet),
 	}
 
 	keyValue := irs.KeyValue{}
@@ -389,22 +391,22 @@ func (vpcHandler *KTVpcVPCHandler) createSubnet(subnetReqInfo *irs.SubnetInfo) (
 	gatewayIP := cidrBlock[0] + "." + cidrBlock[1] + "." + cidrBlock[2] + "." + "1"
 
 	detailTierInfo := subnets.SubnetDetail{
-		CIDR:      	subnetReqInfo.IPv4_CIDR,
-		StartIP:   	vmStartIP, // For VM
-		EndIP:     	vmEndIP,
-		LBStartIP: 	lbStartIP, // For NLB
-		LBEndIP:   	lbEndIP,
-		BMStartIP: 	bmStartIP, // For BareMetal Machine
-		BMEndIP:   	bmEndIP,
-		GatewayIP:  gatewayIP,
+		CIDR:      subnetReqInfo.IPv4_CIDR,
+		StartIP:   vmStartIP, // For VM
+		EndIP:     vmEndIP,
+		LBStartIP: lbStartIP, // For NLB
+		LBEndIP:   lbEndIP,
+		BMStartIP: bmStartIP, // For BareMetal Machine
+		BMEndIP:   bmEndIP,
+		GatewayIP: gatewayIP,
 	}
 
 	// Create Subnet (No Zone info)
 	createOpts := subnets.CreateOpts{
-		Name:       subnetReqInfo.IId.NameId,   // Required
-		Type:       "tier",                     // Required
-		IsCustom: 	true,                       // Required		
-		Detail:     detailTierInfo,
+		Name:     subnetReqInfo.IId.NameId, // Required
+		Type:     "tier",                   // Required
+		IsCustom: true,                     // Required
+		Detail:   detailTierInfo,
 	}
 	// cblogger.Info("\n### Subnet createOpts : ")
 	// spew.Dump(createOpts)
@@ -451,12 +453,12 @@ func (vpcHandler *KTVpcVPCHandler) getKTVpc(vpcId string) (*networks.VPC, error)
 	}
 
 	start := call.Start()
-    vpc, err := networks.Get(vpcHandler.NetworkClient, vpcId).ExtractVPC()
-    if err != nil {
+	vpc, err := networks.Get(vpcHandler.NetworkClient, vpcId).ExtractVPC()
+	if err != nil {
 		newErr := fmt.Errorf("Failed to Get the VPC info.")
 		cblogger.Error(newErr.Error())
-        return nil, newErr
-    }
+		return nil, newErr
+	}
 	loggingInfo(callLogInfo, start)
 
 	return vpc, nil
@@ -490,21 +492,21 @@ func (vpcHandler *KTVpcVPCHandler) listKTVPC() ([]*networks.VPC, error) {
 	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, "listKTVPC()", "listKTVPC()")
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
-    listOpts := networks.ListOpts{
-        Page: 1,
-        Size: 2000, // Max page size, to list all data in a single page
+	listOpts := networks.ListOpts{
+		Page: 1,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
-    pager := networks.List(vpcHandler.NetworkClient, listOpts)
-    loggingInfo(callLogInfo, start)
+	pager := networks.List(vpcHandler.NetworkClient, listOpts)
+	loggingInfo(callLogInfo, start)
 
 	var vpcAdrsList []*networks.VPC
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-        vpcList, err := networks.ExtractVPCs(page)
-        if err != nil {
+		vpcList, err := networks.ExtractVPCs(page)
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Extract VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
-		    return false, newErr
+			return false, newErr
 		}
 		if len(vpcList) < 1 {
 			newErr := fmt.Errorf("Failed to Get Any VPC Info.")
@@ -515,18 +517,18 @@ func (vpcHandler *KTVpcVPCHandler) listKTVPC() ([]*networks.VPC, error) {
 			vpcAdrsList = append(vpcAdrsList, &vpc)
 		}
 
- 		return true, nil
+		return true, nil
 	})
-    if err != nil {
-        if err != nil {
+	if err != nil {
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Get VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
-		    return nil, newErr
+			return nil, newErr
 		}
-    }
+	}
 
- 	return vpcAdrsList, nil
+	return vpcAdrsList, nil
 }
 
 func (vpcHandler *KTVpcVPCHandler) listKTSubnet() ([]*subnets.Subnet, error) {
@@ -534,22 +536,22 @@ func (vpcHandler *KTVpcVPCHandler) listKTSubnet() ([]*subnets.Subnet, error) {
 	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, "listKTSubnet()", "listKTSubnet()")
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
-    listOpts := subnets.ListOpts{
-        Page: 			1,
-        Size: 			2000, 	// Max page size, to list all data in a single page
-		NetworkType: 	"ALL", 	// [Optional] [default: trust] TRUST / UNTRUST / ALL
+	listOpts := subnets.ListOpts{
+		Page:        1,
+		Size:        2000,  // Max page size, to list all data in a single page
+		NetworkType: "ALL", // [Optional] [default: trust] TRUST / UNTRUST / ALL
 	}
 	start := call.Start()
-    pager := subnets.List(vpcHandler.NetworkClient, listOpts)
-    loggingInfo(callLogInfo, start)
-	
+	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
+	loggingInfo(callLogInfo, start)
+
 	var subnetAdrsList []*subnets.Subnet
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-        subnetlist, err := subnets.ExtractSubnets(page)
-        if err != nil {
+		subnetlist, err := subnets.ExtractSubnets(page)
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Extract Subnet list : [%v]", err)
 			cblogger.Error(newErr.Error())
-		    return false, newErr
+			return false, newErr
 		}
 		if len(subnetlist) < 1 {
 			newErr := fmt.Errorf("Failed to Find Any Subnet!!")
@@ -559,25 +561,25 @@ func (vpcHandler *KTVpcVPCHandler) listKTSubnet() ([]*subnets.Subnet, error) {
 		for _, subnet := range subnetlist {
 			subnetAdrsList = append(subnetAdrsList, &subnet)
 		}
-    
- 		return true, nil
+
+		return true, nil
 	})
-    if err != nil {
-        if err != nil {
+	if err != nil {
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Get Subnet list : [%v]", err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
-		    return nil, newErr
+			return nil, newErr
 		}
-    } 
- 	return subnetAdrsList, nil
+	}
+	return subnetAdrsList, nil
 }
 
 // getNetworkID() Gets Network ID of targetName from Subnet(Tier) List
 func (vpcHandler *KTVpcVPCHandler) getNetworkID(targetName string) (*string, error) {
 	cblogger.Info("KT Cloud driver: called getNetworkID()!!")
 	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, "getNetworkID()", "getNetworkID()")
-	
+
 	if strings.EqualFold(targetName, "") {
 		newErr := fmt.Errorf("Invalid targetName!!")
 		cblogger.Error(newErr.Error())
@@ -630,14 +632,14 @@ func (vpcHandler *KTVpcVPCHandler) getTierIdWithNetworkId(networkId string) (*st
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 		1,
-		Size: 		2000, 		// Max page size, to list all data in a single page
-		NetworkID: 	networkId, 	// Tier NetworkId
+		Page:      1,
+		Size:      2000,      // Max page size, to list all data in a single page
+		NetworkID: networkId, // Tier NetworkId
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
 	loggingInfo(callLogInfo, start)
-	
+
 	var subnetAdrsList []*subnets.Subnet
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		subnetlist, err := subnets.ExtractSubnets(page)
@@ -654,7 +656,7 @@ func (vpcHandler *KTVpcVPCHandler) getTierIdWithNetworkId(networkId string) (*st
 		for _, subnet := range subnetlist {
 			subnetAdrsList = append(subnetAdrsList, &subnet)
 		}
-	
+
 		return true, nil
 	})
 	if err != nil {
@@ -664,7 +666,7 @@ func (vpcHandler *KTVpcVPCHandler) getTierIdWithNetworkId(networkId string) (*st
 			loggingError(callLogInfo, newErr)
 			return nil, newErr
 		}
-	} 
+	}
 
 	// Caution!!
 	if len(subnetAdrsList) == 0 || strings.EqualFold(subnetAdrsList[0].RefID, "") {
@@ -690,14 +692,14 @@ func (vpcHandler *KTVpcVPCHandler) getNetworkIdWithTierId(tierId string) (*strin
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 	1,
-		Size: 	2000, 	// Max page size, to list all data in a single page
-		RefID: 	tierId, // Tier Ref Id
+		Page:  1,
+		Size:  2000,   // Max page size, to list all data in a single page
+		RefID: tierId, // Tier Ref Id
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
 	loggingInfo(callLogInfo, start)
-	
+
 	var subnetAdrsList []*subnets.Subnet
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		subnetlist, err := subnets.ExtractSubnets(page)
@@ -714,7 +716,7 @@ func (vpcHandler *KTVpcVPCHandler) getNetworkIdWithTierId(tierId string) (*strin
 		for _, subnet := range subnetlist {
 			subnetAdrsList = append(subnetAdrsList, &subnet)
 		}
-	
+
 		return true, nil
 	})
 	if err != nil {
@@ -735,7 +737,6 @@ func (vpcHandler *KTVpcVPCHandler) getNetworkIdWithTierId(tierId string) (*strin
 	}
 	return &subnetAdrsList[0].NetworkID, nil
 }
-
 
 func (vpcHandler *KTVpcVPCHandler) getTierNetIdWithTierName(tierName string) (*string, error) {
 	cblogger.Info("KT Cloud VPC Driver: called getTierNetIdWithTierName()!")
@@ -809,6 +810,39 @@ func (vpcHandler *KTVpcVPCHandler) getTierRefIdWithTierName(tierName string) (*s
 	return &tierRefId, nil
 }
 
+// getTierInfoWithPrivateIP finds the KT tier (subnet) whose CIDR contains the given private IP.
+// In KT Cloud, nova interfaces report the zone subnet UUID (not the tier UUID).
+// This function provides a more reliable way to find the correct Spider-managed tier.
+// Returns (refName, refId, error).
+func (vpcHandler *KTVpcVPCHandler) getTierInfoWithPrivateIP(privateIP string) (string, string, error) {
+	if strings.EqualFold(privateIP, "") {
+		return "", "", fmt.Errorf("Invalid private IP")
+	}
+	ip := net.ParseIP(privateIP)
+	if ip == nil {
+		return "", "", fmt.Errorf("Failed to parse private IP: %s", privateIP)
+	}
+	subnets, err := vpcHandler.listKTSubnet()
+	if err != nil {
+		return "", "", fmt.Errorf("Failed to list KT subnets: %v", err)
+	}
+	for _, subnet := range subnets {
+		if subnet.CIDR == "" || subnet.RefName == "" || subnet.RefID == "" {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(subnet.CIDR)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(ip) {
+			cblogger.Infof("Found KT tier for private IP %s: RefName=%s, RefID=%s",
+				privateIP, subnet.RefName, subnet.RefID)
+			return subnet.RefName, subnet.RefID, nil
+		}
+	}
+	return "", "", fmt.Errorf("No KT tier found for private IP: %s", privateIP)
+}
+
 // Get VPC ID with Tier 'NetworkID'
 func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (*string, error) {
 	cblogger.Info("KT Cloud VPC Driver: called getVPCIdWithTierNetId()!")
@@ -824,14 +858,14 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 		1,
-		Size: 		2000, 			// Max page size, to list all data in a single page
-		NetworkID: 	tierNetworkId, 	// Tier NetworkID (Not RefID parameter)
+		Page:      1,
+		Size:      2000,          // Max page size, to list all data in a single page
+		NetworkID: tierNetworkId, // Tier NetworkID (Not RefID parameter)
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
 	loggingInfo(callLogInfo, start)
-	
+
 	var subnetAdrsList []*subnets.Subnet
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		subnetlist, err := subnets.ExtractSubnets(page)
@@ -848,7 +882,7 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (
 		for _, subnet := range subnetlist {
 			subnetAdrsList = append(subnetAdrsList, &subnet)
 		}
-	
+
 		return true, nil
 	})
 	if err != nil {
@@ -861,7 +895,7 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierNetId(tierNetworkId string) (
 	}
 	if !strings.EqualFold(subnetAdrsList[0].VpcID, "") {
 		cblogger.Infof("# VPC ID : [%s]", subnetAdrsList[0].VpcID)
-	}	
+	}
 
 	// Caution!!
 	if len(subnetAdrsList) == 0 || strings.EqualFold(subnetAdrsList[0].VpcID, "") {
@@ -888,14 +922,14 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierRefId(tierRefId string) (*str
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
 	listOpts := subnets.ListOpts{
-		Page: 	1,
-		Size: 	2000, 		// Max page size, to list all data in a single page
-		RefID: 	tierRefId, 	// Tier RefID (Not NetworkID parameter)
+		Page:  1,
+		Size:  2000,      // Max page size, to list all data in a single page
+		RefID: tierRefId, // Tier RefID (Not NetworkID parameter)
 	}
 	start := call.Start()
 	pager := subnets.List(vpcHandler.NetworkClient, listOpts)
 	loggingInfo(callLogInfo, start)
-	
+
 	var subnetAdrsList []*subnets.Subnet
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
 		subnetlist, err := subnets.ExtractSubnets(page)
@@ -912,7 +946,7 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierRefId(tierRefId string) (*str
 		for _, subnet := range subnetlist {
 			subnetAdrsList = append(subnetAdrsList, &subnet)
 		}
-	
+
 		return true, nil
 	})
 	if err != nil {
@@ -925,7 +959,7 @@ func (vpcHandler *KTVpcVPCHandler) getVPCIdWithTierRefId(tierRefId string) (*str
 	}
 	if !strings.EqualFold(subnetAdrsList[0].VpcID, "") {
 		cblogger.Infof("# VPC ID : [%s]", subnetAdrsList[0].VpcID)
-	}	
+	}
 
 	// Caution!!
 	if len(subnetAdrsList) == 0 || strings.EqualFold(subnetAdrsList[0].VpcID, "") {
@@ -942,21 +976,21 @@ func (vpcHandler *KTVpcVPCHandler) ListIID() ([]*irs.IID, error) {
 	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, "ListIID()", "ListIID()")
 
 	// ### If enter a different number to ListOpts, the value will not be retrieved correctly.
-    listOpts := networks.ListOpts{
-        Page: 1,
-        Size: 2000, // Max page size, to list all data in a single page
+	listOpts := networks.ListOpts{
+		Page: 1,
+		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
-    pager := networks.List(vpcHandler.NetworkClient, listOpts)
-    loggingInfo(callLogInfo, start)
+	pager := networks.List(vpcHandler.NetworkClient, listOpts)
+	loggingInfo(callLogInfo, start)
 
-    var iidList []*irs.IID
+	var iidList []*irs.IID
 	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-        vpcs, err := networks.ExtractVPCs(page)
-        if err != nil {
+		vpcs, err := networks.ExtractVPCs(page)
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Extract VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
-		    return false, newErr
+			return false, newErr
 		}
 
 		if len(vpcs) < 1 {
@@ -964,25 +998,25 @@ func (vpcHandler *KTVpcVPCHandler) ListIID() ([]*irs.IID, error) {
 			cblogger.Infof("No VPC found : %v", newErr)
 			return false, newErr
 		}
-    
-        for _, vpc := range vpcs {
+
+		for _, vpc := range vpcs {
 			iid := &irs.IID{
 				NameId:   vpc.Name,
 				SystemId: vpc.VpcID,
 			}
 			iidList = append(iidList, iid)
 		}
- 	return true, nil
+		return true, nil
 	})
-    if err != nil {
-        if err != nil {
+	if err != nil {
+		if err != nil {
 			newErr := fmt.Errorf("Failed to Get VPC list : [%v]", err)
 			cblogger.Error(newErr.Error())
 			loggingError(callLogInfo, newErr)
-		    return nil, newErr
+			return nil, newErr
 		}
-    }    
-    return iidList, nil
+	}
+	return iidList, nil
 }
 
 // getSubnetStatus retrieves the status of a specific subnet by its 'NetworkId'.
@@ -994,20 +1028,20 @@ func (vpcHandler *KTVpcVPCHandler) getSubnetStatus(networkId string) (string, er
 		return "", newErr
 	}
 
-    result := subnets.Get(vpcHandler.NetworkClient, networkId)
-    if result.Err != nil {
-        cblogger.Errorf("Failed to Get the subnet info with NetworkId [%s]: %v", networkId, result.Err)
-        return "", result.Err
-    }    
-    subnet, err := result.ExtractSubnet()
-    if err != nil {
-        cblogger.Errorf("Failed to Extract subnet info: %v", err)
-        return "", err
-    }    
-    if subnet == nil {
-        return "UNKNOWN", fmt.Errorf("Subnet with ID [%s] not found", networkId)
-    }
-    return subnet.Status, nil
+	result := subnets.Get(vpcHandler.NetworkClient, networkId)
+	if result.Err != nil {
+		cblogger.Errorf("Failed to Get the subnet info with NetworkId [%s]: %v", networkId, result.Err)
+		return "", result.Err
+	}
+	subnet, err := result.ExtractSubnet()
+	if err != nil {
+		cblogger.Errorf("Failed to Extract subnet info: %v", err)
+		return "", err
+	}
+	if subnet == nil {
+		return "UNKNOWN", fmt.Errorf("Subnet with ID [%s] not found", networkId)
+	}
+	return subnet.Status, nil
 }
 
 // waitForSubnetStatus waits for a subnet to reach a specific status.
@@ -1016,58 +1050,58 @@ func (vpcHandler *KTVpcVPCHandler) getSubnetStatus(networkId string) (string, er
 func (vpcHandler *KTVpcVPCHandler) waitForSubnetStatus(networkId string, desiredStatus string, maxAttempts int, delaySeconds int) error {
 	cblogger.Info("KT Cloud VPC driver: called waitForSubnetStatus()!!")
 
-    cblogger.Infof("\n# Waiting for subnet [%s] to reach status [%s]", networkId, desiredStatus)    
-    for attempt := 1; attempt <= maxAttempts; attempt++ {
-        status, err := vpcHandler.getSubnetStatus(networkId)
-        if err != nil {
-            cblogger.Errorf("Error checking subnet status (attempt %d/%d): %v", attempt, maxAttempts, err)
-            // Keep trying even if there are errors
-            time.Sleep(time.Duration(delaySeconds) * time.Second)
-            continue
-        }        
-        cblogger.Infof("\n# Subnet [%s] status: %s (attempt %d/%d)", networkId, status, attempt, maxAttempts)
-        
-        if status == desiredStatus {
-            cblogger.Infof("\n# Subnet [%s] reached desired status [%s]", networkId, desiredStatus)
-            return nil
-        }        
-        if status == "ERROR" || status == "FAILED" {
-            return fmt.Errorf("subnet reached error state: %s", status)
-        }
-        
-        time.Sleep(time.Duration(delaySeconds) * time.Second)
-    }
-    
-    return fmt.Errorf("maximum number of attempts (%d) exceeded waiting for subnet [%s] to reach status [%s]", maxAttempts, networkId, desiredStatus)
+	cblogger.Infof("\n# Waiting for subnet [%s] to reach status [%s]", networkId, desiredStatus)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		status, err := vpcHandler.getSubnetStatus(networkId)
+		if err != nil {
+			cblogger.Errorf("Error checking subnet status (attempt %d/%d): %v", attempt, maxAttempts, err)
+			// Keep trying even if there are errors
+			time.Sleep(time.Duration(delaySeconds) * time.Second)
+			continue
+		}
+		cblogger.Infof("\n# Subnet [%s] status: %s (attempt %d/%d)", networkId, status, attempt, maxAttempts)
+
+		if status == desiredStatus {
+			cblogger.Infof("\n# Subnet [%s] reached desired status [%s]", networkId, desiredStatus)
+			return nil
+		}
+		if status == "ERROR" || status == "FAILED" {
+			return fmt.Errorf("subnet reached error state: %s", status)
+		}
+
+		time.Sleep(time.Duration(delaySeconds) * time.Second)
+	}
+
+	return fmt.Errorf("maximum number of attempts (%d) exceeded waiting for subnet [%s] to reach status [%s]", maxAttempts, networkId, desiredStatus)
 }
 
 // isSubnetActive checks if a subnet is in ACTIVE status.
 func (vpcHandler *KTVpcVPCHandler) isSubnetActive(networkId string) (bool, error) {
-    status, err := vpcHandler.getSubnetStatus(networkId)
-    if err != nil {
-        return false, err
-    }
-    return status == "ACTIVE", nil
+	status, err := vpcHandler.getSubnetStatus(networkId)
+	if err != nil {
+		return false, err
+	}
+	return status == "ACTIVE", nil
 }
 
 // waitForSubnetActive waits for a subnet to reach ACTIVE status. (20 attempts, 3-second intervals)
 func (vpcHandler *KTVpcVPCHandler) waitForSubnetActive(networkId string) error {
 	cblogger.Info("KT Cloud VPC driver: called waitForSubnetActive()!!")
 
-    return vpcHandler.waitForSubnetStatus(networkId, "ACTIVE", 20, 3)
+	return vpcHandler.waitForSubnetStatus(networkId, "ACTIVE", 20, 3)
 }
 
 // isSubnetDeleted checks if a subnet has been successfully deleted.
 // It returns true if the subnet can't be found (404 error).
-func (vpcHandler *KTVpcVPCHandler) isSubnetDeleted(networkId string) (bool, error) {	
-    result := subnets.Get(vpcHandler.NetworkClient, networkId)
-    if result.Err != nil {
-        // 404 error means that the subnet has been deleted.
-        if _, ok := result.Err.(ktvpcsdk.ErrDefault404); ok {
-            return true, nil
-        }
-        return false, result.Err
-    }
+func (vpcHandler *KTVpcVPCHandler) isSubnetDeleted(networkId string) (bool, error) {
+	result := subnets.Get(vpcHandler.NetworkClient, networkId)
+	if result.Err != nil {
+		// 404 error means that the subnet has been deleted.
+		if _, ok := result.Err.(ktvpcsdk.ErrDefault404); ok {
+			return true, nil
+		}
+		return false, result.Err
+	}
 
 	return false, nil
 }
@@ -1076,177 +1110,177 @@ func (vpcHandler *KTVpcVPCHandler) isSubnetDeleted(networkId string) (bool, erro
 func (vpcHandler *KTVpcVPCHandler) waitForSubnetDeletion(networkId string) error {
 	cblogger.Info("KT Cloud VPC driver: called waitForSubnetDeletion()!!")
 
-    maxAttempts := 3
-    delaySeconds := 3
-    
-    for attempt := 1; attempt <= maxAttempts; attempt++ {
-        isSubnetActive, err := vpcHandler.isSubnetActive(networkId)
-        if err != nil {
-            cblogger.Errorf("Error checking subnet deletion (attempt %d/%d): %v", attempt, maxAttempts, err)
-            time.Sleep(time.Duration(delaySeconds) * time.Second)
-            continue
-        }
-        if !isSubnetActive {
-            cblogger.Infof("Subnet [%s] is Not Active", networkId)
-            return nil
-        }
-        
-        cblogger.Infof("\nSubnet [%s] is still being deleted (attempt %d/%d)", networkId, attempt, maxAttempts)
-        time.Sleep(time.Duration(delaySeconds) * time.Second)
-    }
-    
-//     for attempt := 1; attempt <= maxAttempts; attempt++ {
-//         deleted, err := vpcHandler.isSubnetDeleted(networkId)
-//         if err != nil {
-//             cblogger.Errorf("Error checking subnet deletion (attempt %d/%d): %v", attempt, maxAttempts, err)
-//             time.Sleep(time.Duration(delaySeconds) * time.Second)
-//             continue
-//         }        
-//         if deleted {
-//             cblogger.Infof("Subnet [%s] has been deleted", networkId)
-//             return nil
-//         }
-		
-//         cblogger.Infof("\nSubnet [%s] is still being deleted (attempt %d/%d)", networkId, attempt, maxAttempts)
-//         time.Sleep(time.Duration(delaySeconds) * time.Second)
-//     }
+	maxAttempts := 3
+	delaySeconds := 3
 
-    return fmt.Errorf("maximum number of attempts (%d) exceeded waiting for subnet [%s] to be deleted", maxAttempts, networkId)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		isSubnetActive, err := vpcHandler.isSubnetActive(networkId)
+		if err != nil {
+			cblogger.Errorf("Error checking subnet deletion (attempt %d/%d): %v", attempt, maxAttempts, err)
+			time.Sleep(time.Duration(delaySeconds) * time.Second)
+			continue
+		}
+		if !isSubnetActive {
+			cblogger.Infof("Subnet [%s] is Not Active", networkId)
+			return nil
+		}
+
+		cblogger.Infof("\nSubnet [%s] is still being deleted (attempt %d/%d)", networkId, attempt, maxAttempts)
+		time.Sleep(time.Duration(delaySeconds) * time.Second)
+	}
+
+	//     for attempt := 1; attempt <= maxAttempts; attempt++ {
+	//         deleted, err := vpcHandler.isSubnetDeleted(networkId)
+	//         if err != nil {
+	//             cblogger.Errorf("Error checking subnet deletion (attempt %d/%d): %v", attempt, maxAttempts, err)
+	//             time.Sleep(time.Duration(delaySeconds) * time.Second)
+	//             continue
+	//         }
+	//         if deleted {
+	//             cblogger.Infof("Subnet [%s] has been deleted", networkId)
+	//             return nil
+	//         }
+
+	//         cblogger.Infof("\nSubnet [%s] is still being deleted (attempt %d/%d)", networkId, attempt, maxAttempts)
+	//         time.Sleep(time.Duration(delaySeconds) * time.Second)
+	//     }
+
+	return fmt.Errorf("maximum number of attempts (%d) exceeded waiting for subnet [%s] to be deleted", maxAttempts, networkId)
 }
 
 // getSubnet retrieves detailed information about a specific subnet by its IID
 // Supports both NameId (tier name) and SystemId (tier ID) lookup
 func (vpcHandler *KTVpcVPCHandler) getSubnet(subnetIID irs.IID) (irs.SubnetInfo, error) {
-    cblogger.Info("KT Cloud VPC Driver: called getSubnet()!")
-    callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, subnetIID.SystemId, "getSubnet()")
+	cblogger.Info("KT Cloud VPC Driver: called getSubnet()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, subnetIID.SystemId, "getSubnet()")
 
-    // Validate input
-    if strings.EqualFold(subnetIID.NameId, "") && strings.EqualFold(subnetIID.SystemId, "") {
-        newErr := fmt.Errorf("invalid subnet IID: both NameId and SystemId are empty")
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
+	// Validate input
+	if strings.EqualFold(subnetIID.NameId, "") && strings.EqualFold(subnetIID.SystemId, "") {
+		newErr := fmt.Errorf("invalid subnet IID: both NameId and SystemId are empty")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
 
-    var tierId string
-    var err error
+	var tierId string
+	var err error
 
-    // Determine tier ID from provided IID
-    if !strings.EqualFold(subnetIID.SystemId, "") {
-        tierId = subnetIID.SystemId
-        cblogger.Infof("Using provided SystemId (TierId): %s", tierId)
-    } else {
-        // Get tier ID from tier name
-        tierIdPtr, getErr := vpcHandler.getTierRefIdWithTierName(subnetIID.NameId)
-        if getErr != nil {
-            newErr := fmt.Errorf("failed to get tier ID with name [%s]: %w", subnetIID.NameId, getErr)
-            cblogger.Error(newErr.Error())
-            loggingError(callLogInfo, newErr)
-            return irs.SubnetInfo{}, newErr
-        }
-        tierId = *tierIdPtr
-        cblogger.Infof("Found TierId [%s] for tier name [%s]", tierId, subnetIID.NameId)
-    }
+	// Determine tier ID from provided IID
+	if !strings.EqualFold(subnetIID.SystemId, "") {
+		tierId = subnetIID.SystemId
+		cblogger.Infof("Using provided SystemId (TierId): %s", tierId)
+	} else {
+		// Get tier ID from tier name
+		tierIdPtr, getErr := vpcHandler.getTierRefIdWithTierName(subnetIID.NameId)
+		if getErr != nil {
+			newErr := fmt.Errorf("failed to get tier ID with name [%s]: %w", subnetIID.NameId, getErr)
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return irs.SubnetInfo{}, newErr
+		}
+		tierId = *tierIdPtr
+		cblogger.Infof("Found TierId [%s] for tier name [%s]", tierId, subnetIID.NameId)
+	}
 
-    // Get network ID from tier ID
-    networkIdPtr, err := vpcHandler.getNetworkIdWithTierId(tierId)
-    if err != nil {
-        newErr := fmt.Errorf("failed to get network ID for tier [%s]: %w", tierId, err)
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
-    cblogger.Infof("Found NetworkId [%s] for TierId [%s]", *networkIdPtr, tierId)
+	// Get network ID from tier ID
+	networkIdPtr, err := vpcHandler.getNetworkIdWithTierId(tierId)
+	if err != nil {
+		newErr := fmt.Errorf("failed to get network ID for tier [%s]: %w", tierId, err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
+	cblogger.Infof("Found NetworkId [%s] for TierId [%s]", *networkIdPtr, tierId)
 
-    // Get subnet details using network ID
-    start := call.Start()
-    subnet, err := vpcHandler.getKTSubnet(*networkIdPtr)
-    if err != nil {
-        newErr := fmt.Errorf("failed to get subnet info for network ID [%s]: %w", *networkIdPtr, err)
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
-    loggingInfo(callLogInfo, start)
+	// Get subnet details using network ID
+	start := call.Start()
+	subnet, err := vpcHandler.getKTSubnet(*networkIdPtr)
+	if err != nil {
+		newErr := fmt.Errorf("failed to get subnet info for network ID [%s]: %w", *networkIdPtr, err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
+	loggingInfo(callLogInfo, start)
 
-    // Check if subnet was found
-    if subnet == nil {
-        newErr := fmt.Errorf("subnet not found with network ID [%s]", *networkIdPtr)
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
+	// Check if subnet was found
+	if subnet == nil {
+		newErr := fmt.Errorf("subnet not found with network ID [%s]", *networkIdPtr)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
 
-    // Validate subnet data
-    if strings.EqualFold(subnet.RefID, "") {
-        newErr := fmt.Errorf("invalid subnet data: RefID is empty")
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
+	// Validate subnet data
+	if strings.EqualFold(subnet.RefID, "") {
+		newErr := fmt.Errorf("invalid subnet data: RefID is empty")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
 
-    // Map to CB-Spider subnet info format
-    subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
-    if subnetInfo == nil {
-        newErr := fmt.Errorf("failed to map subnet info")
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return irs.SubnetInfo{}, newErr
-    }
+	// Map to CB-Spider subnet info format
+	subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
+	if subnetInfo == nil {
+		newErr := fmt.Errorf("failed to map subnet info")
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return irs.SubnetInfo{}, newErr
+	}
 
-    cblogger.Infof("Successfully retrieved subnet info: %s (%s)", subnetInfo.IId.NameId, subnetInfo.IId.SystemId)
-    return *subnetInfo, nil
+	cblogger.Infof("Successfully retrieved subnet info: %s (%s)", subnetInfo.IId.NameId, subnetInfo.IId.SystemId)
+	return *subnetInfo, nil
 }
 
 // listSubnet retrieves all subnets in the current zone
 func (vpcHandler *KTVpcVPCHandler) listSubnet(vpcIID irs.IID) ([]*irs.SubnetInfo, error) {
-    cblogger.Info("KT Cloud VPC Driver: called listSubnet()!")
-    callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, vpcIID.SystemId, "listSubnet()")
+	cblogger.Info("KT Cloud VPC Driver: called listSubnet()!")
+	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, vpcIID.SystemId, "listSubnet()")
 
-    // Validate VPC IID if provided
-    if !strings.EqualFold(vpcIID.SystemId, "") {
-        // Verify VPC exists
-        _, err := vpcHandler.getKTVpc(vpcIID.SystemId)
-        if err != nil {
-            newErr := fmt.Errorf("failed to verify VPC [%s]: %w", vpcIID.SystemId, err)
-            cblogger.Error(newErr.Error())
-            loggingError(callLogInfo, newErr)
-            return nil, newErr
-        }
-    }
+	// Validate VPC IID if provided
+	if !strings.EqualFold(vpcIID.SystemId, "") {
+		// Verify VPC exists
+		_, err := vpcHandler.getKTVpc(vpcIID.SystemId)
+		if err != nil {
+			newErr := fmt.Errorf("failed to verify VPC [%s]: %w", vpcIID.SystemId, err)
+			cblogger.Error(newErr.Error())
+			loggingError(callLogInfo, newErr)
+			return nil, newErr
+		}
+	}
 
-    // Get subnet list
-    start := call.Start()
-    subnets, err := vpcHandler.listKTSubnet() // ALL Subnet : TRUST and UNTRUST
-    if err != nil {
-        newErr := fmt.Errorf("failed to get subnet list: %w", err)
-        cblogger.Error(newErr.Error())
-        loggingError(callLogInfo, newErr)
-        return nil, newErr
-    }
-    loggingInfo(callLogInfo, start)
+	// Get subnet list
+	start := call.Start()
+	subnets, err := vpcHandler.listKTSubnet() // ALL Subnet : TRUST and UNTRUST
+	if err != nil {
+		newErr := fmt.Errorf("failed to get subnet list: %w", err)
+		cblogger.Error(newErr.Error())
+		loggingError(callLogInfo, newErr)
+		return nil, newErr
+	}
+	loggingInfo(callLogInfo, start)
 
-    if len(subnets) < 1 {
-        cblogger.Info("No subnets found")
-        return []*irs.SubnetInfo{}, nil
-    }
+	if len(subnets) < 1 {
+		cblogger.Info("No subnets found")
+		return []*irs.SubnetInfo{}, nil
+	}
 
-    // Map subnets to CB-Spider format
-    var subnetInfoList []*irs.SubnetInfo
-    for _, subnet := range subnets {
-        // Filter by VPC if specified
-        if !strings.EqualFold(vpcIID.SystemId, "") && !strings.EqualFold(subnet.VpcID, vpcIID.SystemId) {
-            continue
-        }
+	// Map subnets to CB-Spider format
+	var subnetInfoList []*irs.SubnetInfo
+	for _, subnet := range subnets {
+		// Filter by VPC if specified
+		if !strings.EqualFold(vpcIID.SystemId, "") && !strings.EqualFold(subnet.VpcID, vpcIID.SystemId) {
+			continue
+		}
 
-        subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
-        if subnetInfo != nil {
-            subnetInfoList = append(subnetInfoList, subnetInfo)
-        } else {
-            cblogger.Warnf("Failed to map subnet [%s], skipping", subnet.RefName)
-        }
-    }
+		subnetInfo := vpcHandler.mappingSubnetInfo(*subnet)
+		if subnetInfo != nil {
+			subnetInfoList = append(subnetInfoList, subnetInfo)
+		} else {
+			cblogger.Warnf("Failed to map subnet [%s], skipping", subnet.RefName)
+		}
+	}
 
-    cblogger.Infof("Successfully retrieved %d subnets", len(subnetInfoList))
-    return subnetInfoList, nil
+	cblogger.Infof("Successfully retrieved %d subnets", len(subnetInfoList))
+	return subnetInfoList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/NCPDriver.go
@@ -21,6 +21,7 @@ import (
 	ires "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
 	ncloud "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	server "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	vas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
 	vmysql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
@@ -175,6 +176,15 @@ func getPostgresqlClient(connectionInfo idrv.ConnectionInfo) (*vpostgresql.APICl
 	return client, nil
 }
 
+func getClassicServerClient(connectionInfo idrv.ConnectionInfo) (*server.APIClient, error) {
+	apiKeys := ncloud.APIKey{
+		AccessKey: connectionInfo.CredentialInfo.ClientId,
+		SecretKey: connectionInfo.CredentialInfo.ClientSecret,
+	}
+	client := server.NewAPIClient(server.NewConfiguration(&apiKeys))
+	return client, nil
+}
+
 func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (icon.CloudConnection, error) {
 	// 1. get info of credential and region for Test A Cloud from connectionInfo.
 	// 2. create a client object(or service  object) of Test A Cloud with credential info.
@@ -224,6 +234,12 @@ func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ic
 		return nil, err
 	}
 
+	classicClient, err := getClassicServerClient(connectionInfo)
+	if err != nil {
+		cblogger.Warnf("Failed to create Classic server client (non-fatal): %v", err)
+		classicClient = nil
+	}
+
 	iConn := ncpcon.NcpVpcCloudConnection{
 		CredentialInfo: connectionInfo.CredentialInfo,
 		RegionInfo:     connectionInfo.RegionInfo,
@@ -235,6 +251,7 @@ func (driver *NcpVpcDriver) ConnectCloud(connectionInfo idrv.ConnectionInfo) (ic
 		VnasClient:     vnasClient,
 		MysqlClient:    mysqlClient,
 		PostgresClient: postgresClient,
+		ClassicClient:  classicClient,
 	}
 
 	return &iConn, nil

--- a/cloud-control-manager/cloud-driver/drivers/ncp/connect/NcpVpcCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/connect/NcpVpcCloudConnection.go
@@ -21,6 +21,7 @@ import (
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 
+	server "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	vas "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vautoscaling"
 	vlb "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vloadbalancer"
 	vmysql "github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vmysql"
@@ -45,6 +46,7 @@ type NcpVpcCloudConnection struct {
 	VnasClient     *vnas.APIClient
 	MysqlClient    *vmysql.APIClient
 	PostgresClient *vpostgresql.APIClient
+	ClassicClient  *server.APIClient // fallback for Classic API operations
 }
 
 var cblogger *logrus.Logger
@@ -88,8 +90,12 @@ func (cloudConn *NcpVpcCloudConnection) CreateImageHandler() (irs.ImageHandler, 
 
 func (cloudConn *NcpVpcCloudConnection) CreateKeyPairHandler() (irs.KeyPairHandler, error) {
 	cblogger.Info("NCP VPC Cloud Driver: called CreateKeyPairHandler()!")
-	keypairHandler := ncprs.NcpVpcKeyPairHandler{CredentialInfo: cloudConn.CredentialInfo, RegionInfo: cloudConn.RegionInfo, VMClient: cloudConn.VmClient}
-
+	keypairHandler := ncprs.NcpVpcKeyPairHandler{
+		CredentialInfo: cloudConn.CredentialInfo,
+		RegionInfo:     cloudConn.RegionInfo,
+		VMClient:       cloudConn.VmClient,
+		ClassicClient:  cloudConn.ClassicClient,
+	}
 	return &keypairHandler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
@@ -382,6 +382,19 @@ func (nvch *NcpVpcClusterHandler) createCluster(clusterReqInfo *irs.ClusterInfo)
 			no, _ := strconv.ParseInt(subnet.IId.SystemId, 10, 32)
 			lbPublicSubnetNo = int32(no)
 		} else {
+			// Skip any LOADB-type subnets (e.g. created by the NLB handler) from the
+			// worker-node subnet list — NCP rejects LOADB subnets in SubnetNoList.
+			isLoadb := false
+			for _, kv := range subnet.KeyValueList {
+				if strings.EqualFold(kv.Key, "UsageType") && strings.Contains(strings.ToUpper(kv.Value), usageTypeCodeLoadb) {
+					isLoadb = true
+					break
+				}
+			}
+			if isLoadb {
+				cblogger.Infof("Skipping LOADB subnet [%s/%s] from worker node subnet list", subnet.IId.NameId, subnet.IId.SystemId)
+				continue
+			}
 			no, _ := strconv.ParseInt(subnet.IId.SystemId, 10, 32)
 			subnetNoList = append(subnetNoList, int32(no))
 		}

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/KeyPairHandler.go
@@ -15,6 +15,7 @@ import (
 	// "github.com/davecgh/go-spew/spew"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
+	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/server"
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/services/vserver"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
@@ -27,6 +28,7 @@ type NcpVpcKeyPairHandler struct {
 	CredentialInfo idrv.CredentialInfo
 	RegionInfo     idrv.RegionInfo
 	VMClient       *vserver.APIClient
+	ClassicClient  *server.APIClient // fallback for deleteLoginKey
 }
 
 func (keyPairHandler *NcpVpcKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, error) {
@@ -211,13 +213,27 @@ func (keyPairHandler *NcpVpcKeyPairHandler) DeleteKey(keyIID irs.IID) (bool, err
 	// keypairDelReq := server.DeleteLoginKeyRequest{
 	// 	KeyName: ncloud.String(keyIID.NameId),
 	// }
-
 	callLogStart := call.Start()
 	result, err := keyPairHandler.VMClient.V2Api.DeleteLoginKeys(&keypairDelReq)
 	if err != nil {
-		cblogger.Errorf("Failed to Delete the KeyPair : %s, %v", keyIID.NameId, err)
-		LoggingError(callLogInfo, err)
-		return false, err
+		cblogger.Warnf("VPC DeleteLoginKeys failed (1300/etc), trying Classic API fallback: %v", err)
+		// Fallback: NCP VPC login keys are shared with Classic; try server/v2/deleteLoginKey
+		if keyPairHandler.ClassicClient != nil {
+			classicReq := server.DeleteLoginKeyRequest{
+				KeyName: ncloud.String(keyIID.NameId),
+			}
+			_, classicErr := keyPairHandler.ClassicClient.V2Api.DeleteLoginKey(&classicReq)
+			if classicErr != nil {
+				cblogger.Errorf("Failed to Delete the KeyPair : %s, %v", keyIID.NameId, classicErr)
+				LoggingError(callLogInfo, classicErr)
+				return false, classicErr
+			}
+			cblogger.Infof("Classic API fallback succeeded for keypair: %s", keyIID.NameId)
+		} else {
+			cblogger.Errorf("Failed to Delete the KeyPair : %s, %v", keyIID.NameId, err)
+			LoggingError(callLogInfo, err)
+			return false, err
+		}
 	}
 	LoggingInfo(callLogInfo, callLogStart)
 

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -797,6 +797,12 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 			}
 		}
 
+		// Delete the S/G info from DB
+		_, unRegErr := sim.UnRegisterSecurityGroup(vmIID.SystemId)
+		if unRegErr != nil {
+			cblogger.Debug(unRegErr.Error())
+		}
+
 		return irs.VMStatus("Terminating"), nil
 
 	case "Not Exist!!":

--- a/spiderwatch/conf/spiderwatch.yaml
+++ b/spiderwatch/conf/spiderwatch.yaml
@@ -49,7 +49,7 @@ spider:
   # Directory for Spider meta_db volume mount
   meta_db_dir: "${HOME}/cb-spider/meta_db"
   # MC_INSIGHT_API_TOKEN for Spider
-  mc_insight_api_token: ""
+  mc_insight_api_token: "c72df1af9b1f0c29"
   # Server address advertised inside the Spider container
   server_address: "0.0.0.0:1024"
   # Timeout for each individual Spider API call (seconds)
@@ -140,7 +140,7 @@ csps:
       # /23 provides 507 usable IPs; Azure AKS requires 333+ IPs in the subnet
       subnet_cidr: "192.168.0.0/23"
     vm_test:
-      image_name: "Canonical:ubuntu-25_10:minimal:25.10.202512100"
+      image_name: "Canonical:ubuntu-25_04-daily:minimal:25.04.202601140"
       spec_name: "Standard_B1ls"
     disk_test:
       disk_type: "PremiumSSD"
@@ -243,9 +243,9 @@ csps:
       type: "PUBLIC"
       scope: "REGION"
       listener_protocol: "TCP"
-      listener_port: "80"
+      listener_port: "22"
       target_protocol: "TCP"
-      target_port: "80"
+      target_port: "22"
       health_protocol: "TCP"
       health_port: "22"
       health_interval: "default"
@@ -294,13 +294,13 @@ csps:
       health_timeout: "default"
       health_threshold: "default"
     cluster_test:
-      version: ""
+      version: "1.30.0"
       # Tencent TKE: NodeGroup added after cluster is Active (Type-I)
       # Tencent TKE uses Static Token (credentials embedded in kubeconfig)
       kubeconfig_type: "static"
       # Tencent TKE: NodeGroup is added after cluster is Active (Type-I)
       node_group_type: "type1"
-      node_group_image_name: ""
+      node_group_image_name: "tlinux3.1x86_64"
       node_group_vm_spec_name: "S5.MEDIUM8"
       node_group_root_disk_type: "CLOUD_PREMIUM"
       node_group_root_disk_size: "50"
@@ -405,7 +405,7 @@ csps:
       health_timeout: "default"
       health_threshold: "default"
     cluster_test:
-      version: "1.33.4-nks.1"  # Available: 1.34.3-nks.1, 1.33.4-nks.1
+      version: "1.34.3-nks.1"  # Available: 1.34.3-nks.1
       # NCP NKS: NodeGroup included in cluster create (Type-II)
       # NCP NKS uses Dynamic Token (Spider Default exec-plugin calling Spider Token API)
       kubeconfig_type: "spider_default"
@@ -470,8 +470,8 @@ csps:
     connection: kt-mokdong1-config
     enabled: true
     vpc_test:
-      vpc_cidr: "192.168.0.0/16"
-      subnet_cidr: "192.168.1.0/24"
+      vpc_cidr: "10.0.0.0/16"
+      subnet_cidr: "10.26.102.0/24"
     vm_test:
       image_name: "1a772df6-262e-43a7-896f-98fa23d715c7"
       spec_name: "4x8.itl"

--- a/spiderwatch/internal/runner/runner.go
+++ b/spiderwatch/internal/runner/runner.go
@@ -289,8 +289,24 @@ var spiderImageInfo string
 func (r *Runner) startContainer(ctx context.Context, cfg *config.Config) error {
 	log.Infof("runner: pulling image %s", cfg.Spider.Image)
 	pullArgs := []string{"pull", cfg.Spider.Image}
-	if out, err := exec.CommandContext(ctx, "docker", pullArgs...).CombinedOutput(); err != nil {
-		return fmt.Errorf("runner: docker pull: %w - %s", err, strings.TrimSpace(string(out)))
+	const maxPullAttempts = 5
+	var pullErr error
+	for attempt := 1; attempt <= maxPullAttempts; attempt++ {
+		var out []byte
+		out, pullErr = exec.CommandContext(ctx, "docker", pullArgs...).CombinedOutput()
+		if pullErr == nil {
+			break
+		}
+		log.Warnf("runner: docker pull attempt %d/%d failed: %s", attempt, maxPullAttempts, strings.TrimSpace(string(out)))
+		if attempt < maxPullAttempts {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("runner: docker pull cancelled: %w", ctx.Err())
+			case <-time.After(2 * time.Second):
+			}
+		} else {
+			return fmt.Errorf("runner: docker pull: %w - %s", pullErr, strings.TrimSpace(string(out)))
+		}
 	}
 
 	// Capture the image digest and creation timestamp for traceability.
@@ -1618,6 +1634,16 @@ func (r *Runner) testNLBCRUD(ctx context.Context, client *http.Client, cfg *conf
 	{
 		// 2. CREATE NLB
 		createOp := st.op("create", func() error {
+			vmGroup := nlbVMGroup{
+				Protocol: nlbCfg.TargetProtocol,
+				Port:     nlbCfg.TargetPort,
+			}
+			// Some CSPs (e.g. KT Cloud) require at least one VM at NLB creation time
+			// because the NLB operates at subnet level and needs a VM to determine the subnet.
+			// Include the test VM in the create body if it already exists.
+			if st.vmCreated {
+				vmGroup.VMs = []string{st.vmName}
+			}
 			body := nlbCreateBody{
 				ConnectionName: connection,
 				ReqInfo: nlbReqInfo{
@@ -1629,10 +1655,7 @@ func (r *Runner) testNLBCRUD(ctx context.Context, client *http.Client, cfg *conf
 						Protocol: nlbCfg.ListenerProtocol,
 						Port:     nlbCfg.ListenerPort,
 					},
-					VMGroup: nlbVMGroup{
-						Protocol: nlbCfg.TargetProtocol,
-						Port:     nlbCfg.TargetPort,
-					},
+					VMGroup: vmGroup,
 					HealthChecker: nlbHealthChecker{
 						Protocol:  nlbCfg.HealthProtocol,
 						Port:      nlbCfg.HealthPort,
@@ -1707,12 +1730,34 @@ func (r *Runner) testNLBCRUD(ctx context.Context, client *http.Client, cfg *conf
 			addBody.ReqInfo.VMs = []string{st.vmName}
 			b, _ := json.Marshal(addBody)
 			url := fmt.Sprintf("%s/nlb/%s/vms", apiBase, st.nlbName)
-			errBody, code, err := doReq(http.MethodPost, url, b)
-			if err != nil {
-				return err
-			}
-			if code >= 400 {
-				return fmt.Errorf("HTTP %d: %s", code, string(errBody))
+			const maxAddVMRetries = 5
+			const addVMRetryInterval = 10 * time.Second
+			for attempt := 1; attempt <= maxAddVMRetries; attempt++ {
+				errBody, code, err := doReq(http.MethodPost, url, b)
+				if err != nil {
+					// Network-level error (e.g. connection reset, timeout) — retry.
+					log.Warnf("runner: NLB add-vm attempt %d/%d network error: %v", attempt, maxAddVMRetries, err)
+					if attempt == maxAddVMRetries {
+						return err
+					}
+					select {
+					case <-ctx.Done():
+						return fmt.Errorf("context cancelled: %w", ctx.Err())
+					case <-time.After(addVMRetryInterval):
+					}
+					b, _ = json.Marshal(addBody)
+					continue
+				}
+				if code >= 400 {
+					bodyStr := strings.ToLower(string(errBody))
+					// VM was already added during NLB creation (e.g. KT Cloud requires VM at create time).
+					if strings.Contains(bodyStr, "already exist") || strings.Contains(bodyStr, "already in") {
+						log.Infof("runner: NLB add-vm: VM already in NLB (added at creation), treating as success")
+						return nil
+					}
+					return fmt.Errorf("HTTP %d: %s", code, string(errBody))
+				}
+				return nil
 			}
 			return nil
 		})
@@ -2491,7 +2536,17 @@ func (r *Runner) testClusterCRUD(ctx context.Context, client *http.Client, cfg *
 			for attempt := 1; attempt <= maxAttempts; attempt++ {
 				body, code, err := doReq(http.MethodGet, getURL, nil)
 				if err != nil {
-					return err
+					// Transient network error (e.g. IAM auth timeout) — log and continue polling.
+					log.Warnf("runner: cluster %s wait-ng-active attempt %d/%d network error (retrying): %v", st.clusterName, attempt, maxAttempts, err)
+					if attempt == maxAttempts {
+						return err
+					}
+					select {
+					case <-ctx.Done():
+						return fmt.Errorf("context cancelled waiting for cluster ng-active: %w", ctx.Err())
+					case <-time.After(pollInterval):
+					}
+					continue
 				}
 				if code >= 400 {
 					return fmt.Errorf("HTTP %d: %s", code, string(body))
@@ -2770,7 +2825,17 @@ func (r *Runner) testClusterCRUD(ctx context.Context, client *http.Client, cfg *
 			for attempt := 1; attempt <= maxAttempts; attempt++ {
 				body, code, err := doReq(http.MethodGet, getURL, nil)
 				if err != nil {
-					return err
+					// Transient network error (e.g. IAM auth timeout) — log and continue polling.
+					log.Warnf("runner: cluster %s wait-active attempt %d/%d network error (retrying): %v", st.clusterName, attempt, maxAttempts, err)
+					if attempt == maxAttempts {
+						return err
+					}
+					select {
+					case <-ctx.Done():
+						return fmt.Errorf("context cancelled waiting for cluster Active: %w", ctx.Err())
+					case <-time.After(pollInterval):
+					}
+					continue
 				}
 				if code >= 400 {
 					return fmt.Errorf("HTTP %d: %s", code, string(body))
@@ -3577,7 +3642,46 @@ func (r *Runner) testCleanup(ctx context.Context, client *http.Client, cfg *conf
 	// 404 responses are treated as success (resource already gone).
 	if st.s3Created || inResources("s3") {
 		op := st.op("s3-delete", func() error {
-			// Use ?force to delete the bucket and all its objects in one call.
+			const s3Prefix = "spider-watch-"
+
+			// List all buckets and delete every one with the spider-watch- prefix.
+			// This catches buckets created in previous runs (their seq differs from st.s3Name).
+			listURL := fmt.Sprintf("%s/s3?ConnectionName=%s", apiBase, connection)
+			listBody, listCode, listErr := doReq(http.MethodGet, listURL, nil)
+			if listErr == nil && listCode < 400 {
+				var listResp struct {
+					Buckets struct {
+						Bucket []struct {
+							Name string `json:"Name"`
+						} `json:"Bucket"`
+					} `json:"Buckets"`
+				}
+				if jerr := json.Unmarshal(listBody, &listResp); jerr == nil {
+					for _, b := range listResp.Buckets.Bucket {
+						if !strings.HasPrefix(b.Name, s3Prefix) {
+							continue
+						}
+						delURL := fmt.Sprintf("%s/s3/%s?force&ConnectionName=%s", apiBase, b.Name, connection)
+						delBody, delCode, delErr := doReq(http.MethodDelete, delURL, nil)
+						if delErr != nil {
+							log.Warnf("runner: s3-delete bucket %s error: %v", b.Name, delErr)
+							continue
+						}
+						if delCode == http.StatusNotFound || isDoesNotExistBody(delBody) {
+							log.Infof("runner: s3-delete bucket %s already gone", b.Name)
+							continue
+						}
+						if delCode >= 400 {
+							log.Warnf("runner: s3-delete bucket %s HTTP %d: %s", b.Name, delCode, string(delBody))
+						} else {
+							log.Infof("runner: s3-delete bucket %s deleted", b.Name)
+						}
+					}
+					return nil
+				}
+			}
+
+			// Fallback: delete only the current-run bucket by name.
 			url := fmt.Sprintf("%s/s3/%s?force&ConnectionName=%s", apiBase, st.s3Name, connection)
 			body, code, err := doReq(http.MethodDelete, url, nil)
 			if err != nil {
@@ -4024,7 +4128,7 @@ func (r *Runner) testCleanup(ctx context.Context, client *http.Client, cfg *conf
 		rr.Operations = append(rr.Operations, op)
 	}
 	if st.kpCreated || inResources("keypair") {
-		op := delWithRetry("kp-delete", apiBase+"/keypair/"+st.kpName, 3)
+		op := delWithRetry("kp-delete", apiBase+"/keypair/"+st.kpName, 20)
 		rr.Operations = append(rr.Operations, op)
 	}
 	if st.sgCreated || inResources("securitygroup") {


### PR DESCRIPTION
## Problem

Multiple regressions and latent bugs introduced by the multi-NIC support
changes, plus a pre-existing NCP issue with cluster creation and keypair
deletion.

## Changes

### Azure — NLB `AddVM` fix
- Fix bug caused by multi-NIC support code breaking backend pool VM attachment

### Alibaba — NLB `AddVM` fix
- Fix bug caused by multi-NIC support code breaking backend pool VM attachment

### KT — `GetVM` fix
- Fix incorrect SubnetNameId handling when returning VM info under multi-NIC support
- Fix latent potential error added during multi-NIC support work

### NCP — Cluster creation fix ([#1262](https://github.com/cloud-barista/cb-spider/issues/1262#issuecomment-4602501148))
- Skip LOADB-type subnets (created by NLB handler) during cluster creation to
  avoid conflict when an NLB already exists in the VPC

### NCP — `DeleteKeyPair` fallback fix
- Add fallback: if VPC SDK keypair deletion fails, retry deletion via Classic SDK
- Root cause: regression introduced in `fix(ncp): bump ncloud-sdk-go-v2 to v1.6.29` ([#1750](https://github.com/cloud-barista/cb-spider/pull/1750))

### NCP — VM deletion metadb cleanup fix
- Fix stale `security_group_infos` rows remaining in metadb after VM deletion

## Notes

SpiderWatch config and runner improvements (timeout/retry tuning, Nginx health
check, retired image/version updates for Azure and NCP) are included as minor
accompanying changes.