### PR TITLE
[Docs] Restructure RDBMS MariaDB/MySQL test guides by scenario and fix StorageType docs

### DIFF
--- a/test/rdbms-mariadb-test/README.md
+++ b/test/rdbms-mariadb-test/README.md
@@ -48,7 +48,7 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 | AWS | ✅ | ✅ | `10.6` | Amazon RDS for MariaDB |
 | Alibaba | ✅ | ✅ | `10.6` | AliCloud RDS for MariaDB |
 | OpenStack | ⚠️ | ❌ | `10.6` | **현재 이 환경은 MariaDB Trove datastore 구축 전 상태** (설치되면 정상 동작 예상) — 시험 스크립트는 그대로 유지 |
-| NHN | ✅ | ❌ | `MARIADB_V10622` | NHN RDS for MariaDB |
+| NHN | ✅ | ❌ | `MARIADB_V101118` | NHN RDS for MariaDB |
 
 
 ## RDBMS Instance Configuration
@@ -58,9 +58,9 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 | CSP | Engine | Version | Spec | Storage |
 |-----|--------|---------|------|---------|
 | AWS | mariadb | 10.6 | db.t3.medium | 100GB |
-| Alibaba | mariadb | 10.6 | rds.mariadb.s4.large | 20GB |
+| Alibaba | mariadb | 10.6 | metainfo 동적 조회 (예: `mariadb.n2.medium.2c`, 조회 실패 시 `rds.mariadb.s4.large`로 폴백) | 20GB |
 | OpenStack | mariadb | 10.6 | m1.small | 20GB (Trove 구축 후 정상 동작 예상) |
-| NHN | mariadb | MARIADB_V10622 | m2.c2m4 | 20GB |
+| NHN | mariadb | MARIADB_V101118 | m2.c2m4 | 20GB |
 
 ## Usage
 
@@ -147,4 +147,63 @@ rdbms-mariadb-test/
     ├── common-rdbms-tag-test.sh
     ├── run-all-csp-rdbms-tag-tests.sh          # 실행 대상: AWS/Alibaba (SupportsTag=true AND MariaDB 지원)
     └── aws-rdbms-tag-test.sh / alibaba-rdbms-tag-test.sh
