### PR TITLE
[RDBMS/MariaDB] Verify and complete MariaDB support across CSPs

### DIFF
--- a/cloud-control-manager/CloudDriverHandler_common.go
+++ b/cloud-control-manager/CloudDriverHandler_common.go
@@ -183,6 +183,7 @@ func createConnectionInfo(cloudConnectName string, targetZoneName string) (idrv.
 			RDSUserAccessKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "User Access Key"),
 			RDSSecretAccessKey: KeyValueListGetValue(crdInfo.KeyValueInfoList, "Secret Access Key"),
 			RDSAppKey:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "appKey"),
+			RDSMariaDBAppKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "mariadbAppKey"),
 			ConnectionName:     cloudConnectName,
 		},
 		RegionInfo: idrv.RegionInfo{
@@ -281,6 +282,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 				RDSUserAccessKey   string `json:"RDSUserAccessKey"`
 				RDSSecretAccessKey string `json:"RDSSecretAccessKey"`
 				RDSAppKey          string `json:"RDSAppKey"`
+				RDSMariaDBAppKey   string `json:"RDSMariaDBAppKey"`
 			} `json:"CredentialInfo"`
 			RegionInfo struct {
 				Region     string `json:"Region"`
@@ -328,6 +330,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 			RDSUserAccessKey:   apiResponse.ConnectionInfo.CredentialInfo.RDSUserAccessKey,
 			RDSSecretAccessKey: apiResponse.ConnectionInfo.CredentialInfo.RDSSecretAccessKey,
 			RDSAppKey:          apiResponse.ConnectionInfo.CredentialInfo.RDSAppKey,
+			RDSMariaDBAppKey:   apiResponse.ConnectionInfo.CredentialInfo.RDSMariaDBAppKey,
 		},
 		RegionInfo: idrv.RegionInfo{
 			Region:     apiResponse.ConnectionInfo.RegionInfo.Region,
@@ -393,6 +396,7 @@ func GetCloudConnectionByDriverNameAndCredentialName(driverName string, credenti
 			RDSUserAccessKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "User Access Key"),
 			RDSSecretAccessKey: KeyValueListGetValue(crdInfo.KeyValueInfoList, "Secret Access Key"),
 			RDSAppKey:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "appKey"),
+			RDSMariaDBAppKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "mariadbAppKey"),
 		},
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/TagHandler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3"
 
