### PR TITLE
[S3/FileSystem] Fix: Auto-clean metadb when resource not found in CSP on delete

### DIFF
--- a/api-runtime/common-runtime/FileSystemManager.go
+++ b/api-runtime/common-runtime/FileSystemManager.go
@@ -377,7 +377,11 @@ func DeleteFileSystem(connectionName string, nameID string) (bool, error) {
 	}
 	result, err := handler.DeleteFileSystem(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId})
 	if err != nil {
-		return false, err
+		cblog.Error(err)
+		if !checkNotFoundError(err) {
+			return false, err
+		}
+		// if not found in CSP, continue to delete metadb
 	}
 	_, err = infostore.DeleteByConditions(&FileSystemIIDInfo{}, CONNECTION_NAME_COLUMN, iidInfo.ConnectionName, NAME_ID_COLUMN, nameID)
 	if err != nil {

--- a/api-runtime/common-runtime/S3Manager.go
+++ b/api-runtime/common-runtime/S3Manager.go
@@ -645,10 +645,13 @@ func DeleteS3Bucket(connectionName, bucketName string, force string) (bool, erro
 		err = deleteAzureBucket(connInfo, iidInfo.SystemId)
 		if err != nil {
 			cblog.Error(err)
-			if force != "true" {
+			if checkNotFoundError(err) {
+				// if not found in CSP, continue
+				force = "true"
+			} else if force != "true" {
 				return false, err
 			}
-			cblog.Infof("Azure delete failed but force=true, proceeding with metadata deletion")
+			cblog.Infof("Azure delete: not found in CSP or force=true, proceeding with metadata deletion")
 		}
 		_, err = infostore.DeleteByConditions(&S3BucketIIDInfo{}, "connection_name", iidInfo.ConnectionName, "name_id", bucketName)
 		if err != nil {
@@ -673,12 +676,8 @@ func DeleteS3Bucket(connectionName, bucketName string, force string) (bool, erro
 	if err != nil {
 		cblog.Error(err)
 		if checkNotFoundError(err) {
-			// if not found in CSP, require explicit force parameter
-			if force != "true" {
-				cblog.Errorf("Bucket %s not found in CSP. Use force=true parameter to delete metadata only.", bucketName)
-				return false, fmt.Errorf("bucket not found in CSP (metadata exists). Use force=true to delete metadata only")
-			}
-			cblog.Infof("Bucket %s not found in CSP, proceeding with force delete (metadata only)", bucketName)
+			// if not found in CSP, continue
+			force = "true"
 		} else if force != "true" {
 			return false, err
 		}

--- a/api-runtime/rest-runtime/admin-web/html/s3.html
+++ b/api-runtime/rest-runtime/admin-web/html/s3.html
@@ -914,14 +914,6 @@ function deleteBucket(name, forceDelete = false) {
                             }
                             return;
                         } else if (errorCode === 'NoSuchBucket') {
-                            // Check if this is a metadata-only bucket
-                            if (errorMessage.includes('metadata exists') || errorMessage.includes('Use force=true')) {
-                                hideProgressBar();
-                                if (confirm(`Bucket "${name}" not found in CSP, but metadata exists.\n\nDo you want to force delete the metadata only?`)) {
-                                    deleteBucket(name, true);
-                                }
-                                return;
-                            }
                             throw new Error(`Bucket "${name}" does not exist.`);
                         } else if (errorCode === 'AccessDenied') {
                             throw new Error(`Access denied: You don't have permission to delete bucket "${name}".`);
@@ -1143,10 +1135,6 @@ function deleteSelectedBuckets() {
                     if (errorText.includes('BucketNotEmpty')) {
                         return { bucket: bucketName, error: 'Bucket is not empty' };
                     } else if (errorText.includes('NoSuchBucket')) {
-                        // Check if metadata exists
-                        if (errorText.includes('metadata exists') || errorText.includes('Use force=true')) {
-                            return { bucket: bucketName, error: 'Not found in CSP', needsForce: true };
-                        }
                         return { bucket: bucketName, error: 'Bucket does not exist' };
                     } else if (errorText.includes('AccessDenied')) {
                         return { bucket: bucketName, error: 'Access denied' };
@@ -1166,7 +1154,6 @@ function deleteSelectedBuckets() {
         
         const successes = results.filter(r => r.success);
         const failures = results.filter(r => r.error);
-        const needsForce = results.filter(r => r.needsForce);
         
         if (failures.length > 0) {
             let message = `Deletion completed:\n\n`;
@@ -1178,29 +1165,6 @@ function deleteSelectedBuckets() {
                 message += `- ${f.bucket}: ${f.error}\n`;
             });
             alert(message);
-            
-            // Handle buckets that need force delete
-            if (needsForce.length > 0) {
-                const forceList = needsForce.map(f => f.bucket).join(', ');
-                if (confirm(`The following bucket(s) not found in CSP but metadata exists:\n${forceList}\n\nDo you want to force delete the metadata?`)) {
-                    showProgressBar();
-                    const forceDeletePromises = needsForce.map(item => {
-                        return fetch(`/spider/s3/${item.bucket}?force=true&ConnectionName=${connConfig}`, {
-                            method: 'DELETE',
-                            headers: { 'X-Connection-Name': connConfig }
-                        });
-                    });
-                    Promise.all(forceDeletePromises).then(() => {
-                        hideProgressBar();
-                        location.reload();
-                    }).catch(e => {
-                        hideProgressBar();
-                        alert('Error during force deletion: ' + e.message);
-                        location.reload();
-                    });
-                    return;
-                }
-            }
         }
         
         location.reload();


### PR DESCRIPTION
- Apply `checkNotFoundError` pattern to `DeleteS3Bucket` (both Azure and MinIO paths): automatically set `force="true"` when CSP returns a not-found error, so Spider metadb is cleaned up without requiring an explicit `force` parameter
- Apply the same pattern to `DeleteFileSystem`: proceed with metadb deletion when the CSP resource is not found, instead of returning the error
- Remove the now-unnecessary "NoSuchBucket with metadata exists → prompt user to force-delete" dialog from s3.html single-bucket delete
- Remove `needsForce` tracking and the force re-delete loop from s3.html bulk delete
- RDBMSManager.go already had this fix applied; no change needed

> **Background:** When a resource is deleted directly from the CSP side, Spider metadb retains a stale entry. Previously, S3 and FileSystem Delete calls would return an error in this case, requiring the caller to explicitly pass `force=true`. This aligns their behavior with the fix already applied to VM, VPC, Disk, NLB, SecurityGroup, KeyPair, MyImage, and Cluster in commit `20ab7df`.