+```
+
+각 시험 시나리오(StorageType 검증, DB 관리, Tag 관리)에 대한 상세 내용과 개별 시험 결과는 해당 하위 디렉토리의 README.md를 참고하세요.
+
+- [storage-type-test/README.md](storage-type-test/README.md)
+- [database-test/README.md](database-test/README.md)
+- [tag-test/README.md](tag-test/README.md)
+
+## 시험 결과
+
+### 2026-08-10
+
+`./all_test.sh` 전체 시험 수트 실행 결과입니다 (Step 2/4/5/7은 하위 시험 또는 OpenStack MariaDB Trove datastore 미구축으로 인한 실패 — 상세는 각 하위 디렉토리 README 참고).
+
+```
+ PASS | Step 1: Network Prepare (VPC/Subnet/SG)
+ FAIL | Step 2: StorageType Validation Test (exit code: 1)
+ PASS | Step 3: Delete StorageType RDBMS Instances
+ FAIL | Step 4: RDBMS Instance Create (all CSPs) (exit code: 1)
+ FAIL | Step 5: Database Management Test (CRUD inside instance) (exit code: 1)
+ PASS | Step 6: Tag Management Test (SupportsTag=true CSPs)
+ FAIL | Step 7: RDBMS Instance Delete (all CSPs) (exit code: 1)
+ PASS | Step 8: Network Cleanup (VPC/Subnet/SG)
+
+ Total: 4 PASS, 4 FAIL
+```
+
+OpenStack을 제외한 3개 CSP(AWS/Alibaba/NHN)는 Create부터 Delete까지 전 단계 PASS했습니다. OpenStack은 이 환경에 MariaDB Trove datastore가 아직 구축되지 않아 `Datastore version '10.6' cannot be found` 오류로 인스턴스 생성에 실패했고, 이로 인해 이후 DB 관리 시험(Step 5) 및 삭제(Step 7)에서도 OpenStack만 실패로 이어졌습니다 (인스턴스 부재로 인한 연쇄 실패이며, datastore 구축 후 정상 동작 예상).
+
+**RDBMS Instance Create (Step 4) 상세:**
+
+```
+=================================================================================================================================================================================
+                                          RDBMS CREATE & INFO TEST SUMMARY - ALL CSPs (MariaDB)
+=================================================================================================================================================================================
+CSP          | Status      | Engine   | Version      | Spec                     | Storage                  | Endpoint                                 | PublicAccess | Elapsed
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AWS          | Available   | mariadb  | 10.6.27      | db.t3.medium             | 100GB|gp2                | cb-spider-mariadb-test-***.ap-southeast-2.rds.amazonaws.com:3306        | true         | 4m44s
+ALIBABA      | Available   | mariadb  | 10.6         | mariadb.n2.medium.2c     | 20GB|cloud_essd          | *.*.*.*:3306                             | true         | 3m20s
+OPENSTACK    | CREATE_ERROR | Datastore version '10.6' cannot be found. |              |                          |                                          |              | -
+NHN          | Available   | mariadb  | MARIADB_V101118 | m2.c2m4                  | 20GB|General SSD         | ***.external.kr1.mariadb.rds.nhncloudservice.com:3306                   | true         | 10m8s
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Failed : 1
+```
+
+**RDBMS Instance Delete (Step 7) 상세:**
+
+```
+============================================================
+     RDBMS DELETE SUMMARY - ALL CSPs (MariaDB)
+============================================================
+CSP          | Result         | Detail               | Elapsed
+------------------------------------------------------------
+AWS          | DELETED        | ok                   | 3m56s
+ALIBABA      | DELETED        | ok                   | 23s
+OPENSTACK    | NOT_FOUND      | Relational Database 'cb-spider-mariadb-test' does not exist in connection 'openstack-config01' | -
+NHN          | DELETED        | ok                   | 19s
+------------------------------------------------------------
+Failed : 1
 ```

--- a/test/rdbms-mariadb-test/database-test/README.md
+++ b/test/rdbms-mariadb-test/database-test/README.md
@@ -1,0 +1,203 @@
+# CB-Spider RDBMS Database Management Test (MariaDB)
+
+RDBMS 인스턴스 내부의 Database CRUD API를 검증하는 테스트 스위트입니다. MariaDB를 지원하는 4개 CSP(AWS, Alibaba, OpenStack, NHN)에 대해 병렬로 실행하며, RDBMS 인스턴스 안에서 데이터베이스를 생성/조회/삭제하는 전체 흐름을 검증합니다.
+
+## Prerequisites
+
+### CB-Spider Running
+
+```bash
+cd ./bin; ./start.sh
+```
+
+### RDBMS 인스턴스 사전 생성
+
+이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+
+```bash
+cd ..
+./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-rdbms-tests.sh
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## Test Flow
+
+각 CSP에 대해 다음 순서로 Database CRUD를 검증합니다:
+
+1. **CreateDatabase** — `POST /spider/rdbms/{Name}/databases` — `spidertestdb` 데이터베이스 생성
+2. **ListDatabases** — `GET /spider/rdbms/{Name}/databases` — 데이터베이스 목록 조회 성공 확인
+3. **FoundInList** — 목록에서 `spidertestdb` 존재 확인
+4. **DeleteDatabase** — `DELETE /spider/rdbms/{Name}/databases/spidertestdb` — 데이터베이스 삭제
+5. **VerifyDeleted** — `GET /spider/rdbms/{Name}/databases` — 삭제 후 목록에서 제거 확인
+
+### 구현 방식
+
+CB-Spider는 다음 두 가지 방식으로 Database 관리를 지원합니다:
+
+| 방식 | 조건 | 설명 |
+|------|------|------|
+| **CSP 네이티브 API** | 드라이버가 `rdbmsDatabaseManager` 인터페이스 구현 | 각 CSP의 데이터베이스 관리 API 직접 호출 |
+| **SQL 직접 실행** | 드라이버 미구현 시 자동 폴백 | `MasterUserPassword`로 접속하여 SQL 실행 (`CREATE/DROP DATABASE`) |
+
+`MasterUserPassword`는 SQL 폴백 경로에서 필요하므로 항상 포함합니다.
+
+## Configuration
+
+```bash
+export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
+export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+```
+
+테스트 DB 이름을 변경하려면:
+
+```bash
+export DB_NAME=mydb ./aws-database-test.sh
+```
+
+## How to Run Tests
+
+### All CSPs in Parallel
+
+```bash
+./run-all-csp-database-tests.sh
+```
+
+- MariaDB 지원 4개 CSP(AWS/Alibaba/OpenStack/NHN)에 대해 병렬로 Database CRUD 검증 실행
+- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+
+**Example output:**
+```
+=======================================================================================================
+             RDBMS DATABASE MANAGEMENT TEST SUMMARY - ALL CSPs (MariaDB)
+=======================================================================================================
+CSP          | CreateDB   | ListDB   | FoundInList  | DeleteDB   | VerifyDeleted | Elapsed
+-------------------------------------------------------------------------------------------------------
+AWS          | PASS       | PASS     | FOUND        | PASS       | PASS          | 17s
+ALIBABA      | PASS       | PASS     | FOUND        | PASS       | PASS          | 21s
+OPENSTACK    | PASS       | PASS     | FOUND        | PASS       | PASS          | 4s
+NHN          | PASS       | PASS     | FOUND        | PASS       | PASS          | 31s
+-------------------------------------------------------------------------------------------------------
+
+Total: 4 PASS, 0 FAIL
+```
+
+### Individual CSP
+
+특정 CSP만 단독 실행:
+
+```bash
+./aws-database-test.sh
+./alibaba-database-test.sh
+./openstack-database-test.sh
+./nhn-database-test.sh
+```
+
+단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_mgmt_results`)이 사용됩니다.
+
+## Script Structure
+
+```
+database-test/
+├── run-all-csp-database-tests.sh   # Orchestrator: 전체 병렬 실행, PASS/FAIL 집계
+├── common-database-test.sh         # Common: CreateDB → ListDB → DeleteDB → VerifyDeleted
+├── aws-database-test.sh
+├── alibaba-database-test.sh
+├── openstack-database-test.sh
+└── nhn-database-test.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
+| `DB_NAME` | `spidertestdb` | 생성/삭제할 테스트 데이터베이스 이름 |
+| `RESULT_DIR` | `/tmp/rdbms_mgmt_results` | Result file output directory |
+| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+
+```bash
+# Example: verbose output
+VERBOSE=1 ./run-all-csp-database-tests.sh
+```
+
+## Result Format
+
+결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 7개 필드:
+
+```
+CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
+```
+
+| 필드 | 설명 |
+|------|------|
+| `CSP` | CSP 이름 (예: AWS) |
+| `CreateDB` | 데이터베이스 생성 결과 (`PASS` / `FAIL`) |
+| `ListDB` | 데이터베이스 목록 조회 결과 |
+| `FoundInList` | 생성된 DB가 목록에 존재 (`FOUND` / `NOT_FOUND`) |
+| `DeleteDB` | 데이터베이스 삭제 결과 |
+| `VerifyDeleted` | 삭제 후 목록에서 제거 확인 결과 |
+| `Elapsed` | 경과 시간 |
+
+## API Reference
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| CreateDatabase | `POST` | `/spider/rdbms/{Name}/databases` |
+| ListDatabases | `GET` | `/spider/rdbms/{Name}/databases` |
+| DeleteDatabase | `DELETE` | `/spider/rdbms/{Name}/databases/{DBName}` |
+
+모든 요청의 body:
+```json
+{
+  "ConnectionName": "<connection-name>",
+  "DatabaseName": "<db-name>",
+  "MasterUserPassword": "<password>"
+}
+```
+(`DatabaseName`은 CreateDatabase 전용, `MasterUserPassword`는 SQL 폴백 경로에 필요)
+
+## Logs & Results
+
+```
+/tmp/rdbms_mgmt_results_<PID>/result_<csp>.txt
+/tmp/rdbms_mgmt_logs_<PID>/log_<csp>.txt
+```
+
+실행 중 모니터링:
+
+```bash
+tail -f /tmp/rdbms_mgmt_logs_<PID>/log_aws.txt
+```
+
+## CSP-Specific Notes
+
+| CSP | Note |
+|-----|------|
+| OpenStack | 이 환경은 MariaDB Trove datastore 구축 전 상태로, 상위 create 시험(Step 4)이 실패하면 인스턴스가 없어 본 시험도 FAIL로 이어짐. Trove datastore 구성 후 정상 동작 예상 |
+
+## 시험 결과
+
+### 2026-08-10
+
+상위 디렉토리 create 시험(Step 4)에서 OpenStack 인스턴스 생성이 `DBEngineVersion '10.6'` 미지원으로 실패하여, 본 시험에서도 OpenStack만 FAIL로 나타남 (인스턴스 부재).
+
+```
+=======================================================================================================
+            RDBMS DATABASE MANAGEMENT TEST SUMMARY - ALL CSPs (MariaDB)
+=======================================================================================================
+CSP          | CreateDB   | ListDB   | FoundInList  | DeleteDB   | VerifyDeleted | Elapsed
+-------------------------------------------------------------------------------------------------------
+AWS          | PASS       | PASS     | FOUND        | PASS       | PASS          | 17s
+ALIBABA      | PASS       | PASS     | FOUND        | PASS       | PASS          | 21s
+OPENSTACK    | FAIL       | FAIL     | NOT_FOUND    | FAIL       | FAIL          | 4s
+NHN          | PASS       | PASS     | FOUND        | PASS       | PASS          | 31s
+-------------------------------------------------------------------------------------------------------
+Total: 3 PASS, 1 FAIL
+```

