### PR TITLE
[NHN] Refactor: Rename RDS credential key appKey to mysqlAppKey

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-RDBMS-Query.go
@@ -237,7 +237,7 @@ func RDBMSTestConnection(c echo.Context) error {
 // DB schema creation/deletion must go through the NHN Cloud RDS v3.0 REST API.
 // ============================================================
 
-// getNHNRDSCredentials fetches the NHN RDS API credentials (appKey, userAccessKey, secretAccessKey)
+// getNHNRDSCredentials fetches the NHN RDS for MySQL API credentials (mysqlAppKey, userAccessKey, secretAccessKey)
 // from the CB-Spider connection config and its associated credential info.
 func getNHNRDSCredentials(connName string) (appKey, userAccessKey, secretAccessKey string, err error) {
 	ccBody, err := getResource_JsonByte("connectionconfig", connName)
@@ -270,7 +270,7 @@ func getNHNRDSCredentials(connName string) (appKey, userAccessKey, secretAccessK
 
 	for _, kv := range cred.KeyValueInfoList {
 		switch kv.Key {
-		case "appKey":
+		case "mysqlAppKey":
 			appKey = kv.Value
 		case "User Access Key":
 			userAccessKey = kv.Value
@@ -279,7 +279,7 @@ func getNHNRDSCredentials(connName string) (appKey, userAccessKey, secretAccessK
 		}
 	}
 	if appKey == "" || userAccessKey == "" || secretAccessKey == "" {
-		return "", "", "", fmt.Errorf("missing NHN RDS credentials in %q (appKey=%v, userAccessKey=%v, secretAccessKey=%v)",
+		return "", "", "", fmt.Errorf("missing NHN RDS credentials in %q (mysqlAppKey=%v, userAccessKey=%v, secretAccessKey=%v)",
 			cc.CredentialName, appKey != "", userAccessKey != "", secretAccessKey != "")
 	}
 	return appKey, userAccessKey, secretAccessKey, nil

--- a/cloud-control-manager/CloudDriverHandler_common.go
+++ b/cloud-control-manager/CloudDriverHandler_common.go
@@ -182,7 +182,7 @@ func createConnectionInfo(cloudConnectName string, targetZoneName string) (idrv.
 			ClusterId:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "ClusterId"),
 			RDSUserAccessKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "User Access Key"),
 			RDSSecretAccessKey: KeyValueListGetValue(crdInfo.KeyValueInfoList, "Secret Access Key"),
-			RDSAppKey:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "appKey"),
+			RDSMySQLAppKey:     KeyValueListGetValue(crdInfo.KeyValueInfoList, "mysqlAppKey"),
 			RDSMariaDBAppKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "mariadbAppKey"),
 			ConnectionName:     cloudConnectName,
 		},
@@ -281,7 +281,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 				Username           string `json:"Username"`
 				RDSUserAccessKey   string `json:"RDSUserAccessKey"`
 				RDSSecretAccessKey string `json:"RDSSecretAccessKey"`
-				RDSAppKey          string `json:"RDSAppKey"`
+				RDSMySQLAppKey     string `json:"RDSMySQLAppKey"`
 				RDSMariaDBAppKey   string `json:"RDSMariaDBAppKey"`
 			} `json:"CredentialInfo"`
 			RegionInfo struct {
@@ -329,7 +329,7 @@ func CreateCloudConnection(connectName string) (icon.CloudConnection, error) {
 			Username:           apiResponse.ConnectionInfo.CredentialInfo.Username,
 			RDSUserAccessKey:   apiResponse.ConnectionInfo.CredentialInfo.RDSUserAccessKey,
 			RDSSecretAccessKey: apiResponse.ConnectionInfo.CredentialInfo.RDSSecretAccessKey,
-			RDSAppKey:          apiResponse.ConnectionInfo.CredentialInfo.RDSAppKey,
+			RDSMySQLAppKey:     apiResponse.ConnectionInfo.CredentialInfo.RDSMySQLAppKey,
 			RDSMariaDBAppKey:   apiResponse.ConnectionInfo.CredentialInfo.RDSMariaDBAppKey,
 		},
 		RegionInfo: idrv.RegionInfo{
@@ -395,7 +395,7 @@ func GetCloudConnectionByDriverNameAndCredentialName(driverName string, credenti
 			ClusterId:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "ClusterId"),
 			RDSUserAccessKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "User Access Key"),
 			RDSSecretAccessKey: KeyValueListGetValue(crdInfo.KeyValueInfoList, "Secret Access Key"),
-			RDSAppKey:          KeyValueListGetValue(crdInfo.KeyValueInfoList, "appKey"),
+			RDSMySQLAppKey:     KeyValueListGetValue(crdInfo.KeyValueInfoList, "mysqlAppKey"),
 			RDSMariaDBAppKey:   KeyValueListGetValue(crdInfo.KeyValueInfoList, "mariadbAppKey"),
 		},
 	}

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -407,17 +407,17 @@ func (handler *NhnCloudRDBMSHandler) listRDSStorageTypesWithEndpoint(ctx context
 // rdsEffectiveAppKey returns the App Key to use for the given NHN RDS endpoint URL.
 // RDS for MySQL and RDS for MariaDB are separate NHN Cloud services with separate App Keys.
 // If the caller has configured RDSMariaDBAppKey and the endpoint targets the MariaDB service,
-// that key is used; otherwise RDSAppKey is returned.
+// that key is used; otherwise RDSMySQLAppKey is returned.
 func (handler *NhnCloudRDBMSHandler) rdsEffectiveAppKey(endpoint string) string {
 	if strings.Contains(endpoint, "rds-mariadb") {
 		if handler.CredentialInfo.RDSMariaDBAppKey != "" {
 			return handler.CredentialInfo.RDSMariaDBAppKey
 		}
 		cblogger.Warnf("[NHN RDS] WARNING: calling MariaDB endpoint but RDSMariaDBAppKey (mariadbAppKey) is not set; " +
-			"falling back to RDSAppKey — this will likely cause Unauthorized or 500 from NHN API. " +
+			"falling back to RDSMySQLAppKey — this will likely cause Unauthorized or 500 from NHN API. " +
 			"Register 'mariadbAppKey' in your NHN credential (NHN Console → RDS for MariaDB → URL & AppKey).")
 	}
-	return handler.CredentialInfo.RDSAppKey
+	return handler.CredentialInfo.RDSMySQLAppKey
 }
 
 func (handler *NhnCloudRDBMSHandler) getRDS(ctx context.Context, path string, v interface{}) error {
@@ -493,8 +493,8 @@ func (handler *NhnCloudRDBMSHandler) rdsMariaDBEndpoint() (string, error) {
 func (handler *NhnCloudRDBMSHandler) checkRDSCredentials() error {
 	isUnset := func(v string) bool { return v == "" || v == "Not set" }
 	var missing []string
-	if isUnset(handler.CredentialInfo.RDSAppKey) {
-		missing = append(missing, "'appKey'")
+	if isUnset(handler.CredentialInfo.RDSMySQLAppKey) {
+		missing = append(missing, "'mysqlAppKey'")
 	}
 	if isUnset(handler.CredentialInfo.RDSUserAccessKey) {
 		missing = append(missing, "'User Access Key'")
@@ -506,7 +506,7 @@ func (handler *NhnCloudRDBMSHandler) checkRDSCredentials() error {
 		return fmt.Errorf(
 			"NHN Cloud RDBMS requires 3 credential keys that are not yet registered: %s.\n"+
 				"How to obtain and register them:\n"+
-				"  1. appKey       : NHN Cloud Console → Database → RDS for MySQL/MariaDB → URL & AppKey\n"+
+				"  1. mysqlAppKey  : NHN Cloud Console → Database → RDS for MySQL → URL & AppKey\n"+
 				"  2. User Access Key  : NHN Cloud Console → My Page → API Security Settings → User Access Key ID\n"+
 				"  3. Secret Access Key: same page as above → Secret Access Key\n"+
 				"Add the missing key(s) to your CB-Spider credential and try again.",
@@ -1098,7 +1098,7 @@ func (handler *NhnCloudRDBMSHandler) putRDS(ctx context.Context, path string, bo
 		return fmt.Errorf("failed to create NHN Cloud RDS PUT request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-TC-APP-KEY", handler.CredentialInfo.RDSAppKey)
+	req.Header.Set("X-TC-APP-KEY", handler.CredentialInfo.RDSMySQLAppKey)
 	req.Header.Set("X-TC-AUTHENTICATION-ID", handler.CredentialInfo.RDSUserAccessKey)
 	req.Header.Set("X-TC-AUTHENTICATION-SECRET", handler.CredentialInfo.RDSSecretAccessKey)
 

--- a/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
+++ b/cloud-control-manager/cloud-driver/interfaces/CloudDriver.go
@@ -87,8 +87,8 @@ type CredentialInfo struct {
 	//----- RDS Access Info
 	RDSUserAccessKey   string // RDS User Access Key
 	RDSSecretAccessKey string // RDS Secret Access Key
-	RDSAppKey          string // RDS AppKey (e.g., NHN Cloud RDS for MySQL)
-	RDSMariaDBAppKey   string // RDS MariaDB-specific AppKey (e.g., NHN Cloud RDS for MariaDB; falls back to RDSAppKey if empty)
+	RDSMySQLAppKey     string // RDS MySQL-specific AppKey (e.g., NHN Cloud RDS for MySQL)
+	RDSMariaDBAppKey   string // RDS MariaDB-specific AppKey (e.g., NHN Cloud RDS for MariaDB; falls back to RDSMySQLAppKey if empty)
 }
 
 type RegionInfo struct {


### PR DESCRIPTION
- Rename CredentialInfo.RDSAppKey to RDSMySQLAppKey to pair explicitly with the existing RDSMariaDBAppKey
- Update credential key lookup from "appKey" to "mysqlAppKey" in CloudDriverHandler_common.go and AdminWeb-RDBMS-Query.go
- Update rdsEffectiveAppKey(), checkRDSCredentials(), and putRDS() in the NHN RDBMS driver to use the renamed field and credential key
- Sync RDBMS-and-Driver-API.md and RDBMS-Driver-Development-Report.md with the renamed identifiers, and fix a stale NHN MariaDB version example (MARIADB_V10622 → MARIADB_V101118)