### PR TITLE
[AdminWeb] Fix: Resolve hardcoded port and session cookie conflict when running multiple Spider instances

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Common.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Common.go
@@ -104,9 +104,12 @@ func makeSelect_html(onchangeFunctionName string, strList []string, id string) s
 
 //----------------
 
+func spiderBaseURL() string {
+	return "http://localhost" + cr.ServerPort
+}
+
 func getResourceList_JsonByte(resourceName string) ([]byte, error) {
-	// cr.ServicePort = ":1024"
-	url := "http://" + "localhost" + cr.ServerPort + "/spider/" + resourceName
+	url := spiderBaseURL() + "/spider/" + resourceName
 
 	// get object list
 	res, err := httpGetWithAuth(url)
@@ -201,7 +204,7 @@ func getResource_JsonByte(resourceName string, name string) ([]byte, error) {
 }
 
 func getPriceInfoJsonString(connConfig string, resourceName string, productFamily string, regionName string, filter []cres.KeyValue, simpleVMSpecInfo bool, target interface{}) error {
-	url := fmt.Sprintf("http://localhost:1024/spider/%s/%s/%s?ConnectionName=%s", resourceName, productFamily, regionName, connConfig)
+	url := fmt.Sprintf("%s/spider/%s/%s/%s?ConnectionName=%s", spiderBaseURL(), resourceName, productFamily, regionName, connConfig)
 
 	if simpleVMSpecInfo {
 		url += "&simple=true"
@@ -379,7 +382,7 @@ func genLoggingResult2(response string) string {
 
 // Fetch regions and map them to RegionName -> "Region / Zone"
 func fetchRegions() (map[string]string, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/region")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/region")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching regions: %v", err)
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Connection.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Connection.go
@@ -599,7 +599,7 @@ type Drivers struct {
 }
 
 func fetchConnectionConfigs() (map[string][]ConnectionConfig, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/connectionconfig")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/connectionconfig")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching connection configurations: %v", err)
 	}
@@ -619,7 +619,7 @@ func fetchConnectionConfigs() (map[string][]ConnectionConfig, error) {
 }
 
 func fetchProviders() ([]string, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/cloudos")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/cloudos")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching providers: %v", err)
 	}
@@ -634,7 +634,7 @@ func fetchProviders() ([]string, error) {
 }
 
 func fetchDrivers() (map[string]string, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/driver")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/driver")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching drivers: %v", err)
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Credential.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Credential.go
@@ -39,7 +39,7 @@ type CredentialMetaInfo struct {
 }
 
 func fetchCredentials() (map[string][]CredentialInfo, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/credential")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/credential")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching credentials: %v", err)
 	}
@@ -59,7 +59,7 @@ func fetchCredentials() (map[string][]CredentialInfo, error) {
 }
 
 func fetchCredentialMetaInfo(provider string) ([]string, error) {
-	resp, err := httpGetWithAuth(fmt.Sprintf("http://localhost:1024/spider/cloudos/metainfo/%s", provider))
+	resp, err := httpGetWithAuth(spiderBaseURL() + fmt.Sprintf("/spider/cloudos/metainfo/%s", provider))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching credential meta info for provider %s: %v", provider, err)
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Dashboard.go
@@ -88,7 +88,7 @@ func fetchResourceCounts(config ConnectionConfig, provider string, wg *sync.Wait
 	counts.ConnectionName = config.ConfigName
 	counts.RegionName = config.RegionName
 
-	baseURL := "http://localhost:1024/spider"
+	baseURL := spiderBaseURL() + "/spider"
 	resources := []string{"vpc", "subnet", "securitygroup", "vm", "keypair", "disk", "nlb", "publicip", "nic", "cluster", "myimage", "s3", "rdbms"}
 
 	for _, resource := range resources {

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Driver.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Driver.go
@@ -159,7 +159,7 @@ func makeDriverTRListHTML(bgcolor string, height string, fontSize string, infoLi
 }
 
 func fetchDriverInfos() ([]*dim.CloudDriverInfo, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/driver")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/driver")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching drivers: %v", err)
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-FileSystem.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-FileSystem.go
@@ -111,7 +111,7 @@ func FileSystemManagement(c echo.Context) error {
 
 func fetchFileSystems(connConfig string) ([]FileSystemInfo, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "http://localhost:1024/spider/filesystem", nil)
+	req, err := http.NewRequest("GET", spiderBaseURL()+"/spider/filesystem", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Main.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	cblogger "github.com/cloud-barista/cb-log"
+	cr "github.com/cloud-barista/cb-spider/api-runtime/common-runtime"
 	"github.com/labstack/echo/v4"
 )
 
@@ -35,7 +36,15 @@ type sessionEntry struct {
 	Expires  time.Time
 }
 
-const sessionCookieName = "cb_spider_session"
+// sessionCookieName returns a port-specific name to prevent cookie collision between multiple Spider instances.
+func sessionCookieName() string {
+	port := strings.TrimPrefix(cr.ServerPort, ":")
+	if port == "" {
+		port = "1024"
+	}
+	return "cb_spider_session_" + port
+}
+
 const sessionMaxAge = 4 * time.Hour
 
 func generateSessionToken() (string, error) {
@@ -127,7 +136,7 @@ func AdminWebSessionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		// Check session cookie
-		cookie, err := c.Cookie(sessionCookieName)
+		cookie, err := c.Cookie(sessionCookieName())
 		if err != nil || cookie.Value == "" {
 			return redirectToLogin(c)
 		}
@@ -197,7 +206,7 @@ func AuthInfo(c echo.Context) error {
 	loggedIn := false
 	sessionUser := ""
 	if authEnabled {
-		if cookie, err := c.Cookie(sessionCookieName); err == nil && cookie.Value != "" {
+		if cookie, err := c.Cookie(sessionCookieName()); err == nil && cookie.Value != "" {
 			if user, valid := validateSession(cookie.Value); valid {
 				loggedIn = true
 				sessionUser = user
@@ -240,7 +249,7 @@ func Login(c echo.Context) error {
 			})
 		}
 		c.SetCookie(&http.Cookie{
-			Name:     sessionCookieName,
+			Name:     sessionCookieName(),
 			Value:    token,
 			Path:     "/spider/adminweb",
 			HttpOnly: true,
@@ -264,12 +273,12 @@ func Logout(c echo.Context) error {
 	cblog.Info("call Logout()")
 
 	// Delete server-side session
-	if cookie, err := c.Cookie(sessionCookieName); err == nil && cookie.Value != "" {
+	if cookie, err := c.Cookie(sessionCookieName()); err == nil && cookie.Value != "" {
 		deleteSession(cookie.Value)
 	}
 	// Clear cookie
 	c.SetCookie(&http.Cookie{
-		Name:     sessionCookieName,
+		Name:     sessionCookieName(),
 		Value:    "",
 		Path:     "/spider/adminweb",
 		HttpOnly: true,

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Region.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Region.go
@@ -26,7 +26,7 @@ type RegionMetaInfo struct {
 }
 
 func fetchRegionInfos() (map[string][]RegionInfo, error) {
-	resp, err := httpGetWithAuth("http://localhost:1024/spider/region")
+	resp, err := httpGetWithAuth(spiderBaseURL() + "/spider/region")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching regions: %v", err)
 	}
@@ -46,7 +46,7 @@ func fetchRegionInfos() (map[string][]RegionInfo, error) {
 }
 
 func fetchRegionMetaInfo(provider string) ([]string, error) {
-	resp, err := httpGetWithAuth(fmt.Sprintf("http://localhost:1024/spider/cloudos/metainfo/%s", provider))
+	resp, err := httpGetWithAuth(spiderBaseURL() + fmt.Sprintf("/spider/cloudos/metainfo/%s", provider))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching region meta info for provider %s: %v", provider, err)
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-S3.go
@@ -105,7 +105,7 @@ func S3Management(c echo.Context) error {
 func fetchS3Buckets(connConfig string) ([]S3BucketInfo, error) {
 	// Use new S3 API endpoint: /spider/s3
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "http://localhost:1024/spider/s3", nil)
+	req, err := http.NewRequest("GET", spiderBaseURL()+"/spider/s3", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func fetchS3Buckets(connConfig string) ([]S3BucketInfo, error) {
 
 func fetchVersioningStatus(connConfig, bucketName string) string {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:1024/spider/s3/%s?versioning", bucketName), nil)
+	req, err := http.NewRequest("GET", spiderBaseURL()+fmt.Sprintf("/spider/s3/%s?versioning", bucketName), nil)
 	if err != nil {
 		return "Error"
 	}
@@ -255,7 +255,7 @@ func fetchVersioningStatus(connConfig, bucketName string) string {
 
 func fetchCORSStatus(connConfig, bucketName string) string {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:1024/spider/s3/%s?cors", bucketName), nil)
+	req, err := http.NewRequest("GET", spiderBaseURL()+fmt.Sprintf("/spider/s3/%s?cors", bucketName), nil)
 	if err != nil {
 		return "Not configured"
 	}

--- a/api-runtime/rest-runtime/admin-web/AdminWeb-SystemStats.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-SystemStats.go
@@ -67,7 +67,7 @@ type ResourceUsage struct {
 
 // Function to fetch System Information
 func fetchSystemInfo() (SystemInfo, error) {
-	url := "http://localhost:1024/spider/sysstats/system"
+	url := spiderBaseURL() + "/spider/sysstats/system"
 	resp, err := httpGetWithAuth(url)
 	if err != nil {
 		return SystemInfo{}, fmt.Errorf("error fetching System Info: %v", err)
@@ -88,7 +88,7 @@ func fetchSystemInfo() (SystemInfo, error) {
 
 // Function to fetch Resource Usage
 func fetchResourceUsage() (ResourceUsage, error) {
-	url := "http://localhost:1024/spider/sysstats/usage"
+	url := spiderBaseURL() + "/spider/sysstats/usage"
 	resp, err := httpGetWithAuth(url)
 	if err != nil {
 		return ResourceUsage{}, fmt.Errorf("error fetching Resource Usage: %v", err)


### PR DESCRIPTION
## Problem
When running multiple CB-Spider instances on different ports (e.g., :1024 and :1025),
the AdminWeb dashboard always fetched resource data from the hardcoded port `:1024`,
showing incorrect data regardless of which instance was accessed.
Additionally, both instances shared the same session cookie name (`cb_spider_session`),
causing browsers to invalidate the login session of one instance when logging into the other.

## Changes

### AdminWeb – Dynamic base URL
- Add `spiderBaseURL()` helper in `AdminWeb-Common.go` that returns `"http://localhost" + cr.ServerPort`
- Replace all hardcoded `http://localhost:1024` in internal API calls across 9 files:
  `AdminWeb-Common.go`, `AdminWeb-Connection.go`, `AdminWeb-Credential.go`,
  `AdminWeb-Dashboard.go`, `AdminWeb-Driver.go`, `AdminWeb-FileSystem.go`,
  `AdminWeb-Region.go`, `AdminWeb-S3.go`, `AdminWeb-SystemStats.go`

### AdminWeb – Port-scoped session cookie
- Change `sessionCookieName` from a package-level constant to a function `sessionCookieName()`
  that appends the server port (e.g., `cb_spider_session_1025`)
- Prevents browser cookie collision between multiple Spider instances on the same host