--- a/test/rdbms-mariadb-test/storage-type-test/README.md
+++ b/test/rdbms-mariadb-test/storage-type-test/README.md
@@ -1,0 +1,268 @@
+# CB-Spider RDBMS StorageType Test (MariaDB)
+
+MariaDB를 지원하는 각 CSP(AWS, Alibaba, OpenStack, NHN)의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트입니다. 각 CSP의 `rdbmsmetainfo` API에서 지원 StorageType 목록을 동적으로 조회한 뒤, 옵션별로 인스턴스를 병렬 생성하고 반환된 StorageType이 요청과 일치하는지 검증합니다.
+
+## Prerequisites
+
+### CB-Spider Running
+
+```bash
+cd ./bin; ./start.sh
+```
+
+### Pre-created Network Resources
+
+RDBMS 생성 전에 각 CSP에 VPC/Subnet(및 AWS의 Security Group)이 미리 생성되어 있어야 합니다.
+
+```bash
+cd ..
+./run-all-csp-network-prepare.sh
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## Test Flow
+
+각 CSP에 대해 다음 순서로 StorageType별 검증을 수행합니다:
+
+1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=...` — 지원하는 StorageType 목록을 동적으로 조회
+2. **CreateRDBMS** (StorageType별 병렬) — `POST /spider/rdbms` — 옵션별로 `cb-mariadb-st-<type>` 인스턴스 생성
+3. **Poll Available** — `GET /spider/rdbms/{Name}` — Available 상태가 될 때까지 폴링 (기본 30초 간격, 최대 3600초)
+4. **VerifyStorageType** — 반환된 StorageType이 요청과 일치하는지 확인 (`Result` 필드에 `PASS`/`FAIL` 기록)
+5. **(옵션) AutoDelete** — `AUTO_DELETE=true`이면 검증 직후 인스턴스 자동 삭제. 기본값(`false`)에서는 `delete-all-csp-storage-type-rdbms.sh`로 별도 정리
+
+### StorageType 선택 가능 여부
+
+| CSP | SupportsStorageTypeSelection | 비고 |
+|-----|------------------------------|------|
+| AWS | ✅ | gp2, gp3, io1, io2 |
+| Alibaba | ✅ | cloud_essd, cloud_essd2, cloud_essd3 |
+| OpenStack | ✅ | `__DEFAULT__`, `RBD` (MariaDB Trove datastore 구축 필요) |
+| NHN | ✅ | General HDD, General SSD |
+
+## Configuration
+
+```bash
+export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
+export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+```
+
+## How to Run Tests
+
+### All CSPs in Parallel
+
+```bash
+./run-all-csp-storage-type-tests.sh
+```
+
+- MariaDB 지원 4개 CSP(AWS/Alibaba/OpenStack/NHN)에 대해 병렬로 StorageType별 검증 실행
+- 완료 후 통합 결과 테이블 및 PASS/FAIL/SKIP 집계 출력
+
+**Example output:**
+```
+================================================================================================================================
+                           RDBMS StorageType Test Summary - All CSPs (MariaDB)
+================================================================================================================================
+CSP          | StorageType(Req)     | StorageType(Ret)   | Result | DB Status      | Elapsed    | Reason
+--------------------------------------------------------------------------------------------------------------------------------
+AWS          | gp2                  | gp2                | PASS   | Available      | 4m41s      | -
+ALIBABA      | cloud_essd           | cloud_essd         | PASS   | Available      | 3m26s      | -
+OPENSTACK    | __DEFAULT__          | N/A                | FAIL   | CREATE_ERROR   | 1s         | -
+NHN          | General HDD          | General HDD        | PASS   | Available      | 9m22s      | -
+--------------------------------------------------------------------------------------------------------------------------------
+
+Total: 4  PASS: 3  FAIL: 1  SKIP: 0
+```
+
+### Individual CSP
+
+특정 CSP만 단독 실행:
+
+```bash
+./aws-storage-type-test.sh
+./alibaba-storage-type-test.sh
+./openstack-storage-type-test.sh
+./nhn-storage-type-test.sh
+```
+
+단독 실행 시 결과/로그 디렉토리는 `RESULT_DIR` / `LOG_DIR` 환경변수로 지정하거나 기본값(`/tmp/st_results_<PID>`, `/tmp/st_logs_<PID>`)이 사용됩니다.
+
+### Delete All Instances
+
+```bash
+./delete-all-csp-storage-type-rdbms.sh
+```
+
+- StorageTypeOptions를 다시 조회해 `cb-mariadb-st-<type>` 이름의 인스턴스를 유추한 뒤 전체 CSP 병렬 삭제
+
+## Script Structure
+
+```
+storage-type-test/
+├── run-all-csp-storage-type-tests.sh    # Orchestrator: 전체 CSP 병렬 실행 (AWS/Alibaba/OpenStack/NHN)
+├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: 전체 CSP 병렬 삭제
+├── common-storage-type-test.sh          # Common: Create → Poll Available → Get Info → Verify → (옵션) Delete
+├── aws-storage-type-test.sh
+├── alibaba-storage-type-test.sh
+├── openstack-storage-type-test.sh
+└── nhn-storage-type-test.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
+| `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per instance (seconds) |
+| `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
+| `AUTO_DELETE` | `false` | `true`이면 검증 완료 직후 인스턴스 자동 삭제 |
+| `VERBOSE` | `0` | `1`로 설정 시 CSP별 전체 로그 덤프 출력 |
+
+```bash
+# Example: verbose output
+VERBOSE=1 ./run-all-csp-storage-type-tests.sh
+```
+
+## Result Format
+
+결과 파일(`result_<csp>_<storagetype>.txt`)은 파이프(|) 구분 7개 필드:
+
+```
+CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
+```
+
+| 필드 | 설명 |
+|------|------|
+| `CSP` | CSP 이름 (예: AWS) |
+| `StorageType(Requested)` | 요청한 StorageType 값 |
+| `StorageType(Returned)` | 생성 후 조회된 StorageType 값 (`N/A`는 생성 실패) |
+| `Result` | `PASS` / `FAIL` / `SKIP` |
+| `DB_Status` | 인스턴스 상태 (`Available`, `CREATE_ERROR`, `TIMEOUT` 등) |
+| `Elapsed` | 경과 시간 |
+| `Reason` | 특이사항 (예: OpenStack은 StorageType 미제공으로 Available만으로 PASS 처리) |
+
+## API Reference
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| FetchStorageTypeOptions | `GET` | `/spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=` |
+| CreateRDBMS | `POST` | `/spider/rdbms` |
+| GetRDBMS | `GET` | `/spider/rdbms/{Name}?ConnectionName=` |
+| DeleteRDBMS | `DELETE` | `/spider/rdbms/{Name}` |
+
+## Logs & Results
+
+```
+/tmp/st_test_<PID>/results/result_<csp>_<storagetype>.txt
+/tmp/st_test_<PID>/logs/log_<csp>.txt
+```
+
+전체 삭제 실행 시:
+```
+/tmp/st_del_<PID>/results/result_<csp>_<storagetype>.txt
+/tmp/st_del_<PID>/logs/log_<csp>.txt
+```
+
+실행 중 모니터링:
+
+```bash
+tail -f /tmp/st_test_<PID>/logs/log_aws.txt
+```
+
+## CSP-Specific Notes
+
+### AWS
+
+`StorageTypeOptions`는 metainfo API에서 동적으로 조회되며, 각 타입에 대해 아래 설정으로 인스턴스를 생성합니다.
+
+| 항목 | 값 |
+|------|-----|
+| DBEngine / Version | `mariadb` / `10.6` |
+| DBInstanceSpec | `db.t3.medium` |
+| StorageSize | `100 GB` (io1/io2 포함 전 타입 동일) |
+| Connection | `aws-config01` |
+| Region / Zone | `ap-southeast-2` / `ap-southeast-2a` |
+| SubnetNames | `subnet-01`, `subnet-02` (서로 다른 AZ, SubnetGroup 생성 필수) |
+| SecurityGroupNames | `sg-01` |
+
+**특이사항**
+- io1/io2: `Iops: "3000"` 필드 필수
+
+---
+
+### Alibaba
+
+`StorageTypeOptions`와 `DBInstanceSpecOptions`를 모두 metainfo API에서 동적으로 조회하며, 지역/존에 유효한 스펙을 자동 선택합니다(하드코딩된 스펙은 StorageType과 호환되지 않을 수 있음).
+
+| 항목 | 값 |
+|------|-----|
+| DBEngine / Version | `mariadb` / `10.6` |
+| DBInstanceSpec | metainfo `DBInstanceSpecOptions[0]` (조회 실패 시 `rds.mariadb.s4.large`로 폴백) |
+| StorageSize | 기본 `20 GB`, `cloud_essd2`는 `500 GB`, `cloud_essd3`는 `1500 GB` |
+| Connection | `alibaba-beijing-config` |
+| Region / Zone | `cn-beijing` / `cn-beijing-f` |
+| SubnetNames | `subnet-01` |
+
+**특이사항**
+- cloud_essd2/cloud_essd3는 최소 StorageSize 요건이 있어 스크립트에서 자동으로 크기를 늘려 요청
+
+---
+
+### OpenStack
+
+| 항목 | 값 |
+|------|-----|
+| DBEngine / Version | `mariadb` / `10.6` |
+| DBInstanceSpec | `m1.small` |
+| StorageSize | `20 GB` |
+| Connection | `openstack-config01` |
+| Region / Zone | `RegionOne` / `nova` |
+
+**특이사항**
+- MariaDB Trove datastore가 구축전 상태
+
+---
+
+### NHN
+
+| 항목 | 값 |
+|------|-----|
+| DBEngine / Version | `mariadb` / `MARIADB_V101118` |
+| DBInstanceSpec | `m2.c2m4` |
+| StorageSize | `20 GB` |
+| Connection | `nhn-korea-pangyo1-config` |
+| Region / Zone | `KR1` / `kr-pub-a` |
+| SubnetNames | `subnet-01` |
+
+
+## 시험 결과
+
+### 2026-08-10
+
+OpenStack은 이 환경에 MariaDB Trove datastore가 아직 구축되지 않아 `DBEngineVersion '10.6' cannot be found` 오류로 CREATE_ERROR 발생 (datastore 구축 후 정상 동작 예상).
+
+```
+================================================================================================================================
+                          RDBMS StorageType Test Summary - All CSPs (MariaDB)
+================================================================================================================================
+CSP          | StorageType(Req)     | StorageType(Ret)   | Result | DB Status      | Elapsed    | Reason
+--------------------------------------------------------------------------------------------------------------------------------
+AWS          | gp2                  | gp2                | PASS   | Available      | 4m41s      | -
+AWS          | gp3                  | gp3                | PASS   | Available      | 4m41s      | -
+AWS          | io1                  | io1                | PASS   | Available      | 4m41s      | -
+AWS          | io2                  | io2                | PASS   | Available      | 4m42s      | -
+ALIBABA      | cloud_essd           | cloud_essd         | PASS   | Available      | 3m26s      | -
+ALIBABA      | cloud_essd2          | cloud_essd2        | PASS   | Available      | 3m6s       | -
+ALIBABA      | cloud_essd3          | cloud_essd3        | PASS   | Available      | 3m36s      | -
+OPENSTACK    | __DEFAULT__          | N/A                | FAIL   | CREATE_ERROR   | 1s         | -
+OPENSTACK    | RBD                  | N/A                | FAIL   | CREATE_ERROR   | 1s         | -
+NHN          | General HDD          | General HDD        | PASS   | Available      | 9m22s      | -
+NHN          | General SSD          | General SSD        | PASS   | Available      | 10m20s     | -
+--------------------------------------------------------------------------------------------------------------------------------
+Total: 11  PASS: 9  FAIL: 2  SKIP: 0
+```

--- a/test/rdbms-mariadb-test/tag-test/README.md
+++ b/test/rdbms-mariadb-test/tag-test/README.md
@@ -1,0 +1,176 @@
+# CB-Spider RDBMS Tag Management Test (MariaDB)
+
+RDBMS 리소스의 Tag CRUD API를 검증하는 테스트 스위트입니다. `RDBMSMetaInfo.SupportsTag=true`이면서 MariaDB를 지원하는 CSP(AWS, Alibaba)에 대해서만 실행됩니다. OpenStack/NHN은 MariaDB는 지원하지만 SupportsTag=false이므로 시험 대상에서 제외됩니다.
+
+## Prerequisites
+
+### CB-Spider Running
+
+```bash
+cd ./bin; ./start.sh
+```
+
+### RDBMS 인스턴스 사전 생성
+
+이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+
+```bash
+cd ..
+./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-rdbms-tests.sh
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## Supported CSPs
+
+MariaDB 지원 여부와 `RDBMSMetaInfo.SupportsTag` 값을 모두 만족해야 시험 대상이 됩니다.
+
+| CSP | MariaDB 지원 | SupportsTag | 시험 대상 |
+|-----|------------|-------------|---------|
+| AWS | ✅ | `true` | ✅ |
+| Alibaba | ✅ | `true` | ✅ |
+| OpenStack | ⚠️ | `false` | ❌ |
+| NHN | ✅ | `false` | ❌ |
+
+## Test Flow
+
+각 CSP에 대해 다음 순서로 Tag CRUD를 검증합니다:
+
+1. **AddTag(1)** — `POST /spider/tag` — 첫 번째 태그 추가 (`spider-rdbms-tag` / `rdbms-tag-value`)
+2. **ListTag** — `GET /spider/tag?...` — 목록에서 첫 번째 태그 존재 확인
+3. **GetTag** — `GET /spider/tag/{Key}?...` — 태그 값 일치 확인
+4. **AddTag(2)** — `POST /spider/tag` — 두 번째 태그 추가 (`spider-rdbms-tag2` / `rdbms-tag-value2`)
+5. **RemoveTag** — `DELETE /spider/tag/{Key}` — 첫 번째 태그 삭제
+6. **VerifyRemoved** — `GET /spider/tag?...` — 첫 번째 태그가 목록에서 제거되었는지 확인
+7. **Cleanup** — 두 번째 태그 삭제 (정리)
+
+모든 단계가 PASS여야 해당 CSP가 전체 PASS로 판정됩니다.
+
+## Configuration
+
+```bash
+export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
+export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+```
+
+## How to Run Tests
+
+### All Supported CSPs in Parallel
+
+```bash
+./run-all-csp-rdbms-tag-tests.sh
+```
+
+- SupportsTag=true이면서 MariaDB를 지원하는 2개 CSP(AWS, Alibaba)에 대해 병렬로 Tag CRUD 검증 실행
+- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+
+**Example output:**
+```
+===================================================================================================================
+         RDBMS TAG MANAGEMENT TEST SUMMARY (SupportsTag=true CSPs) - MariaDB
+===================================================================================================================
+CSP          | AddTag   | ListTag  | GetTag  | AddTag2  | RemoveTag  | VerifyRemoved | Elapsed
+-------------------------------------------------------------------------------------------------------------------
+AWS          | PASS     | PASS     | PASS    | PASS     | PASS       | PASS          | 7s
+ALIBABA      | PASS     | PASS     | PASS    | PASS     | PASS       | PASS          | 5s
+-------------------------------------------------------------------------------------------------------------------
+
+Total: 2 PASS, 0 FAIL
+```
+
+### Individual CSP
+
+특정 CSP만 단독 실행:
+
+```bash
+./aws-rdbms-tag-test.sh
+./alibaba-rdbms-tag-test.sh
+```
+
+단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_tag_results`)이 사용됩니다.
+
+## Script Structure
+
+```
+tag-test/
+├── run-all-csp-rdbms-tag-tests.sh   # Orchestrator: AWS/Alibaba 병렬 실행, PASS/FAIL 집계
+├── common-rdbms-tag-test.sh         # Common: AddTag → ListTag → GetTag → AddTag2 → RemoveTag → VerifyRemoved
+├── aws-rdbms-tag-test.sh
+└── alibaba-rdbms-tag-test.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
+| `RESULT_DIR` | `/tmp/rdbms_tag_results` | Result file output directory |
+| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+
+```bash
+# Example: verbose output
+VERBOSE=1 ./run-all-csp-rdbms-tag-tests.sh
+```
+
+## Result Format
+
+결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 8개 필드:
+
+```
+CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
+```
+
+| 필드 | 설명 |
+|------|------|
+| `CSP` | CSP 이름 (예: AWS) |
+| `AddTag` | 첫 번째 태그 추가 결과 (`PASS` / `FAIL`) |
+| `ListTag` | 태그 목록 조회 및 존재 확인 결과 |
+| `GetTag` | 특정 태그 조회 및 값 일치 확인 결과 |
+| `AddTag2` | 두 번째 태그 추가 결과 |
+| `RemoveTag` | 첫 번째 태그 삭제 결과 |
+| `VerifyRemoved` | 삭제 후 목록에서 제거 확인 결과 |
+| `Elapsed` | 경과 시간 |
+
+## Logs & Results
+
+```
+/tmp/rdbms_tag_results_<PID>/result_<csp>.txt
+/tmp/rdbms_tag_logs_<PID>/log_<csp>.txt
+```
+
+실행 중 모니터링:
+
+```bash
+tail -f /tmp/rdbms_tag_logs_<PID>/log_aws.txt
+```
+
+## Tag API Reference
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| AddTag | `POST` | `/spider/tag` |
+| ListTag | `GET` | `/spider/tag?ConnectionName=&ResourceType=rdbms&ResourceName=` |
+| GetTag | `GET` | `/spider/tag/{Key}?ConnectionName=&ResourceType=rdbms&ResourceName=` |
+| RemoveTag | `DELETE` | `/spider/tag/{Key}` |
+
+## 시험 결과
+
+### 2026-08-10
+
+```
+===================================================================================================================
+         RDBMS TAG MANAGEMENT TEST SUMMARY (SupportsTag=true CSPs) - MariaDB
+===================================================================================================================
+CSP          | AddTag   | ListTag  | GetTag  | AddTag2  | RemoveTag  | VerifyRemoved | Elapsed
+-------------------------------------------------------------------------------------------------------------------
+AWS          | PASS     | PASS     | PASS    | PASS     | PASS       | PASS          | 7s
+ALIBABA      | PASS     | PASS     | PASS    | PASS     | PASS       | PASS          | 5s
+-------------------------------------------------------------------------------------------------------------------
+Total: 2 PASS, 0 FAIL
+```