@@ -178,19 +179,42 @@ func (tagHandler *AzureTagHandler) ListTag(resType irs.RSType, resIID irs.IID) (
 	resIID.SystemId = resourceID
 	hiscallInfo := GetCallLogScheme(tagHandler.Region, call.TAG, string(resType), "ListTag()")
 
-	start := call.Start()
-	tagsResource, err := tagHandler.Client.GetAtScope(tagHandler.Ctx, resIID.SystemId, nil)
-	if err != nil {
-		getErr := errors.New(fmt.Sprintf("Failed to list tags for resource ID %s: %s", resIID.SystemId, err.Error()))
-		cblogger.Error(getErr.Error())
-		LoggingError(hiscallInfo, getErr)
-		return nil, getErr
-	}
-	LoggingInfo(hiscallInfo, start)
+	// Azure ARM's tag read path can lag briefly behind a just-completed
+	// AddTag/RemoveTag write (the write's PollUntilDone reports success, but an
+	// immediate GetAtScope can still return stale/empty tags). Retry a couple of
+	// times on an empty result before trusting it, so a fresh tag isn't missed.
+	const maxAttempts = 3
+	const retryInterval = 2 * time.Second
 
 	var tagList []irs.KeyValue
-	for key, value := range tagsResource.Properties.Tags {
-		tagList = append(tagList, irs.KeyValue{Key: key, Value: *value})
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		start := call.Start()
+		tagsResource, err := tagHandler.Client.GetAtScope(tagHandler.Ctx, resIID.SystemId, nil)
+		if err != nil {
+			getErr := errors.New(fmt.Sprintf("Failed to list tags for resource ID %s: %s", resIID.SystemId, err.Error()))
+			cblogger.Error(getErr.Error())
+			LoggingError(hiscallInfo, getErr)
+			return nil, getErr
+		}
+		LoggingInfo(hiscallInfo, start)
+
+		tagList = nil
+		if tagsResource.Properties != nil {
+			for key, value := range tagsResource.Properties.Tags {
+				if value == nil {
+					// Azure may return system/internal tags with nil values; skip them.
+					continue
+				}
+				tagList = append(tagList, irs.KeyValue{Key: key, Value: *value})
+			}
+		}
+
+		if len(tagList) > 0 || attempt >= maxAttempts {
+			break
+		}
+		cblogger.Warnf("[Azure] ListTag: empty result for resource %s (attempt %d/%d), retrying in %s in case of tag propagation lag",
+			resIID.SystemId, attempt, maxAttempts, retryInterval)
+		time.Sleep(retryInterval)
 	}
 
 	return tagList, nil
@@ -215,6 +239,9 @@ func (tagHandler *AzureTagHandler) GetTag(resType irs.RSType, resIID irs.IID, ke
 	LoggingInfo(hiscallInfo, start)
 
 	if value, exists := tagsResource.Properties.Tags[key]; exists {
+		if value == nil {
+			return irs.KeyValue{}, errors.New("tag not found")
+		}
 		return irs.KeyValue{Key: key, Value: *value}, nil
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
@@ -714,8 +714,28 @@ func (handler *IbmRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, error
 	calllogger.Info(call.String(hiscallInfo))
 
 	info := handler.convertResourceInstanceToRDBMSInfo(result)
-	if err := handler.enrichRDBMSInfoFromCloudDB(&info, result); err != nil {
-		return irs.RDBMSInfo{}, err
+
+	// enrichRDBMSInfoFromCloudDB chains several IBM Cloud Databases/Global Tagging
+	// API calls (deployment info, scaling groups, tags, connection). A transient
+	// network blip in any one of them (observed e.g. as ECONNRESET against the
+	// Global Tagging API) would otherwise wipe out an already-successful,
+	// available instance's info entirely. Retry a few times before giving up.
+	const maxEnrichAttempts = 3
+	const enrichRetryInterval = 5 * time.Second
+	var enrichErr error
+	for attempt := 1; attempt <= maxEnrichAttempts; attempt++ {
+		enrichErr = handler.enrichRDBMSInfoFromCloudDB(&info, result)
+		if enrichErr == nil {
+			break
+		}
+		if attempt < maxEnrichAttempts {
+			cblogger.Warnf("[IBM] GetRDBMS: enrichment attempt %d/%d failed for %s, retrying in %s: %v",
+				attempt, maxEnrichAttempts, info.IId.NameId, enrichRetryInterval, enrichErr)
+			time.Sleep(enrichRetryInterval)
+		}
+	}
+	if enrichErr != nil {
+		return irs.RDBMSInfo{}, enrichErr
 	}
 	return info, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -253,7 +253,7 @@ type nhnRDSJobResponse struct {
 	ResourceRelations []nhnRDSResourceRelation `json:"resourceRelations"`
 }
 
-// GetMetaInfo returns metadata queried dynamically from NHN Cloud RDS for MySQL API v3.0.
+// GetMetaInfo returns metadata queried dynamically from NHN Cloud RDS for MySQL/MariaDB API v3.0.
 func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo, error) {
 	cblogger.Info("NHN Cloud Driver: called GetMetaInfo()")
 	callLogInfo := getCallLogScheme(handler.RegionInfo.Region, call.RDBMS, "GetMetaInfo", "GetMetaInfo()")
@@ -264,8 +264,8 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
-	if requestedEngine != "mysql" {
-		err := fmt.Errorf("NHN Cloud RDS native metadata API supports only mysql, requested: %s", requestedEngine)
+	if requestedEngine != "mysql" && requestedEngine != "mariadb" {
+		err := fmt.Errorf("NHN Cloud RDS supports mysql and mariadb engines, requested: %s", requestedEngine)
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
@@ -278,21 +278,26 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	dbVersions, err := handler.listRDSDBVersions(ctx)
+	endpointFn := handler.rdsEndpoint
+	if requestedEngine == "mariadb" {
+		endpointFn = handler.rdsMariaDBEndpoint
+	}
+
+	dbVersions, err := handler.listRDSDBVersionsWithEndpoint(ctx, endpointFn)
 	if err != nil {
 		newErr := fmt.Errorf("failed to list DB versions from NHN Cloud RDS API: %w", err)
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return irs.RDBMSMetaInfo{}, newErr
 	}
-	dbFlavors, err := handler.listRDSDBFlavors(ctx)
+	dbFlavors, err := handler.listRDSDBFlavorsWithEndpoint(ctx, endpointFn)
 	if err != nil {
 		newErr := fmt.Errorf("failed to list DB flavors from NHN Cloud RDS API: %w", err)
 		cblogger.Error(newErr.Error())
 		LoggingError(callLogInfo, newErr)
 		return irs.RDBMSMetaInfo{}, newErr
 	}
-	storageTypes, err := handler.listRDSStorageTypes(ctx)
+	storageTypes, err := handler.listRDSStorageTypesWithEndpoint(ctx, endpointFn)
 	if err != nil {
 		newErr := fmt.Errorf("failed to list storage types from NHN Cloud RDS API: %w", err)
 		cblogger.Error(newErr.Error())
@@ -301,29 +306,29 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 	}
 
 	if len(dbVersions) == 0 {
-		err := errors.New("NHN Cloud RDS API returned no DB versions")
+		err := fmt.Errorf("NHN Cloud RDS API returned no DB versions for engine: %s", requestedEngine)
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
 	if len(dbFlavors) == 0 {
-		err := errors.New("NHN Cloud RDS API returned no DB flavors")
+		err := fmt.Errorf("NHN Cloud RDS API returned no DB flavors for engine: %s", requestedEngine)
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
 	if len(storageTypes) == 0 {
-		err := errors.New("NHN Cloud RDS API returned no storage types")
+		err := fmt.Errorf("NHN Cloud RDS API returned no storage types for engine: %s", requestedEngine)
 		LoggingError(callLogInfo, err)
 		return irs.RDBMSMetaInfo{}, err
 	}
 
 	supportedEngines := map[string][]string{
-		"mysql": dbVersions,
+		requestedEngine: dbVersions,
 	}
 	instanceSpecOptions := map[string][]string{
-		"mysql": dbFlavors,
+		requestedEngine: dbFlavors,
 	}
 	storageTypeOptions := map[string][]string{
-		"mysql": storageTypes,
+		requestedEngine: storageTypes,
 	}
 
 	storageSizeRange := irs.StorageSizeRange{Min: 20, Max: 2048}
@@ -340,8 +345,12 @@ func (handler *NhnCloudRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMeta
 }
 
 func (handler *NhnCloudRDBMSHandler) listRDSDBVersions(ctx context.Context) ([]string, error) {
+	return handler.listRDSDBVersionsWithEndpoint(ctx, handler.rdsEndpoint)
+}
+
+func (handler *NhnCloudRDBMSHandler) listRDSDBVersionsWithEndpoint(ctx context.Context, endpointFn func() (string, error)) ([]string, error) {
 	var result nhnRDSDBVersionsResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-versions", &result); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-versions", &result); err != nil {
 		return nil, err
 	}
 	if err := checkRDSResponseHeader(result.Header); err != nil {
@@ -358,8 +367,12 @@ func (handler *NhnCloudRDBMSHandler) listRDSDBVersions(ctx context.Context) ([]s
 }
 
 func (handler *NhnCloudRDBMSHandler) listRDSDBFlavors(ctx context.Context) ([]string, error) {
+	return handler.listRDSDBFlavorsWithEndpoint(ctx, handler.rdsEndpoint)
+}
+
+func (handler *NhnCloudRDBMSHandler) listRDSDBFlavorsWithEndpoint(ctx context.Context, endpointFn func() (string, error)) ([]string, error) {
 	var result nhnRDSFlavorListResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-flavors", &result); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-flavors", &result); err != nil {
 		return nil, err
 	}
 	if err := checkRDSResponseHeader(result.Header); err != nil {
@@ -368,7 +381,6 @@ func (handler *NhnCloudRDBMSHandler) listRDSDBFlavors(ctx context.Context) ([]st
 
 	flavors := make([]string, 0, len(result.DBFlavors))
 	for _, flavor := range result.DBFlavors {
-		// Use DBFlavorName (e.g., "m2.c2m4") instead of UUID for better readability
 		if flavor.DBFlavorName != "" {
 			flavors = append(flavors, flavor.DBFlavorName)
 		}
@@ -377,8 +389,12 @@ func (handler *NhnCloudRDBMSHandler) listRDSDBFlavors(ctx context.Context) ([]st
 }
 
 func (handler *NhnCloudRDBMSHandler) listRDSStorageTypes(ctx context.Context) ([]string, error) {
+	return handler.listRDSStorageTypesWithEndpoint(ctx, handler.rdsEndpoint)
+}
+
+func (handler *NhnCloudRDBMSHandler) listRDSStorageTypesWithEndpoint(ctx context.Context, endpointFn func() (string, error)) ([]string, error) {
 	var result nhnRDSStorageTypesResponse
-	if err := handler.getRDS(ctx, "/v3.0/storage-types", &result); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/storage-types", &result); err != nil {
 		return nil, err
 	}
 	if err := checkRDSResponseHeader(result.Header); err != nil {
@@ -388,23 +404,47 @@ func (handler *NhnCloudRDBMSHandler) listRDSStorageTypes(ctx context.Context) ([
 	return extractStringValues(result.StorageTypes, "storageType"), nil
 }
 
+// rdsEffectiveAppKey returns the App Key to use for the given NHN RDS endpoint URL.
+// RDS for MySQL and RDS for MariaDB are separate NHN Cloud services with separate App Keys.
+// If the caller has configured RDSMariaDBAppKey and the endpoint targets the MariaDB service,
+// that key is used; otherwise RDSAppKey is returned.
+func (handler *NhnCloudRDBMSHandler) rdsEffectiveAppKey(endpoint string) string {
+	if strings.Contains(endpoint, "rds-mariadb") {
+		if handler.CredentialInfo.RDSMariaDBAppKey != "" {
+			return handler.CredentialInfo.RDSMariaDBAppKey
+		}
+		cblogger.Warnf("[NHN RDS] WARNING: calling MariaDB endpoint but RDSMariaDBAppKey (mariadbAppKey) is not set; " +
+			"falling back to RDSAppKey — this will likely cause Unauthorized or 500 from NHN API. " +
+			"Register 'mariadbAppKey' in your NHN credential (NHN Console → RDS for MariaDB → URL & AppKey).")
+	}
+	return handler.CredentialInfo.RDSAppKey
+}
+
 func (handler *NhnCloudRDBMSHandler) getRDS(ctx context.Context, path string, v interface{}) error {
-	endpoint, err := handler.rdsEndpoint()
+	return handler.getRDSWithEndpoint(ctx, handler.rdsEndpoint, path, v)
+}
+
+// rdsEndpointForEngine returns the appropriate RDS endpoint function for the given DB engine name.
+// MariaDB engine (case-insensitive "mariadb") uses rdsMariaDBEndpoint; all others use rdsEndpoint.
+func (handler *NhnCloudRDBMSHandler) rdsEndpointForEngine(dbEngine string) func() (string, error) {
+	if strings.EqualFold(dbEngine, "mariadb") {
+		return handler.rdsMariaDBEndpoint
+	}
+	return handler.rdsEndpoint
+}
+
+// getRDSWithEndpoint sends a GET request to the given NHN RDS endpoint (MySQL or MariaDB).
+func (handler *NhnCloudRDBMSHandler) getRDSWithEndpoint(ctx context.Context, endpointFn func() (string, error), path string, v interface{}) error {
+	endpoint, err := endpointFn()
 	if err != nil {
 		return err
 	}
-	cblogger.Infof("[NHN RDS] calling %s%s (appKey len=%d, accessKeyID len=%d, secretKey len=%d)",
-		endpoint, path,
-		len(handler.CredentialInfo.RDSAppKey),
-		len(handler.CredentialInfo.RDSUserAccessKey),
-		len(handler.CredentialInfo.RDSSecretAccessKey),
-	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+path, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create NHN Cloud RDS request: %w", err)
 	}
-	req.Header.Set("X-TC-APP-KEY", handler.CredentialInfo.RDSAppKey)
+	req.Header.Set("X-TC-APP-KEY", handler.rdsEffectiveAppKey(endpoint))
 	req.Header.Set("X-TC-AUTHENTICATION-ID", handler.CredentialInfo.RDSUserAccessKey)
 	req.Header.Set("X-TC-AUTHENTICATION-SECRET", handler.CredentialInfo.RDSSecretAccessKey)
 
@@ -422,7 +462,6 @@ func (handler *NhnCloudRDBMSHandler) getRDS(ctx context.Context, path string, v 
 	if err != nil {
 		return fmt.Errorf("failed to read NHN Cloud RDS API response: %w", err)
 	}
-	cblogger.Infof("[NHN RDS] raw response: %s", string(body))
 
 	if err := json.Unmarshal(body, v); err != nil {
 		return fmt.Errorf("failed to decode NHN Cloud RDS API response: %w", err)
@@ -437,6 +476,17 @@ func (handler *NhnCloudRDBMSHandler) rdsEndpoint() (string, error) {
 		return fmt.Sprintf("https://%s-rds-mysql.api.nhncloudservice.com", region), nil
 	default:
 		return "", fmt.Errorf("unsupported NHN Cloud RDS for MySQL region: %s", handler.RegionInfo.Region)
+	}
+}
+
+// rdsMariaDBEndpoint returns the NHN Cloud RDS for MariaDB API base URL for the current region.
+func (handler *NhnCloudRDBMSHandler) rdsMariaDBEndpoint() (string, error) {
+	region := strings.ToLower(handler.RegionInfo.Region)
+	switch region {
+	case "kr1", "kr2", "jp1":
+		return fmt.Sprintf("https://%s-rds-mariadb.api.nhncloudservice.com", region), nil
+	default:
+		return "", fmt.Errorf("unsupported NHN Cloud RDS for MariaDB region: %s", handler.RegionInfo.Region)
 	}
 }
 
@@ -456,7 +506,7 @@ func (handler *NhnCloudRDBMSHandler) checkRDSCredentials() error {
 		return fmt.Errorf(
 			"NHN Cloud RDBMS requires 3 credential keys that are not yet registered: %s.\n"+
 				"How to obtain and register them:\n"+
-				"  1. appKey       : NHN Cloud Console → Database → RDS for MySQL → URL & AppKey\n"+
+				"  1. appKey       : NHN Cloud Console → Database → RDS for MySQL/MariaDB → URL & AppKey\n"+
 				"  2. User Access Key  : NHN Cloud Console → My Page → API Security Settings → User Access Key ID\n"+
 				"  3. Secret Access Key: same page as above → Secret Access Key\n"+
 				"Add the missing key(s) to your CB-Spider credential and try again.",
@@ -504,22 +554,36 @@ func (handler *NhnCloudRDBMSHandler) ListIID() ([]*irs.IID, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var result nhnRDSListInstancesResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-instances", &result); err != nil {
-		LoggingError(callLogInfo, err)
-		return nil, err
-	}
-	if err := checkRDSResponseHeader(result.Header); err != nil {
-		LoggingError(callLogInfo, err)
-		return nil, err
-	}
+	iidList := make([]*irs.IID, 0)
 
-	iidList := make([]*irs.IID, 0, len(result.DBInstances))
-	for _, inst := range result.DBInstances {
+	// MySQL instances
+	var mysqlResult nhnRDSListInstancesResponse
+	if err := handler.getRDS(ctx, "/v3.0/db-instances", &mysqlResult); err != nil {
+		LoggingError(callLogInfo, err)
+		return nil, err
+	}
+	if err := checkRDSResponseHeader(mysqlResult.Header); err != nil {
+		LoggingError(callLogInfo, err)
+		return nil, err
+	}
+	for _, inst := range mysqlResult.DBInstances {
 		iidList = append(iidList, &irs.IID{
 			NameId:   inst.DBInstanceName,
 			SystemId: inst.DBInstanceId,
 		})
+	}
+
+	// MariaDB instances (best-effort; only if MariaDB endpoint is available)
+	var mariaResult nhnRDSListInstancesResponse
+	if err := handler.getRDSWithEndpoint(ctx, handler.rdsMariaDBEndpoint, "/v3.0/db-instances", &mariaResult); err != nil {
+		cblogger.Warnf("[NHN RDS] ListIID: MariaDB endpoint unavailable (non-fatal): %v", err)
+	} else if err := checkRDSResponseHeader(mariaResult.Header); err == nil {
+		for _, inst := range mariaResult.DBInstances {
+			iidList = append(iidList, &irs.IID{
+				NameId:   inst.DBInstanceName,
+				SystemId: inst.DBInstanceId,
+			})
+		}
 	}
 
 	LoggingInfo(callLogInfo, start)
@@ -591,8 +655,14 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
+	// Choose endpoint based on DB engine version: MARIADB_V* → MariaDB endpoint
+	endpointFn := handler.rdsEndpoint
+	if strings.HasPrefix(strings.ToUpper(rdbmsReqInfo.DBEngineVersion), "MARIADB_") {
+		endpointFn = handler.rdsMariaDBEndpoint
+	}
+
 	// Resolve DB flavor UUID from name or pass-through if already a UUID
-	flavorId, err := handler.resolveRDSFlavorId(ctx, rdbmsReqInfo.DBInstanceSpec)
+	flavorId, err := handler.resolveRDSFlavorIdWithEndpoint(ctx, endpointFn, rdbmsReqInfo.DBInstanceSpec)
 	if err != nil {
 		newErr := fmt.Errorf("failed to resolve NHN Cloud RDS flavor '%s': %w", rdbmsReqInfo.DBInstanceSpec, err)
 		LoggingError(callLogInfo, newErr)
@@ -600,7 +670,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	}
 
 	// Fetch a parameter group for the requested DB version
-	paramGroupId, err := handler.findDefaultParameterGroupId(ctx, rdbmsReqInfo.DBEngineVersion)
+	paramGroupId, err := handler.findDefaultParameterGroupIdWithEndpoint(ctx, endpointFn, rdbmsReqInfo.DBEngineVersion)
 	if err != nil {
 		newErr := fmt.Errorf("failed to find NHN Cloud RDS parameter group: %w", err)
 		LoggingError(callLogInfo, newErr)
@@ -624,7 +694,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 		if !rdbmsReqInfo.PublicAccess && subnetId != "" {
 			subnetCidr = handler.fetchSubnetCidr(ctx, subnetId)
 		}
-		autoSGId, sgErr := handler.createDefaultDBSecurityGroup(ctx, rdbmsReqInfo.IId.NameId, rdbmsReqInfo.PublicAccess, subnetCidr)
+		autoSGId, sgErr := handler.createDefaultDBSecurityGroup(ctx, endpointFn, rdbmsReqInfo.IId.NameId, rdbmsReqInfo.PublicAccess, subnetCidr)
 		if sgErr != nil {
 			LoggingError(callLogInfo, sgErr)
 			return irs.RDBMSInfo{}, sgErr
@@ -670,7 +740,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	}
 
 	var createResp nhnRDSJobResponse
-	if err := handler.postRDS(ctx, "/v3.0/db-instances", reqBody, &createResp); err != nil {
+	if err := handler.postRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances", reqBody, &createResp); err != nil {
 		newErr := fmt.Errorf("failed to submit NHN Cloud RDS create request: %w", err)
 		LoggingError(callLogInfo, newErr)
 		return irs.RDBMSInfo{}, newErr
@@ -681,7 +751,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	}
 
 	// Poll until the async job completes and we have the instance UUID
-	dbInstanceId, err := handler.pollRDSJob(ctx, createResp.JobId)
+	dbInstanceId, err := handler.pollRDSJobWithEndpoint(ctx, endpointFn, createResp.JobId)
 	if err != nil {
 		newErr := handler.rollbackCreatedRDBMS(irs.IID{NameId: rdbmsReqInfo.IId.NameId},
 			fmt.Errorf("NHN Cloud RDS instance creation job failed: %w", err))
@@ -695,7 +765,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	var getResp nhnRDSGetInstanceResponse
 	for attempt := 1; ; attempt++ {
 		getResp = nhnRDSGetInstanceResponse{}
-		fetchErr := handler.getRDS(ctx, "/v3.0/db-instances/"+dbInstanceId, &getResp)
+		fetchErr := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &getResp)
 		if fetchErr == nil {
 			fetchErr = checkRDSResponseHeader(getResp.Header)
 		}
@@ -719,7 +789,7 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	var enrichment nhnRDSEnrichmentData
 	for attempt := 1; ; attempt++ {
 		var enrichErr error
-		enrichment, enrichErr = handler.fetchRDBMSEnrichment(ctx, dbInstanceId, getResp.DBFlavorId)
+		enrichment, enrichErr = handler.fetchRDBMSEnrichmentWithEndpoint(ctx, endpointFn, dbInstanceId, getResp.DBFlavorId)
 		if enrichErr == nil {
 			break
 		}
@@ -737,6 +807,10 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	result := convertNhnRDSInstanceToRDBMSInfo(getResp.nhnRDSDBInstance, rdbmsReqInfo.VpcIID.NameId, enrichment)
 	// NHN appends a random suffix to the DB name; restore the user's requested name
 	result.IId.NameId = rdbmsReqInfo.IId.NameId
+	// Set engine based on DBVersion prefix for MariaDB
+	if strings.HasPrefix(strings.ToUpper(rdbmsReqInfo.DBEngineVersion), "MARIADB_") {
+		result.DBEngine = "mariadb"
+	}
 	return result, nil
 }
 
@@ -765,38 +839,44 @@ func (handler *NhnCloudRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	var result nhnRDSListInstancesResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-instances", &result); err != nil {
-		newErr := fmt.Errorf("failed to list NHN Cloud RDS instances: %w", err)
-		LoggingError(callLogInfo, newErr)
-		return nil, newErr
-	}
-	if err := checkRDSResponseHeader(result.Header); err != nil {
-		LoggingError(callLogInfo, err)
-		return nil, err
-	}
+	rdbmsList := make([]*irs.RDBMSInfo, 0)
 
-	// NHN list endpoint omits storage/network/backup details.
-	// Fetch each instance individually to get full field data.
-	rdbmsList := make([]*irs.RDBMSInfo, 0, len(result.DBInstances))
-	for _, listInst := range result.DBInstances {
-		var detail nhnRDSGetInstanceResponse
-		if err := handler.getRDS(ctx, "/v3.0/db-instances/"+listInst.DBInstanceId, &detail); err != nil {
-			newErr := fmt.Errorf("failed to get details for NHN Cloud RDS instance '%s': %w", listInst.DBInstanceId, err)
-			LoggingError(callLogInfo, newErr)
-			return nil, newErr
+	for _, endpointFn := range []func() (string, error){handler.rdsEndpoint, handler.rdsMariaDBEndpoint} {
+		var result nhnRDSListInstancesResponse
+		if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances", &result); err != nil {
+			cblogger.Warnf("[NHN RDS] ListRDBMS: endpoint unavailable (non-fatal): %v", err)
+			continue
 		}
-		if err := checkRDSResponseHeader(detail.Header); err != nil {
-			LoggingError(callLogInfo, err)
-			return nil, err
+		if err := checkRDSResponseHeader(result.Header); err != nil {
+			cblogger.Warnf("[NHN RDS] ListRDBMS: response header error (non-fatal): %v", err)
+			continue
 		}
-		enrichment, err := handler.fetchRDBMSEnrichment(ctx, listInst.DBInstanceId, detail.DBFlavorId)
-		if err != nil {
-			LoggingError(callLogInfo, err)
-			return nil, err
+
+		// NHN list endpoint omits storage/network/backup details.
+		// Fetch each instance individually to get full field data.
+		for _, listInst := range result.DBInstances {
+			var detail nhnRDSGetInstanceResponse
+			if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+listInst.DBInstanceId, &detail); err != nil {
+				newErr := fmt.Errorf("failed to get details for NHN Cloud RDS instance '%s': %w", listInst.DBInstanceId, err)
+				LoggingError(callLogInfo, newErr)
+				return nil, newErr
+			}
+			if err := checkRDSResponseHeader(detail.Header); err != nil {
+				LoggingError(callLogInfo, err)
+				return nil, err
+			}
+			enrichment, err := handler.fetchRDBMSEnrichmentWithEndpoint(ctx, endpointFn, listInst.DBInstanceId, detail.DBFlavorId)
+			if err != nil {
+				LoggingError(callLogInfo, err)
+				return nil, err
+			}
+			info := convertNhnRDSInstanceToRDBMSInfo(detail.nhnRDSDBInstance, "", enrichment)
+			// Set engine based on DBVersion prefix for MariaDB
+			if strings.HasPrefix(strings.ToUpper(detail.DBVersion), "MARIADB_") {
+				info.DBEngine = "mariadb"
+			}
+			rdbmsList = append(rdbmsList, &info)
 		}
-		info := convertNhnRDSInstanceToRDBMSInfo(detail.nhnRDSDBInstance, "", enrichment)
-		rdbmsList = append(rdbmsList, &info)
 	}
 
 	LoggingInfo(callLogInfo, start)
@@ -817,39 +897,45 @@ func (handler *NhnCloudRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	dbInstanceId := rdbmsIID.SystemId
-	if dbInstanceId == "" {
-		foundId, err := handler.findRDSInstanceIDByName(ctx, rdbmsIID.NameId)
+	// Try to get instance from MySQL endpoint first, then MariaDB endpoint if not found
+	for _, endpointFn := range []func() (string, error){handler.rdsEndpoint, handler.rdsMariaDBEndpoint} {
+		dbInstanceId := rdbmsIID.SystemId
+		if dbInstanceId == "" {
+			foundId, err := handler.findRDSInstanceIDByNameWithEndpoint(ctx, endpointFn, rdbmsIID.NameId)
+			if err != nil {
+				continue
+			}
+			dbInstanceId = foundId
+		}
+
+		var result nhnRDSGetInstanceResponse
+		if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &result); err != nil {
+			continue
+		}
+		if err := checkRDSResponseHeader(result.Header); err != nil {
+			continue
+		}
+
+		cblogger.Infof("[NHN RDBMS] Backup info from API - BackupPeriod: %d, BackupSchedules count: %d",
+			result.Backup.BackupPeriod, len(result.Backup.BackupSchedules))
+
+		enrichment, err := handler.fetchRDBMSEnrichmentWithEndpoint(ctx, endpointFn, dbInstanceId, result.DBFlavorId)
 		if err != nil {
 			LoggingError(callLogInfo, err)
 			return irs.RDBMSInfo{}, err
 		}
-		dbInstanceId = foundId
+
+		LoggingInfo(callLogInfo, start)
+		info := convertNhnRDSInstanceToRDBMSInfo(result.nhnRDSDBInstance, "", enrichment)
+		if strings.HasPrefix(strings.ToUpper(result.DBVersion), "MARIADB_") {
+			info.DBEngine = "mariadb"
+		}
+		return info, nil
 	}
 
-	var result nhnRDSGetInstanceResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-instances/"+dbInstanceId, &result); err != nil {
-		newErr := fmt.Errorf("failed to get NHN Cloud RDS instance '%s': %w", dbInstanceId, err)
-		LoggingError(callLogInfo, newErr)
-		return irs.RDBMSInfo{}, newErr
-	}
-	if err := checkRDSResponseHeader(result.Header); err != nil {
-		LoggingError(callLogInfo, err)
-		return irs.RDBMSInfo{}, err
-	}
-
-	// Debug: Log backup information from NHN API response
-	cblogger.Infof("[NHN RDBMS] Backup info from API - BackupPeriod: %d, BackupSchedules count: %d",
-		result.Backup.BackupPeriod, len(result.Backup.BackupSchedules))
-
-	enrichment, err := handler.fetchRDBMSEnrichment(ctx, dbInstanceId, result.DBFlavorId)
-	if err != nil {
-		LoggingError(callLogInfo, err)
-		return irs.RDBMSInfo{}, err
-	}
-
-	LoggingInfo(callLogInfo, start)
-	return convertNhnRDSInstanceToRDBMSInfo(result.nhnRDSDBInstance, "", enrichment), nil
+	err := fmt.Errorf("NHN Cloud RDS instance not found: %s (name: %s)", rdbmsIID.SystemId, rdbmsIID.NameId)
+	LoggingError(callLogInfo, err)
+	return irs.RDBMSInfo{}, err
 }
 
 func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
@@ -865,26 +951,23 @@ func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	dbInstanceId := rdbmsIID.SystemId
-	if dbInstanceId == "" {
-		foundId, err := handler.findRDSInstanceIDByName(ctx, rdbmsIID.NameId)
-		if err != nil {
-			LoggingError(callLogInfo, err)
-			return false, err
-		}
-		dbInstanceId = foundId
+	// Determine which endpoint the instance belongs to (MySQL or MariaDB)
+	endpointFn, dbInstanceId, err := handler.resolveInstanceEndpoint(ctx, rdbmsIID)
+	if err != nil {
+		LoggingError(callLogInfo, err)
+		return false, err
 	}
 
 	// Collect DB security group IDs before deleting the instance so we can
 	// clean up any SGs that were auto-created by CB-Spider.
 	var getInstResp nhnRDSGetInstanceResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-instances/"+dbInstanceId, &getInstResp); err == nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &getInstResp); err == nil {
 		_ = checkRDSResponseHeader(getInstResp.Header) // ignore header error here
 	}
-	autoSGIds := handler.collectAutoCBSpiderSGIds(ctx, getInstResp.DBSecurityGroupIds)
+	autoSGIds := handler.collectAutoCBSpiderSGIdsWithEndpoint(ctx, endpointFn, getInstResp.DBSecurityGroupIds)
 
 	var deleteResp nhnRDSJobResponse
-	if err := handler.deleteRDS(ctx, "/v3.0/db-instances/"+dbInstanceId, &deleteResp); err != nil {
+	if err := handler.deleteRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &deleteResp); err != nil {
 		newErr := fmt.Errorf("failed to delete NHN Cloud RDS instance '%s': %w", dbInstanceId, err)
 		LoggingError(callLogInfo, newErr)
 		return false, newErr
@@ -896,7 +979,7 @@ func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error)
 
 	// Delete auto-created DB SGs (best-effort; log but do not fail)
 	for _, sgId := range autoSGIds {
-		if delErr := handler.deleteRDS(ctx, "/v3.0/db-security-groups/"+sgId, nil); delErr != nil {
+		if delErr := handler.deleteRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-security-groups/"+sgId, nil); delErr != nil {
 			cblogger.Warnf("[NHN RDS] failed to delete auto-created DB security group '%s': %v", sgId, delErr)
 		} else {
 			cblogger.Infof("[NHN RDS] deleted auto-created DB security group '%s'", sgId)
@@ -911,7 +994,12 @@ func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error)
 
 // postRDS sends a POST request to the NHN RDS for MySQL API.
 func (handler *NhnCloudRDBMSHandler) postRDS(ctx context.Context, path string, body interface{}, v interface{}) error {
-	endpoint, err := handler.rdsEndpoint()
+	return handler.postRDSWithEndpoint(ctx, handler.rdsEndpoint, path, body, v)
+}
+
+// postRDSWithEndpoint sends a POST request to the NHN RDS API at the given endpoint.
+func (handler *NhnCloudRDBMSHandler) postRDSWithEndpoint(ctx context.Context, endpointFn func() (string, error), path string, body interface{}, v interface{}) error {
+	endpoint, err := endpointFn()
 	if err != nil {
 		return err
 	}
@@ -926,11 +1014,9 @@ func (handler *NhnCloudRDBMSHandler) postRDS(ctx context.Context, path string, b
 		return fmt.Errorf("failed to create NHN Cloud RDS POST request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-TC-APP-KEY", handler.CredentialInfo.RDSAppKey)
+	req.Header.Set("X-TC-APP-KEY", handler.rdsEffectiveAppKey(endpoint))
 	req.Header.Set("X-TC-AUTHENTICATION-ID", handler.CredentialInfo.RDSUserAccessKey)
 	req.Header.Set("X-TC-AUTHENTICATION-SECRET", handler.CredentialInfo.RDSSecretAccessKey)
-
-	cblogger.Infof("[NHN RDS] POST %s%s", endpoint, path)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -942,7 +1028,6 @@ func (handler *NhnCloudRDBMSHandler) postRDS(ctx context.Context, path string, b
 	if err != nil {
 		return fmt.Errorf("failed to read NHN Cloud RDS API response: %w", err)
 	}
-	cblogger.Infof("[NHN RDS] POST %s%s response(%d): %s", endpoint, path, resp.StatusCode, string(respBody))
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("NHN Cloud RDS API returned HTTP %s: %s", resp.Status, string(respBody))
@@ -1027,7 +1112,6 @@ func (handler *NhnCloudRDBMSHandler) putRDS(ctx context.Context, path string, bo
 	if err != nil {
 		return fmt.Errorf("failed to read NHN Cloud RDS API response: %w", err)
 	}
-	cblogger.Infof("[NHN RDS] PUT %s%s response(%d): %s", endpoint, path, resp.StatusCode, string(respBody))
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("NHN Cloud RDS API returned HTTP %s: %s", resp.Status, string(respBody))
@@ -1042,9 +1126,10 @@ func (handler *NhnCloudRDBMSHandler) putRDS(ctx context.Context, path string, bo
 }
 
 // createDefaultDBSecurityGroup creates a NHN Cloud RDS DB Security Group and returns its ID.
+// endpointFn selects the correct RDS endpoint (MySQL or MariaDB) for the DB instance being created.
 // If publicAccess is true, allows inbound DB port from 0.0.0.0/0.
 // If publicAccess is false and subnetCidr is non-empty, restricts inbound to the subnet CIDR only.
-func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Context, name string, publicAccess bool, subnetCidr string) (string, error) {
+func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Context, endpointFn func() (string, error), name string, publicAccess bool, subnetCidr string) (string, error) {
 	cidr := "0.0.0.0/0"
 	if !publicAccess && subnetCidr != "" {
 		cidr = subnetCidr
@@ -1068,7 +1153,7 @@ func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Co
 		},
 	}
 	var resp nhnRDSCreateDBSecurityGroupResponse
-	if err := handler.postRDS(ctx, "/v3.0/db-security-groups", reqBody, &resp); err != nil {
+	if err := handler.postRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-security-groups", reqBody, &resp); err != nil {
 		return "", fmt.Errorf("failed to create NHN Cloud RDS DB security group: %w", err)
 	}
 	if err := checkRDSResponseHeader(resp.Header); err != nil {
@@ -1079,7 +1164,12 @@ func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Co
 
 // deleteRDS sends a DELETE request to the NHN RDS for MySQL API.
 func (handler *NhnCloudRDBMSHandler) deleteRDS(ctx context.Context, path string, v interface{}) error {
-	endpoint, err := handler.rdsEndpoint()
+	return handler.deleteRDSWithEndpoint(ctx, handler.rdsEndpoint, path, v)
+}
+
+// deleteRDSWithEndpoint sends a DELETE request to the NHN RDS API at the given endpoint.
+func (handler *NhnCloudRDBMSHandler) deleteRDSWithEndpoint(ctx context.Context, endpointFn func() (string, error), path string, v interface{}) error {
+	endpoint, err := endpointFn()
 	if err != nil {
 		return err
 	}
@@ -1088,7 +1178,7 @@ func (handler *NhnCloudRDBMSHandler) deleteRDS(ctx context.Context, path string,
 	if err != nil {
 		return fmt.Errorf("failed to create NHN Cloud RDS DELETE request: %w", err)
 	}
-	req.Header.Set("X-TC-APP-KEY", handler.CredentialInfo.RDSAppKey)
+	req.Header.Set("X-TC-APP-KEY", handler.rdsEffectiveAppKey(endpoint))
 	req.Header.Set("X-TC-AUTHENTICATION-ID", handler.CredentialInfo.RDSUserAccessKey)
 	req.Header.Set("X-TC-AUTHENTICATION-SECRET", handler.CredentialInfo.RDSSecretAccessKey)
 
@@ -1102,7 +1192,6 @@ func (handler *NhnCloudRDBMSHandler) deleteRDS(ctx context.Context, path string,
 	if err != nil {
 		return fmt.Errorf("failed to read NHN Cloud RDS API response: %w", err)
 	}
-	cblogger.Infof("[NHN RDS] DELETE %s%s response(%d): %s", endpoint, path, resp.StatusCode, string(respBody))
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("NHN Cloud RDS API returned HTTP %s: %s", resp.Status, string(respBody))
@@ -1145,6 +1234,177 @@ func (handler *NhnCloudRDBMSHandler) pollRDSJob(ctx context.Context, jobId strin
 			}
 		}
 	}
+}
+
+// pollRDSJobWithEndpoint polls a NHN RDS async job at the given endpoint and returns the created resourceId.
+func (handler *NhnCloudRDBMSHandler) pollRDSJobWithEndpoint(ctx context.Context, endpointFn func() (string, error), jobId string) (string, error) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("timed out waiting for NHN Cloud RDS job %s", jobId)
+		case <-ticker.C:
+			var jobResp nhnRDSJobResponse
+			if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/jobs/"+jobId, &jobResp); err != nil {
+				return "", fmt.Errorf("failed to poll NHN Cloud RDS job %s: %w", jobId, err)
+			}
+			switch jobResp.JobStatus {
+			case "COMPLETED":
+				for _, rel := range jobResp.ResourceRelations {
+					if rel.ResourceType == "DB_INSTANCE" {
+						return rel.ResourceId, nil
+					}
+				}
+				return "", fmt.Errorf("NHN Cloud RDS job %s completed but no DB_INSTANCE in resourceRelations", jobId)
+			case "FAILED":
+				return "", fmt.Errorf("NHN Cloud RDS job %s failed", jobId)
+			default:
+				cblogger.Infof("[NHN RDS] job %s status: %s (waiting...)", jobId, jobResp.JobStatus)
+			}
+		}
+	}
+}
+
+// findRDSInstanceIDByNameWithEndpoint finds a DB instance UUID by name at the given endpoint.
+func (handler *NhnCloudRDBMSHandler) findRDSInstanceIDByNameWithEndpoint(ctx context.Context, endpointFn func() (string, error), name string) (string, error) {
+	var result nhnRDSListInstancesResponse
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances", &result); err != nil {
+		return "", fmt.Errorf("failed to list NHN Cloud RDS instances: %w", err)
+	}
+	if err := checkRDSResponseHeader(result.Header); err != nil {
+		return "", err
+	}
+	for _, inst := range result.DBInstances {
+		if inst.DBInstanceName == name || strings.HasPrefix(inst.DBInstanceName, name+"-") {
+			return inst.DBInstanceId, nil
+		}
+	}
+	return "", fmt.Errorf("NHN Cloud RDS instance with name '%s' not found", name)
+}
+
+// resolveInstanceEndpoint determines which RDS endpoint (MySQL or MariaDB) an instance belongs to.
+// Returns the endpoint function and the resolved instance ID.
+func (handler *NhnCloudRDBMSHandler) resolveInstanceEndpoint(ctx context.Context, rdbmsIID irs.IID) (func() (string, error), string, error) {
+	for _, endpointFn := range []func() (string, error){handler.rdsEndpoint, handler.rdsMariaDBEndpoint} {
+		dbInstanceId := rdbmsIID.SystemId
+		if dbInstanceId == "" {
+			foundId, err := handler.findRDSInstanceIDByNameWithEndpoint(ctx, endpointFn, rdbmsIID.NameId)
+			if err != nil {
+				continue
+			}
+			dbInstanceId = foundId
+		}
+		// Verify the instance exists at this endpoint
+		var checkResp nhnRDSGetInstanceResponse
+		if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &checkResp); err != nil {
+			continue
+		}
+		if checkRDSResponseHeader(checkResp.Header) == nil {
+			return endpointFn, dbInstanceId, nil
+		}
+	}
+	return nil, "", fmt.Errorf("NHN Cloud RDS instance not found: %s (name: %s)", rdbmsIID.SystemId, rdbmsIID.NameId)
+}
+
+// fetchRDBMSEnrichmentWithEndpoint calls enrichment APIs using the given endpoint function.
+func (handler *NhnCloudRDBMSHandler) fetchRDBMSEnrichmentWithEndpoint(ctx context.Context, endpointFn func() (string, error), dbInstanceId string, flavorId string) (nhnRDSEnrichmentData, error) {
+	var data nhnRDSEnrichmentData
+	data.DBFlavorName = handler.resolveRDSFlavorNameWithEndpoint(ctx, endpointFn, flavorId)
+
+	var usersResp nhnRDSDBUserListResponse
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId+"/db-users", &usersResp); err != nil {
+		return data, fmt.Errorf("failed to list DB users for NHN Cloud RDS instance '%s': %w", dbInstanceId, err)
+	}
+	if err := checkRDSResponseHeader(usersResp.Header); err != nil {
+		return data, fmt.Errorf("db-users response error for instance '%s': %w", dbInstanceId, err)
+	}
+	for _, u := range usersResp.DBUsers {
+		if u.DBUserStatus == "STABLE" {
+			data.MasterUserName = u.DBUserName
+			break
+		}
+	}
+
+	var netResp nhnRDSNetworkInfoResponse
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId+"/network-info", &netResp); err != nil {
+		return data, fmt.Errorf("failed to get network info for NHN Cloud RDS instance '%s': %w", dbInstanceId, err)
+	}
+	if err := checkRDSResponseHeader(netResp.Header); err != nil {
+		return data, fmt.Errorf("network-info response error for instance '%s': %w", dbInstanceId, err)
+	}
+	data.SubnetId = netResp.Subnet.SubnetId
+	data.SubnetName = netResp.Subnet.SubnetName
+	data.SubnetCidr = netResp.Subnet.SubnetCidr
+	for _, ep := range netResp.EndPoints {
+		if ep.EndPointType == "EXTERNAL" {
+			data.UsePublicAccess = true
+			if ep.Domain != "" {
+				data.PublicEndpoint = ep.Domain
+			} else {
+				data.PublicEndpoint = ep.IPAddress
+			}
+			break
+		}
+	}
+
+	var storResp nhnRDSStorageInfoResponse
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId+"/storage-info", &storResp); err != nil {
+		return data, fmt.Errorf("failed to get storage info for NHN Cloud RDS instance '%s': %w", dbInstanceId, err)
+	}
+	if err := checkRDSResponseHeader(storResp.Header); err != nil {
+		return data, fmt.Errorf("storage-info response error for instance '%s': %w", dbInstanceId, err)
+	}
+	data.StorageType = storResp.StorageType
+	data.StorageSize = storResp.StorageSize
+
+	var backupResp struct {
+		Header nhnRDSResponseHeader `json:"header"`
+		nhnRDSBackupConfig
+	}
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId+"/backup-info", &backupResp); err == nil {
+		if checkErr := checkRDSResponseHeader(backupResp.Header); checkErr == nil {
+			data.BackupConfig = backupResp.nhnRDSBackupConfig
+		}
+	}
+
+	return data, nil
+}
+
+// collectAutoCBSpiderSGIdsWithEndpoint inspects DB SG IDs using the given endpoint.
+func (handler *NhnCloudRDBMSHandler) collectAutoCBSpiderSGIdsWithEndpoint(ctx context.Context, endpointFn func() (string, error), sgIds []string) []string {
+	var auto []string
+	for _, id := range sgIds {
+		var detail nhnRDSDBSecurityGroupDetailResponse
+		if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-security-groups/"+id, &detail); err != nil {
+			continue
+		}
+		if checkRDSResponseHeader(detail.Header) != nil {
+			continue
+		}
+		if strings.HasPrefix(detail.Description, "Auto-created by CB-Spider:") {
+			auto = append(auto, id)
+		}
+	}
+	return auto
+}
+
+// resolveRDSFlavorNameWithEndpoint resolves a DB flavor UUID to its name using the given endpoint.
+func (handler *NhnCloudRDBMSHandler) resolveRDSFlavorNameWithEndpoint(ctx context.Context, endpointFn func() (string, error), flavorId string) string {
+	var result nhnRDSFlavorListResponse
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-flavors", &result); err != nil {
+		return flavorId
+	}
+	if checkRDSResponseHeader(result.Header) != nil {
+		return flavorId
+	}
+	for _, f := range result.DBFlavors {
+		if f.DBFlavorId == flavorId {
+			return f.DBFlavorName
+		}
+	}
+	return flavorId
 }
 
 // findRDSInstanceIDByName finds a DB instance UUID by name using the NHN native API.
@@ -1238,6 +1498,11 @@ func convertNhnRDSInstanceToRDBMSInfo(inst nhnRDSDBInstance, ownerVPCName string
 
 	createdTime, _ := time.Parse(time.RFC3339, inst.CreatedYmdt)
 
+	dbEngine := "mysql"
+	if strings.HasPrefix(strings.ToUpper(inst.DBVersion), "MARIADB_") {
+		dbEngine = "mariadb"
+	}
+
 	return irs.RDBMSInfo{
 		IId: irs.IID{
 			NameId:   inst.DBInstanceName,
@@ -1245,7 +1510,7 @@ func convertNhnRDSInstanceToRDBMSInfo(inst nhnRDSDBInstance, ownerVPCName string
 		},
 		VpcIID: irs.IID{NameId: ownerVPCName, SystemId: "NA"},
 
-		DBEngine:        "mysql",
+		DBEngine:        dbEngine,
 		DBEngineVersion: inst.DBVersion,
 		DBInstanceSpec:  e.DBFlavorName,
 		DBInstanceType:  "NA",
@@ -1395,11 +1660,15 @@ func (handler *NhnCloudRDBMSHandler) resolveRDSFlavorName(ctx context.Context, f
 // resolveRDSFlavorId resolves a DB flavor name (e.g. "m2.c2m4") to its UUID via
 // GET /v3.0/db-flavors. If the input already looks like a UUID it is returned as-is.
 func (handler *NhnCloudRDBMSHandler) resolveRDSFlavorId(ctx context.Context, nameOrId string) (string, error) {
+	return handler.resolveRDSFlavorIdWithEndpoint(ctx, handler.rdsEndpoint, nameOrId)
+}
+
+func (handler *NhnCloudRDBMSHandler) resolveRDSFlavorIdWithEndpoint(ctx context.Context, endpointFn func() (string, error), nameOrId string) (string, error) {
 	if isRDSUUID(nameOrId) {
 		return nameOrId, nil
 	}
 	var result nhnRDSFlavorListResponse
-	if err := handler.getRDS(ctx, "/v3.0/db-flavors", &result); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-flavors", &result); err != nil {
 		return "", fmt.Errorf("failed to list NHN Cloud RDS flavors: %w", err)
 	}
 	if err := checkRDSResponseHeader(result.Header); err != nil {
@@ -1416,8 +1685,12 @@ func (handler *NhnCloudRDBMSHandler) resolveRDSFlavorId(ctx context.Context, nam
 // findDefaultParameterGroupId fetches parameter groups from GET /v3.0/parameter-groups
 // and returns one whose dbVersion matches, or the first available group.
 func (handler *NhnCloudRDBMSHandler) findDefaultParameterGroupId(ctx context.Context, dbVersion string) (string, error) {
+	return handler.findDefaultParameterGroupIdWithEndpoint(ctx, handler.rdsEndpoint, dbVersion)
+}
+
+func (handler *NhnCloudRDBMSHandler) findDefaultParameterGroupIdWithEndpoint(ctx context.Context, endpointFn func() (string, error), dbVersion string) (string, error) {
 	var result nhnRDSParameterGroupListResponse
-	if err := handler.getRDS(ctx, "/v3.0/parameter-groups", &result); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/parameter-groups", &result); err != nil {
 		return "", fmt.Errorf("failed to list NHN Cloud RDS parameter groups: %w", err)
 	}
 	if err := checkRDSResponseHeader(result.Header); err != nil {
@@ -1459,8 +1732,8 @@ type nhnRDSSchemaJobResponse struct {
 	JobId  string               `json:"jobId"`
 }
 
-// pollRDSJobSimple waits for a NHN RDS async job to reach a terminal state (no resource extraction).
-func (handler *NhnCloudRDBMSHandler) pollRDSJobSimple(ctx context.Context, jobId string) error {
+// pollRDSJobSimpleWithEndpoint polls a NHN RDS async job to reach a terminal state using the given endpoint.
+func (handler *NhnCloudRDBMSHandler) pollRDSJobSimpleWithEndpoint(ctx context.Context, endpointFn func() (string, error), jobId string) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -1469,7 +1742,7 @@ func (handler *NhnCloudRDBMSHandler) pollRDSJobSimple(ctx context.Context, jobId
 			return fmt.Errorf("timed out waiting for NHN Cloud RDS job %s", jobId)
 		case <-ticker.C:
 			var jobResp nhnRDSJobResponse
-			if err := handler.getRDS(ctx, "/v3.0/jobs/"+jobId, &jobResp); err != nil {
+			if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/jobs/"+jobId, &jobResp); err != nil {
 				return fmt.Errorf("failed to poll NHN Cloud RDS job %s: %w", jobId, err)
 			}
 			switch jobResp.JobStatus {
@@ -1489,15 +1762,16 @@ func (handler *NhnCloudRDBMSHandler) CreateDatabase(rdbmsSystemId, dbEngine, dbN
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
+	endpointFn := handler.rdsEndpointForEngine(dbEngine)
 	var resp nhnRDSSchemaJobResponse
-	if err := handler.postRDS(ctx, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId),
+	if err := handler.postRDSWithEndpoint(ctx, endpointFn, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId),
 		nhnRDSCreateSchemaRequest{DBSchemaName: dbName}, &resp); err != nil {
 		return fmt.Errorf("NHN RDS CreateDatabase: %w", err)
 	}
 	if err := checkRDSResponseHeader(resp.Header); err != nil {
 		return fmt.Errorf("NHN RDS CreateDatabase: %w", err)
 	}
-	return handler.pollRDSJobSimple(ctx, resp.JobId)
+	return handler.pollRDSJobSimpleWithEndpoint(ctx, endpointFn, resp.JobId)
 }
 
 // ListDatabases lists DB schemas on the NHN Cloud RDS instance.
@@ -1506,7 +1780,7 @@ func (handler *NhnCloudRDBMSHandler) ListDatabases(rdbmsSystemId, dbEngine strin
 	defer cancel()
 
 	var resp nhnRDSListSchemasResponse
-	if err := handler.getRDS(ctx, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId), &resp); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, handler.rdsEndpointForEngine(dbEngine), fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId), &resp); err != nil {
 		return nil, fmt.Errorf("NHN RDS ListDatabases: %w", err)
 	}
 	if err := checkRDSResponseHeader(resp.Header); err != nil {
@@ -1524,9 +1798,10 @@ func (handler *NhnCloudRDBMSHandler) DeleteDatabase(rdbmsSystemId, dbEngine, dbN
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
+	endpointFn := handler.rdsEndpointForEngine(dbEngine)
 	// Find the schema ID by name.
 	var listResp nhnRDSListSchemasResponse
-	if err := handler.getRDS(ctx, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId), &listResp); err != nil {
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas", rdbmsSystemId), &listResp); err != nil {
 		return fmt.Errorf("NHN RDS DeleteDatabase (list): %w", err)
 	}
 	if err := checkRDSResponseHeader(listResp.Header); err != nil {
@@ -1544,13 +1819,13 @@ func (handler *NhnCloudRDBMSHandler) DeleteDatabase(rdbmsSystemId, dbEngine, dbN
 	}
 
 	var resp nhnRDSSchemaJobResponse
-	if err := handler.deleteRDS(ctx, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas/%s", rdbmsSystemId, schemaId), &resp); err != nil {
+	if err := handler.deleteRDSWithEndpoint(ctx, endpointFn, fmt.Sprintf("/v3.0/db-instances/%s/db-schemas/%s", rdbmsSystemId, schemaId), &resp); err != nil {
 		return fmt.Errorf("NHN RDS DeleteDatabase: %w", err)
 	}
 	if err := checkRDSResponseHeader(resp.Header); err != nil {
 		return fmt.Errorf("NHN RDS DeleteDatabase: %w", err)
 	}
-	return handler.pollRDSJobSimple(ctx, resp.JobId)
+	return handler.pollRDSJobSimpleWithEndpoint(ctx, endpointFn, resp.JobId)
 }
 
 // isRDSUUID returns true if s is in standard UUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).

--- a/cloud-control-manager/cloud-driver/drivers/tencent/connect/TencentCloudConnection.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/connect/TencentCloudConnection.go
@@ -195,7 +195,12 @@ func (cloudConn *TencentCloudConnection) CreateRDBMSHandler() (irs.RDBMSHandler,
 		ClusterClient:  cloudConn.ClusterClient,
 		CDBClient:      cloudConn.CDBClient,
 	}
-	handler := trs.TencentRDBMSHandler{Region: cloudConn.Region, Client: cloudConn.CDBClient, VMClient: cloudConn.VMClient, TagHandler: &tagHandler}
+	handler := trs.TencentRDBMSHandler{
+		Region:     cloudConn.Region,
+		Client:     cloudConn.CDBClient,
+		VMClient:   cloudConn.VMClient,
+		TagHandler: &tagHandler,
+	}
 	return &handler, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/RDBMSHandler.go
@@ -40,15 +40,33 @@ type TencentRDBMSHandler struct {
 // "Sets the root account password.")
 const tencentDefaultAdminUser = "root"
 
+// allCDBInstanceStatuses returns every Tencent CDB instance status value
+// (0=creating, 1=running, 4=isolating, 5=isolated/recycle-bin), so
+// DescribeDBInstances also surfaces isolated instances. Tencent's default
+// (no Status filter) omits Status=5 instances even though they still hold
+// a VPC/subnet IP until permanently offlined.
+func allCDBInstanceStatuses() []*uint64 {
+	statuses := []uint64{0, 1, 4, 5}
+	ptrs := make([]*uint64, len(statuses))
+	for i := range statuses {
+		ptrs[i] = &statuses[i]
+	}
+	return ptrs
+}
+
 func (handler *TencentRDBMSHandler) GetMetaInfo(dbEngine string) (irs.RDBMSMetaInfo, error) {
 	cblogger.Debug("Tencent CDB GetMetaInfo() called")
 
-	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "DescribeCdbZoneConfig()")
-	start := call.Start()
 	requestedEngine, err := irs.NormalizeRDBMSEngine(dbEngine)
 	if err != nil {
 		return irs.RDBMSMetaInfo{}, err
 	}
+
+	// MySQL (CDB) path. Tencent Cloud does not support MariaDB
+	// (Create MariaDB not supported); requestedEngine "mariadb" is rejected
+	// below by BuildRDBMSMetaInfo since it is absent from the supported engine map.
+	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "GetMetaInfo", "DescribeCdbZoneConfig()")
+	start := call.Start()
 
 	supportedEngines, instanceSpecOptions, storageTypeOptions, storageSizeRange, err := handler.fetchCDBMetaOptions()
 	if err != nil {
@@ -290,6 +308,7 @@ func (handler *TencentRDBMSHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, "ListIID", "DescribeDBInstances()")
 	start := call.Start()
 
+	// CDB (MySQL) instances
 	var iidList []*irs.IID
 	var offset uint64 = 0
 	var limit uint64 = 100
@@ -298,6 +317,10 @@ func (handler *TencentRDBMSHandler) ListIID() ([]*irs.IID, error) {
 		request := cdb.NewDescribeDBInstancesRequest()
 		request.Offset = &offset
 		request.Limit = &limit
+		// Include isolated (recycle-bin) instances: without this, DescribeDBInstances
+		// omits Status=5 instances, which still hold a VPC/subnet IP until permanently
+		// offlined and would otherwise be invisible to CB-Spider.
+		request.Status = allCDBInstanceStatuses()
 
 		response, err := handler.Client.DescribeDBInstances(request)
 		if err != nil {
@@ -549,29 +572,41 @@ func (handler *TencentRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (irs
 
 	// Enable public endpoint when requested.
 	// The earlier wait for Running is warning-only, so the instance may still be
-	// initializing; retry before giving up and rolling back.
+	// initializing; retry before giving up.
+	// NOTE: OpenWanService / waitForWanStatus failures do NOT trigger rollback.
+	// Rolling back a successfully created instance because a secondary feature
+	// (public endpoint) could not be enabled leaves a zombie resource when the
+	// delete call is also refused (e.g. Tencent InternalError while initializing).
+	// Instead we log a warning and proceed so that the IID is registered in
+	// CB-Spider and the instance can be managed (and deleted) normally later.
 	if rdbmsReqInfo.PublicAccess {
-		const maxWanAttempts = 3
+		const maxWanAttempts = 5
+		wanRequested := false
 		for attempt := 1; ; attempt++ {
 			openWanReq := cdb.NewOpenWanServiceRequest()
 			openWanReq.InstanceId = &instanceId
 			_, openWanErr := handler.Client.OpenWanService(openWanReq)
 			if openWanErr == nil {
+				wanRequested = true
 				break
 			}
 			if attempt >= maxWanAttempts {
-				return irs.RDBMSInfo{}, handler.rollbackCreatedRDBMS(irs.IID{NameId: rdbmsReqInfo.IId.NameId, SystemId: instanceId},
-					fmt.Errorf("failed to enable public access after %d attempts: %w", attempt, openWanErr))
+				cblogger.Warnf("[Tencent] OpenWanService failed after %d attempts for instance %s; "+
+					"public access will not be enabled. Enable it manually via the Tencent console if needed: %v",
+					attempt, instanceId, openWanErr)
+				break
 			}
-			cblogger.Warnf("[Tencent] OpenWanService failed (attempt %d/%d), retrying in 10s: %v", attempt, maxWanAttempts, openWanErr)
-			time.Sleep(10 * time.Second)
+			cblogger.Warnf("[Tencent] OpenWanService failed (attempt %d/%d), retrying in 15s: %v", attempt, maxWanAttempts, openWanErr)
+			time.Sleep(15 * time.Second)
 		}
 
-		// Wait until WAN is enabled to return a public endpoint.
-		err = handler.waitForWanStatus(instanceId, 1, 300)
-		if err != nil {
-			return irs.RDBMSInfo{}, handler.rollbackCreatedRDBMS(irs.IID{NameId: rdbmsReqInfo.IId.NameId, SystemId: instanceId},
-				fmt.Errorf("public access requested but WAN was not enabled: %w", err))
+		if wanRequested {
+			// Wait until WAN is enabled to return a public endpoint.
+			if waitErr := handler.waitForWanStatus(instanceId, 1, 300); waitErr != nil {
+				cblogger.Warnf("[Tencent] WAN status wait failed for instance %s; "+
+					"public endpoint may not be available yet. Check the Tencent console: %v",
+					instanceId, waitErr)
+			}
 		}
 	}
 
@@ -614,10 +649,13 @@ func (handler *TencentRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 	var offset uint64 = 0
 	var limit uint64 = 100
 
+	// CDB (MySQL) instances
 	for {
 		request := cdb.NewDescribeDBInstancesRequest()
 		request.Offset = &offset
 		request.Limit = &limit
+		// Include isolated (recycle-bin) instances; see ListIID for why.
+		request.Status = allCDBInstanceStatuses()
 
 		response, err := handler.Client.DescribeDBInstances(request)
 		if err != nil {
@@ -633,7 +671,6 @@ func (handler *TencentRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 
 		for _, inst := range response.Response.Items {
 			rdbmsInfo := handler.convertToRDBMSInfo(inst)
-			// Retrieve backup configuration for each instance
 			handler.enrichBackupInfo(&rdbmsInfo)
 			rdbmsList = append(rdbmsList, &rdbmsInfo)
 		}
@@ -684,41 +721,96 @@ func (handler *TencentRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, e
 	return rdbmsInfo, nil
 }
 
+// getCDBInstanceStatus looks up a CDB instance's current Status, including
+// isolated (recycle-bin) instances. found=false means Tencent no longer knows
+// about the instance at all (already permanently deleted).
+func (handler *TencentRDBMSHandler) getCDBInstanceStatus(instanceId string) (status int64, found bool, err error) {
+	request := cdb.NewDescribeDBInstancesRequest()
+	request.InstanceIds = []*string{&instanceId}
+	request.Status = allCDBInstanceStatuses()
+
+	response, err := handler.Client.DescribeDBInstances(request)
+	if err != nil {
+		return 0, false, err
+	}
+	if response.Response == nil || len(response.Response.Items) == 0 {
+		return 0, false, nil
+	}
+	if response.Response.Items[0].Status == nil {
+		return 0, true, nil
+	}
+	return *response.Response.Items[0].Status, true, nil
+}
+
 func (handler *TencentRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error) {
-	hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "IsolateDBInstance()")
-	start := call.Start()
-
-	// Step 1: Isolate the instance (moves to recycle bin, status → 4:isolating → 5:isolated)
-	isolateReq := cdb.NewIsolateDBInstanceRequest()
-	isolateReq.InstanceId = &rdbmsIID.SystemId
-
-	_, err := handler.Client.IsolateDBInstance(isolateReq)
-	hiscallInfo.ElapsedTime = call.Elapsed(start)
-	if err != nil {
-		cblogger.Error(err)
-		LoggingError(hiscallInfo, err)
-		return false, err
-	}
-	calllogger.Info(call.String(hiscallInfo))
-
-	// Step 2: Wait for isolated status (5) before calling Offline.
-	// OfflineIsolatedInstances fails if the instance is still in isolating state (4).
 	const isolatedStatus int64 = 5
-	if waitErr := handler.waitForInstanceStatus(rdbmsIID.SystemId, isolatedStatus, 300); waitErr != nil {
-		cblogger.Warnf("[Tencent] Timeout waiting for instance %s to reach isolated status; attempting Offline anyway: %v",
-			rdbmsIID.SystemId, waitErr)
+
+	// Idempotency: a prior delete attempt may have already isolated the instance
+	// (or fully removed it) but failed on the final permanent-delete step below.
+	// Re-checking the live status lets a retried/first-time delete request finish
+	// the job in one call instead of leaving the instance stuck in the recycle bin
+	// holding a VPC/subnet IP indefinitely.
+	currentStatus, found, statusErr := handler.getCDBInstanceStatus(rdbmsIID.SystemId)
+	if statusErr != nil {
+		cblogger.Warnf("[Tencent] DeleteRDBMS: failed to check current status of %s, proceeding with isolate: %v", rdbmsIID.SystemId, statusErr)
+	}
+	if statusErr == nil && !found {
+		cblogger.Infof("[Tencent] DeleteRDBMS: instance %s not found; treating as already deleted", rdbmsIID.SystemId)
+		return true, nil
 	}
 
-	// Step 3: Permanently delete (Eliminate Now)
-	offlineReq := cdb.NewOfflineIsolatedInstancesRequest()
-	offlineReq.InstanceIds = []*string{&rdbmsIID.SystemId}
+	if statusErr != nil || currentStatus != isolatedStatus {
+		// Step 1: Isolate the instance (moves to recycle bin, status → 4:isolating → 5:isolated)
+		hiscallInfo := GetCallLogScheme(handler.Region, call.RDBMS, rdbmsIID.NameId, "IsolateDBInstance()")
+		start := call.Start()
 
-	_, err = handler.Client.OfflineIsolatedInstances(offlineReq)
-	if err != nil {
-		return false, fmt.Errorf("instance isolated but permanent delete (OfflineIsolatedInstances) failed: %w", err)
+		isolateReq := cdb.NewIsolateDBInstanceRequest()
+		isolateReq.InstanceId = &rdbmsIID.SystemId
+
+		_, err := handler.Client.IsolateDBInstance(isolateReq)
+		hiscallInfo.ElapsedTime = call.Elapsed(start)
+		if err != nil {
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return false, err
+		}
+		calllogger.Info(call.String(hiscallInfo))
+
+		// Step 2: Wait for isolated status (5) before calling Offline.
+		// OfflineIsolatedInstances fails if the instance is still in isolating state (4).
+		if waitErr := handler.waitForInstanceStatus(rdbmsIID.SystemId, isolatedStatus, 300); waitErr != nil {
+			cblogger.Warnf("[Tencent] Timeout waiting for instance %s to reach isolated status; attempting permanent delete anyway: %v",
+				rdbmsIID.SystemId, waitErr)
+		}
 	}
 
-	return true, nil
+	// Step 3: Permanently delete (Eliminate Now). Retry on transient failures so the
+	// instance - and the VPC/subnet IP it holds - is fully released on the first
+	// delete request instead of requiring a manual retry later.
+	const maxOfflineAttempts = 5
+	const offlineRetryIntervalSec = 20
+	var offlineErr error
+	for attempt := 1; attempt <= maxOfflineAttempts; attempt++ {
+		offlineReq := cdb.NewOfflineIsolatedInstancesRequest()
+		offlineReq.InstanceIds = []*string{&rdbmsIID.SystemId}
+
+		_, offlineErr = handler.Client.OfflineIsolatedInstances(offlineReq)
+		if offlineErr == nil {
+			return true, nil
+		}
+		if strings.Contains(offlineErr.Error(), "InstanceNotFound") || strings.Contains(offlineErr.Error(), "ResourceNotFound") {
+			// Already gone, e.g. a race with a previous delete attempt.
+			return true, nil
+		}
+		if attempt >= maxOfflineAttempts {
+			break
+		}
+		cblogger.Warnf("[Tencent] OfflineIsolatedInstances failed for %s (attempt %d/%d), retrying in %ds: %v",
+			rdbmsIID.SystemId, attempt, maxOfflineAttempts, offlineRetryIntervalSec, offlineErr)
+		time.Sleep(time.Duration(offlineRetryIntervalSec) * time.Second)
+	}
+
+	return false, fmt.Errorf("instance isolated but permanent delete (OfflineIsolatedInstances) failed after %d attempts: %w", maxOfflineAttempts, offlineErr)
 }
 
 // ===== Helper Functions =====
@@ -868,6 +960,10 @@ func (handler *TencentRDBMSHandler) waitForInstanceStatus(instanceId string, tar
 	for elapsed := 0; elapsed < timeoutSec; elapsed += 15 {
 		request := cdb.NewDescribeDBInstancesRequest()
 		request.InstanceIds = []*string{&instanceId}
+		// Without this, DescribeDBInstances omits isolated (Status=5) instances by
+		// default, so waiting for the isolated status during delete would never see
+		// the instance transition and would spin until timeout every time.
+		request.Status = allCDBInstanceStatuses()
 
 		response, err := handler.Client.DescribeDBInstances(request)
 		if err != nil {

--- a/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
+++ b/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
@@ -87,7 +87,8 @@ type CredentialInfo struct {
 	//----- RDS Access Info
 	RDSUserAccessKey   string // RDS User Access Key
 	RDSSecretAccessKey string // RDS Secret Access Key
-	RDSAppKey          string // RDS AppKey
+	RDSAppKey          string // RDS AppKey (e.g., NHN Cloud RDS for MySQL)
+	RDSMariaDBAppKey   string // RDS MariaDB-specific AppKey (e.g., NHN Cloud RDS for MariaDB; falls back to RDSAppKey if empty)
 }
 
 type RegionInfo struct {

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/swaggo/echo-swagger v1.4.1
-	github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.531+incompatible
+	github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.1453+incompatible
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.128
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.1.48
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cbs v1.0.492

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/swaggo/files/v2 v2.0.0 h1:hmAt8Dkynw7Ssz46F6pn8ok6YmGZqHSVLZ+HQM7i0kw
 github.com/swaggo/files/v2 v2.0.0/go.mod h1:24kk2Y9NYEJ5lHuCra6iVwkMjIekMCaFq/0JQj66kyM=
 github.com/swaggo/swag v1.16.6 h1:qBNcx53ZaX+M5dxVyTrgQ0PJ/ACK+NzhwcbieTt+9yI=
 github.com/swaggo/swag v1.16.6/go.mod h1:ngP2etMK5a0P3QBizic5MEwpRmluJZPHjXcMoj4Xesg=
-github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.531+incompatible h1:LEXOEMQ6CcllV1S7UVETOiPQVIK3/i/eaCinbghFZuo=
-github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.531+incompatible/go.mod h1:72Wo6Gt6F8d8V+njrAmduVoT9QjPwCyXktpqCWr7PUc=
+github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.1453+incompatible h1:1Y1AbLxunBvKTP3YldwNjjzXmSafvwdlp/KfSEw+iio=
+github.com/tencentcloud/tencentcloud-sdk-go-intl-en v3.0.1453+incompatible/go.mod h1:72Wo6Gt6F8d8V+njrAmduVoT9QjPwCyXktpqCWr7PUc=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.128 h1:Ta1xkmxroqe64JX8PG2Gm8uuwhqfDrDS4sNBpN/RfWw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/as v1.3.128/go.mod h1:FylqFCAh7zQ8C0ynNEDmGIy3/T1P3AYSGGieM+qWtlk=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam v1.1.48 h1:LyOX4QhWesJqOeErrdZfj8whtXEheaAuwg/tcMEO1Gg=

--- a/test/rdbms-mariadb-test/README.md
+++ b/test/rdbms-mariadb-test/README.md
@@ -1,0 +1,150 @@
+# CB-Spider RDBMS API Test (MariaDB)
+
+Automated test suite for CB-Spider RDBMS API — creates MariaDB instances across CSPs in parallel, waits until each becomes available, then collects and displays a unified result table.
+
+**대상 CSP: MariaDB를 지원하는 AWS · Alibaba · OpenStack · NHN **
+**미지원 CSP: Azure / GCP / IBM / NCP / Tencent **
+  - Tencent: 가이드에는 제공, 실제 API 호출시 "Not Supported" 관련 에러 반환으로 현재는 지원하지 않음
+
+## Prerequisites
+
+### CB-Spider Running
+
+```bash
+cd ./bin; ./start.sh
+```
+
+### CSP Connection Configuration
+
+Before running tests, register connection names for each CSP in CB-Spider.
+
+| CSP | Connection Name | Region | Zone |
+|-----|----------------|--------|------|
+| AWS | `aws-config01` | `ap-southeast-2` | `ap-southeast-2a` |
+| Alibaba | `alibaba-beijing-config` | `cn-beijing` | `cn-beijing-f` |
+| OpenStack | `openstack-config01` | `RegionOne` | `nova` |
+| NHN | `nhn-korea-pangyo1-config` | `KR1` | `kr-pub-a` |
+
+> Azure / GCP / IBM / NCP / Tencent는 MariaDB 미지원으로 이 테스트 스위트에서 제외되어 커넥션 등록이 필요 없습니다.
+
+### Pre-created Network Resources
+
+RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야 합니다.
+
+```bash
+./run-all-csp-network-prepare.sh
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## MariaDB Engine Support by CSP
+
+| CSP | MariaDB 지원 | Tag 지원 | 버전 | 비고 |
+|-----|------------|---------|------|------|
+| AWS | ✅ | ✅ | `10.6` | Amazon RDS for MariaDB |
+| Alibaba | ✅ | ✅ | `10.6` | AliCloud RDS for MariaDB |
+| OpenStack | ⚠️ | ❌ | `10.6` | **현재 이 환경은 MariaDB Trove datastore 구축 전 상태** (설치되면 정상 동작 예상) — 시험 스크립트는 그대로 유지 |
+| NHN | ✅ | ❌ | `MARIADB_V10622` | NHN RDS for MariaDB |
+
+
+## RDBMS Instance Configuration
+
+인스턴스 이름은 `cb-spider-mariadb-test`입니다.
+
+| CSP | Engine | Version | Spec | Storage |
+|-----|--------|---------|------|---------|
+| AWS | mariadb | 10.6 | db.t3.medium | 100GB |
+| Alibaba | mariadb | 10.6 | rds.mariadb.s4.large | 20GB |
+| OpenStack | mariadb | 10.6 | m1.small | 20GB (Trove 구축 후 정상 동작 예상) |
+| NHN | mariadb | MARIADB_V10622 | m2.c2m4 | 20GB |
+
+## Usage
+
+### Quick Start (Full Test Suite)
+
+```bash
+# 전체 테스트 순차 실행 (네트워크 준비 → StorageType 검증 → RDBMS 생성 → DB 관리 → Tag → 삭제 → 네트워크 정리)
+./all_test.sh
+
+# 실패 시 즉시 중단
+STOP_ON_FAIL=1 ./all_test.sh
+```
+
+### Step-by-step
+
+```bash
+# 1. 네트워크 사전 자원 생성
+./run-all-csp-network-prepare.sh
+
+# 2. StorageType 검증 테스트
+./storage-type-test/run-all-csp-storage-type-tests.sh
+./storage-type-test/delete-all-csp-storage-type-rdbms.sh
+
+# 3. RDBMS 인스턴스 생성 및 검증
+./run-all-csp-rdbms-tests.sh
+
+# 4. DB 관리 테스트 (CreateDB / ListDB / DeleteDB)
+./database-test/run-all-csp-database-tests.sh
+
+# 5. Tag 관리 테스트
+./tag-test/run-all-csp-rdbms-tag-tests.sh
+
+# 6. RDBMS 인스턴스 삭제
+./delete-all-csp-rdbms.sh
+
+# 7. 네트워크 자원 삭제
+./delete-all-csp-network.sh
+```
+
+### Per-CSP Execution
+
+```bash
+./aws-rdbms-test.sh
+./alibaba-rdbms-test.sh
+./openstack-rdbms-test.sh
+./nhn-rdbms-test.sh
+```
+
+### Configuration
+
+| 환경변수 | 기본값 | 설명 |
+|---------|--------|------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
+| `MAX_WAIT_SEC` | `3600` | 인스턴스 Available 대기 최대 시간 (초) |
+| `POLL_INTERVAL` | `30` | 상태 폴링 간격 (초) |
+| `STOP_ON_FAIL` | `0` | `1`이면 첫 번째 실패 시 중단 |
+| `VERBOSE` | `0` | `1`이면 CSP별 상세 로그 출력 |
+
+## Script Structure
+
+```
+rdbms-mariadb-test/
+├── all_test.sh                          # 전체 테스트 수트
+├── common-rdbms-test.sh                 # 공통: Create → Poll → Get Info
+├── common-rdbms-delete.sh               # 공통: Delete → Poll until gone
+├── common-network-prepare.sh            # 공통: VPC/Subnet/SG 생성
+├── common-network-cleanup.sh            # 공통: VPC/Subnet/SG 삭제
+├── run-all-csp-rdbms-tests.sh           # 전체 CSP 병렬 RDBMS 생성
+├── delete-all-csp-rdbms.sh              # 전체 CSP 병렬 RDBMS 삭제
+├── run-all-csp-network-prepare.sh       # 전체 CSP 네트워크 사전 준비
+├── delete-all-csp-network.sh            # 전체 CSP 네트워크 정리
+├── aws-rdbms-test.sh / alibaba-rdbms-test.sh / openstack-rdbms-test.sh / nhn-rdbms-test.sh   # MariaDB 지원 4개 CSP만 존재
+├── database-test/
+│   ├── common-database-test.sh
+│   ├── run-all-csp-database-tests.sh          # 실행 대상: AWS/Alibaba/OpenStack/NHN
+│   └── aws-database-test.sh / alibaba-database-test.sh / openstack-database-test.sh / nhn-database-test.sh
+├── storage-type-test/
+│   ├── common-storage-type-test.sh
+│   ├── run-all-csp-storage-type-tests.sh      # 실행 대상: AWS/Alibaba/OpenStack/NHN
+│   ├── delete-all-csp-storage-type-rdbms.sh
+│   └── aws-storage-type-test.sh / alibaba-storage-type-test.sh / openstack-storage-type-test.sh / nhn-storage-type-test.sh
+└── tag-test/
+    ├── common-rdbms-tag-test.sh
+    ├── run-all-csp-rdbms-tag-tests.sh          # 실행 대상: AWS/Alibaba (SupportsTag=true AND MariaDB 지원)
+    └── aws-rdbms-tag-test.sh / alibaba-rdbms-tag-test.sh
+```

--- a/test/rdbms-mariadb-test/alibaba-network-prepare.sh
+++ b/test/rdbms-mariadb-test/alibaba-network-prepare.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Alibaba Cloud Network Prerequisite Prepare Script
+# Creates vpc-01/subnet-01, as used by alibaba-rdbms-test.sh.
+# Author: CB-Spider Team
+
+export CSP_NAME="ALIBABA"
+export CONNECTION_NAME="alibaba-beijing-config"
+export VPC_NAME="vpc-01"
+export VPC_CIDR="10.0.0.0/16"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_network_results}/result_alibaba.txt"
+
+export SUBNET_JSON='[{"Name": "subnet-01", "IPv4_CIDR": "10.0.1.0/24", "Zone": "cn-beijing-f"}]'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-network-prepare.sh"

--- a/test/rdbms-mariadb-test/alibaba-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/alibaba-rdbms-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Alibaba Cloud RDBMS Test Script (MariaDB)
+# Note: Subnet required
+# Author: CB-Spider Team
+
+export CSP_NAME="ALIBABA"
+export CONNECTION_NAME="alibaba-beijing-config"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_alibaba.txt"
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+# Fetch DBInstanceSpecOptions from MetaInfo to pick a spec valid for the default
+# storage type (cloud_essd). Hardcoded specs (e.g. rds.mariadb.s4.large) are only
+# valid for local_ssd and will fail with InvalidDBInstanceClass.NotFound on cloud_essd.
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${CONNECTION_NAME}" 2>&1)
+db_instance_spec=$(echo "${meta_resp}" | jq -r '.DBInstanceSpecOptions[0]? // empty' 2>/dev/null)
+if [[ -z "${db_instance_spec}" ]]; then
+    db_instance_spec="rds.mariadb.s4.large"
+    echo "[${CSP_NAME}] No DBInstanceSpecOptions in metainfo; falling back to ${db_instance_spec}"
+else
+    echo "[${CSP_NAME}] Using DBInstanceSpec from metainfo: ${db_instance_spec}"
+fi
+
+export CREATE_JSON="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"cb-spider-mariadb-test\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mariadb\",
+    \"DBEngineVersion\": \"10.6\",
+    \"DBInstanceSpec\": \"${db_instance_spec}\",
+    \"StorageSize\": \"20\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mariadb-test/all_test.sh
+++ b/test/rdbms-mariadb-test/all_test.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Full Test Suite (MariaDB)
+# Runs all RDBMS tests in sequence:
+#   1. Network Prepare   - VPC/Subnet/SG 사전 생성
+#   2. StorageType Test  - CSP별 StorageType 생성 검증
+#   3. StorageType RDBMS Delete
+#   4. RDBMS Create      - MariaDB 지원 CSP(AWS/Alibaba/OpenStack/NHN) 인스턴스 생성
+#   5. Database Test     - 인스턴스 내부 DB CRUD 검증
+#   6. Tag Test          - SupportsTag=true CSP(AWS/Alibaba) 태그 CRUD 검증
+#   7. RDBMS Delete      - MariaDB 지원 CSP 인스턴스 삭제
+#   8. Network Cleanup   - VPC/Subnet/SG 삭제
+# Author: CB-Spider Team
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+declare -a STEP_RESULTS
+
+run_step() {
+    local step_num="$1"
+    local step_name="$2"
+    local script="$3"
+
+    echo ""
+    echo "############################################################"
+    printf "#  Step %-2s: %-48s  #\n" "${step_num}" "${step_name}"
+    echo "############################################################"
+    echo ""
+
+    bash "${script}"
+    local exit_code=$?
+
+    if [[ ${exit_code} -eq 0 ]]; then
+        STEP_RESULTS+=("PASS | Step ${step_num}: ${step_name}")
+        PASS_COUNT=$((PASS_COUNT + 1))
+        echo ""
+        echo "[OK] Step ${step_num} completed successfully."
+    else
+        STEP_RESULTS+=("FAIL | Step ${step_num}: ${step_name} (exit code: ${exit_code})")
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        echo ""
+        echo "[FAIL] Step ${step_num} finished with exit code ${exit_code}."
+        if [[ "${STOP_ON_FAIL:-0}" == "1" ]]; then
+            echo "[ABORT] STOP_ON_FAIL=1 — stopping test suite."
+            print_summary
+            exit 1
+        fi
+    fi
+}
+
+print_summary() {
+    echo ""
+    echo "############################################################"
+    echo "#              FULL TEST SUITE SUMMARY (MariaDB)           #"
+    echo "############################################################"
+    echo ""
+    for result in "${STEP_RESULTS[@]}"; do
+        echo "  ${result}"
+    done
+    echo ""
+    printf "  Total: %d PASS, %d FAIL\n" "${PASS_COUNT}" "${FAIL_COUNT}"
+    echo ""
+    echo "############################################################"
+    echo ""
+}
+
+echo ""
+echo "############################################################"
+echo "#     CB-Spider RDBMS Full Test Suite (MariaDB) - START    #"
+echo "############################################################"
+echo ""
+echo "Spider URL : ${SPIDER_URL}"
+echo "STOP_ON_FAIL: ${STOP_ON_FAIL:-0} (set to 1 to abort on first failure)"
+echo ""
+
+# ── Step 1: Network Prepare ───────────────────────────────────────────────────
+run_step 1 "Network Prepare (VPC/Subnet/SG)" \
+    "${SCRIPT_DIR}/run-all-csp-network-prepare.sh"
+
+# ── Step 2: StorageType Test ──────────────────────────────────────────────────
+run_step 2 "StorageType Validation Test" \
+    "${SCRIPT_DIR}/storage-type-test/run-all-csp-storage-type-tests.sh"
+
+# ── Step 3: Delete StorageType RDBMS instances ───────────────────────────────
+run_step 3 "Delete StorageType RDBMS Instances" \
+    "${SCRIPT_DIR}/storage-type-test/delete-all-csp-storage-type-rdbms.sh"
+
+# ── Step 4: RDBMS Create ──────────────────────────────────────────────────────
+run_step 4 "RDBMS Instance Create (all CSPs)" \
+    "${SCRIPT_DIR}/run-all-csp-rdbms-tests.sh"
+
+# ── Step 5: Database Management Test ─────────────────────────────────────────
+run_step 5 "Database Management Test (CRUD inside instance)" \
+    "${SCRIPT_DIR}/database-test/run-all-csp-database-tests.sh"
+
+# ── Step 6: Tag Management Test ───────────────────────────────────────────────
+run_step 6 "Tag Management Test (SupportsTag=true CSPs)" \
+    "${SCRIPT_DIR}/tag-test/run-all-csp-rdbms-tag-tests.sh"
+
+# ── Step 7: RDBMS Delete ──────────────────────────────────────────────────────
+run_step 7 "RDBMS Instance Delete (all CSPs)" \
+    "${SCRIPT_DIR}/delete-all-csp-rdbms.sh"
+
+# ── Step 8: Network Cleanup ───────────────────────────────────────────────────
+run_step 8 "Network Cleanup (VPC/Subnet/SG)" \
+    "${SCRIPT_DIR}/delete-all-csp-network.sh"
+
+# ── Final Summary ─────────────────────────────────────────────────────────────
+print_summary
+
+[[ ${FAIL_COUNT} -eq 0 ]]

--- a/test/rdbms-mariadb-test/aws-network-prepare.sh
+++ b/test/rdbms-mariadb-test/aws-network-prepare.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# AWS Network Prerequisite Prepare Script
+# Creates vpc-01 (10.0.0.0/16) with subnet-01/subnet-02 in two different AZs
+# (required for the RDS SubnetGroup) and sg-01, as used by aws-rdbms-test.sh.
+# Override AWS_AZ1/AWS_AZ2 to match your account's available AZs.
+# Author: CB-Spider Team
+
+export CSP_NAME="AWS"
+export CONNECTION_NAME="aws-config01"
+export VPC_NAME="vpc-01"
+export VPC_CIDR="10.0.0.0/16"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_network_results}/result_aws.txt"
+
+AWS_AZ1="${AWS_AZ1:-ap-southeast-2a}"
+AWS_AZ2="${AWS_AZ2:-ap-southeast-2b}"
+
+export SUBNET_JSON="[
+  {\"Name\": \"subnet-01\", \"IPv4_CIDR\": \"10.0.1.0/24\", \"Zone\": \"${AWS_AZ1}\"},
+  {\"Name\": \"subnet-02\", \"IPv4_CIDR\": \"10.0.2.0/24\", \"Zone\": \"${AWS_AZ2}\"}
+]"
+
+export SG_NAME="sg-01"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-network-prepare.sh"

--- a/test/rdbms-mariadb-test/aws-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/aws-rdbms-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# AWS RDBMS Test Script (MariaDB)
+# Note: Requires 2+ subnets in different Availability Zones (SubnetGroup requirement)
+# Author: CB-Spider Team
+
+export CSP_NAME="AWS"
+export CONNECTION_NAME="aws-config01"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_aws.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "aws-config01",
+  "ReqInfo": {
+    "Name": "cb-spider-mariadb-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mariadb",
+    "DBEngineVersion": "10.6",
+    "DBInstanceSpec": "db.t3.medium",
+    "StorageSize": "100",
+    "SubnetNames": ["subnet-01", "subnet-02"],
+    "SecurityGroupNames": ["sg-01"],
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mariadb-test/common-network-cleanup.sh
+++ b/test/rdbms-mariadb-test/common-network-cleanup.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Test - Network Prerequisite Cleanup Script
+# Deletes the Security Group (if any) and then the VPC/Subnet created by
+# common-network-prepare.sh. Safe to run even if the resources don't exist.
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   VPC_NAME        - VPC name to delete
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SG_NAME         - Security Group name to delete (omit if none was created)
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+# CSPs release the network resources (ENI/IP/subnet association) that were held
+# by the just-deleted RDBMS instance asynchronously, so a delete attempted right
+# after RDBMS deletion can hit a transient DependencyViolation/ResourceInUse-type
+# error. Some CSPs (e.g. Alibaba: RDS -> vSwitch dependency release) have been
+# observed to take several minutes, well past a handful of quick retries, so we
+# back off linearly (capped) instead of a fixed short interval.
+RETRY_COUNT="${NETWORK_DELETE_RETRIES:-12}"
+RETRY_INTERVAL="${NETWORK_DELETE_RETRY_INTERVAL:-15}"
+RETRY_MAX_INTERVAL="${NETWORK_DELETE_RETRY_MAX_INTERVAL:-60}"
+
+# retry_delay_sec N -> sleep duration before the (N+1)th attempt: grows linearly
+# with the attempt number, capped at RETRY_MAX_INTERVAL, so early retries stay
+# fast while later ones give slow CSP-side cleanup enough time to finish.
+retry_delay_sec() {
+    local attempt="$1"
+    local delay=$((RETRY_INTERVAL * attempt))
+    if [[ ${delay} -gt ${RETRY_MAX_INTERVAL} ]]; then
+        delay="${RETRY_MAX_INTERVAL}"
+    fi
+    echo "${delay}"
+}
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+echo "[${CSP_NAME}] [${timestamp}] Cleaning up network resources (VPC: ${VPC_NAME})..."
+
+# ── Security Group (optional, delete first: VPC delete would otherwise fail while it's attached) ──
+sg_status="SKIPPED"
+if [[ -n "${SG_NAME}" ]]; then
+    sg_err=""
+    for ((attempt = 1; attempt <= RETRY_COUNT; attempt++)); do
+        sg_del=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+          "${SPIDER_URL}/spider/securitygroup/${SG_NAME}" \
+          -H 'Content-Type: application/json' \
+          -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+        sg_err=$(echo "${sg_del}" | jq -r '.message // empty' 2>/dev/null)
+
+        [[ -z "${sg_err}" ]] && break
+
+        if [[ ${attempt} -lt ${RETRY_COUNT} ]]; then
+            delay=$(retry_delay_sec "${attempt}")
+            echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' delete attempt ${attempt}/${RETRY_COUNT} failed: ${sg_err} (retrying in ${delay}s)"
+            sleep "${delay}"
+        else
+            echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' delete attempt ${attempt}/${RETRY_COUNT} failed: ${sg_err}"
+        fi
+    done
+
+    if [[ -n "${sg_err}" ]]; then
+        echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' delete: ${sg_err}"
+        sg_status="NOT_FOUND_OR_ERROR"
+    else
+        echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' deleted."
+        sg_status="DELETED"
+    fi
+fi
+
+# ── VPC/Subnet ────────────────────────────────────────────────────────────────
+vpc_err=""
+for ((attempt = 1; attempt <= RETRY_COUNT; attempt++)); do
+    vpc_del=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+      "${SPIDER_URL}/spider/vpc/${VPC_NAME}" \
+      -H 'Content-Type: application/json' \
+      -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+    vpc_err=$(echo "${vpc_del}" | jq -r '.message // empty' 2>/dev/null)
+
+    [[ -z "${vpc_err}" ]] && break
+
+    if [[ ${attempt} -lt ${RETRY_COUNT} ]]; then
+        delay=$(retry_delay_sec "${attempt}")
+        echo "[${CSP_NAME}] VPC '${VPC_NAME}' delete attempt ${attempt}/${RETRY_COUNT} failed: ${vpc_err} (retrying in ${delay}s)"
+        sleep "${delay}"
+    else
+        echo "[${CSP_NAME}] VPC '${VPC_NAME}' delete attempt ${attempt}/${RETRY_COUNT} failed: ${vpc_err}"
+    fi
+done
+
+if [[ -n "${vpc_err}" ]]; then
+    echo "[${CSP_NAME}] VPC '${VPC_NAME}' delete: ${vpc_err}"
+    vpc_status="NOT_FOUND_OR_ERROR"
+else
+    echo "[${CSP_NAME}] VPC '${VPC_NAME}' deleted."
+    vpc_status="DELETED"
+fi
+
+end_time=$(date +%s)
+elapsed=$((end_time - start_time))
+
+echo "[${CSP_NAME}] Done. VPC: ${vpc_status}, SG: ${sg_status}"
+echo "${CSP_NAME}|${vpc_status}|${sg_status}|${elapsed}s" > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/common-network-prepare.sh
+++ b/test/rdbms-mariadb-test/common-network-prepare.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Test - Network Prerequisite Prepare Script
+# Creates the VPC/Subnet (and Security Group, if requested) required before
+# running the RDBMS creation tests in this directory. Idempotent: skips
+# creation and reports EXISTS if the resource is already there.
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   VPC_NAME        - VPC name to create
+#   VPC_CIDR        - VPC IPv4 CIDR
+#   SUBNET_JSON     - JSON array for SubnetInfoList
+#                     (e.g. '[{"Name":"subnet-01","IPv4_CIDR":"10.0.1.0/24"}]')
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SG_NAME         - Security Group name to create (omit to skip; only AWS needs one)
+#   SG_RULES_JSON   - JSON array for SecurityRules
+#                     (default: allow inbound TCP 3306 from 0.0.0.0/0)
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+# Note: not using "${SG_RULES_JSON:-...}" here — bash ends a ${VAR:-default}
+# expansion at the first unescaped '}', so a default containing literal JSON
+# braces gets truncated mid-object.
+if [[ -z "${SG_RULES_JSON}" ]]; then
+    SG_RULES_JSON='[{"Direction":"inbound","IPProtocol":"TCP","FromPort":"3306","ToPort":"3306"}]'
+fi
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+echo "[${CSP_NAME}] [${timestamp}] Preparing network resources (VPC: ${VPC_NAME})..."
+
+# ── VPC/Subnet ────────────────────────────────────────────────────────────────
+vpc_check=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/vpc/${VPC_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+vpc_err=$(echo "${vpc_check}" | jq -r '.message // empty' 2>/dev/null)
+
+if [[ -z "${vpc_err}" ]]; then
+    echo "[${CSP_NAME}] VPC '${VPC_NAME}' already exists. Skipping creation."
+    vpc_status="EXISTS"
+else
+    create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/vpc" \
+      -H 'Content-Type: application/json' \
+      -d "{
+        \"ConnectionName\": \"${CONNECTION_NAME}\",
+        \"ReqInfo\": {
+          \"Name\": \"${VPC_NAME}\",
+          \"IPv4_CIDR\": \"${VPC_CIDR}\",
+          \"SubnetInfoList\": ${SUBNET_JSON}
+        }
+      }" 2>&1)
+
+    create_err=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${create_err}" ]]; then
+        echo "[${CSP_NAME}] ERROR creating VPC: ${create_err}"
+        echo "${CSP_NAME}|VPC_ERROR|SKIPPED|-" > "${RESULT_FILE}"
+        exit 1
+    fi
+    echo "[${CSP_NAME}] VPC '${VPC_NAME}' created."
+    vpc_status="CREATED"
+fi
+
+# ── Security Group (optional) ────────────────────────────────────────────────
+sg_status="SKIPPED"
+if [[ -n "${SG_NAME}" ]]; then
+    sg_check=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/securitygroup/${SG_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+    sg_err=$(echo "${sg_check}" | jq -r '.message // empty' 2>/dev/null)
+
+    if [[ -z "${sg_err}" ]]; then
+        echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' already exists. Skipping creation."
+        sg_status="EXISTS"
+    else
+        sg_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/securitygroup" \
+          -H 'Content-Type: application/json' \
+          -d "{
+            \"ConnectionName\": \"${CONNECTION_NAME}\",
+            \"ReqInfo\": {
+              \"Name\": \"${SG_NAME}\",
+              \"VPCName\": \"${VPC_NAME}\",
+              \"SecurityRules\": ${SG_RULES_JSON}
+            }
+          }" 2>&1)
+
+        sg_create_err=$(echo "${sg_resp}" | jq -r '.message // empty' 2>/dev/null)
+        if [[ -n "${sg_create_err}" ]]; then
+            echo "[${CSP_NAME}] ERROR creating SecurityGroup: ${sg_create_err}"
+            echo "${CSP_NAME}|${vpc_status}|SG_ERROR|-" > "${RESULT_FILE}"
+            exit 1
+        fi
+        echo "[${CSP_NAME}] SecurityGroup '${SG_NAME}' created."
+        sg_status="CREATED"
+    fi
+fi
+
+end_time=$(date +%s)
+elapsed=$((end_time - start_time))
+
+echo "[${CSP_NAME}] Done. VPC: ${vpc_status}, SG: ${sg_status}"
+echo "${CSP_NAME}|${vpc_status}|${sg_status}|${elapsed}s" > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/common-rdbms-delete.sh
+++ b/test/rdbms-mariadb-test/common-rdbms-delete.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Common Delete Script
+# Deletes the RDBMS instance and waits until it is fully removed.
+# Author: CB-Spider Team
+#
+# Required env vars (set by caller):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name to delete
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#   MAX_WAIT_SEC    - Max seconds to wait for deletion (default: 1800)
+#   POLL_INTERVAL   - Polling interval in seconds (default: 15)
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"
+POLL_INTERVAL="${POLL_INTERVAL:-15}"
+THROTTLE_RETRY_COUNT="${THROTTLE_RETRY_COUNT:-5}"
+THROTTLE_RETRY_INTERVAL="${THROTTLE_RETRY_INTERVAL:-10}"
+
+# CSP APIs (Alibaba, AWS, Tencent, ...) reject bursts of concurrent delete
+# calls with a rate-limit/throttling error. Detect that class of error so it
+# can be retried instead of failing the whole delete immediately.
+is_throttling_error() {
+    echo "$1" | grep -qiE "throttl|rate.?limit|requestlimitexceeded|too many requests"
+}
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Ensure result directory exists
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+echo "[${CSP_NAME}] [${timestamp}] Deleting RDBMS '${RDBMS_NAME}'..."
+
+# ── Verify instance exists before deleting ────────────────────────────────────
+check_resp=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${check_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] Instance not found or error: ${err_msg}"
+    echo "${CSP_NAME}|NOT_FOUND|${err_msg}|-" > "${RESULT_FILE}"
+    exit 0
+fi
+
+# ── Send DELETE request (retry on throttling) ────────────────────────────────
+# Note: DELETE requires ConnectionName in request body, not query parameter
+for attempt in $(seq 1 "${THROTTLE_RETRY_COUNT}"); do
+    del_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+      "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}" \
+      -H 'Content-Type: application/json' \
+      -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+
+    del_result=$(echo "${del_resp}" | jq -r '.Result // .result // empty' 2>/dev/null)
+    del_err=$(echo "${del_resp}"    | jq -r '.message // empty' 2>/dev/null)
+
+    if [[ -z "${del_err}" ]] || ! is_throttling_error "${del_err}"; then
+        break
+    fi
+
+    echo "[${CSP_NAME}] DELETE attempt ${attempt}/${THROTTLE_RETRY_COUNT} throttled, retrying: ${del_err}"
+    [[ ${attempt} -lt ${THROTTLE_RETRY_COUNT} ]] && sleep "${THROTTLE_RETRY_INTERVAL}"
+done
+
+if [[ -n "${del_err}" ]]; then
+    echo "[${CSP_NAME}] DELETE error: ${del_err}"
+    echo "${CSP_NAME}|DELETE_ERROR|${del_err}|-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+echo "[${CSP_NAME}] DELETE accepted (result: ${del_result:-ok}). Waiting for removal..."
+
+# ── Poll until instance is gone ───────────────────────────────────────────────
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    # Instance is gone when the API returns an error/message
+    poll_err=$(echo "${poll_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${poll_err}" ]]; then
+        echo "[${CSP_NAME}] Instance removed (elapsed: ${elapsed}s)"
+        break
+    fi
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // "unknown"' 2>/dev/null)
+    echo "[${CSP_NAME}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}] TIMEOUT waiting for deletion to complete"
+        echo "${CSP_NAME}|DELETE_TIMEOUT||$(format_elapsed ${elapsed})" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+
+echo "[${CSP_NAME}] Deletion complete (total elapsed: ${elapsed_fmt})"
+echo "${CSP_NAME}|DELETED|ok|${elapsed_fmt}" > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/common-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/common-rdbms-test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Common Test Script (MariaDB)
+# Flow: Create RDBMS -> Poll until Available -> Get Info -> Write result file
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name
+#   CREATE_JSON     - JSON body for POST /spider/rdbms
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#   MAX_WAIT_SEC    - Max seconds to wait for available status (default: 3600)
+#   POLL_INTERVAL   - Polling interval in seconds (default: 30)
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${CSP_NAME}] [${timestamp}] Creating RDBMS '${RDBMS_NAME}'..."
+
+# ── Create RDBMS ─────────────────────────────────────────────────────────────
+create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/rdbms" \
+  -H 'Content-Type: application/json' \
+  -d "${CREATE_JSON}" 2>&1)
+
+# Check for API error response
+err_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR on create: ${err_msg}"
+    # If SKIP_PATTERN is set and the error matches, record as SKIP instead of FAIL
+    if [[ -n "${SKIP_PATTERN:-}" ]] && echo "${err_msg}" | grep -qiE "${SKIP_PATTERN}"; then
+        echo "[${CSP_NAME}] Error matches SKIP_PATTERN — recording as SKIP|NOT_SUPPORTED"
+        mkdir -p "$(dirname "${RESULT_FILE}")"
+        echo "${CSP_NAME}|SKIP|NOT_SUPPORTED||||||||-" > "${RESULT_FILE}"
+        exit 0
+    fi
+    echo "${CSP_NAME}|CREATE_ERROR|${err_msg}||||||||-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+create_status=$(echo "${create_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+echo "[${CSP_NAME}] Create response status: ${create_status}"
+
+# ── Poll until Available ──────────────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for RDBMS to become available (poll every ${POLL_INTERVAL}s, max ${MAX_WAIT_SEC}s)..."
+
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+    status_lower=$(echo "${cur_status}" | tr '[:upper:]' '[:lower:]')
+
+    echo "[${CSP_NAME}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    # Accept various CSP-specific available status strings
+    case "${status_lower}" in
+        available|ready|runnable|active)
+            echo "[${CSP_NAME}] RDBMS is available!"
+            break
+            ;;
+    esac
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}] TIMEOUT: RDBMS did not become available within ${MAX_WAIT_SEC}s"
+        echo "${CSP_NAME}|TIMEOUT||||||||||" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+
+# ── Get RDBMS Info ────────────────────────────────────────────────────────────
+info=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}")
+
+name=$(echo "${info}"       | jq -r '.IId.NameId       // "N/A"')
+status=$(echo "${info}"     | jq -r '.Status           // "N/A"')
+engine=$(echo "${info}"     | jq -r '.DBEngine         // "N/A"')
+version=$(echo "${info}"    | jq -r '.DBEngineVersion  // "N/A"')
+spec=$(echo "${info}"       | jq -r '.DBInstanceSpec   // "N/A"')
+storage=$(echo "${info}"      | jq -r '.StorageSize  // "N/A"')
+storage_type=$(echo "${info}" | jq -r '.StorageType  // "N/A"')
+ep_addr=$(echo "${info}"      | jq -r '.Endpoint     // "N/A"')
+ep_port=$(echo "${info}"    | jq -r '.Port             // "N/A"')
+pub_access=$(echo "${info}" | jq -r '.PublicAccess     // "N/A"')
+
+# Build endpoint display: if Port is valid and not already in Endpoint, append it
+if [[ "${ep_port}" != "N/A" && "${ep_port}" != "null" && "${ep_port}" != "" ]]; then
+    endpoint_display="${ep_addr}:${ep_port}"
+else
+    endpoint_display="${ep_addr}"
+fi
+
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+echo "[${CSP_NAME}] Done. Endpoint: ${endpoint_display} (total elapsed: ${elapsed_fmt})"
+
+# Ensure result directory exists
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+# Write pipe-separated result line
+# Format: CSP|Status|Engine|Version|Spec|Storage(GB)|StorageType|Endpoint|PublicAccess|Elapsed
+echo "${CSP_NAME}|${status}|${engine}|${version}|${spec}|${storage}GB|${storage_type}|${endpoint_display}|${pub_access}|${elapsed_fmt}" \
+  > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/database-test/alibaba-database-test.sh
+++ b/test/rdbms-mariadb-test/database-test/alibaba-database-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# ALIBABA RDBMS Database Management Test Script (MariaDB)
+export CSP_NAME="ALIBABA"
+export CONNECTION_NAME="alibaba-beijing-config"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export MASTER_USER_PASSWORD="Password123!"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_mgmt_results}/result_alibaba.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-database-test.sh"

--- a/test/rdbms-mariadb-test/database-test/aws-database-test.sh
+++ b/test/rdbms-mariadb-test/database-test/aws-database-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# AWS RDBMS Database Management Test Script (MariaDB)
+export CSP_NAME="AWS"
+export CONNECTION_NAME="aws-config01"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export MASTER_USER_PASSWORD="Password123!"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_mgmt_results}/result_aws.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-database-test.sh"

--- a/test/rdbms-mariadb-test/database-test/common-database-test.sh
+++ b/test/rdbms-mariadb-test/database-test/common-database-test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Database Management Common Test Script
+# Flow: CreateDatabase -> ListDatabases -> DeleteDatabase -> ListDatabases(verify)
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME              - Display name (e.g., AWS)
+#   CONNECTION_NAME       - Spider connection config name
+#   RDBMS_NAME            - RDBMS instance name
+#   MASTER_USER_PASSWORD  - MasterUserPassword used when creating the RDBMS instance
+#   RESULT_FILE           - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#   DB_NAME         - Test database name to create (default: spidertestdb)
+#
+# Result file format (7 fields):
+#   CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+DB_NAME="${DB_NAME:-spidertestdb}"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+r_create="FAIL"
+r_list="FAIL"
+r_found="NOT_FOUND"
+r_delete="FAIL"
+r_verify="FAIL"
+
+abort() {
+    local label="$1"
+    local msg="$2"
+    echo "[${CSP_NAME}] ERROR on ${label}: ${msg}"
+    elapsed_fmt=$(format_elapsed $(($(date +%s) - start_time)))
+    echo "${CSP_NAME}|${r_create}|${r_list}|${r_found}|${r_delete}|${r_verify}|${elapsed_fmt}" \
+        > "${RESULT_FILE}"
+    exit 1
+}
+
+echo "[${CSP_NAME}] [${timestamp}] Starting database management test (RDBMS='${RDBMS_NAME}', DB='${DB_NAME}')..."
+
+# ── Pre-cleanup: delete leftover DB from a previous run (ignore errors) ───────
+curl -u "${SPIDER_AUTH}" -sX DELETE \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}/databases/${DB_NAME}" \
+  -H 'Content-Type: application/json' \
+  -d "{\"ConnectionName\": \"${CONNECTION_NAME}\", \"MasterUserPassword\": \"${MASTER_USER_PASSWORD}\"}" \
+  > /dev/null 2>&1
+
+# ── CreateDatabase ────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] CreateDatabase: '${DB_NAME}'"
+
+create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}/databases" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"DatabaseName\": \"${DB_NAME}\",
+    \"MasterUserPassword\": \"${MASTER_USER_PASSWORD}\"
+  }" 2>&1)
+
+create_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ "${create_msg}" == "created" ]]; then
+    r_create="PASS"
+else
+    abort "CreateDatabase" "${create_msg:-unexpected response}"
+fi
+echo "[${CSP_NAME}] CreateDatabase: ${r_create}"
+
+# ── ListDatabases ─────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] ListDatabases: verifying '${DB_NAME}' is present"
+
+list_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}/databases" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"MasterUserPassword\": \"${MASTER_USER_PASSWORD}\"
+  }" 2>&1)
+
+list_err=$(echo "${list_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${list_err}" ]]; then
+    abort "ListDatabases" "${list_err}"
+fi
+
+db_count=$(echo "${list_resp}" | jq -r '.Databases | length // 0' 2>/dev/null)
+db_count="${db_count:-0}"
+r_list="PASS"
+
+if echo "${list_resp}" | jq -e --arg name "${DB_NAME}" '.Databases[]? | select(. == $name)' > /dev/null 2>&1; then
+    r_found="FOUND"
+fi
+echo "[${CSP_NAME}] ListDatabases: ${r_list} (${db_count} DB(s)), FoundInList: ${r_found}"
+
+# ── DeleteDatabase ────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] DeleteDatabase: '${DB_NAME}'"
+
+delete_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}/databases/${DB_NAME}" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"MasterUserPassword\": \"${MASTER_USER_PASSWORD}\"
+  }" 2>&1)
+
+delete_msg=$(echo "${delete_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ "${delete_msg}" == "deleted" ]]; then
+    r_delete="PASS"
+else
+    abort "DeleteDatabase" "${delete_msg:-unexpected response}"
+fi
+echo "[${CSP_NAME}] DeleteDatabase: ${r_delete}"
+
+# ── ListDatabases (verify deleted) ───────────────────────────────────────────
+echo "[${CSP_NAME}] ListDatabases: verifying '${DB_NAME}' is removed"
+
+verify_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+  "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}/databases" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"MasterUserPassword\": \"${MASTER_USER_PASSWORD}\"
+  }" 2>&1)
+
+verify_err=$(echo "${verify_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${verify_err}" ]]; then
+    abort "ListDatabases(verify)" "${verify_err}"
+fi
+
+if ! echo "${verify_resp}" | jq -e --arg name "${DB_NAME}" '.Databases[]? | select(. == $name)' > /dev/null 2>&1; then
+    r_verify="PASS"
+fi
+remaining=$(echo "${verify_resp}" | jq -r '.Databases | length // 0' 2>/dev/null)
+echo "[${CSP_NAME}] VerifyDeleted: ${r_verify} (${remaining} DB(s) remaining)"
+
+# ── Write Result ──────────────────────────────────────────────────────────────
+end_time=$(date +%s)
+elapsed_fmt=$(format_elapsed $((end_time - start_time)))
+
+overall="PASS"
+for r in "${r_create}" "${r_list}" "${r_found}" "${r_delete}" "${r_verify}"; do
+    [[ "${r}" != "PASS" && "${r}" != "FOUND" ]] && overall="FAIL" && break
+done
+
+echo "[${CSP_NAME}] Database management test ${overall} (elapsed: ${elapsed_fmt})"
+echo "[${CSP_NAME}]   CreateDB=${r_create} ListDB=${r_list} FoundInList=${r_found} DeleteDB=${r_delete} VerifyDeleted=${r_verify}"
+
+# Format: CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
+echo "${CSP_NAME}|${r_create}|${r_list}|${r_found}|${r_delete}|${r_verify}|${elapsed_fmt}" \
+  > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/database-test/nhn-database-test.sh
+++ b/test/rdbms-mariadb-test/database-test/nhn-database-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# NHN RDBMS Database Management Test Script (MariaDB)
+export CSP_NAME="NHN"
+export CONNECTION_NAME="nhn-korea-pangyo1-config"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export MASTER_USER_PASSWORD="Password123!"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_mgmt_results}/result_nhn.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-database-test.sh"

--- a/test/rdbms-mariadb-test/database-test/openstack-database-test.sh
+++ b/test/rdbms-mariadb-test/database-test/openstack-database-test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# OPENSTACK RDBMS Database Management Test Script (MariaDB)
+export CSP_NAME="OPENSTACK"
+export CONNECTION_NAME="openstack-config01"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export MASTER_USER_PASSWORD="Password123!"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_mgmt_results}/result_openstack.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-database-test.sh"

--- a/test/rdbms-mariadb-test/database-test/run-all-csp-database-tests.sh
+++ b/test/rdbms-mariadb-test/database-test/run-all-csp-database-tests.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Database Management Test Runner for All CSPs (MariaDB)
+# Tests CreateDatabase / ListDatabases / DeleteDatabase inside RDBMS instances.
+# Only runs against CSPs that support MariaDB (AWS, Alibaba, OpenStack, NHN);
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded.
+# Prerequisite: RDBMS instances must already be created (run ../run-all-csp-rdbms-tests.sh first).
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+export RESULT_DIR="/tmp/rdbms_mgmt_results_$$"
+LOG_DIR="/tmp/rdbms_mgmt_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-database-test.sh"       ;;
+        ALIBABA)   echo "alibaba-database-test.sh"   ;;
+        OPENSTACK) echo "openstack-database-test.sh" ;;
+        NHN)       echo "nhn-database-test.sh"       ;;
+    esac
+}
+
+print_separator() {
+    printf '%103s\n' '' | tr ' ' '-'
+}
+
+print_header() {
+    echo ""
+    printf '%103s\n' '' | tr ' ' '='
+    echo "             RDBMS DATABASE MANAGEMENT TEST SUMMARY - ALL CSPs (MariaDB)"
+    printf '%103s\n' '' | tr ' ' '='
+    echo ""
+    printf "%-12s | %-10s | %-8s | %-12s | %-10s | %-13s | %-10s\n" \
+        "CSP" "CreateDB" "ListDB" "FoundInList" "DeleteDB" "VerifyDeleted" "Elapsed"
+    print_separator
+}
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "# CB-Spider RDBMS Database Management Multi-CSP Test (MariaDB) - All CSPs     #"
+echo "################################################################################"
+echo ""
+echo "Spider URL : ${SPIDER_URL}"
+echo "Result dir : ${RESULT_DIR}"
+echo "Log dir    : ${LOG_DIR}"
+echo ""
+echo "Launching database management tests on all CSPs in parallel..."
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All tests launched. Waiting for completion..."
+echo "[MAIN] Monitor progress: tail -f ${LOG_DIR}/log_<csp_lowercase>.txt"
+echo ""
+
+# ── Wait for all ──────────────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed successfully"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code} (check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+pass_count=0
+fail_count=0
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_create r_list r_found r_delete r_verify r_elapsed \
+            < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_create="NO_RESULT"
+        r_list="-"
+        r_found="-"
+        r_delete="-"
+        r_verify="-"
+        r_elapsed="-"
+    fi
+
+    printf "%-12s | %-10s | %-8s | %-12s | %-10s | %-13s | %-10s\n" \
+        "${r_csp}" "${r_create}" "${r_list}" "${r_found}" "${r_delete}" "${r_verify}" "${r_elapsed}"
+
+    if [[ "${r_create}" == "PASS" && "${r_list}" == "PASS" && "${r_found}" == "FOUND" && \
+          "${r_delete}" == "PASS" && "${r_verify}" == "PASS" ]]; then
+        pass_count=$((pass_count + 1))
+    else
+        fail_count=$((fail_count + 1))
+    fi
+done
+
+print_separator
+echo ""
+printf "Total: %d PASS, %d FAIL\n" "${pass_count}" "${fail_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+printf '%103s\n' '' | tr ' ' '='
+echo ""
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                          Per-CSP Detailed Logs                              #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        [[ -f "${log_file}" ]] && cat "${log_file}" || echo "(no log)"
+    done
+fi
+
+[[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/delete-all-csp-network.sh
+++ b/test/rdbms-mariadb-test/delete-all-csp-network.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+# CB-Spider Network Prerequisite Cleanup Script for All CSPs (MariaDB Test)
+# Deletes the VPC/Subnet (and Security Group, for AWS) created by
+# run-all-csp-network-prepare.sh, on the CSPs that support MariaDB (AWS,
+# Alibaba, OpenStack, NHN) in parallel.
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded, so their
+# VPCs are never created in the first place.
+# Run this AFTER delete-all-csp-rdbms.sh, since the RDBMS instance must be
+# gone before its VPC/Subnet/SecurityGroup can be removed.
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+VPC_NAME="vpc-01"
+
+RESULT_DIR="/tmp/rdbms_network_del_results_$$"
+LOG_DIR="/tmp/rdbms_network_del_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── CSP connection config / SG map ────────────────────────────────────────────
+csp_connection() {
+    case "$1" in
+        AWS)       echo "aws-config01"                 ;;
+        ALIBABA)   echo "alibaba-beijing-config"       ;;
+        OPENSTACK) echo "openstack-config01"           ;;
+        NHN)       echo "nhn-korea-pangyo1-config"     ;;
+    esac
+}
+
+# Only AWS has a Security Group among this test suite's prerequisites
+csp_sg_name() {
+    case "$1" in
+        AWS) echo "sg-01" ;;
+        *)   echo ""      ;;
+    esac
+}
+
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+print_separator() {
+    echo "------------------------------------------------------------"
+}
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+echo ""
+echo "############################################################"
+echo "#  CB-Spider Network Prerequisite Cleanup - All CSPs       #"
+echo "#                   (MariaDB Test)                         #"
+echo "############################################################"
+echo ""
+echo "VPC Name   : ${VPC_NAME}"
+echo "Spider URL : ${SPIDER_URL}"
+echo ""
+echo "Launching parallel cleanup on all CSPs..."
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+for csp in ${CSP_ORDER}; do
+    conn=$(csp_connection "${csp}")
+    sg_name=$(csp_sg_name "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    echo "[MAIN] Cleaning up ${csp} (log: ${log_file})"
+
+    (
+        export CSP_NAME="${csp}"
+        export CONNECTION_NAME="${conn}"
+        export VPC_NAME="${VPC_NAME}"
+        export SG_NAME="${sg_name}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-network-cleanup.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All cleanups launched. Waiting for completion..."
+echo ""
+
+# ── Wait for all ──────────────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} cleanup completed"
+        else
+            echo "[MAIN] ${csp} cleanup failed (exit: ${exit_code}, check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All cleanups finished. Collecting results..."
+echo ""
+
+# ── Result table ──────────────────────────────────────────────────────────────
+echo "============================================================"
+echo "       NETWORK CLEANUP SUMMARY - ALL CSPs"
+echo "============================================================"
+echo ""
+printf "%-12s | %-16s | %-12s | %-10s\n" "CSP" "VPC" "SG" "Elapsed"
+print_separator
+
+fail_count=0
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_vpc r_sg r_elapsed < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_vpc="NO_RESULT"
+        r_sg="-"
+        r_elapsed="-"
+        fail_count=$((fail_count + 1))
+    fi
+
+    printf "%-12s | %-16s | %-12s | %-10s\n" "${r_csp}" "${r_vpc}" "${r_sg}" "${r_elapsed}"
+
+    case "${r_vpc}" in
+        DELETED|NOT_FOUND_OR_ERROR) ;;
+        *) fail_count=$((fail_count + 1)) ;;
+    esac
+done
+
+print_separator
+echo ""
+echo "Failed : ${fail_count}"
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "============================================================"
+echo ""
+
+[[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/delete-all-csp-rdbms.sh
+++ b/test/rdbms-mariadb-test/delete-all-csp-rdbms.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# CB-Spider RDBMS Delete Script for All CSPs
-# Deletes RDBMS instances on all 9 CSPs in parallel and reports results.
+# CB-Spider RDBMS Delete Script for All CSPs (MariaDB)
+# Deletes RDBMS instances on the CSPs that support MariaDB (AWS, Alibaba,
+# OpenStack, NHN) in parallel and reports results.
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded.
 # Author: CB-Spider Team
 # Note: Written for bash 3.2+ compatibility (macOS default shell)
 
@@ -13,7 +15,7 @@ export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
 export MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"  # 30 min timeout per CSP
 export POLL_INTERVAL="${POLL_INTERVAL:-15}"  # poll every 15s
 
-RDBMS_NAME="cb-spider-mysql-test"
+RDBMS_NAME="cb-spider-mariadb-test"
 
 RESULT_DIR="/tmp/rdbms_del_results_$$"
 LOG_DIR="/tmp/rdbms_del_logs_$$"
@@ -23,13 +25,8 @@ mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
 csp_connection() {
     case "$1" in
         AWS)       echo "aws-config01"                 ;;
-        AZURE)     echo "azure-koreacentral-config"    ;;
-        GCP)       echo "gcp-iowa-config"              ;;
         ALIBABA)   echo "alibaba-beijing-config"       ;;
-        TENCENT)   echo "tencent-beijing3-config"      ;;
-        IBM)       echo "ibm-us-east-1-config"         ;;
         OPENSTACK) echo "openstack-config01"           ;;
-        NCP)       echo "ncp-korea1-config"            ;;
         NHN)       echo "nhn-korea-pangyo1-config"     ;;
     esac
 }
@@ -43,7 +40,7 @@ print_separator() {
 # ── Launch ────────────────────────────────────────────────────────────────────
 echo ""
 echo "############################################################"
-echo "#     CB-Spider RDBMS Delete - All CSPs                    #"
+echo "#  CB-Spider RDBMS Delete - All CSPs (MariaDB)             #"
 echo "############################################################"
 echo ""
 echo "RDBMS Name   : ${RDBMS_NAME}"
@@ -54,7 +51,7 @@ echo ""
 echo "Launching parallel deletion on all CSPs..."
 echo ""
 
-CSP_ORDER="AWS AZURE GCP ALIBABA TENCENT IBM OPENSTACK NCP NHN"
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
 
 for csp in ${CSP_ORDER}; do
     conn=$(csp_connection "${csp}")
@@ -99,7 +96,7 @@ echo ""
 
 # ── Result table ──────────────────────────────────────────────────────────────
 echo "============================================================"
-echo "         RDBMS DELETE SUMMARY - ALL CSPs"
+echo "      RDBMS DELETE SUMMARY - ALL CSPs (MariaDB)"
 echo "============================================================"
 echo ""
 printf "%-12s | %-14s | %-20s | %-10s\n" "CSP" "Result" "Detail" "Elapsed"
@@ -122,11 +119,6 @@ for csp in ${CSP_ORDER}; do
     printf "%-12s | %-14s | %-20s | %-10s\n" \
         "${r_csp}" "${r_result}" "${r_detail}" "${r_elapsed}"
 
-    # DELETED: instance confirmed gone.
-    # NOT_FOUND: CB-Spider has no IID for this instance, which may mean the
-    #   CSP resource still exists as a zombie (e.g. after a failed rollback).
-    #   Treat as a warning failure so operators are alerted to check manually.
-    # DELETE_ERROR/DELETE_TIMEOUT/NO_RESULT: hard failure.
     case "${r_result}" in
         DELETED) ;;
         NOT_FOUND)
@@ -157,5 +149,4 @@ if [[ "${VERBOSE:-0}" == "1" ]]; then
     done
 fi
 
-# Propagate failure to caller (all_test.sh) so a real delete error fails this step
 [[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/nhn-network-prepare.sh
+++ b/test/rdbms-mariadb-test/nhn-network-prepare.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# NHN Cloud Network Prerequisite Prepare Script
+# Creates vpc-01/subnet-01, as used by nhn-rdbms-test.sh.
+# Author: CB-Spider Team
+
+export CSP_NAME="NHN"
+export CONNECTION_NAME="nhn-korea-pangyo1-config"
+export VPC_NAME="vpc-01"
+export VPC_CIDR="10.0.0.0/16"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_network_results}/result_nhn.txt"
+
+export SUBNET_JSON='[{"Name": "subnet-01", "IPv4_CIDR": "10.0.1.0/24", "Zone": "kr-pub-a"}]'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-network-prepare.sh"

--- a/test/rdbms-mariadb-test/nhn-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/nhn-rdbms-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# NHN Cloud RDBMS Test Script (MariaDB)
+# Note: Subnet required. Uses NHN RDS for MariaDB endpoint.
+# Author: CB-Spider Team
+
+export CSP_NAME="NHN"
+export CONNECTION_NAME="nhn-korea-pangyo1-config"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_nhn.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "nhn-korea-pangyo1-config",
+  "ReqInfo": {
+    "Name": "cb-spider-mariadb-test",
+    "VPCName": "vpc-01",
+    "SubnetNames": ["subnet-01"],
+    "DBEngine": "mariadb",
+    "DBEngineVersion": "MARIADB_V101118",
+    "DBInstanceSpec": "m2.c2m4",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mariadb-test/openstack-network-prepare.sh
+++ b/test/rdbms-mariadb-test/openstack-network-prepare.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# OpenStack Network Prerequisite Prepare Script
+# Creates vpc-01/subnet-01, as used by openstack-rdbms-test.sh.
+# Author: CB-Spider Team
+
+export CSP_NAME="OPENSTACK"
+export CONNECTION_NAME="openstack-config01"
+export VPC_NAME="vpc-01"
+export VPC_CIDR="10.0.0.0/16"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_network_results}/result_openstack.txt"
+
+export SUBNET_JSON='[{"Name": "subnet-01", "IPv4_CIDR": "10.0.1.0/24"}]'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-network-prepare.sh"

--- a/test/rdbms-mariadb-test/openstack-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/openstack-rdbms-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# OpenStack RDBMS Test Script (MariaDB)
+# Note: MariaDB support depends on OpenStack Trove datastore configuration.
+#       Verify available datastores with: trove datastore-list
+# Author: CB-Spider Team
+
+export CSP_NAME="OPENSTACK"
+export CONNECTION_NAME="openstack-config01"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_results}/result_openstack.txt"
+
+export CREATE_JSON='{
+  "ConnectionName": "openstack-config01",
+  "ReqInfo": {
+    "Name": "cb-spider-mariadb-test",
+    "VPCName": "vpc-01",
+    "DBEngine": "mariadb",
+    "DBEngineVersion": "10.6",
+    "DBInstanceSpec": "m1.small",
+    "StorageSize": "20",
+    "MasterUserName": "myadmin",
+    "MasterUserPassword": "Password123!",
+    "PublicAccess": true
+  }
+}'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-test.sh"

--- a/test/rdbms-mariadb-test/run-all-csp-network-prepare.sh
+++ b/test/rdbms-mariadb-test/run-all-csp-network-prepare.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# CB-Spider Network Prerequisite Prepare Runner for All CSPs (MariaDB Test)
+# Creates the VPC/Subnet (and Security Group, for AWS) required before
+# running the RDBMS creation tests, on the CSPs that support MariaDB
+# (AWS, Alibaba, OpenStack, NHN) in parallel.
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded so their
+# VPCs are never created and their errors don't clutter the results.
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+# Temp directories
+export RESULT_DIR="/tmp/rdbms_network_results_$$"
+LOG_DIR="/tmp/rdbms_network_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-network-prepare.sh"       ;;
+        ALIBABA)   echo "alibaba-network-prepare.sh"   ;;
+        OPENSTACK) echo "openstack-network-prepare.sh" ;;
+        NHN)       echo "nhn-network-prepare.sh"       ;;
+    esac
+}
+
+print_separator() {
+    echo "------------------------------------------------------------"
+}
+
+# ── Run all CSP prepares in parallel ─────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#     CB-Spider Network Prerequisite Prepare - All CSPs (MariaDB Test)        #"
+echo "################################################################################"
+echo ""
+echo "Spider URL : ${SPIDER_URL}"
+echo "Result dir : ${RESULT_DIR}"
+echo "Log dir    : ${LOG_DIR}"
+echo ""
+echo "Launching network preparation on all CSPs in parallel..."
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} network prepare (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP preparations launched. Waiting for completion..."
+echo ""
+
+# ── Wait for all background jobs ─────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed successfully"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code} (check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP preparations finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+echo "============================================================"
+echo "     NETWORK PREREQUISITE PREPARE SUMMARY - ALL CSPs"
+echo "============================================================"
+echo ""
+printf "%-12s | %-10s | %-10s | %-10s\n" "CSP" "VPC" "SG" "Elapsed"
+print_separator
+
+fail_count=0
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_vpc r_sg r_elapsed < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_vpc="NO_RESULT"
+        r_sg="-"
+        r_elapsed="-"
+        fail_count=$((fail_count + 1))
+    fi
+
+    printf "%-12s | %-10s | %-10s | %-10s\n" "${r_csp}" "${r_vpc}" "${r_sg}" "${r_elapsed}"
+
+    case "${r_vpc}" in
+        CREATED|EXISTS) ;;
+        *) fail_count=$((fail_count + 1)) ;;
+    esac
+done
+
+print_separator
+echo ""
+echo "Failed : ${fail_count}"
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "============================================================"
+echo ""
+
+[[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/run-all-csp-rdbms-tests.sh
+++ b/test/rdbms-mariadb-test/run-all-csp-rdbms-tests.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Test Runner for All CSPs (MariaDB)
+# Runs RDBMS creation on the CSPs that support MariaDB (AWS, Alibaba,
+# OpenStack, NHN) in parallel, waits for each to become available, then
+# collects and displays a unified result table.
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded.
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"   # 60 min timeout per CSP
+export POLL_INTERVAL="${POLL_INTERVAL:-30}"   # poll every 30s
+
+# Temp directories
+export RESULT_DIR="/tmp/rdbms_results_$$"
+LOG_DIR="/tmp/rdbms_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-rdbms-test.sh"       ;;
+        ALIBABA)   echo "alibaba-rdbms-test.sh"   ;;
+        OPENSTACK) echo "openstack-rdbms-test.sh" ;;
+        NHN)       echo "nhn-rdbms-test.sh"       ;;
+    esac
+}
+
+print_separator() {
+    printf '%177s\n' '' | tr ' ' '-'
+}
+
+print_header() {
+    echo ""
+    printf '%177s\n' '' | tr ' ' '='
+    echo "                                           RDBMS CREATE & INFO TEST SUMMARY - ALL CSPs (MariaDB)"
+    printf '%177s\n' '' | tr ' ' '='
+    echo ""
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-24s | %-40s | %-12s | %-10s\n" \
+        "CSP" "Status" "Engine" "Version" "Spec" "Storage" "Endpoint" "PublicAccess" "Elapsed"
+    print_separator
+}
+
+# ── Run all CSP tests in parallel ────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#       CB-Spider RDBMS Multi-CSP Test (MariaDB) - Starting All CSPs          #"
+echo "################################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per CSP"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Result dir   : ${RESULT_DIR}"
+echo "Log dir      : ${LOG_DIR}"
+echo ""
+echo "Launching RDBMS creation on all CSPs in parallel..."
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+# Launch all CSP scripts in background; store PIDs in /tmp files (bash 3.2 compatible)
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} test (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP tests launched. Waiting for completion..."
+echo "[MAIN] Monitor progress: tail -f ${LOG_DIR}/log_<csp_lowercase>.txt"
+echo ""
+
+# ── Wait for all background jobs ─────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed successfully"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code} (check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+fail_count=0
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_status r_engine r_version r_spec r_storage r_storage_type r_endpoint r_public r_elapsed \
+            < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_status="NO_RESULT"
+        r_engine="-"
+        r_version="-"
+        r_spec="-"
+        r_storage="-"
+        r_storage_type="-"
+        r_endpoint="-"
+        r_public="-"
+        r_elapsed="-"
+    fi
+
+    r_storage_display="${r_storage}|${r_storage_type}"
+    printf "%-12s | %-11s | %-8s | %-12s | %-24s | %-24s | %-40s | %-12s | %-10s\n" \
+        "${r_csp}" "${r_status}" "${r_engine}" "${r_version}" \
+        "${r_spec}" "${r_storage_display}" "${r_endpoint}" "${r_public}" "${r_elapsed}"
+
+    r_status_lower=$(echo "${r_status}" | tr '[:upper:]' '[:lower:]')
+    case "${r_status_lower}" in
+        available|ready|runnable|active) ;;
+        *) fail_count=$((fail_count + 1)) ;;
+    esac
+done
+
+print_separator
+echo ""
+echo "Failed : ${fail_count}"
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+printf '%177s\n' '' | tr ' ' '='
+echo ""
+
+# ── Per-CSP full log dump (optional, controlled by VERBOSE=1) ────────────────
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                          Per-CSP Detailed Logs                              #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        if [[ -f "${log_file}" ]]; then
+            cat "${log_file}"
+        else
+            echo "(no log)"
+        fi
+    done
+fi
+
+[[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/storage-type-test/alibaba-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/alibaba-storage-type-test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Alibaba Cloud RDBMS StorageType Test Script (MariaDB)
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: Subnet required.
+
+CSP_NAME="ALIBABA"
+CONNECTION_NAME="alibaba-beijing-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions and DBInstanceSpecOptions from metainfo ──────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_alibaba_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_alibaba_skip.txt"
+    exit 0
+fi
+
+# Pick the first available instance spec from MetaInfo — this ensures the spec is
+# actually valid for the region/zone returned by DescribeAvailableZones.
+# Using a hardcoded spec risks incompatibility (e.g., rds.mariadb.s4.large is only
+# valid for local_ssd; cloud_essd requires a different spec class).
+meta_spec=$(echo "${meta_resp}" | jq -r '.DBInstanceSpecOptions[0]? // empty' 2>/dev/null)
+if [[ -z "${meta_spec}" ]]; then
+    meta_spec="rds.mariadb.s4.large"
+    echo "[${CSP_NAME}] No DBInstanceSpecOptions in metainfo; falling back to ${meta_spec}"
+else
+    echo "[${CSP_NAME}] Using DBInstanceSpec from metainfo: ${meta_spec}"
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mariadb-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_alibaba_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_alibaba_${st_safe}.txt"
+
+    # Storage size minimums vary by type (Alibaba cloud_essd2 ≥ 500GB, cloud_essd3 ≥ 1500GB).
+    case "${storage_type}" in
+        cloud_essd2) db_instance_spec="${meta_spec}"; db_storage_size="500"  ;;
+        cloud_essd3) db_instance_spec="${meta_spec}"; db_storage_size="1500" ;;
+        local_ssd)   db_instance_spec="${meta_spec}"; db_storage_size="20"   ;;
+        *)           db_instance_spec="${meta_spec}"; db_storage_size="20"   ;;
+    esac
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mariadb\",
+    \"DBEngineVersion\": \"10.6\",
+    \"DBInstanceSpec\": \"${db_instance_spec}\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"${db_storage_size}\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_alibaba_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_alibaba_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mariadb-test/storage-type-test/aws-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/aws-storage-type-test.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# AWS RDBMS StorageType Test Script (MariaDB)
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: io1/io2 require StorageSize >= 100. SubnetGroup requires 2+ subnets in different AZs.
+
+CSP_NAME="AWS"
+CONNECTION_NAME="aws-config01"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] ERROR fetching metainfo: ${err_msg}"
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_aws_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_aws_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mariadb-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_aws_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_aws_${st_safe}.txt"
+
+    case "${storage_type}" in
+        io1|io2) iops_field="\"Iops\": \"3000\"," ; storage_size="100" ;;
+        *)       iops_field=""                    ; storage_size="100" ;;
+    esac
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mariadb\",
+    \"DBEngineVersion\": \"10.6\",
+    \"DBInstanceSpec\": \"db.t3.medium\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"${storage_size}\",
+    ${iops_field}
+    \"SubnetNames\": [\"subnet-01\", \"subnet-02\"],
+    \"SecurityGroupNames\": [\"sg-01\"],
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_aws_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_aws_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mariadb-test/storage-type-test/common-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/common-storage-type-test.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Common Test Script
+# Flow: Create RDBMS with specific StorageType -> Poll until Available ->
+#       Get Info -> Verify StorageType matches requested -> Write result ->
+#       Delete instance (if AUTO_DELETE=true)
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name
+#   STORAGE_TYPE    - StorageType value being tested (e.g., "gp2")
+#   CREATE_JSON     - Full JSON body for POST /spider/rdbms
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - default: http://localhost:1024
+#   SPIDER_AUTH     - default: admin:****
+#   MAX_WAIT_SEC    - default: 3600
+#   POLL_INTERVAL   - default: 30
+#   AUTO_DELETE     - delete instance after test (default: false)
+#
+# Result file format (7 fields):
+#   CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+AUTO_DELETE="${AUTO_DELETE:-false}"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+echo "[${CSP_NAME}/${STORAGE_TYPE}] [${timestamp}] Creating RDBMS '${RDBMS_NAME}'..."
+
+# ── Create RDBMS ─────────────────────────────────────────────────────────────
+create_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/rdbms" \
+    -H 'Content-Type: application/json' \
+    -d "${CREATE_JSON}" 2>&1)
+
+err_msg=$(echo "${create_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] ERROR on create: ${err_msg}"
+    mkdir -p "$(dirname "${RESULT_FILE}")"
+    elapsed_fmt=$(format_elapsed $(($(date +%s) - start_time)))
+    echo "${CSP_NAME}|${STORAGE_TYPE}|N/A|FAIL|CREATE_ERROR|${elapsed_fmt}|-" > "${RESULT_FILE}"
+    exit 1
+fi
+
+create_status=$(echo "${create_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Create response status: ${create_status}"
+
+# ── Poll until Available ──────────────────────────────────────────────────────
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Waiting for RDBMS (poll every ${POLL_INTERVAL}s, max ${MAX_WAIT_SEC}s)..."
+
+elapsed=0
+while true; do
+    sleep "${POLL_INTERVAL}"
+    elapsed=$((elapsed + POLL_INTERVAL))
+
+    poll_resp=$(curl -u "${SPIDER_AUTH}" -s \
+        "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+    cur_status=$(echo "${poll_resp}" | jq -r '.Status // .rdbms.Status // "unknown"' 2>/dev/null)
+    status_lower=$(echo "${cur_status}" | tr '[:upper:]' '[:lower:]')
+
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] Status: ${cur_status} (elapsed: ${elapsed}s)"
+
+    case "${status_lower}" in
+        available|ready|runnable|active)
+            echo "[${CSP_NAME}/${STORAGE_TYPE}] RDBMS is available!"
+            break
+            ;;
+    esac
+
+    if [[ ${elapsed} -ge ${MAX_WAIT_SEC} ]]; then
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] TIMEOUT: did not become available within ${MAX_WAIT_SEC}s"
+        mkdir -p "$(dirname "${RESULT_FILE}")"
+        echo "${CSP_NAME}|${STORAGE_TYPE}|N/A|FAIL|TIMEOUT|$(format_elapsed ${elapsed})|-" > "${RESULT_FILE}"
+        exit 1
+    fi
+done
+
+end_time=$(date +%s)
+elapsed_total=$((end_time - start_time))
+
+# ── Get RDBMS Info ────────────────────────────────────────────────────────────
+info=$(curl -u "${SPIDER_AUTH}" -s \
+    "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}?ConnectionName=${CONNECTION_NAME}")
+
+db_status=$(echo "${info}"      | jq -r '.Status       // "N/A"')
+returned_type=$(echo "${info}"  | jq -r '.StorageType  // "N/A"')
+
+# ── Verify StorageType ────────────────────────────────────────────────────────
+req_lower=$(echo "${STORAGE_TYPE}"   | tr '[:upper:]' '[:lower:]')
+ret_lower=$(echo "${returned_type}"  | tr '[:upper:]' '[:lower:]')
+
+reason="-"
+
+if [[ "${CSP_NAME}" == "OPENSTACK" ]]; then
+    # OpenStack Trove API does not return volume.type in instance detail responses.
+    # Accept Available status as PASS since StorageType cannot be verified post-creation.
+    if [[ "${ret_lower}" == "n/a" || "${ret_lower}" == "na" || -z "${ret_lower}" ]]; then
+        pass_fail="PASS"
+        reason="OpenStack Trove does not expose StorageType post-creation; Available=PASS"
+    elif [[ "${ret_lower}" == "${req_lower}" ]]; then
+        pass_fail="PASS"
+    else
+        pass_fail="FAIL"
+    fi
+elif [[ "${req_lower}" == "cloud_auto" ]]; then
+    # cloud_auto is Alibaba's auto-select storage type.
+    # Alibaba automatically picks the best cloud storage type at provisioning time.
+    # Accept any cloud-based type (cloud_*/general_essd); reject local_ssd or N/A.
+    if [[ "${ret_lower}" == "n/a" || "${ret_lower}" == "na" || \
+          "${ret_lower}" == "local_ssd" || -z "${ret_lower}" ]]; then
+        pass_fail="FAIL"
+        reason="cloud_auto: auto-select, unexpected returned type '${returned_type}'"
+    else
+        pass_fail="PASS"
+        reason="cloud_auto: auto-select type, CSP chose '${returned_type}'"
+    fi
+elif [[ "${ret_lower}" == "${req_lower}" ]]; then
+    pass_fail="PASS"
+else
+    pass_fail="FAIL"
+fi
+
+elapsed_fmt=$(format_elapsed "${elapsed_total}")
+echo "[${CSP_NAME}/${STORAGE_TYPE}] Requested=${STORAGE_TYPE}, Returned=${returned_type} => ${pass_fail} (${elapsed_fmt})"
+[[ "${reason}" != "-" ]] && echo "[${CSP_NAME}/${STORAGE_TYPE}] Note: ${reason}"
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+# Format: CSP|StorageType_Requested|StorageType_Returned|PASS_FAIL|DB_Status|Elapsed|Reason
+echo "${CSP_NAME}|${STORAGE_TYPE}|${returned_type}|${pass_fail}|${db_status}|${elapsed_fmt}|${reason}" \
+    > "${RESULT_FILE}"
+
+# ── Auto Delete ───────────────────────────────────────────────────────────────
+if [[ "${AUTO_DELETE}" == "true" ]]; then
+    echo "[${CSP_NAME}/${STORAGE_TYPE}] Sending delete request for '${RDBMS_NAME}'..."
+    del_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+        "${SPIDER_URL}/spider/rdbms/${RDBMS_NAME}" \
+        -H 'Content-Type: application/json' \
+        -d "{\"ConnectionName\": \"${CONNECTION_NAME}\"}" 2>&1)
+    del_err=$(echo "${del_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${del_err}" ]]; then
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] Delete warning: ${del_err}"
+    else
+        echo "[${CSP_NAME}/${STORAGE_TYPE}] Delete request accepted."
+    fi
+fi

--- a/test/rdbms-mariadb-test/storage-type-test/delete-all-csp-storage-type-rdbms.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/delete-all-csp-storage-type-rdbms.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Test - Delete All Instances (MariaDB)
+# For each CSP, fetches StorageTypeOptions from rdbmsmetainfo (DBEngine=mariadb),
+# derives the RDBMS names used during StorageType testing (cb-mariadb-st-<type>),
+# and deletes them in parallel. All CSPs run concurrently.
+#
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_DELETE="${SCRIPT_DIR}/../common-rdbms-delete.sh"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-1800}"
+export POLL_INTERVAL="${POLL_INTERVAL:-15}"
+
+BASE_DIR="/tmp/st_del_$$"
+RESULT_DIR="${BASE_DIR}/results"
+LOG_DIR="${BASE_DIR}/logs"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── CSP connection config map ─────────────────────────────────────────────────
+csp_connection() {
+    case "$1" in
+        AWS)       echo "aws-config01"                 ;;
+        ALIBABA)   echo "alibaba-beijing-config"       ;;
+        OPENSTACK) echo "openstack-config01"           ;;
+        NHN)       echo "nhn-korea-pangyo1-config"     ;;
+    esac
+}
+
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# Derive safe name (same logic as in per-CSP test scripts)
+st_safe_name() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15
+}
+
+print_separator() {
+    echo "----------------------------------------------------------------------"
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+echo ""
+echo "########################################################################"
+echo "#  CB-Spider RDBMS StorageType Test - Delete All Instances (MariaDB)  #"
+echo "########################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per instance"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Base dir     : ${BASE_DIR}"
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+# ── Per-CSP delete function (runs in background subshell) ─────────────────────
+run_csp_delete() {
+    local csp="$1"
+    local conn="$2"
+    local csp_lower
+    csp_lower=$(to_lower "${csp}")
+
+    echo "[${csp}] Fetching StorageTypeOptions from rdbmsmetainfo (mariadb)..."
+    meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+        "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${conn}" 2>&1)
+
+    err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${err_msg}" ]]; then
+        echo "[${csp}] ERROR fetching metainfo: ${err_msg}"
+        echo "${csp}|META_ERROR|${err_msg}|-" \
+            > "${RESULT_DIR}/result_${csp_lower}_meta_error.txt"
+        return 1
+    fi
+
+    storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+    if [[ -z "${storage_types}" ]]; then
+        echo "[${csp}] No StorageTypeOptions - nothing to delete"
+        echo "${csp}|SKIP|no StorageTypeOptions|-" \
+            > "${RESULT_DIR}/result_${csp_lower}_skip.txt"
+        return 0
+    fi
+
+    echo "[${csp}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+
+    # Alibaba's RDS API rate-limits bursts of concurrent delete calls
+    local launch_stagger_sec=0
+    [[ "${csp}" == "ALIBABA" ]] && launch_stagger_sec=5
+
+    # Launch one delete job per StorageType
+    while IFS= read -r storage_type; do
+        [[ -z "${storage_type}" ]] && continue
+
+        st_safe=$(st_safe_name "${storage_type}")
+        rdbms_name="cb-mariadb-st-${st_safe}"
+        result_file="${RESULT_DIR}/result_${csp_lower}_${st_safe}.txt"
+        log_file="${LOG_DIR}/log_${csp_lower}_${st_safe}.txt"
+
+        echo "[${csp}] Deleting '${rdbms_name}' (StorageType=${storage_type})..."
+        (
+            export CSP_NAME="${csp}"
+            export CONNECTION_NAME="${conn}"
+            export RDBMS_NAME="${rdbms_name}"
+            export RESULT_FILE="${result_file}"
+            exec "${COMMON_DELETE}"
+        ) > "${log_file}" 2>&1 &
+
+        echo $! > "${LOG_DIR}/pid_${csp_lower}_${st_safe}.txt"
+        [[ ${launch_stagger_sec} -gt 0 ]] && sleep "${launch_stagger_sec}"
+    done <<< "${storage_types}"
+
+    # Wait for all delete jobs for this CSP
+    for pid_file in "${LOG_DIR}"/pid_${csp_lower}_*.txt; do
+        [[ -f "${pid_file}" ]] || continue
+        pid=$(cat "${pid_file}")
+        wait "${pid}"
+    done
+    echo "[${csp}] All delete jobs completed."
+}
+
+# ── Launch per-CSP delete in parallel ─────────────────────────────────────────
+echo "Launching parallel deletion on all CSPs..."
+echo ""
+
+for csp in ${CSP_ORDER}; do
+    conn=$(csp_connection "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} delete (log: ${log_file})"
+    run_csp_delete "${csp}" "${conn}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_csp_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP delete jobs launched. Waiting for completion..."
+echo "[MAIN] Monitor: tail -f ${LOG_DIR}/log_<csp>.txt"
+echo ""
+
+# ── Wait for all CSP jobs ─────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_csp_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} delete completed"
+        else
+            echo "[MAIN] ${csp} delete finished with exit code ${exit_code}"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP delete jobs finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+echo "========================================================================"
+echo "    RDBMS StorageType Test - DELETE SUMMARY - All CSPs (MariaDB)"
+echo "========================================================================"
+echo ""
+printf "%-12s | %-22s | %-14s | %-20s | %-10s\n" \
+    "CSP" "RDBMS Name" "Result" "Detail" "Elapsed"
+print_separator
+
+total=0
+deleted_count=0
+skipped_count=0
+error_count=0
+
+for csp in ${CSP_ORDER}; do
+    csp_lower=$(to_lower "${csp}")
+    csp_results=$(ls "${RESULT_DIR}"/result_${csp_lower}_*.txt 2>/dev/null | sort)
+
+    if [[ -z "${csp_results}" ]]; then
+        printf "%-12s | %-22s | %-14s | %-20s | %-10s\n" \
+            "${csp}" "-" "NO_RESULT" "-" "-"
+        continue
+    fi
+
+    while IFS= read -r result_file; do
+        [[ -f "${result_file}" ]] || continue
+        IFS='|' read -r r_csp r_result r_detail r_elapsed < "${result_file}"
+
+        fname=$(basename "${result_file}" .txt)
+        st_safe="${fname#result_${csp_lower}_}"
+        rdbms_name="cb-mariadb-st-${st_safe}"
+        [[ "${st_safe}" == "skip" || "${st_safe}" == "meta_error" ]] && rdbms_name="-"
+
+        printf "%-12s | %-22s | %-14s | %-20s | %-10s\n" \
+            "${r_csp}" "${rdbms_name}" "${r_result}" "${r_detail}" "${r_elapsed}"
+
+        total=$((total + 1))
+        case "${r_result}" in
+            DELETED) deleted_count=$((deleted_count + 1)) ;;
+            SKIP|NOT_FOUND) skipped_count=$((skipped_count + 1)) ;;
+            *) error_count=$((error_count + 1)) ;;
+        esac
+    done <<< "${csp_results}"
+done
+
+print_separator
+echo ""
+echo "Total: ${total}  DELETED: ${deleted_count}  SKIPPED: ${skipped_count}  ERROR: ${error_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "========================================================================"
+echo ""
+
+[[ ${error_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/storage-type-test/nhn-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/nhn-storage-type-test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# NHN Cloud RDBMS StorageType Test Script (MariaDB)
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: Subnet required.
+
+CSP_NAME="NHN"
+CONNECTION_NAME="nhn-korea-pangyo1-config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] metainfo returned error: ${err_msg}"
+    # NHN RDS for MariaDB is a separate service from RDS for MySQL.
+    # Only treat as SKIP when the service is genuinely not available in this
+    # environment (403 Unauthorized, 404 Not Found, or explicit "service not
+    # activated" messages). Other errors (500, network failures, etc.) are
+    # real failures and must not be silently skipped.
+    if echo "${err_msg}" | grep -qiE "unauthorized|forbidden|not activated|service not available|404|not found|no such service"; then
+        echo "[${CSP_NAME}] NHN RDS for MariaDB not available in this environment — SKIP"
+        echo "${CSP_NAME}|N/A|N/A|SKIP|NOT_APPLICABLE|-|NHN RDS for MariaDB service not enabled" \
+            > "${RESULT_DIR}/result_nhn_skip.txt"
+        exit 0
+    fi
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_nhn_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_nhn_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mariadb-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_nhn_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_nhn_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"SubnetNames\": [\"subnet-01\"],
+    \"DBEngine\": \"mariadb\",
+    \"DBEngineVersion\": \"MARIADB_V101118\",
+    \"DBInstanceSpec\": \"m2.c2m4\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"20\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_nhn_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_nhn_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mariadb-test/storage-type-test/openstack-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/openstack-storage-type-test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# OpenStack RDBMS StorageType Test Script (MariaDB)
+# Fetches StorageTypeOptions from rdbmsmetainfo and runs one test per type in parallel.
+# Note: MariaDB support depends on OpenStack Trove datastore configuration.
+
+CSP_NAME="OPENSTACK"
+CONNECTION_NAME="openstack-config01"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export RESULT_DIR="${RESULT_DIR:-/tmp/st_results_$$}"
+export LOG_DIR="${LOG_DIR:-/tmp/st_logs_$$}"
+
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Fetch StorageTypeOptions ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Fetching StorageTypeOptions from rdbmsmetainfo..."
+meta_resp=$(curl -u "${SPIDER_AUTH}" -sX GET \
+    "${SPIDER_URL}/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=${CONNECTION_NAME}" 2>&1)
+
+err_msg=$(echo "${meta_resp}" | jq -r '.message // empty' 2>/dev/null)
+if [[ -n "${err_msg}" ]]; then
+    echo "[${CSP_NAME}] metainfo returned error: ${err_msg}"
+    # OpenStack Trove may not have MariaDB datastore installed; treat as environment
+    # limitation (SKIP) rather than a test failure. Real errors (connection refused,
+    # authentication failure) will still surface via the HTTP status or empty body.
+    if echo "${err_msg}" | grep -qiE "not supported|no (versions|storage|datastore|engine)|trove"; then
+        echo "[${CSP_NAME}] MariaDB datastore not configured in this OpenStack Trove — SKIP"
+        echo "${CSP_NAME}|N/A|N/A|SKIP|NOT_APPLICABLE|-|MariaDB Trove datastore not installed" \
+            > "${RESULT_DIR}/result_openstack_skip.txt"
+        exit 0
+    fi
+    echo "${CSP_NAME}|N/A|N/A|FAIL|META_ERROR|-" \
+        > "${RESULT_DIR}/result_openstack_meta_error.txt"
+    exit 1
+fi
+
+storage_types=$(echo "${meta_resp}" | jq -r '.StorageTypeOptions[]? // empty' 2>/dev/null)
+if [[ -z "${storage_types}" ]]; then
+    echo "[${CSP_NAME}] No StorageTypeOptions returned - skipping"
+    echo "${CSP_NAME}|N/A|N/A|SKIP|NO_STORAGE_TYPES|-" \
+        > "${RESULT_DIR}/result_openstack_skip.txt"
+    exit 0
+fi
+
+echo "[${CSP_NAME}] StorageTypeOptions: $(echo "${storage_types}" | tr '\n' ' ')"
+echo "[${CSP_NAME}] Launching parallel StorageType tests..."
+
+# ── Launch one test per StorageType ──────────────────────────────────────────
+while IFS= read -r storage_type; do
+    [[ -z "${storage_type}" ]] && continue
+
+    st_safe=$(echo "${storage_type}" | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-15)
+    rdbms_name="cb-mariadb-st-${st_safe}"
+    result_file="${RESULT_DIR}/result_openstack_${st_safe}.txt"
+    log_file="${LOG_DIR}/log_openstack_${st_safe}.txt"
+
+    create_json="{
+  \"ConnectionName\": \"${CONNECTION_NAME}\",
+  \"ReqInfo\": {
+    \"Name\": \"${rdbms_name}\",
+    \"VPCName\": \"vpc-01\",
+    \"DBEngine\": \"mariadb\",
+    \"DBEngineVersion\": \"10.6\",
+    \"DBInstanceSpec\": \"m1.small\",
+    \"StorageType\": \"${storage_type}\",
+    \"StorageSize\": \"20\",
+    \"MasterUserName\": \"myadmin\",
+    \"MasterUserPassword\": \"Password123!\",
+    \"PublicAccess\": true
+  }
+}"
+
+    echo "[${CSP_NAME}] Launching test: StorageType='${storage_type}' (RDBMS: ${rdbms_name})"
+    (
+        export CSP_NAME="${CSP_NAME}"
+        export CONNECTION_NAME="${CONNECTION_NAME}"
+        export RDBMS_NAME="${rdbms_name}"
+        export STORAGE_TYPE="${storage_type}"
+        export CREATE_JSON="${create_json}"
+        export RESULT_FILE="${result_file}"
+        exec "${SCRIPT_DIR}/common-storage-type-test.sh"
+    ) > "${log_file}" 2>&1 &
+
+    echo $! > "${LOG_DIR}/pid_openstack_${st_safe}.txt"
+done <<< "${storage_types}"
+
+# ── Wait for all StorageType tests ────────────────────────────────────────────
+echo "[${CSP_NAME}] Waiting for all StorageType tests to complete..."
+for pid_file in "${LOG_DIR}"/pid_openstack_*.txt; do
+    [[ -f "${pid_file}" ]] || continue
+    pid=$(cat "${pid_file}")
+    wait "${pid}"
+done
+echo "[${CSP_NAME}] All StorageType tests completed."

--- a/test/rdbms-mariadb-test/storage-type-test/run-all-csp-storage-type-tests.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/run-all-csp-storage-type-tests.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# CB-Spider RDBMS StorageType Test Runner - All CSPs (MariaDB)
+# For each CSP:
+#   1. Fetches StorageTypeOptions via rdbmsmetainfo API (DBEngine=mariadb)
+#   2. Creates one RDBMS per StorageType option (in parallel within each CSP)
+#   3. Verifies returned StorageType matches requested
+#   4. Deletes test instances after verification
+# Only CSPs that support MariaDB (AWS, Alibaba, OpenStack, NHN) are run;
+# Azure/GCP/IBM/NCP/Tencent do not support MariaDB and are excluded entirely.
+# All CSPs run concurrently. A unified result table is shown at the end.
+#
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+export MAX_WAIT_SEC="${MAX_WAIT_SEC:-3600}"
+export POLL_INTERVAL="${POLL_INTERVAL:-30}"
+export AUTO_DELETE="${AUTO_DELETE:-false}"
+
+BASE_DIR="/tmp/st_test_$$"
+export RESULT_DIR="${BASE_DIR}/results"
+export LOG_DIR="${BASE_DIR}/logs"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)       echo "aws-storage-type-test.sh"       ;;
+        ALIBABA)   echo "alibaba-storage-type-test.sh"   ;;
+        OPENSTACK) echo "openstack-storage-type-test.sh" ;;
+        NHN)       echo "nhn-storage-type-test.sh"       ;;
+    esac
+}
+
+print_separator() {
+    echo "--------------------------------------------------------------------------------------------------------------------------------"
+}
+
+print_header() {
+    echo ""
+    echo "================================================================================================================================"
+    echo "                           RDBMS StorageType Test Summary - All CSPs (MariaDB)"
+    echo "================================================================================================================================"
+    echo ""
+    printf "%-12s | %-20s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+        "CSP" "StorageType(Req)" "StorageType(Ret)" "Result" "DB Status" "Elapsed" "Reason"
+    print_separator
+}
+
+# ── Banner ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#    CB-Spider RDBMS StorageType Test (MariaDB) - Starting All CSPs           #"
+echo "################################################################################"
+echo ""
+echo "Spider URL   : ${SPIDER_URL}"
+echo "Max wait     : ${MAX_WAIT_SEC}s per instance"
+echo "Poll interval: ${POLL_INTERVAL}s"
+echo "Auto delete  : ${AUTO_DELETE}"
+echo "Base dir     : ${BASE_DIR}"
+echo ""
+echo "Target CSPs  : AWS, Alibaba, OpenStack, NHN (MariaDB support only)"
+echo ""
+echo "Launching all CSP StorageType tests in parallel..."
+echo ""
+
+CSP_ORDER="AWS ALIBABA OPENSTACK NHN"
+
+# ── Launch all CSP scripts in background ─────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_csp_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All CSP tests launched. Waiting for completion..."
+echo "[MAIN] Monitor: tail -f ${LOG_DIR}/log_<csp>.txt"
+echo ""
+
+# ── Wait for all CSP background jobs ─────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_csp_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code}"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All CSP tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+total=0
+pass_count=0
+fail_count=0
+skip_count=0
+
+for csp in ${CSP_ORDER}; do
+    csp_lower=$(to_lower "${csp}")
+    csp_results=$(ls "${RESULT_DIR}"/result_${csp_lower}_*.txt 2>/dev/null | sort)
+
+    if [[ -z "${csp_results}" ]]; then
+        printf "%-12s | %-18s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+            "${csp}" "-" "-" "N/A" "NO_RESULT" "-" "-"
+        fail_count=$((fail_count + 1))
+        continue
+    fi
+
+    while IFS= read -r result_file; do
+        [[ -f "${result_file}" ]] || continue
+        IFS='|' read -r r_csp r_req r_ret r_pass r_status r_elapsed r_reason \
+            < "${result_file}"
+
+        printf "%-12s | %-20s | %-18s | %-6s | %-14s | %-10s | %-s\n" \
+            "${r_csp}" "${r_req}" "${r_ret}" "${r_pass}" "${r_status}" "${r_elapsed}" "${r_reason}"
+
+        total=$((total + 1))
+        case "${r_pass}" in
+            PASS) pass_count=$((pass_count + 1)) ;;
+            FAIL) fail_count=$((fail_count + 1)) ;;
+            SKIP) skip_count=$((skip_count + 1)) ;;
+        esac
+    done <<< "${csp_results}"
+done
+
+print_separator
+echo ""
+echo "Total: ${total}  PASS: ${pass_count}  FAIL: ${fail_count}  SKIP: ${skip_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+echo "================================================================================================================================"
+echo ""
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                         Per-CSP Detailed Logs                               #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        if [[ -f "${log_file}" ]]; then
+            cat "${log_file}"
+        else
+            echo "(no log)"
+        fi
+    done
+fi
+
+[[ ${fail_count} -eq 0 ]]

--- a/test/rdbms-mariadb-test/tag-test/alibaba-rdbms-tag-test.sh
+++ b/test/rdbms-mariadb-test/tag-test/alibaba-rdbms-tag-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# ALIBABA RDBMS Tag Management Test Script (MariaDB, SupportsTag=true)
+export CSP_NAME="ALIBABA"
+export CONNECTION_NAME="alibaba-beijing-config"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_tag_results}/result_alibaba.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-tag-test.sh"

--- a/test/rdbms-mariadb-test/tag-test/aws-rdbms-tag-test.sh
+++ b/test/rdbms-mariadb-test/tag-test/aws-rdbms-tag-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# AWS RDBMS Tag Management Test Script (MariaDB, SupportsTag=true)
+export CSP_NAME="AWS"
+export CONNECTION_NAME="aws-config01"
+export RDBMS_NAME="cb-spider-mariadb-test"
+export RESULT_FILE="${RESULT_DIR:-/tmp/rdbms_tag_results}/result_aws.txt"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${SCRIPT_DIR}/common-rdbms-tag-test.sh"

--- a/test/rdbms-mariadb-test/tag-test/common-rdbms-tag-test.sh
+++ b/test/rdbms-mariadb-test/tag-test/common-rdbms-tag-test.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Tag Management Common Test Script
+# Flow: AddTag -> ListTag -> GetTag -> AddTag(2nd) -> ListTag -> RemoveTag -> ListTag(verify) -> Write result
+# Author: CB-Spider Team
+#
+# Required env vars (set by per-CSP scripts):
+#   CSP_NAME        - Display name (e.g., AWS)
+#   CONNECTION_NAME - Spider connection config name
+#   RDBMS_NAME      - RDBMS instance name to tag
+#   RESULT_FILE     - Path to write pipe-separated result line
+#
+# Optional env vars:
+#   SPIDER_URL      - Spider REST API URL (default: http://localhost:1024)
+#   SPIDER_AUTH     - Basic auth credentials (default: admin:****)
+#
+# Result file format (8 fields):
+#   CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
+
+format_elapsed() {
+    local sec=$1
+    if [[ ${sec} -lt 60 ]]; then
+        echo "${sec}s"
+    else
+        echo "$((sec / 60))m$((sec % 60))s"
+    fi
+}
+
+SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+TAG_KEY1="spider-rdbms-tag"
+TAG_VAL1="rdbms-tag-value"
+TAG_KEY2="spider-rdbms-tag2"
+TAG_VAL2="rdbms-tag-value2"
+
+start_time=$(date +%s)
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+mkdir -p "$(dirname "${RESULT_FILE}")"
+
+r_add1="FAIL"
+r_list="FAIL"
+r_get="FAIL"
+r_add2="FAIL"
+r_remove="FAIL"
+r_verify="FAIL"
+
+check_result() {
+    local label="$1"
+    local resp="$2"
+    local err
+    err=$(echo "${resp}" | jq -r '.message // empty' 2>/dev/null)
+    if [[ -n "${err}" ]]; then
+        echo "[${CSP_NAME}] ERROR on ${label}: ${err}"
+        elapsed_fmt=$(format_elapsed $(($(date +%s) - start_time)))
+        echo "${CSP_NAME}|${r_add1}|${r_list}|${r_get}|${r_add2}|${r_remove}|${r_verify}|${elapsed_fmt}" \
+            > "${RESULT_FILE}"
+        exit 1
+    fi
+}
+
+echo "[${CSP_NAME}] [${timestamp}] Starting RDBMS tag management test for '${RDBMS_NAME}'..."
+
+# ── Pre-cleanup: remove leftover tags from a previous run (ignore errors) ────
+for key in "${TAG_KEY1}" "${TAG_KEY2}"; do
+    curl -u "${SPIDER_AUTH}" -sX DELETE \
+      "${SPIDER_URL}/spider/tag/${key}" \
+      -H 'Content-Type: application/json' \
+      -d "{
+        \"ConnectionName\": \"${CONNECTION_NAME}\",
+        \"ReqInfo\": {\"ResourceType\": \"rdbms\", \"ResourceName\": \"${RDBMS_NAME}\"}
+      }" > /dev/null 2>&1
+done
+
+# ── AddTag (1st) ──────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] AddTag: key='${TAG_KEY1}' value='${TAG_VAL1}'"
+
+add1_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/tag" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"ReqInfo\": {
+      \"ResourceType\": \"rdbms\",
+      \"ResourceName\": \"${RDBMS_NAME}\",
+      \"Tag\": {\"Key\": \"${TAG_KEY1}\", \"Value\": \"${TAG_VAL1}\"}
+    }
+  }" 2>&1)
+
+check_result "AddTag(1)" "${add1_resp}"
+returned_key=$(echo "${add1_resp}" | jq -r '.Key // empty' 2>/dev/null)
+if [[ "${returned_key}" == "${TAG_KEY1}" ]]; then
+    r_add1="PASS"
+fi
+echo "[${CSP_NAME}] AddTag(1): ${r_add1}"
+
+# ── ListTag ───────────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] ListTag: verifying '${TAG_KEY1}' is present"
+
+list_resp=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/tag?ConnectionName=${CONNECTION_NAME}&ResourceType=rdbms&ResourceName=${RDBMS_NAME}" 2>&1)
+
+check_result "ListTag" "${list_resp}"
+if echo "${list_resp}" | jq -e --arg k "${TAG_KEY1}" '.tag[]? | select(.Key == $k)' > /dev/null 2>&1; then
+    r_list="PASS"
+fi
+tag_count=$(echo "${list_resp}" | jq -r '.tag | length // 0' 2>/dev/null)
+echo "[${CSP_NAME}] ListTag: ${r_list} (${tag_count} tag(s))"
+
+# ── GetTag ────────────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] GetTag: key='${TAG_KEY1}'"
+
+get_resp=$(curl -u "${SPIDER_AUTH}" -s \
+  "${SPIDER_URL}/spider/tag/${TAG_KEY1}?ConnectionName=${CONNECTION_NAME}&ResourceType=rdbms&ResourceName=${RDBMS_NAME}" 2>&1)
+
+check_result "GetTag" "${get_resp}"
+got_val=$(echo "${get_resp}" | jq -r '.Value // empty' 2>/dev/null)
+if [[ "${got_val}" == "${TAG_VAL1}" ]]; then
+    r_get="PASS"
+fi
+echo "[${CSP_NAME}] GetTag: ${r_get} (Value='${got_val}')"
+
+# ── AddTag (2nd) ──────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] AddTag(2): key='${TAG_KEY2}' value='${TAG_VAL2}'"
+
+add2_resp=$(curl -u "${SPIDER_AUTH}" -sX POST "${SPIDER_URL}/spider/tag" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"ReqInfo\": {
+      \"ResourceType\": \"rdbms\",
+      \"ResourceName\": \"${RDBMS_NAME}\",
+      \"Tag\": {\"Key\": \"${TAG_KEY2}\", \"Value\": \"${TAG_VAL2}\"}
+    }
+  }" 2>&1)
+
+check_result "AddTag(2)" "${add2_resp}"
+returned_key2=$(echo "${add2_resp}" | jq -r '.Key // empty' 2>/dev/null)
+if [[ "${returned_key2}" == "${TAG_KEY2}" ]]; then
+    r_add2="PASS"
+fi
+echo "[${CSP_NAME}] AddTag(2): ${r_add2}"
+
+# ── RemoveTag ─────────────────────────────────────────────────────────────────
+echo "[${CSP_NAME}] RemoveTag: key='${TAG_KEY1}'"
+
+rm1_resp=$(curl -u "${SPIDER_AUTH}" -sX DELETE \
+  "${SPIDER_URL}/spider/tag/${TAG_KEY1}" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"ReqInfo\": {
+      \"ResourceType\": \"rdbms\",
+      \"ResourceName\": \"${RDBMS_NAME}\"
+    }
+  }" 2>&1)
+
+check_result "RemoveTag(1)" "${rm1_resp}"
+rm_result=$(echo "${rm1_resp}" | jq -r '.Result // empty' 2>/dev/null)
+if [[ "${rm_result}" == "true" ]]; then
+    r_remove="PASS"
+fi
+echo "[${CSP_NAME}] RemoveTag: ${r_remove}"
+
+# ── Verify Removed (with retry for eventual consistency) ─────────────────────
+echo "[${CSP_NAME}] ListTag: verifying '${TAG_KEY1}' is removed"
+
+VERIFY_MAX_WAIT="${VERIFY_MAX_WAIT:-60}"
+VERIFY_INTERVAL="${VERIFY_INTERVAL:-5}"
+verify_elapsed=0
+while true; do
+    verify_resp=$(curl -u "${SPIDER_AUTH}" -s \
+      "${SPIDER_URL}/spider/tag?ConnectionName=${CONNECTION_NAME}&ResourceType=rdbms&ResourceName=${RDBMS_NAME}" 2>&1)
+
+    check_result "ListTag(verify)" "${verify_resp}"
+    if ! echo "${verify_resp}" | jq -e --arg k "${TAG_KEY1}" '.tag[]? | select(.Key == $k)' > /dev/null 2>&1; then
+        r_verify="PASS"
+        break
+    fi
+    if [[ ${verify_elapsed} -ge ${VERIFY_MAX_WAIT} ]]; then
+        break
+    fi
+    echo "[${CSP_NAME}] VerifyRemoved: tag still present, retrying in ${VERIFY_INTERVAL}s (${verify_elapsed}s elapsed)..."
+    sleep "${VERIFY_INTERVAL}"
+    verify_elapsed=$((verify_elapsed + VERIFY_INTERVAL))
+done
+
+remaining=$(echo "${verify_resp}" | jq -r '.tag | length // 0' 2>/dev/null)
+echo "[${CSP_NAME}] VerifyRemoved: ${r_verify} (${remaining} tag(s) remaining)"
+
+# ── Cleanup: RemoveTag (2nd) ──────────────────────────────────────────────────
+echo "[${CSP_NAME}] Cleanup: removing '${TAG_KEY2}'"
+curl -u "${SPIDER_AUTH}" -sX DELETE \
+  "${SPIDER_URL}/spider/tag/${TAG_KEY2}" \
+  -H 'Content-Type: application/json' \
+  -d "{
+    \"ConnectionName\": \"${CONNECTION_NAME}\",
+    \"ReqInfo\": {
+      \"ResourceType\": \"rdbms\",
+      \"ResourceName\": \"${RDBMS_NAME}\"
+    }
+  }" > /dev/null 2>&1
+
+# ── Write Result ──────────────────────────────────────────────────────────────
+end_time=$(date +%s)
+elapsed_fmt=$(format_elapsed $((end_time - start_time)))
+
+overall="PASS"
+for r in "${r_add1}" "${r_list}" "${r_get}" "${r_add2}" "${r_remove}" "${r_verify}"; do
+    [[ "${r}" != "PASS" ]] && overall="FAIL" && break
+done
+
+echo "[${CSP_NAME}] Tag test ${overall} (elapsed: ${elapsed_fmt})"
+echo "[${CSP_NAME}]   AddTag(1)=${r_add1} ListTag=${r_list} GetTag=${r_get} AddTag(2)=${r_add2} RemoveTag=${r_remove} VerifyRemoved=${r_verify}"
+
+# Format: CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
+echo "${CSP_NAME}|${r_add1}|${r_list}|${r_get}|${r_add2}|${r_remove}|${r_verify}|${elapsed_fmt}" \
+  > "${RESULT_FILE}"

--- a/test/rdbms-mariadb-test/tag-test/run-all-csp-rdbms-tag-tests.sh
+++ b/test/rdbms-mariadb-test/tag-test/run-all-csp-rdbms-tag-tests.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# CB-Spider RDBMS Tag Management Test Runner (MariaDB)
+# Runs AddTag/ListTag/GetTag/RemoveTag tests for CSPs where RDBMSMetaInfo.SupportsTag=true
+# AND MariaDB is supported.
+# Supported CSPs: AWS, ALIBABA
+# (Azure/GCP/IBM/NCP/Tencent do not support MariaDB; OpenStack/NHN do not support Tag.)
+# Prerequisite: RDBMS instances must already be created (run run-all-csp-rdbms-tests.sh first).
+# Author: CB-Spider Team
+# Note: Written for bash 3.2+ compatibility (macOS default shell)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
+
+export RESULT_DIR="/tmp/rdbms_tag_results_$$"
+LOG_DIR="/tmp/rdbms_tag_logs_$$"
+mkdir -p "${RESULT_DIR}" "${LOG_DIR}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+to_lower() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+csp_script() {
+    case "$1" in
+        AWS)     echo "aws-rdbms-tag-test.sh"     ;;
+        ALIBABA) echo "alibaba-rdbms-tag-test.sh" ;;
+    esac
+}
+
+print_separator() {
+    printf '%115s\n' '' | tr ' ' '-'
+}
+
+print_header() {
+    echo ""
+    printf '%115s\n' '' | tr ' ' '='
+    echo "          RDBMS TAG MANAGEMENT TEST SUMMARY (SupportsTag=true CSPs) - MariaDB"
+    printf '%115s\n' '' | tr ' ' '='
+    echo ""
+    printf "%-12s | %-8s | %-8s | %-7s | %-8s | %-10s | %-13s | %-10s\n" \
+        "CSP" "AddTag" "ListTag" "GetTag" "AddTag2" "RemoveTag" "VerifyRemoved" "Elapsed"
+    print_separator
+}
+
+# ── Launch ────────────────────────────────────────────────────────────────────
+echo ""
+echo "################################################################################"
+echo "#    CB-Spider RDBMS Tag Management Test (MariaDB) - SupportsTag=true CSPs    #"
+echo "#                          AWS / ALIBABA                                      #"
+echo "################################################################################"
+echo ""
+echo "Spider URL : ${SPIDER_URL}"
+echo "Result dir : ${RESULT_DIR}"
+echo "Log dir    : ${LOG_DIR}"
+echo ""
+echo "Launching tag management tests in parallel..."
+echo ""
+
+# Only CSPs where RDBMSMetaInfo.SupportsTag=true AND MariaDB is supported
+CSP_ORDER="AWS ALIBABA"
+
+for csp in ${CSP_ORDER}; do
+    script=$(csp_script "${csp}")
+    log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+    echo "[MAIN] Starting ${csp} (log: ${log_file})"
+    "${SCRIPT_DIR}/${script}" > "${log_file}" 2>&1 &
+    echo $! > "${LOG_DIR}/pid_${csp}.txt"
+done
+
+echo ""
+echo "[MAIN] All tests launched. Waiting for completion..."
+echo "[MAIN] Monitor progress: tail -f ${LOG_DIR}/log_<csp_lowercase>.txt"
+echo ""
+
+# ── Wait for all ──────────────────────────────────────────────────────────────
+for csp in ${CSP_ORDER}; do
+    pid=$(cat "${LOG_DIR}/pid_${csp}.txt" 2>/dev/null)
+    if [[ -n "${pid}" ]]; then
+        wait "${pid}"
+        exit_code=$?
+        if [[ ${exit_code} -eq 0 ]]; then
+            echo "[MAIN] ${csp} completed successfully"
+        else
+            echo "[MAIN] ${csp} finished with exit code ${exit_code} (check ${LOG_DIR}/log_$(to_lower "${csp}").txt)"
+        fi
+    fi
+done
+
+echo ""
+echo "[MAIN] All tests finished. Collecting results..."
+echo ""
+
+# ── Print result table ────────────────────────────────────────────────────────
+print_header
+
+pass_count=0
+fail_count=0
+
+for csp in ${CSP_ORDER}; do
+    result_file="${RESULT_DIR}/result_$(to_lower "${csp}").txt"
+
+    if [[ -f "${result_file}" ]]; then
+        IFS='|' read -r r_csp r_add1 r_list r_get r_add2 r_remove r_verify r_elapsed \
+            < "${result_file}"
+    else
+        r_csp="${csp}"
+        r_add1="NO_RESULT"
+        r_list="-"
+        r_get="-"
+        r_add2="-"
+        r_remove="-"
+        r_verify="-"
+        r_elapsed="-"
+    fi
+
+    printf "%-12s | %-8s | %-8s | %-7s | %-8s | %-10s | %-13s | %-10s\n" \
+        "${r_csp}" "${r_add1}" "${r_list}" "${r_get}" "${r_add2}" "${r_remove}" "${r_verify}" "${r_elapsed}"
+
+    if [[ "${r_add1}" == "PASS" && "${r_list}" == "PASS" && "${r_get}" == "PASS" && \
+          "${r_add2}" == "PASS" && "${r_remove}" == "PASS" && "${r_verify}" == "PASS" ]]; then
+        pass_count=$((pass_count + 1))
+    else
+        fail_count=$((fail_count + 1))
+    fi
+done
+
+print_separator
+echo ""
+printf "Total: %d PASS, %d FAIL\n" "${pass_count}" "${fail_count}"
+echo ""
+echo "Logs   : ${LOG_DIR}/"
+echo "Results: ${RESULT_DIR}/"
+echo ""
+printf '%115s\n' '' | tr ' ' '='
+echo ""
+
+if [[ "${VERBOSE:-0}" == "1" ]]; then
+    echo ""
+    echo "################################################################################"
+    echo "#                          Per-CSP Detailed Logs                              #"
+    echo "################################################################################"
+    for csp in ${CSP_ORDER}; do
+        log_file="${LOG_DIR}/log_$(to_lower "${csp}").txt"
+        echo ""
+        echo "────────────────────────────── ${csp} ──────────────────────────────"
+        [[ -f "${log_file}" ]] && cat "${log_file}" || echo "(no log)"
+    done
+fi
+
+[[ ${fail_count} -eq 0 ]]


### PR DESCRIPTION
- Add NHN RDS for MariaDB support (previously MySQL-only)
- Remove Tencent MariaDB (TDSQL) support — this code was added alongside
  MySQL support but never verified; live API testing now confirms it doesn't
  work ("Create MariaDB not supported")
- Add test/rdbms-mariadb-test/: first end-to-end test suite covering MariaDB
  create/delete, StorageType, DB management, and Tag management across all
  CSPs — confirms the existing AWS/Alibaba/OpenStack MariaDB code (already
  present from the original MySQL support work) actually works end-to-end
- Harden Tencent/Azure/IBM RDBMS reliability (delete retry, tag list retry,
  info-fetch retry) — issues surfaced by this MariaDB verification testing

See test/rdbms-mariadb-test/README.md for CSP support matrix, test usage, and
script structure.
