### PR TITLE
[Tag] Docs: Add RDBMS to supported resource types in Tag Management swagger

### DIFF
--- a/api-runtime/rest-runtime/TagRest.go
+++ b/api-runtime/rest-runtime/TagRest.go
@@ -33,7 +33,8 @@ type TagAddRequest struct {
 // @ID add-tag
 // @Summary Add Tag
 // @Description Add a tag to a specified resource.
-// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+// @Description ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
 // @Tags [Tag Management]
 // @Accept  json
 // @Produce  json
@@ -64,7 +65,8 @@ func AddTag(c echo.Context) error {
 // @ID list-tag
 // @Summary List Tags
 // @Description Retrieve a list of tags for a specified resource.
-// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+// @Description ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
 // @Tags [Tag Management]
 // @Accept  json
 // @Produce  json
@@ -117,7 +119,8 @@ func ListTag(c echo.Context) error {
 // @ID get-tag
 // @Summary Get Tag
 // @Description Retrieve a specific tag for a specified resource.
-// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+// @Description ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
 // @Tags [Tag Management]
 // @Accept  json
 // @Produce  json
@@ -171,7 +174,8 @@ type TagRemoveRequest struct {
 // @ID remove-tag
 // @Summary Remove Tag
 // @Description Remove a specific tag from a specified resource.
-// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+// @Description ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+// @Description ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
 // @Tags [Tag Management]
 // @Accept  json
 // @Produce  json

--- a/api/docs.go
+++ b/api/docs.go
@@ -11379,7 +11379,7 @@ const docTemplate = `{
         },
         "/tag": {
             "get": {
-                "description": "Retrieve a list of tags for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Retrieve a list of tags for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11445,7 +11445,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Add a tag to a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Add a tag to a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11498,7 +11498,7 @@ const docTemplate = `{
         },
         "/tag/{Key}": {
             "get": {
-                "description": "Retrieve a specific tag for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Retrieve a specific tag for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11568,7 +11568,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Remove a specific tag from a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Remove a specific tag from a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -11376,7 +11376,7 @@
         },
         "/tag": {
             "get": {
-                "description": "Retrieve a list of tags for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Retrieve a list of tags for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11442,7 +11442,7 @@
                 }
             },
             "post": {
-                "description": "Add a tag to a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Add a tag to a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11495,7 +11495,7 @@
         },
         "/tag/{Key}": {
             "get": {
-                "description": "Retrieve a specific tag for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Retrieve a specific tag for a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],
@@ -11565,7 +11565,7 @@
                 }
             },
             "delete": {
-                "description": "Remove a specific tag from a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER",
+                "description": "Remove a specific tag from a specified resource.\n※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS\n※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -12618,7 +12618,8 @@ paths:
       - application/json
       description: |-
         Retrieve a list of tags for a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+        ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
       operationId: list-tag
       parameters:
       - description: Connection Name. ex) aws-connection
@@ -12666,7 +12667,8 @@ paths:
       - application/json
       description: |-
         Add a tag to a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+        ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
       operationId: add-tag
       parameters:
       - description: Request body for adding a tag
@@ -12704,7 +12706,8 @@ paths:
       - application/json
       description: |-
         Remove a specific tag from a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+        ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
       operationId: remove-tag
       parameters:
       - description: Request body for removing a specific tag
@@ -12746,7 +12749,8 @@ paths:
       - application/json
       description: |-
         Retrieve a specific tag for a specified resource.
-        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER
+        ※ Resource types: VPC, SUBNET, SG, KEY, VM, NLB, DISK, MYIMAGE, CLUSTER, RDBMS
+        ※ RDBMS: tagging support (mysql, mariadb, etc.) varies by CSP driver — check GetMetaInfo().SupportsTag before use
       operationId: get-tag
       parameters:
       - description: Connection Name. ex) aws-connection


### PR DESCRIPTION
- Add RDBMS to the @Description resource-type list in AddTag, ListTag, GetTag, and RemoveTag swagger annotations (TagRest.go)
- Note that RDBMS tagging support (MySQL, MariaDB, etc.) varies by CSP driver — callers should check GetMetaInfo().SupportsTag before tagging an RDBMS resource