--- a/test/rdbms-mysql-test/storage-type-test/README.md
+++ b/test/rdbms-mysql-test/storage-type-test/README.md
@@ -1,29 +1,123 @@
 # CB-Spider RDBMS StorageType Test
 
-각 CSP의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트.
+각 CSP의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트입니다. 각 CSP의 `rdbmsmetainfo` API에서 지원 StorageType 목록을 동적으로 조회한 뒤, 옵션별로 인스턴스를 병렬 생성하고 반환된 StorageType이 요청과 일치하는지 검증합니다.
 
-## 실행
+## Prerequisites
+
+### CB-Spider Running
 
 ```bash
-# 전체 CSP 병렬 실행
+cd ./bin; ./start.sh
+```
+
+### Pre-created Network Resources
+
+RDBMS 생성 전에 각 CSP에 VPC/Subnet(및 AWS의 Security Group)이 미리 생성되어 있어야 합니다.
+
+```bash
+cd ..
+./run-all-csp-network-prepare.sh
+```
+
+### Required Tools
+
+- `bash` 3.2+
+- `curl`
+- `jq`
+
+## Test Flow
+
+각 CSP에 대해 다음 순서로 StorageType별 검증을 수행합니다:
+
+1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=...` — 지원하는 StorageType 목록을 동적으로 조회
+2. **CreateRDBMS** (StorageType별 병렬) — `POST /spider/rdbms` — 옵션별로 `cb-mysql-st-<type>` 인스턴스 생성
+3. **Poll Available** — `GET /spider/rdbms/{Name}` — Available 상태가 될 때까지 폴링 (기본 30초 간격, 최대 3600초)
+4. **VerifyStorageType** — 반환된 StorageType이 요청과 일치하는지 확인 (`Result` 필드에 `PASS`/`FAIL` 기록)
+5. **(옵션) AutoDelete** — `AUTO_DELETE=true`이면 검증 직후 인스턴스 자동 삭제. 기본값(`false`)에서는 `delete-all-csp-storage-type-rdbms.sh`로 별도 정리
+
+Azure/IBM/NCP는 `SupportsStorageTypeSelection=false`로 StorageType 지정이 불가능하여 스크립트 실행 시 즉시 SKIP 처리됩니다.
+
+### StorageType 선택 가능 여부
+
+| CSP | SupportsStorageTypeSelection | 비고 |
+|-----|------------------------------|------|
+| AWS | ✅ | gp2, gp3, io1, io2 |
+| GCP | ✅ | 머신 시리즈에 따라 자동 결정 (직접 선택 아님) |
+| Alibaba | ✅ | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd |
+| Tencent | ✅ | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM |
+| OpenStack | ✅ | `__DEFAULT__`, `RBD` |
+| NHN | ✅ | General HDD, General SSD |
+| Azure | ❌ | SKIP |
+| IBM | ❌ | SKIP |
+| NCP | ❌ | SKIP |
+
+## Configuration
+
+```bash
+export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
+export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+```
+
+## How to Run Tests
+
+### All CSPs in Parallel
+
+```bash
 ./run-all-csp-storage-type-tests.sh
