### PR TITLE
[NHN] Fix: Skip internet gateway deletion gracefully when not attached during DeleteVPC

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/VPCHandler.go
@@ -1385,9 +1385,8 @@ func (vpcHandler *NhnCloudVPCHandler) removeInternetGateway(vpcId string) (bool,
 	}
 
 	if strings.EqualFold(iGWId, "") {
-		newErr := fmt.Errorf("Failed to Get the Internet Gateway ID!!")
-		cblogger.Error(newErr.Error())
-		return false, newErr
+		cblogger.Info("### No Internet Gateway attached to the VPC. Skip deleting Internet Gateway.")
+		return true, nil
 	}
 
 	deleteErr := vpcHandler.deleteInternetGateway(iGWId)


### PR DESCRIPTION

- When `DeleteVPC` is called and no Internet Gateway is attached to the VPC's default routing table, the driver was returning an error (`Failed to Get the Internet Gateway ID!!`) instead of proceeding with VPC deletion
- Fixed by checking if `iGWId` is empty in `removeInternetGateway()` and returning `true, nil` with an Info log instead of an error
- This allows VPCs without an Internet Gateway to be deleted cleanly without false failures