### PR TITLE
[Azure] Fix: Propagate actual error from CheckExistDisk in CreateDisk validation

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/DiskHandler.go
@@ -503,7 +503,7 @@ func (diskHandler *AzureDiskHandler) validationDiskReq(diskReq irs.DiskInfo) err
 	}
 	exist, err := CheckExistDisk(diskReq.IId, diskHandler.Region.Region, diskHandler.DiskClient, diskHandler.Ctx)
 	if err != nil {
-		return errors.New("failed Check disk Name Exist")
+		return fmt.Errorf("failed to check disk name existence, %w", err)
 	}
 	if exist {
 		return errors.New("invalid DiskReqInfo NameId, Already exist")


### PR DESCRIPTION
## Changes
- `validationDiskReq()` (Azure): replace `errors.New("failed Check disk Name Exist")`
  with `fmt.Errorf("failed to check disk name existence, %w", err)`
  to preserve and propagate the original error from `CheckExistDisk()`