+```
 
-# CSP별 단독 실행
+- 9개 CSP에 대해 병렬로 StorageType별 검증 실행 (Azure/IBM/NCP는 자동 SKIP)
+- 완료 후 통합 결과 테이블 및 PASS/FAIL/SKIP 집계 출력
+
+**Example output:**
+```
+================================================================================================================================
+                               RDBMS StorageType Test Summary - All CSPs
+================================================================================================================================
+CSP          | StorageType(Req)     | StorageType(Ret)   | Result | DB Status      | Elapsed    | Reason
+--------------------------------------------------------------------------------------------------------------------------------
+AWS          | gp2                  | gp2                | PASS   | Available      | 5m43s      | -
+AZURE        | N/A                  | N/A                | SKIP   | NOT_APPLICABLE | -          | SupportsStorageTypeSelection=false
+GCP          | PD_SSD               | PD_SSD             | PASS   | Available      | 4m10s      | -
+...
+--------------------------------------------------------------------------------------------------------------------------------
+
+Total: 22  PASS: 19  FAIL: 0  SKIP: 3
+```
+
+### Individual CSP
+
+특정 CSP만 단독 실행:
+
+```bash
 ./aws-storage-type-test.sh
+./azure-storage-type-test.sh          # SKIP (StorageType 선택 불가)
 ./gcp-storage-type-test.sh
