### PR TITLE
[Build] Chore: Wire cli spctl into root Makefile and clean up build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ default: swag
 				-X 'main.CommitSHA=$(COMMIT_SHA)' \
 				-X 'main.BuildTime=$(BUILD_TIME)'" \
 			-o bin/cb-spider ./api-runtime
+	@$(MAKE) --no-print-directory -C cli
 
 dyna plugin plug dynamic: swag
 	@printf '\t[CB-Spider] building ./bin/cb-spider-dyna (dynamic mode)...\n'
@@ -56,6 +57,7 @@ replace:
 clean clear:
 	@printf '\t[CB-Spider] cleaning...\n'
 	@rm -rf bin/cb-spider bin/cb-spider-dyna bin/cb-spider-arm bin/cb-spider-android-arm64
+	@$(MAKE) --no-print-directory -C cli clean
 
 
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -3,10 +3,7 @@ COMMIT_SHA := $(shell git rev-parse --short HEAD)
 BUILD_TIME := $(shell date)
 
 default:
-	@echo "VERSION: $(VERSION)"
-	@echo "COMMIT_SHA: $(COMMIT_SHA)"
-	@echo "BUILD_TIME: $(BUILD_TIME)"
-	@echo -e '\t[CB-Spider] building spctl...'
+	@printf '\t[CB-Spider] building cli spctl...\n'
 	@go mod download
 	@go mod tidy
 	@cp ../api/swagger.json ./cmd
@@ -17,6 +14,6 @@ default:
 	@rm ./cmd/swagger.json
 
 clean clear:
-	@echo -e '\t[CB-Spider] cleaning...'
+	@printf '\t[CB-Spider] cleaning cli spctl...\n'
 	@rm -rf ./spctl
 


### PR DESCRIPTION
- Run cli Makefile's default target from root default so make also builds cli/spctl
- Run cli Makefile's clean target from root clean/clear so make clean also removes cli/spctl
- Remove debug VERSION/COMMIT_SHA/BUILD_TIME echo lines and non-portable echo -e (printed literal -e on macOS's default shell) from cli/Makefile
- Unify build/clean log lines to printf '\t[CB-Spider] ...\n', matching the root Makefile's style