### PR TITLE
Replace NCP SecurityGroup handling method

### DIFF
--- a/api-runtime/common-runtime/VMManager.go
+++ b/api-runtime/common-runtime/VMManager.go
@@ -1787,8 +1787,9 @@ func getSetNameId(ConnectionName string, vmInfo *cres.VMInfo) error {
 		vmInfo.SecurityGroupIIds[i].NameId = iidInfo.NameId
 	}
 	if len(vmInfo.SecurityGroupIIds) < 1 {
+		// Not fatal: this function also serves GetVM/ListVM, and a VM without a
+		// resolvable SecurityGroup must still be readable and registerable.
 		cblog.Infof("%s: SecurityGroupIIds is empty", vmInfo.IId.NameId)
-		return fmt.Errorf("%s: SecurityGroupIIds is empty", vmInfo.IId.NameId)
 	}
 
 	if vmInfo.KeyPairIId.SystemId != "" {

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -30,7 +30,6 @@ import (
 	cblog "github.com/cloud-barista/cb-log"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	keycommon "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/common"
-	sim "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/ncp/resources/info_manager/security_group_info_manager"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
 )
@@ -346,23 +345,6 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 		return irs.VMInfo{}, newErr
 	}
 	cblogger.Infof("deleteInitScript Result : [%s]", *scriptDelResult)
-
-	// Register SecurityGroupInfo to DB
-	var keyValueList []irs.KeyValue
-	for _, sgIID := range vmReqInfo.SecurityGroupIIDs {
-		keyValueList = append(keyValueList, irs.KeyValue{
-			Key:   sgIID.SystemId,
-			Value: sgIID.SystemId,
-		})
-	}
-
-	providerName := "NCP"
-	_, regErr := sim.RegisterSecurityGroup(newVMIID.SystemId, providerName, keyValueList)
-	if regErr != nil {
-		cblogger.Error(regErr)
-		return irs.VMInfo{}, regErr
-	}
-	// cblogger.Infof(" === Registered S/G Info to DB : [%v]", sgInfo)
 
 	curStat, statErr := vmHandler.waitForDiskAttach(newVMIID) // # Waiting while Root disk is fully attached!!"
 	if statErr != nil {
@@ -723,13 +705,6 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 			}
 		}
 
-		// Delete the S/G info from DB
-		_, unRegErr := sim.UnRegisterSecurityGroup(vmIID.SystemId)
-		if unRegErr != nil {
-			cblogger.Debug(unRegErr.Error())
-			// return irs.Failed, unRegErr
-		}
-
 		return irs.VMStatus("Terminating"), nil
 
 	case "Running":
@@ -795,12 +770,6 @@ func (vmHandler *NcpVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, erro
 				cblogger.Error(err)
 				return vmStatus, err
 			}
-		}
-
-		// Delete the S/G info from DB
-		_, unRegErr := sim.UnRegisterSecurityGroup(vmIID.SystemId)
-		if unRegErr != nil {
-			cblogger.Debug(unRegErr.Error())
 		}
 
 		return irs.VMStatus("Terminating"), nil
@@ -1094,39 +1063,23 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 		KeyValueList:   irs.StructToKeyValueList(NcpInstance),
 	}
 
-	// Get SecurityGroupInfo from DB
-	sgInfo, getSGErr := sim.GetSecurityGroup(*NcpInstance.ServerInstanceNo)
-	if getSGErr != nil {
-		cblogger.Debug(getSGErr)
-		// return irs.VMInfo{}, getSGErr
-	}
 	securityHandler := NcpVpcSecurityHandler{
 		RegionInfo: vmHandler.RegionInfo,
 		VMClient:   vmHandler.VMClient,
 	}
-	if countSgKvList(*sgInfo) > 0 {
-		var sgIIDs []irs.IID
-		for _, kv := range sgInfo.KeyValueInfoList {
-			sgInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: kv.Value})
-			if err != nil {
-				newErr := fmt.Errorf("Failed to Get the S/G info : [%v]", err)
-				cblogger.Debug(newErr.Error())
-				// return irs.VMInfo{}, newErr
-			}
-			sgIIDs = append(sgIIDs, irs.IID{NameId: sgInfo.IId.NameId, SystemId: kv.Value})
-		}
-		vmInfo.SecurityGroupIIds = sgIIDs
-	}
 