-# ...
+./alibaba-storage-type-test.sh
+./tencent-storage-type-test.sh
+./ibm-storage-type-test.sh            # SKIP (StorageType 선택 불가)
+./openstack-storage-type-test.sh
+./ncp-storage-type-test.sh            # SKIP (StorageType 선택 불가)
+./nhn-storage-type-test.sh
+```
 
-# 전체 삭제
+단독 실행 시 결과/로그 디렉토리는 `RESULT_DIR` / `LOG_DIR` 환경변수로 지정하거나 기본값(`/tmp/st_results_<PID>`, `/tmp/st_logs_<PID>`)이 사용됩니다.
+
+### Delete All Instances
+
+```bash
 ./delete-all-csp-storage-type-rdbms.sh
 ```
 
-## 스크립트 구조
+- StorageTypeOptions를 다시 조회해 `cb-mysql-st-<type>` 이름의 인스턴스를 유추한 뒤 전체 CSP 병렬 삭제
+
+## Script Structure
 
 ```
-.
-├── run-all-csp-storage-type-tests.sh   # 전체 CSP 병렬 실행
-├── delete-all-csp-storage-type-rdbms.sh # 전체 CSP 병렬 삭제
-├── common-storage-type-test.sh          # 공통: Create → Poll Available → Get Info
+storage-type-test/
+├── run-all-csp-storage-type-tests.sh    # Orchestrator: 전체 CSP 병렬 실행
+├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: 전체 CSP 병렬 삭제
+├── common-storage-type-test.sh          # Common: Create → Poll Available → Get Info → Verify → (옵션) Delete
 ├── aws-storage-type-test.sh
 ├── gcp-storage-type-test.sh
 ├── alibaba-storage-type-test.sh
