### PR TITLE
[KT] Fix: Isolate subnet deletion per Spider instance and improve VM termination cleanup

### DIFF
--- a/api-runtime/common-runtime/VPC-SubnetManager.go
+++ b/api-runtime/common-runtime/VPC-SubnetManager.go
@@ -1511,6 +1511,20 @@ func DeleteVPC(connectionName string, rsType string, nameID string, force string
 
 	// (2) delete Resource(SystemId)
 	driverIId := getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
+
+	// KT VPC is metadata-only and subnets are zone-wide; pre-delete only this Spider's subnets to avoid touching other Spider instances' tiers.
+	if providerName, pErr := ccm.GetProviderNameByConnectionName(connectionName); pErr == nil && providerName == "KT" {
+		var subnetIIDInfoList []*SubnetIIDInfo
+		if listErr := infostore.ListByConditions(&subnetIIDInfoList, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName, OWNER_VPC_NAME_COLUMN, iidInfo.NameId); listErr == nil {
+			for _, subnetInfo := range subnetIIDInfoList {
+				subnetDriverIId := getDriverIID(cres.IID{NameId: subnetInfo.NameId, SystemId: subnetInfo.SystemId})
+				if _, removeErr := handler.(cres.VPCHandler).RemoveSubnet(driverIId, subnetDriverIId); removeErr != nil {
+					cblog.Warnf("DeleteVPC: failed to remove subnet %s (continuing): %v", subnetInfo.NameId, removeErr)
+				}
+			}
+		}
+	}
+
 	result := false
 	result, err = handler.(cres.VPCHandler).DeleteVPC(driverIId)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -716,16 +716,13 @@ func (vmHandler *KTVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, error
 
 	// Handle public IP and private IP cases separately
 	if !strings.EqualFold(vm.PublicIP, "") {
-		// Delete Firewall Rules
+		// Firewall deletion failure is non-fatal: warn and continue to avoid orphaned PF rules and VM.
 		_, dellFwErr := vmHandler.removeFirewallRules(vm.PublicIP)
 		if dellFwErr != nil {
-			newErr := fmt.Errorf("Failed to Delete Firewall Rules : [%v]", dellFwErr)
-			cblogger.Error(newErr.Error())
-			loggingError(callLogInfo, newErr)
-			return irs.Failed, newErr
+			cblogger.Warnf("Failed to Delete Firewall Rules (continuing termination): [%v]", dellFwErr)
+			loggingError(callLogInfo, fmt.Errorf("Failed to Delete Firewall Rules : [%v]", dellFwErr))
 		}
 
-		// Delete Port Forwarding Rules
 		_, dellPfErr := vmHandler.removePortForwardingRules(vm.PublicIP)
 		if dellPfErr != nil {
 			newErr := fmt.Errorf("Failed to Delete Port Forwarding Rules : [%v]", dellPfErr)
@@ -744,16 +741,22 @@ func (vmHandler *KTVpcVMHandler) TerminateVM(vmIID irs.IID) (irs.VMStatus, error
 		}
 
 	} else {
-		cblogger.Info("The VM doesn't have any connected Pulbic IP!! Waitting for Termination!!")
+		// PublicIP is empty: try to clean up PF rules by private IP (MappedIP) to avoid orphans.
+		cblogger.Info("The VM doesn't have any connected Public IP. Attempting PF rule cleanup by private IP.")
+		if !strings.EqualFold(vm.PrivateIP, "") {
+			_, dellPfErr := vmHandler.removePortForwardingRulesByPrivateIP(vm.PrivateIP)
+			if dellPfErr != nil {
+				cblogger.Warnf("Failed to Delete Port Forwarding Rules by private IP (continuing): [%v]", dellPfErr)
+			}
+		}
 	}
 
 	if !strings.EqualFold(vm.PrivateIP, "") {
-		// Delete Firewall Rules
+		// Firewall deletion failure is non-fatal: warn and continue so VM deletion is not blocked.
 		_, dellFwErr := vmHandler.removeFirewallRules(vm.PrivateIP)
 		if dellFwErr != nil {
-			cblogger.Error(dellFwErr.Error())
+			cblogger.Warnf("Failed to Delete Firewall Rules for private IP (continuing termination): [%v]", dellFwErr)
 			loggingError(callLogInfo, dellFwErr)
-			return irs.Failed, dellFwErr
 		}
 	} else {
 		cblogger.Info("The VM doesn't have any Private IP!! Waitting for Termination!!")
@@ -1928,6 +1931,51 @@ func (vmHandler *KTVpcVMHandler) removePortForwardingRules(publicIp string) (boo
 	// Wait 3 seconds for deletion to complete
 	time.Sleep(3 * time.Second)
 
+	return true, nil
+}
+
+// removePortForwardingRulesByPrivateIP deletes PF rules matching by MappedIP (private IP),
+// used when PublicIP is unavailable from GetVM().
+func (vmHandler *KTVpcVMHandler) removePortForwardingRulesByPrivateIP(privateIP string) (bool, error) {
+	cblogger.Info("KT Cloud VPC Driver: called removePortForwardingRulesByPrivateIP()!")
+
+	if strings.EqualFold(privateIP, "") {
+		return false, fmt.Errorf("Invalid Private IP Address!!")
+	}
+
+	listOpts := portforward.ListOpts{
+		Page: 1,
+		Size: 2000,
+	}
+	pager := portforward.List(vmHandler.NetworkClient, listOpts)
+
+	var pfIDs []string
+	err := pager.EachPage(func(page pagination.Page) (bool, error) {
+		pfs, err := portforward.ExtractPFs(page)
+		if err != nil {
+			return false, fmt.Errorf("Failed to Extract Portforwarding Rules : [%v]", err)
+		}
+		for _, pf := range pfs {
+			if pf.MappedIP == privateIP {
+				pfIDs = append(pfIDs, pf.ID)
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("Failed to Get Portforwarding Rule ID List : [%v]", err)
+	}
+
+	for _, pfID := range pfIDs {
+		result := portforward.Delete(vmHandler.NetworkClient, pfID)
+		if result.Err != nil {
+			cblogger.Warnf("Failed to Delete Portforwarding Rule (ID: %s): [%v]", pfID, result.Err)
+		} else {
+			cblogger.Infof("Successfully Deleted Portforwarding Rule by private IP (ID: %s)", pfID)
+		}
+	}
+
+	time.Sleep(3 * time.Second)
 	return true, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VPCHandler.go
@@ -189,7 +189,6 @@ func (vpcHandler *KTVpcVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 // Note) KT Cloud (D platform) supports only one VPC that has been created.
 func (vpcHandler *KTVpcVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 	cblogger.Info("KT Cloud VPC Driver: called DeleteVPC()!")
-	callLogInfo := getCallLogScheme(vpcHandler.RegionInfo.Zone, call.VPCSUBNET, vpcIID.SystemId, "DeleteVPC()")
 
 	if strings.EqualFold(vpcIID.SystemId, "") {
 		newErr := fmt.Errorf("Invalid VPC SystemId!!")
@@ -197,36 +196,8 @@ func (vpcHandler *KTVpcVPCHandler) DeleteVPC(vpcIID irs.IID) (bool, error) {
 		return false, newErr
 	}
 
-	// Check whether the VPC exists.
-	vpcInfo, err := vpcHandler.GetVPC(vpcIID)
-	if err != nil {
-		cblogger.Errorf("Failed to Find the VPC with the SystemID. : [%s] : [%v]", vpcIID.SystemId, err)
-		loggingError(callLogInfo, err)
-		return false, err
-	}
-
-	// Delete the Subnets belonged in the VPC
-	for _, subnetInfo := range vpcInfo.SubnetInfoList {
-		if !strings.EqualFold(subnetInfo.IId.NameId, "Private") && !strings.EqualFold(subnetInfo.IId.NameId, "DMZ") && !strings.EqualFold(subnetInfo.IId.NameId, "external") && !strings.EqualFold(subnetInfo.IId.NameId, "NLB-SUBNET") {
-			_, err := vpcHandler.RemoveSubnet(irs.IID{SystemId: vpcIID.SystemId}, irs.IID{SystemId: subnetInfo.IId.SystemId})
-			if (err != nil) && !strings.Contains(err.Error(), ":true") { // Cauton!! : Abnormal Error when removing a subnet on D1 Platform
-				newErr := fmt.Errorf("Failed to Delete the Subnet : [%v]", err)
-				cblogger.Error(newErr.Error())
-				loggingError(callLogInfo, newErr)
-				return false, newErr
-			}
-		}
-	}
-
-	result, err := vpcHandler.GetVPC(vpcIID)
-	if err != nil {
-		cblogger.Errorf("Failed to Find the VPC with the SystemID. : [%s] : [%v]", vpcIID.SystemId, err)
-		loggingError(callLogInfo, err)
-		return false, err
-	} else {
-		cblogger.Infof("Succeeded in Deleting the VPC : " + result.IId.SystemId)
-	}
-
+	// KT VPC is metadata-only; subnet deletion is handled by the common runtime per Spider instance.
+	cblogger.Infof("Succeeded in Deleting the VPC (metadata-only): %s", vpcIID.SystemId)
 	return true, nil
 }
 


### PR DESCRIPTION
## Problem
1. **DeleteVPC** — KT VPC is metadata-only; subnets are zone-wide. Multiple Spider instances shared the same tiers, so one Spider's DeleteVPC deleted other Spiders' subnets.
2. **TerminateVM** — Firewall deletion failure blocked PF rule and VM deletion. Empty PublicIP silently skipped PF rule cleanup.

## Changes
- `VPC-SubnetManager.go`: Pre-delete only this Spider's subnets via `RemoveSubnet()` before `DeleteVPC()` (KT only)
- `VPCHandler.go`: Remove zone-wide subnet deletion loop from `DeleteVPC()`
- `VMHandler.go`: Make firewall deletion non-fatal (warn + continue); add `removePortForwardingRulesByPrivateIP()` for cleanup when PublicIP is unavailable

## Impact
- Other CSPs: no change
- KT multi-Spider: each Spider deletes only its own subnets
- KT TerminateVM: VM and PF rules are always cleaned up