-	// Build NICs info from GetNetworkInterfaceList filtered by InstanceNo
+	// Build NICs info from GetNetworkInterfaceList filtered by InstanceNo.
+	// ACGs are attached to the NICs, so the VM's S/G list is read from the CSP here.
 	{
 		nicReq := &vserver.GetNetworkInterfaceListRequest{
 			RegionCode: ncloud.String(vmHandler.RegionInfo.Region),
+			InstanceNo: NcpInstance.ServerInstanceNo,
 		}
 		nicResp, nicErr := vmHandler.VMClient.V2Api.GetNetworkInterfaceList(nicReq)
 		if nicErr == nil && nicResp != nil {
 			var vmNICs []irs.VMNICInfo
 			var allPrivateIPs []string
+			var acgNos []string
 			devIdx := 0
 			for _, ni := range nicResp.NetworkInterfaceList {
 				if ni.InstanceNo == nil || ncloud.StringValue(ni.InstanceNo) != ncloud.StringValue(NcpInstance.ServerInstanceNo) {
@@ -1153,6 +1106,11 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 				}
 				nicInfo.PrivateIPs = privateIPs
 				allPrivateIPs = append(allPrivateIPs, privateIPs...)
+				for _, acg := range ni.AccessControlGroupNoList {
+					if acgNo := ncloud.StringValue(acg); acgNo != "" && !containsString(acgNos, acgNo) {
+						acgNos = append(acgNos, acgNo)
+					}
+				}
 				vmNICs = append(vmNICs, nicInfo)
 				if devIdx == 0 {
 					vmInfo.NetworkInterface = ncloud.StringValue(ni.NetworkInterfaceName)
@@ -1164,6 +1122,13 @@ func (vmHandler *NcpVpcVMHandler) mappingVMInfo(NcpInstance *vserver.ServerInsta
 			}
 			if len(allPrivateIPs) > 0 {
 				vmInfo.PrivateIPs = allPrivateIPs
+			}
+			for _, acgNo := range acgNos {
+				sgInfo, err := securityHandler.GetSecurity(irs.IID{SystemId: acgNo})
+				if err != nil {
+					cblogger.Debug(fmt.Errorf("Failed to Get the S/G info : [%v]", err).Error())
+				}
+				vmInfo.SecurityGroupIIds = append(vmInfo.SecurityGroupIIds, irs.IID{NameId: sgInfo.IId.NameId, SystemId: acgNo})
 			}
 		}
 	}
@@ -1864,11 +1829,13 @@ func (vmHandler *NcpVpcVMHandler) GetRootPassword(vmId *string, privateKey *stri
 	return result.RootPassword, nil
 }
 
-func countSgKvList(sg sim.SecurityGroupInfo) int {
-	if sg.KeyValueInfoList == nil {
-		return 0
+func containsString(list []string, item string) bool {
+	for _, v := range list {
+		if v == item {
+			return true
+		}
 	}
-	return len(sg.KeyValueInfoList)
+	return false
 }
 
 func (vmHandler *NcpVpcVMHandler) ListIID() ([]*irs.IID, error) {


### PR DESCRIPTION
기존 NCP 드라이버에서는 
Security Group 에 대한 정보를 사설 테이블에 기록하는데, 이 테이블이 완전히 관리되지 못하는 것으로 보입니다. 또한, 공통 런타임이 VM 조회, 등록 등에서 SG 매핑이 불가하면, 하드 에러로 처리하고 있습니다.

이에 의해서, CB-TB에 의한 기존 정보 등록 작업(VM 등록)은 필연적으로 실패합니다. (CB-SP를 통한 별도 직접 등록도 불가했을 것입니다.)

본 PR은 이 문제를 해결하기 위해서,
ACG를 NIC 조회 결과(AccessControlGroupNoList)에서 직접 획득하도록 수정하고, 사설 기록 방식을 제거 합니다.

아울러, 공통 런타임 (api-runtime/common-runtime/VMManager.go) 에서, return fmt.Errorf(...) 제거, 경고 로그만 유지하는것으로 제안합니다.