@@ -35,9 +129,69 @@
 └── ncp-storage-type-test.sh             # SKIP (StorageType 선택 불가)
 ```
 
----
+## Environment Variables
 
-## CSP별 시험 설정
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
+| `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per instance (seconds) |
+| `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
+| `AUTO_DELETE` | `false` | `true`이면 검증 완료 직후 인스턴스 자동 삭제 |
+| `VERBOSE` | `0` | `1`로 설정 시 CSP별 전체 로그 덤프 출력 |
+
+```bash
+# Example: verbose output
+VERBOSE=1 ./run-all-csp-storage-type-tests.sh
+```
+
+## Result Format
+
+결과 파일(`result_<csp>_<storagetype>.txt`)은 파이프(|) 구분 7개 필드:
+
+```
+CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
+```
+
+| 필드 | 설명 |
+|------|------|
+| `CSP` | CSP 이름 (예: AWS) |
+| `StorageType(Requested)` | 요청한 StorageType 값 |
+| `StorageType(Returned)` | 생성 후 조회된 StorageType 값 (`N/A`는 생성 실패) |
+| `Result` | `PASS` / `FAIL` / `SKIP` |
+| `DB_Status` | 인스턴스 상태 (`Available`, `CREATE_ERROR`, `TIMEOUT`, `NOT_APPLICABLE` 등) |
+| `Elapsed` | 경과 시간 |
+| `Reason` | 특이사항 (예: SupportsStorageTypeSelection=false, cloud_auto 자동 선택 등) |
+
+## API Reference
+
+| Operation | Method | Path |
+|-----------|--------|------|
+| FetchStorageTypeOptions | `GET` | `/spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=` |
+| CreateRDBMS | `POST` | `/spider/rdbms` |
+| GetRDBMS | `GET` | `/spider/rdbms/{Name}?ConnectionName=` |
+| DeleteRDBMS | `DELETE` | `/spider/rdbms/{Name}` |
+
+## Logs & Results
+
+```
+/tmp/st_test_<PID>/results/result_<csp>_<storagetype>.txt
+/tmp/st_test_<PID>/logs/log_<csp>.txt
+```
+
+전체 삭제 실행 시:
+```
+/tmp/st_del_<PID>/results/result_<csp>_<storagetype>.txt
+/tmp/st_del_<PID>/logs/log_<csp>.txt
+```
+
+실행 중 모니터링:
+
+```bash
+tail -f /tmp/st_test_<PID>/logs/log_aws.txt
+```
+
+## CSP-Specific Notes
 
 ### AWS
 
@@ -47,7 +201,6 @@
 | gp3 | db.t3.medium | 100 GB | - |
 | io1 | db.t3.medium | 100 GB | **3000 (필수)** |
 | io2 | db.t3.medium | 100 GB | **3000 (필수)** |
-| standard | db.t3.medium | 100 GB | - |
 
 - StorageTypeOptions: metainfo API에서 동적으로 조회
 - Connection: `aws-config01`
@@ -182,24 +335,6 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - Region: `KR` / Zone: `KR-1`
 - NCP MySQL G3은 SSD 자동 적용, DataStorageTypeCode 지정 불가
 - 테스트 스크립트 실행 시 즉시 SKIP 처리
-
----
-
-## StorageType 선택 가능 여부 요약
-
-| CSP | SupportsStorageTypeSelection | 비고 |
-|-----|------------------------------|------|
-| AWS | ✅ | gp2, gp3, io1, io2, standard |
-| GCP | ✅ | 머신 시리즈에 따라 자동 결정 (직접 선택 아님) |
-| Alibaba | ✅ | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd |
-| Tencent | ✅ | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM |
-| OpenStack | ✅ | __DEFAULT__, RBD  |
-| NHN | ✅ | General HDD, General SSD |
-| Azure | ❌ | SKIP |
-| IBM | ❌ | SKIP |
-| NCP | ❌ | SKIP |
-
----
 
 ## 시험 결과
 


### PR DESCRIPTION
- Split MariaDB test README into per-scenario guides, mirroring the MySQL test layout
- Restructure and align StorageType test README section order with the database-test guide, adding the missing Configuration section
- Fix incorrect NHN engine version and Alibaba DBInstanceSpec description in the MariaDB test guide
- Correct OpenStack/NHN StorageType SKIP-detection notes to match actual script logic
- Add 2026-08-10 MariaDB test run results to each scenario README