### PR TITLE
[NCP] Fix: MyImage full lifecycle — VM creation, deletion, source VM tracking, and created time

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/MyImageHandler.go
@@ -13,8 +13,10 @@ package resources
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+
 	// "github.com/davecgh/go-spew/spew"
 
 	"github.com/NaverCloudPlatform/ncloud-sdk-go-v2/ncloud"
@@ -50,10 +52,13 @@ func (myImageHandler *NcpVpcMyImageHandler) SnapshotVM(snapshotReqInfo irs.MyIma
 
 	// Note) CreateMemberServerImageInstance() : For XEN/RHV
 	// Note) CreateServerImage() : For XEN/RHV/KVM
+	// NCP VPC ServerImage API does not return source VM info; store it in description for later retrieval.
+	sourceVMDesc := "sourceVMId:" + snapshotReqInfo.SourceVM.SystemId
 	snapshotReq := vserver.CreateServerImageRequest{ // Not CreateBlockStorageSnapshotInstanceRequest{}
-		RegionCode:         &myImageHandler.RegionInfo.Region,
-		ServerInstanceNo:   &snapshotReqInfo.SourceVM.SystemId,
-		ServerImageName: 	&snapshotReqInfo.IId.NameId,
+		RegionCode:             &myImageHandler.RegionInfo.Region,
+		ServerInstanceNo:       &snapshotReqInfo.SourceVM.SystemId,
+		ServerImageName:        &snapshotReqInfo.IId.NameId,
+		ServerImageDescription: &sourceVMDesc,
 	}
 	callLogStart := call.Start()
 	result, err := myImageHandler.VMClient.V2Api.CreateServerImage(&snapshotReq) // Not CreateBlockStorageSnapshotInstance
@@ -64,7 +69,6 @@ func (myImageHandler *NcpVpcMyImageHandler) SnapshotVM(snapshotReqInfo irs.MyIma
 		return irs.MyImageInfo{}, newErr
 	}
 	LoggingInfo(callLogInfo, callLogStart)
-
 
 	// cblogger.Info("\n\n### result.ServerImageList : ")
 	// spew.Dump(result.ServerImageList)
@@ -107,8 +111,8 @@ func (myImageHandler *NcpVpcMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, e
 	callLogInfo := GetCallLogScheme(myImageHandler.RegionInfo.Region, call.MYIMAGE, "ListMyImage()", "ListMyImage()")
 
 	imageListReq := vserver.GetServerImageListRequest{ // Not GetBlockStorageSnapshotInstanceListRequest
-		RegionCode: 				&myImageHandler.RegionInfo.Region,
-		ServerImageTypeCodeList: 	[]*string{ncloud.String("SELF")}, // Caution) Options: SELF | NCP
+		RegionCode:              &myImageHandler.RegionInfo.Region,
+		ServerImageTypeCodeList: []*string{ncloud.String("SELF")}, // Caution) Options: SELF | NCP
 	}
 	callLogStart := call.Start()
 	result, err := myImageHandler.VMClient.V2Api.GetServerImageList(&imageListReq) // Caution : Not GetBlockStorageSnapshotInstanceList()
@@ -225,6 +229,29 @@ func (myImageHandler *NcpVpcMyImageHandler) CheckWindowsImage(myImageIID irs.IID
 	return isWindowsImage, nil
 }
 
+// isKvmMyImage returns true when the MyImage was created from a KVM-based VM.
+// BlockStorageMappingList in CreateServerInstances is only supported for KVM.
+func (myImageHandler *NcpVpcMyImageHandler) isKvmMyImage(myImageIID irs.IID) (bool, error) {
+	cblogger.Info("NCP VPC Cloud Driver: called isKvmMyImage()")
+
+	if strings.EqualFold(myImageIID.SystemId, "") {
+		return false, fmt.Errorf("Invalid SystemId")
+	}
+
+	myImageInfo, err := myImageHandler.GetMyImage(myImageIID)
+	if err != nil {
+		return false, fmt.Errorf("Failed to Get MyImage Info: [%v]", err)
+	}
+
+	for _, keyInfo := range myImageInfo.KeyValueList {
+		if keyInfo.Key == "HypervisorType" {
+			cblogger.Infof("\n### HypervisorType : [%s]", keyInfo.Value)
+			return strings.Contains(strings.ToUpper(keyInfo.Value), "KVM"), nil
+		}
+	}
+	return false, nil
+}
+
 func (myImageHandler *NcpVpcMyImageHandler) DeleteMyImage(myImageIID irs.IID) (bool, error) {
 	cblogger.Info("NCP VPC Cloud Driver: called DeleteMyImage()")
 	InitLog()
@@ -258,8 +285,32 @@ func (myImageHandler *NcpVpcMyImageHandler) DeleteMyImage(myImageIID irs.IID) (b
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return false, newErr
-	} else {
-		cblogger.Info("Succeeded in Deleting the Snapshot Image.")
+	}
+	// totalRows == 0 means the image was not found or not deleted on the CSP side.
+	if ncloud.Int32Value(result.TotalRows) < 1 {
+		newErr := fmt.Errorf("DeleteServerImage returned success but no image was deleted (ServerImageNo: %s)", myImageIID.SystemId)
+		cblogger.Error(newErr.Error())
+		LoggingError(callLogInfo, newErr)
+		return false, newErr
+	}
+	cblogger.Info("Succeeded in Deleting the Snapshot Image.")
+
+	// deleteServerImage does not auto-delete the underlying block storage snapshots; delete them explicitly.
+	for _, bsm := range result.ServerImageList[0].BlockStorageMappingList {
+		if bsm.BlockStorageSnapshotInstanceNo == nil {
+			continue
+		}
+		snapshotNoStr := strconv.Itoa(int(ncloud.Int32Value(bsm.BlockStorageSnapshotInstanceNo)))
+		delSnapReq := vserver.DeleteBlockStorageSnapshotInstancesRequest{
+			RegionCode:                         ncloud.String(myImageHandler.RegionInfo.Region),
+			BlockStorageSnapshotInstanceNoList: []*string{ncloud.String(snapshotNoStr)},
+		}
+		_, snapErr := myImageHandler.VMClient.V2Api.DeleteBlockStorageSnapshotInstances(&delSnapReq)
+		if snapErr != nil {
+			cblogger.Warnf("Failed to Delete BlockStorageSnapshot [%s] for MyImage [%s]: [%v]", snapshotNoStr, myImageIID.SystemId, snapErr)
+		} else {
+			cblogger.Infof("Deleted BlockStorageSnapshot [%s] for MyImage [%s]", snapshotNoStr, myImageIID.SystemId)
+		}
 	}
 
 	return true, nil
@@ -319,8 +370,8 @@ func (myImageHandler *NcpVpcMyImageHandler) GetImageStatus(myImageIID irs.IID) (
 	}
 
 	imageReq := vserver.GetServerImageDetailRequest{ // Not GetBlockStorageSnapshotInstanceDetailRequest{}
-		RegionCode:     &myImageHandler.RegionInfo.Region,
-		ServerImageNo: 	&myImageIID.SystemId,
+		RegionCode:    &myImageHandler.RegionInfo.Region,
+		ServerImageNo: &myImageIID.SystemId,
 	}
 	callLogStart := call.Start()
 	result, err := myImageHandler.VMClient.V2Api.GetServerImageDetail(&imageReq) // Caution : Not GetBlockStorageSnapshotInstanceDetail()
@@ -368,22 +419,31 @@ func (myImageHandler *NcpVpcMyImageHandler) mappingMyImageInfo(myImage *vserver.
 	// spew.Dump(myImage)
 	// cblogger.Info("\n")
 
-	// convertedTime, err := convertTimeFormat(*myImage.CreateDate)
-	// if err != nil {
-	// 	newErr := fmt.Errorf("Failed to Convert the Time Format!!")
-	// 	cblogger.Error(newErr.Error())
-	// 	return nil, newErr
-	// }
+	var createdTime time.Time
+	if myImage.CreateDate != nil {
+		// NCP VPC returns createDate as "2006-01-02T15:04:05+0900" (no colon in offset).
+		if t, err := time.Parse("2006-01-02T15:04:05-0700", *myImage.CreateDate); err == nil {
+			createdTime = t.UTC()
+		} else {
+			cblogger.Warnf("Failed to parse CreateDate [%s]: %v", *myImage.CreateDate, err)
+		}
+	}
 
 	myImageInfo := &irs.MyImageInfo{
 		IId: irs.IID{
-			NameId:   	*myImage.ServerImageName,
-			SystemId: 	*myImage.ServerImageNo,
+			NameId:   *myImage.ServerImageName,
+			SystemId: *myImage.ServerImageNo,
 		},
-		// SourceVM:    	irs.IID{SystemId: *myImage.OriginalServerInstanceNo},
-		Status:      	convertImageStatus(*myImage.ServerImageStatus.Code),
-		// CreatedTime: 	convertedTime,
-		KeyValueList:   irs.StructToKeyValueList(myImage),
+		Status:       convertImageStatus(*myImage.ServerImageStatus.Code),
+		CreatedTime:  createdTime,
+		KeyValueList: irs.StructToKeyValueList(myImage),
+	}
+
+	// Parse source VM SystemId encoded in description (NCP VPC API does not return this natively).
+	if myImage.ServerImageDescription != nil {
+		if strings.HasPrefix(*myImage.ServerImageDescription, "sourceVMId:") {
+			myImageInfo.SourceVM = irs.IID{SystemId: strings.TrimPrefix(*myImage.ServerImageDescription, "sourceVMId:")}
+		}
 	}
 	return myImageInfo, nil
 }
@@ -411,7 +471,7 @@ func (myImageHandler *NcpVpcMyImageHandler) getOriginImageOSPlatform(myImageIID 
 	var originalImageProductCode string
 	// Use Key/Value info of the myImageInfo.
 	for _, keyInfo := range myImageInfo.KeyValueList {
-		if keyInfo.Key == "osType" {
+		if keyInfo.Key == "OsType" {
 			originalImageProductCode = keyInfo.Value
 			break
 		}
@@ -419,13 +479,13 @@ func (myImageHandler *NcpVpcMyImageHandler) getOriginImageOSPlatform(myImageIID 
 	// cblogger.Infof("\n### OriginalServerImageProductCode : [%s]", originalImageProductCode)
 
 	var originImagePlatform string
-	if strings.Contains(strings.ToUpper(originalImageProductCode), "UBNTU") {
+	if strings.Contains(strings.ToUpper(originalImageProductCode), "UBUNTU") {
 		originImagePlatform = "UBUNTU"
-	} else if strings.Contains(strings.ToUpper(originalImageProductCode), "CNTOS") {
+	} else if strings.Contains(strings.ToUpper(originalImageProductCode), "CENTOS") {
 		originImagePlatform = "CENTOS"
 	} else if strings.Contains(strings.ToUpper(originalImageProductCode), "ROCKY") {
 		originImagePlatform = "ROCKY"
-	} else if strings.Contains(strings.ToUpper(originalImageProductCode), "WND") {
+	} else if strings.Contains(strings.ToUpper(originalImageProductCode), "WIN") {
 		originImagePlatform = "WINDOWS"
 	} else {
 		newErr := fmt.Errorf("Failed to Get OriginImageOSPlatform of the MyImage!!")

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -101,8 +101,7 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 	var publicImageId string
 	var publicImageSpecId string
 	var myImageId string
-	// var myImageSpecId string
-	// var serverProductCode string
+	var myImageSpecId string
 
 	var initScriptNo *string
 	var instanceReq vserver.CreateServerInstancesRequest
@@ -221,21 +220,8 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 			return irs.VMInfo{}, newErr
 		} else {
 			myImageId = vmReqInfo.ImageIID.SystemId
-			// myImageSpecId = vmReqInfo.VMSpecName
+			myImageSpecId = vmReqInfo.VMSpecName
 		}
-
-		// vmSpecHandler := NcpVpcVMSpecHandler{
-		// 	RegionInfo:  vmHandler.RegionInfo,
-		// 	VMClient:    vmHandler.VMClient,
-		// }
-		// var getErr error
-		// serverProductCode, getErr = vmSpecHandler.getNcpVpcServerProductCode(myImageSpecId)
-		// if err != nil {
-		// 	newErr := fmt.Errorf("Failed to Get ServerProductCode from NCP VPC : ", getErr)
-		// 	cblogger.Error(newErr.Error())
-		// 	LoggingError(callLogInfo, newErr)
-		// 	return irs.VMInfo{}, newErr
-		// }
 
 		myImageHandler := NcpVpcMyImageHandler{
 			RegionInfo: vmHandler.RegionInfo,
@@ -268,21 +254,15 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 			}
 		}
 
-		// ### Note) "These parameters cannot be used at the same time : [memberServerImageInstanceNo, serverImageProductCode, serverSpecCode]"
-		// $$$ Need to check what to set as a vmSpec when creating a VM with a MyImge(MemberServerImageInstanceNo).
+		// MyImage (ServerImageNo from CreateServerImage API) uses the same new-API path as public images.
 		instanceReq = vserver.CreateServerInstancesRequest{
-			RegionCode:                  ncloud.String(vmHandler.RegionInfo.Region),
-			ServerName:                  ncloud.String(instanceName),
-			MemberServerImageInstanceNo: ncloud.String(myImageId),
-			// ServerImageProductCode: 		ncloud.String(publicImageId), // In case using New publicImageId(from New API). Use 'ServerImageNo' parameter!!
-			// ServerProductCode:      		ncloud.String(serverProductCode), // In case using New vmSpecId(from New API). Use 'ServerSpecCode' parameter!!
-			LoginKeyName: ncloud.String(keyPairId),
-			VpcNo:        ncloud.String(vpcId),
-			SubnetNo:     ncloud.String(subnetId), // Applied for Zone-based control!!
-
-			// Note) If enabled and set "", an error will occur on VM creation with 'MemberServerImageInstanceNo'.
-			// ServerImageNo: 				ncloud.String(publicImageId), // Added for using imageId from New API
-			// ServerSpecCode: 				ncloud.String(publicImageSpecId), // Added for using specId from New API
+			RegionCode:     ncloud.String(vmHandler.RegionInfo.Region),
+			ServerName:     ncloud.String(instanceName),
+			ServerImageNo:  ncloud.String(myImageId),
+			ServerSpecCode: ncloud.String(myImageSpecId),
+			LoginKeyName:   ncloud.String(keyPairId),
+			VpcNo:          ncloud.String(vpcId),
+			SubnetNo:       ncloud.String(subnetId), // Applied for Zone-based control!!
 
 			// ### Caution!! : AccessControlGroup corresponds to Server > 'ACG', not VPC > 'Network ACL' in the NCP VPC console.
 			NetworkInterfaceList: []*vserver.NetworkInterfaceParameter{
@@ -296,6 +276,21 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 			IsProtectServerTermination: ncloud.Bool(false), // Caution!! : If set to 'true', Terminate (VM return) is not controlled by API.
 			ServerCreateCount:          minCount,
 			InitScriptNo:               initScriptNo,
+		}
+
+		// BlockStorageMappingList is only supported for KVM; XEN/RHV images must omit it.
+		isKvm, kvmErr := myImageHandler.isKvmMyImage(vmReqInfo.ImageIID)
+		if kvmErr != nil {
+			cblogger.Warnf("Failed to determine hypervisor type for MyImage [%s], skipping BlockStorageMappingList: [%v]", myImageId, kvmErr)
+		}
+		if isKvm {
+			instanceReq.BlockStorageMappingList = []*vserver.BlockStorageMappingParameter{
+				{
+					Order:                      orderInt32,
+					BlockStorageVolumeTypeCode: ncloud.String(KVMRootDiskType),
+					BlockStorageSize:           ncloud.String(vmReqInfo.RootDiskSize),
+				},
+			}
 		}
 	}
 	// cblogger.Info("# instanceReq")

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMSpecHandler.go
@@ -379,3 +379,44 @@ func (vmSpecHandler *NcpVpcVMSpecHandler) getNcpVpcServerProductCode(specName st
 		return *vmSpec.ServerProductCode, nil
 	}
 }
+
+// getServerProductCodeForMyImage returns a ServerProductCode for use with MemberServerImageInstanceNo.
+// NCP VPC requires querying GetServerProductList with the MyImage number to get compatible product codes;
+// the result is matched to the requested spec by CPU count and memory size.
+func (vmSpecHandler *NcpVpcVMSpecHandler) getServerProductCodeForMyImage(myImageInstanceNo, specName string) (string, error) {
+	cblogger.Info("NCP VPC Cloud driver: called getServerProductCodeForMyImage()!")
+	InitLog()
+
+	if strings.EqualFold(myImageInstanceNo, "") || strings.EqualFold(specName, "") {
+		return "", fmt.Errorf("Invalid myImageInstanceNo or specName")
+	}
+
+	vmSpec, err := vmSpecHandler.getNcpVpcVMSpec(specName)
+	if err != nil {
+		return "", fmt.Errorf("Failed to Get VMSpec [%s] : [%v]", specName, err)
+	}
+
+	productListReq := vserver.GetServerProductListRequest{
+		RegionCode:                  ncloud.String(vmSpecHandler.RegionInfo.Region),
+		MemberServerImageInstanceNo: ncloud.String(myImageInstanceNo),
+	}
+	result, err := vmSpecHandler.VMClient.V2Api.GetServerProductList(&productListReq)
+	if err != nil {
+		return "", fmt.Errorf("Failed to Get ServerProductList for MyImage [%s] : [%v]", myImageInstanceNo, err)
+	}
+	if len(result.ProductList) < 1 {
+		return "", fmt.Errorf("No ServerProduct found for MyImage [%s]", myImageInstanceNo)
+	}
+
+	for _, product := range result.ProductList {
+		if ncloud.Int32Value(product.CpuCount) == ncloud.Int32Value(vmSpec.CpuCount) &&
+			ncloud.Int64Value(product.MemorySize) == ncloud.Int64Value(vmSpec.MemorySize) {
+			cblogger.Infof("Matched ServerProductCode [%s] for spec [%s] (CPU:%d, Mem:%d)",
+				ncloud.StringValue(product.ProductCode), specName,
+				ncloud.Int32Value(product.CpuCount), ncloud.Int64Value(product.MemorySize))
+			return ncloud.StringValue(product.ProductCode), nil
+		}
+	}
+	return "", fmt.Errorf("No matching ServerProduct for spec [%s] (CPU:%d, Mem:%d) in MyImage [%s]",
+		specName, ncloud.Int32Value(vmSpec.CpuCount), ncloud.Int64Value(vmSpec.MemorySize), myImageInstanceNo)
+}


### PR DESCRIPTION
## Problem
NCP VPC MyImage-based VM creation always failed, and several MyImage management issues were found during a cross-CSP MyImage coverage sweep.

## Changes

### VMHandler.go
- Use `ServerImageNo` + `ServerSpecCode` (new API) instead of `MemberServerImageInstanceNo` + `ServerProductCode` (legacy) — `CreateServerImage` returns `ServerImageNo`, not `MemberServerImageInstanceNo`
- Include `BlockStorageMappingList` only for KVM MyImages; XEN/RHV do not support it

### MyImageHandler.go
- Fix `getOriginImageOSPlatform`: key `"osType"` → `"OsType"`, tokens `UBNTU/CNTOS/WND` → `UBUNTU/CENTOS/WIN`
- Add `isKvmMyImage`: detect KVM hypervisor from KeyValueList
- Fix `DeleteMyImage`: check `TotalRows > 0` to catch silent no-ops; explicitly delete associated block storage snapshots (`deleteServerImage` does not cascade-delete them)
- Fix `mappingMyImageInfo`: parse `createDate` and convert to UTC for correct AdminWeb rendering
- Fix `SnapshotVM`: encode source VM SystemId in `ServerImageDescription` and parse it back in `mappingMyImageInfo` (NCP VPC API does not return source VM info natively)

### VMSpecHandler.go
- Add `getServerProductCodeForMyImage`: resolve `ServerProductCode` from `GetServerProductList` by CPU/memory match (retained for potential legacy-image use)

## Root Causes
- `getOriginImageOSPlatform` had two independent bugs (key case mismatch + legacy tokens), making every MyImage VM creation a guaranteed 500 error
- `CreateServerImage` returns `ServerImageNo`, so VM creation must use the new-API pair, not `MemberServerImageInstanceNo`
- `deleteServerImage` does not auto-delete underlying block storage snapshots