### PR TITLE
[Multi-Cloud] Fix: Add missing list pagination across 8 cloud drivers

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -1185,19 +1185,34 @@ func aliDeleteNatGateway(vpcClient *vpc2016.Client, regionId, natGatewayId strin
 }
 
 func aliDescribeClustersV1(csClient *cs2015.Client, regionId string) ([]*cs2015.DescribeClustersV1ResponseBodyClusters, error) {
-	describeClustersV1Request := &cs2015.DescribeClustersV1Request{
-		ClusterType: tea.String("ManagedKubernetes"),
-		RegionId:    tea.String(regionId),
-		//RegionId: tea.String("ap-northeast-1"),
-	}
-	cblogger.Debug(describeClustersV1Request)
-	describeClustersV1Response, err := csClient.DescribeClustersV1(describeClustersV1Request)
-	if err != nil {
-		return make([]*cs2015.DescribeClustersV1ResponseBodyClusters, 0), err
-	}
-	cblogger.Debug(describeClustersV1Response.Body)
+	var allClusters []*cs2015.DescribeClustersV1ResponseBodyClusters
+	pageNumber := int64(1)
 
-	return describeClustersV1Response.Body.Clusters, nil
+	for {
+		describeClustersV1Request := &cs2015.DescribeClustersV1Request{
+			ClusterType: tea.String("ManagedKubernetes"),
+			RegionId:    tea.String(regionId),
+			//RegionId: tea.String("ap-northeast-1"),
+			PageNumber: tea.Int64(pageNumber),
+			PageSize:   tea.Int64(50),
+		}
+		cblogger.Debug(describeClustersV1Request)
+		describeClustersV1Response, err := csClient.DescribeClustersV1(describeClustersV1Request)
+		if err != nil {
+			return make([]*cs2015.DescribeClustersV1ResponseBodyClusters, 0), err
+		}
+		cblogger.Debug(describeClustersV1Response.Body)
+
+		allClusters = append(allClusters, describeClustersV1Response.Body.Clusters...)
+
+		pageInfo := describeClustersV1Response.Body.PageInfo
+		if pageInfo == nil || pageInfo.TotalCount == nil || int64(len(allClusters)) >= int64(*pageInfo.TotalCount) {
+			break
+		}
+		pageNumber++
+	}
+
+	return allClusters, nil
 }
 
 func aliDescribeClusterDetail(csClient *cs2015.Client, clusterId string) (*cs2015.DescribeClusterDetailResponseBody, error) {
@@ -1244,18 +1259,32 @@ func existNotDeletedClusterWithTagInVpc(csClient *cs2015.Client, regionId, vpcId
 }
 
 func aliDescribeVSwitches(vpcClient *vpc2016.Client, regionId, vpcId string) ([]*vpc2016.DescribeVSwitchesResponseBodyVSwitchesVSwitch, error) {
-	describeVSwitchesRequest := &vpc2016.DescribeVSwitchesRequest{
-		RegionId: tea.String(regionId),
-		VpcId:    tea.String(vpcId),
-	}
-	//cblogger.Debug(describeVSwitchesRequest)
-	describeVSwitchesResponse, err := vpcClient.DescribeVSwitches(describeVSwitchesRequest)
-	if err != nil {
-		return make([]*vpc2016.DescribeVSwitchesResponseBodyVSwitchesVSwitch, 0), err
-	}
-	//cblogger.Debug(describeVSwitchesResponse.Body.VSwitches.VSwitch)
+	var allVSwitches []*vpc2016.DescribeVSwitchesResponseBodyVSwitchesVSwitch
+	pageNumber := int32(1)
 
-	return describeVSwitchesResponse.Body.VSwitches.VSwitch, nil
+	for {
+		describeVSwitchesRequest := &vpc2016.DescribeVSwitchesRequest{
+			RegionId:   tea.String(regionId),
+			VpcId:      tea.String(vpcId),
+			PageNumber: tea.Int32(pageNumber),
+			PageSize:   tea.Int32(50),
+		}
+		//cblogger.Debug(describeVSwitchesRequest)
+		describeVSwitchesResponse, err := vpcClient.DescribeVSwitches(describeVSwitchesRequest)
+		if err != nil {
+			return make([]*vpc2016.DescribeVSwitchesResponseBodyVSwitchesVSwitch, 0), err
+		}
+		//cblogger.Debug(describeVSwitchesResponse.Body.VSwitches.VSwitch)
+
+		allVSwitches = append(allVSwitches, describeVSwitchesResponse.Body.VSwitches.VSwitch...)
+
+		if describeVSwitchesResponse.Body.TotalCount == nil || int32(len(allVSwitches)) >= *describeVSwitchesResponse.Body.TotalCount {
+			break
+		}
+		pageNumber++
+	}
+
+	return allVSwitches, nil
 }
 
 // compareVersionStrings compares two version strings (supports 3-digit and 4-digit versions)
@@ -1699,17 +1728,32 @@ func aliDescribeClusterNodePoolDetail(csClient *cs2015.Client, clusterId, nodepo
 }
 
 func aliDescribeClusterNodes(csClient *cs2015.Client, clusterId, nodepoolId string) ([]*cs2015.DescribeClusterNodesResponseBodyNodes, error) {
-	describeClusterNodesRequest := &cs2015.DescribeClusterNodesRequest{
-		NodepoolId: tea.String(nodepoolId),
-	}
-	//cblogger.Debug(describeClusterNodesRequest)
-	describeClusterNodesResponse, err := csClient.DescribeClusterNodes(tea.String(clusterId), describeClusterNodesRequest)
-	if err != nil {
-		return nil, err
-	}
-	//cblogger.Debug(describeClusterNodesResponse.Body)
+	var allNodes []*cs2015.DescribeClusterNodesResponseBodyNodes
+	pageNumber := 1
 
-	return describeClusterNodesResponse.Body.Nodes, nil
+	for {
+		describeClusterNodesRequest := &cs2015.DescribeClusterNodesRequest{
+			NodepoolId: tea.String(nodepoolId),
+			PageNumber: tea.String(strconv.Itoa(pageNumber)),
+			PageSize:   tea.String("100"),
+		}
+		//cblogger.Debug(describeClusterNodesRequest)
+		describeClusterNodesResponse, err := csClient.DescribeClusterNodes(tea.String(clusterId), describeClusterNodesRequest)
+		if err != nil {
+			return nil, err
+		}
+		//cblogger.Debug(describeClusterNodesResponse.Body)
+
+		allNodes = append(allNodes, describeClusterNodesResponse.Body.Nodes...)
+
+		page := describeClusterNodesResponse.Body.Page
+		if page == nil || page.TotalCount == nil || int64(len(allNodes)) >= int64(*page.TotalCount) {
+			break
+		}
+		pageNumber++
+	}
+
+	return allNodes, nil
 }
 
 func aliModifyClusterNodePoolAutoScalingEnable(csClient *cs2015.Client, clusterId, nodepoolId string, enable bool) (*cs2015.ModifyClusterNodePoolResponseBody, error) {

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/CommonHandler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -391,6 +392,8 @@ func DescribeInstances(client *ecs.Client, regionInfo idrv.RegionInfo, vmIIDs []
 		}
 		request.InstanceIds = string(vmsJson)
 	}
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(100)
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -404,12 +407,29 @@ func DescribeInstances(client *ecs.Client, regionInfo idrv.RegionInfo, vmIIDs []
 		ErrorMSG:     "",
 	}
 
+	var instances []ecs.Instance
+	curPage := 1
 	callLogStart := call.Start()
-	response, err := client.DescribeInstances(request)
+	for {
+		response, err := client.DescribeInstances(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Info(call.String(callLogInfo))
+			return nil, err
+		}
+
+		instances = append(instances, response.Instances.Instance...)
+		if len(instances) >= response.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
+	}
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 
-	return response.Instances.Instance, err
+	return instances, nil
 }
 
 /*
@@ -497,15 +517,26 @@ func DescribeImages(client *ecs.Client, regionInfo idrv.RegionInfo, imageIIDs []
 	if isMyImage {
 		request.ImageOwnerAlias = "self"
 	}
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(100)
 
-	//cblogger.Debug(request)
-	result, err := client.DescribeImages(request)
-	if err != nil {
-		return nil, err
+	var images []ecs.Image
+	curPage := 1
+	for {
+		result, err := client.DescribeImages(request)
+		if err != nil {
+			return nil, err
+		}
+
+		images = append(images, result.Images.Image...)
+		if len(images) >= result.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
 	}
 
-	//cblogger.Debug(result)
-	return result.Images.Image, nil
+	return images, nil
 }
 
 func DescribeImagesIdOnly(client *ecs.Client, regionInfo idrv.RegionInfo, isMyImage bool) ([]*irs.IID, error) {
@@ -1581,26 +1612,37 @@ func aliEcsTagList(Client *ecs.Client, regionInfo idrv.RegionInfo, alibabaResour
 	if keyword != "" {
 		queryParams["Tag.1.Key"] = keyword
 	}
+	queryParams["PageSize"] = "50"
 
+	var aliTagResources []AliTagResource
+	pageNumber := 1
 	start := call.Start()
-	response, err := CallEcsRequest(resType, Client, regionInfo, "DescribeResourceByTags", queryParams)
+	for {
+		queryParams["PageNumber"] = strconv.Itoa(pageNumber)
+		response, err := CallEcsRequest(resType, Client, regionInfo, "DescribeResourceByTags", queryParams)
+		if err != nil {
+			cblogger.Error(err.Error())
+			LoggingError(hiscallInfo, err)
+			break
+		}
+		cblogger.Debug(response.GetHttpContentString())
+		resResources := AliTagResourcesResponse{}
+
+		tagResponseStr := response.GetHttpContentString()
+		if err := json.Unmarshal([]byte(tagResponseStr), &resResources); err != nil {
+			cblogger.Error(err.Error())
+			break
+		}
+
+		aliTagResources = append(aliTagResources, resResources.AliTagResources.Resources...)
+		if len(aliTagResources) >= resResources.TotalCount {
+			break
+		}
+		pageNumber++
+	}
 	LoggingInfo(hiscallInfo, start)
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-	}
-	cblogger.Debug(response.GetHttpContentString())
-	resResources := AliTagResourcesResponse{}
 
-	tagResponseStr := response.GetHttpContentString()
-	err = json.Unmarshal([]byte(tagResponseStr), &resResources)
-
-	if err != nil {
-		cblogger.Error(err.Error())
-		return tagInfo, nil
-	}
-
-	for _, aliTagResource := range resResources.AliTagResources.Resources {
+	for _, aliTagResource := range aliTagResources {
 
 		cblogger.Debug("aliTagResource ", aliTagResource)
 		aTagInfo, err := ExtractTagResourceInfo(&aliTagResource)
@@ -1662,27 +1704,37 @@ func aliVpcTagList(VpcClient *vpc.Client, regionInfo idrv.RegionInfo, alibabaRes
 	queryParams := map[string]string{}
 	queryParams["RegionId"] = regionID
 	queryParams["ResourceType"] = alibabaResourceType //string(resType)//keypair
+	queryParams["PageSize"] = "50"
 
+	var vpcs []Vpc
+	pageNumber := 1
 	start := call.Start()
+	for {
+		queryParams["PageNumber"] = strconv.Itoa(pageNumber)
+		response, err := CallVpcRequest(resType, VpcClient, regionInfo, "DescribeVpcs", queryParams)
+		if err != nil {
+			cblogger.Error(err.Error())
+			LoggingError(hiscallInfo, err)
+			break
+		}
+		cblogger.Debug(response.GetHttpContentString())
+		resResources := DescribeVpcsResponse{}
 
-	response, err := CallVpcRequest(resType, VpcClient, regionInfo, "DescribeVpcs", queryParams)
+		tagResponseStr := response.GetHttpContentString()
+		if err := json.Unmarshal([]byte(tagResponseStr), &resResources); err != nil {
+			cblogger.Error(err.Error())
+			break
+		}
+
+		vpcs = append(vpcs, resResources.Vpcs.Vpc...)
+		if len(vpcs) >= resResources.TotalCount {
+			break
+		}
+		pageNumber++
+	}
 	LoggingInfo(hiscallInfo, start)
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-	}
-	cblogger.Debug(response.GetHttpContentString())
-	resResources := DescribeVpcsResponse{}
 
-	tagResponseStr := response.GetHttpContentString()
-	err = json.Unmarshal([]byte(tagResponseStr), &resResources)
-
-	if err != nil {
-		cblogger.Error(err.Error())
-		return tagInfo, nil
-	}
-
-	for _, vpc := range resResources.Vpcs.Vpc {
+	for _, vpc := range vpcs {
 		for _, tag := range vpc.Tags.Tag {
 			aliTagResource := AliTagResource{
 				ResourceType: "VPC",
@@ -1709,25 +1761,37 @@ func aliSubnetTagList(VpcClient *vpc.Client, regionInfo idrv.RegionInfo, alibaba
 	queryParams := map[string]string{}
 	queryParams["RegionId"] = regionID
 	queryParams["ResourceType"] = alibabaResourceType //string(resType)//keypair
+	queryParams["PageSize"] = "50"
 
+	var vswitches []VSwitch
+	pageNumber := 1
 	start := call.Start()
-	response, err := CallVpcRequest(resType, VpcClient, regionInfo, "DescribeVSwitches", queryParams)
+	for {
+		queryParams["PageNumber"] = strconv.Itoa(pageNumber)
+		response, err := CallVpcRequest(resType, VpcClient, regionInfo, "DescribeVSwitches", queryParams)
+		if err != nil {
+			cblogger.Error(err.Error())
+			LoggingError(hiscallInfo, err)
+			break
+		}
+		cblogger.Debug(response.GetHttpContentString())
+		resResources := DescribeVSwitchesResponse{}
+
+		tagResponseStr := response.GetHttpContentString()
+		if err := json.Unmarshal([]byte(tagResponseStr), &resResources); err != nil {
+			cblogger.Error("Failed to unmarshal response: ", err)
+			break
+		}
+
+		vswitches = append(vswitches, resResources.VSwitches.VSwitch...)
+		if len(vswitches) >= resResources.TotalCount {
+			break
+		}
+		pageNumber++
+	}
 	LoggingInfo(hiscallInfo, start)
-	if err != nil {
-		cblogger.Error(err.Error())
-		LoggingError(hiscallInfo, err)
-	}
-	cblogger.Debug(response.GetHttpContentString())
-	resResources := DescribeVSwitchesResponse{}
 
-	tagResponseStr := response.GetHttpContentString()
-	err = json.Unmarshal([]byte(tagResponseStr), &resResources)
-
-	if err != nil {
-		cblogger.Error("Failed to unmarshal response: ", err)
-	}
-
-	for _, vswitch := range resResources.VSwitches.VSwitch {
+	for _, vswitch := range vswitches {
 		if len(vswitch.Tags.Tag) == 0 {
 			continue
 		}

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/FileSystemHandler.go
@@ -115,27 +115,37 @@ func (fileSystemHandler *AlibabaFileSystemHandler) ListIID() ([]*irs.IID, error)
 
 	request := nas.CreateDescribeFileSystemsRequest()
 	request.Scheme = "https"
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(50)
 
 	hiscallInfo := GetCallLogScheme(fileSystemHandler.Region, call.FILESYSTEM, "ListIID", "DescribeFileSystems()")
 	start := call.Start()
 
-	response, err := fileSystemHandler.Client.DescribeFileSystems(request)
+	var iidList []*irs.IID
+	curPage := 1
+	for {
+		response, err := fileSystemHandler.Client.DescribeFileSystems(request)
+		if err != nil {
+			cblogger.Error(err)
+			LoggingError(hiscallInfo, err)
+			return nil, err
+		}
 
-	if err != nil {
-		cblogger.Error(err)
-		LoggingError(hiscallInfo, err)
-		return nil, err
+		for _, fs := range response.FileSystems.FileSystem {
+			iid := irs.IID{
+				NameId:   fs.Description, // Alibaba NAS uses Description as name
+				SystemId: fs.FileSystemId,
+			}
+			iidList = append(iidList, &iid)
+		}
+
+		if len(iidList) >= response.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
 	}
 	LoggingInfo(hiscallInfo, start)
-
-	var iidList []*irs.IID
-	for _, fs := range response.FileSystems.FileSystem {
-		iid := irs.IID{
-			NameId:   fs.Description, // Alibaba NAS uses Description as name
-			SystemId: fs.FileSystemId,
-		}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/NLBHandler.go
@@ -203,6 +203,8 @@ func (NLBHandler *AlibabaNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 
 	request := slb.CreateDescribeLoadBalancersRequest()
 	request.RegionId = NLBHandler.Region.Region
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(50)
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -215,21 +217,32 @@ func (NLBHandler *AlibabaNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 		ElapsedTime:  "",
 		ErrorMSG:     "",
 	}
+
+	var loadBalancers []slb.LoadBalancer
+	curPage := 1
 	callLogStart := call.Start()
+	for {
+		result, err := NLBHandler.Client.DescribeLoadBalancers(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Info(call.String(callLogInfo))
+			return nil, err
+		}
 
-	result, err := NLBHandler.Client.DescribeLoadBalancers(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	//cblogger.Debug(result)
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Info(call.String(callLogInfo))
-		return nil, err
+		cblogger.Info("result count ", result.TotalCount)
+		loadBalancers = append(loadBalancers, result.LoadBalancers.LoadBalancer...)
+		if len(loadBalancers) >= result.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	callogger.Info(call.String(callLogInfo))
 
-	cblogger.Info("result count ", result.TotalCount)
-	cblogger.Info(result)
 	var nlbInfoList []*irs.NLBInfo
-	for _, curLB := range result.LoadBalancers.LoadBalancer { // LB 목록 조회시 가져오는 값들이 많지 않음. 상세정보는 GetNL로로
+	for _, curLB := range loadBalancers { // LB 목록 조회시 가져오는 값들이 많지 않음. 상세정보는 GetNL로로
 		nlbInfo, nlbErr := NLBHandler.GetNLB(irs.IID{SystemId: curLB.LoadBalancerId})
 
 		if nlbErr != nil {
@@ -238,8 +251,6 @@ func (NLBHandler *AlibabaNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 		nlbInfoList = append(nlbInfoList, &nlbInfo)
 	}
 
-	cblogger.Debug(result)
-	//cblogger.Debug(vpcInfoList)
 	return nlbInfoList, nil
 }
 func (NLBHandler *AlibabaNLBHandler) GetNLB(nlbIID irs.IID) (irs.NLBInfo, error) {

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/PriceInfoHandler.go
@@ -212,15 +212,22 @@ func (priceInfoHandler *AlibabaPriceInfoHandler) GetPriceInfo(productFamily stri
 		instanceTypesRequest.MaximumGPUAmount = requests.NewInteger(gpuMemoryInt)
 	}
 
-	instanceTypesResponse, err := priceInfoHandler.EcsClient.DescribeInstanceTypes(instanceTypesRequest)
-	if err != nil {
-		cblogger.Error("Failed to get instance types: ", err)
-		return "", err
-	}
-
 	instanceTypesInfo := make(map[string]ecs.InstanceType)
-	for _, typeInfo := range instanceTypesResponse.InstanceTypes.InstanceType {
-		instanceTypesInfo[typeInfo.InstanceTypeId] = typeInfo
+	for {
+		instanceTypesResponse, err := priceInfoHandler.EcsClient.DescribeInstanceTypes(instanceTypesRequest)
+		if err != nil {
+			cblogger.Error("Failed to get instance types: ", err)
+			return "", err
+		}
+
+		for _, typeInfo := range instanceTypesResponse.InstanceTypes.InstanceType {
+			instanceTypesInfo[typeInfo.InstanceTypeId] = typeInfo
+		}
+
+		if instanceTypesResponse.NextToken == "" {
+			break
+		}
+		instanceTypesRequest.NextToken = instanceTypesResponse.NextToken
 	}
 
 	filteredInstanceTypesInfo := make(map[string]ecs.InstanceType)

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/SecurityHandler.go
@@ -327,6 +327,8 @@ func (securityHandler *AlibabaSecurityHandler) ListSecurity() ([]*irs.SecurityIn
 	// get SecurityGroup & SecurityGroupAttribute for Alibaba
 	request := ecs.CreateDescribeSecurityGroupsRequest()
 	request.Scheme = "https"
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(50)
 	cblogger.Debug(request)
 
 	// logger for HisCall
@@ -341,25 +343,31 @@ func (securityHandler *AlibabaSecurityHandler) ListSecurity() ([]*irs.SecurityIn
 		ErrorMSG:     "",
 	}
 
+	var securityGroups []ecs.SecurityGroup
+	curPage := 1
 	callLogStart := call.Start()
-	result, err := securityHandler.Client.DescribeSecurityGroups(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		result, err := securityHandler.Client.DescribeSecurityGroups(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
-
-		cblogger.Error(err)
-		return nil, err
+		securityGroups = append(securityGroups, result.SecurityGroups.SecurityGroup...)
+		if len(securityGroups) >= result.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Debug(call.String(callLogInfo))
 
-	cblogger.Debug(result)
-	//cblogger.Debug(result)
-	//ecs.DescribeSecurityGroupsResponse
-
 	var securityInfoList []*irs.SecurityInfo
-	for _, curSecurityGroup := range result.SecurityGroups.SecurityGroup {
+	for _, curSecurityGroup := range securityGroups {
 		curSecurityInfo, errSecurityInfo := securityHandler.ExtractSecurityInfo(&curSecurityGroup)
 		if errSecurityInfo != nil {
 			cblogger.Error(errSecurityInfo)

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
@@ -1188,6 +1188,8 @@ func (vmHandler *AlibabaVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 
 	request := ecs.CreateDescribeInstanceStatusRequest()
 	request.Scheme = "https"
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(100)
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -1201,35 +1203,39 @@ func (vmHandler *AlibabaVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	callLogStart := call.Start()
-	response, err := vmHandler.Client.DescribeInstanceStatus(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
-
-		cblogger.Error(err.Error())
-		return nil, err
-	}
-	callogger.Info(call.String(callLogInfo))
-
-	cblogger.Info("Success", response)
-	if response.TotalCount < 1 {
-		return nil, nil
-	}
-
 	var vmInfoList []*irs.VMStatusInfo
-	for _, vm := range response.InstanceStatuses.InstanceStatus {
-		cblogger.Infof("Cur VM:[%s] / ECS Status : [%s]", vm.InstanceId, vm.Status)
-		vmStatus, errStatus := vmHandler.ConvertVMStatusString(vm.Status)
-		if errStatus != nil {
-			cblogger.Error(errStatus.Error())
-			return nil, errStatus
+	curPage := 1
+	callLogStart := call.Start()
+	for {
+		response, err := vmHandler.Client.DescribeInstanceStatus(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
+			cblogger.Error(err.Error())
+			return nil, err
 		}
-		curVmStatusInfo := irs.VMStatusInfo{IId: irs.IID{SystemId: vm.InstanceId}, VmStatus: vmStatus}
-		vmInfoList = append(vmInfoList, &curVmStatusInfo)
+
+		cblogger.Info("Success", response)
+		for _, vm := range response.InstanceStatuses.InstanceStatus {
+			cblogger.Infof("Cur VM:[%s] / ECS Status : [%s]", vm.InstanceId, vm.Status)
+			vmStatus, errStatus := vmHandler.ConvertVMStatusString(vm.Status)
+			if errStatus != nil {
+				cblogger.Error(errStatus.Error())
+				return nil, errStatus
+			}
+			curVmStatusInfo := irs.VMStatusInfo{IId: irs.IID{SystemId: vm.InstanceId}, VmStatus: vmStatus}
+			vmInfoList = append(vmInfoList, &curVmStatusInfo)
+		}
+
+		if len(vmInfoList) >= response.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	callogger.Info(call.String(callLogInfo))
 
 	return vmInfoList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMSpecHandler.go
@@ -110,14 +110,37 @@ func ExtractVMSpecInfo(Region string, instanceTypeInfo ecs.InstanceType) irs.VMS
 	return vmSpecInfo
 }
 
+// describeAllInstanceTypes fetches every instance type for a region, following
+// the DescribeInstanceTypes NextToken cursor until it's exhausted.
+func describeAllInstanceTypes(client *ecs.Client, region string) ([]ecs.InstanceType, error) {
+	var allTypes []ecs.InstanceType
+	nextToken := ""
+	for {
+		request := ecs.CreateDescribeInstanceTypesRequest()
+		request.Scheme = "https"
+		request.RegionId = region
+		if nextToken != "" {
+			request.NextToken = nextToken
+		}
+
+		resp, err := client.DescribeInstanceTypes(request)
+		if err != nil {
+			return nil, err
+		}
+
+		allTypes = append(allTypes, resp.InstanceTypes.InstanceType...)
+		if resp.NextToken == "" {
+			break
+		}
+		nextToken = resp.NextToken
+	}
+	return allTypes, nil
+}
+
 func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, error) {
 	Region := vmSpecHandler.Region.Region
 	cblogger.Infof("Start ListVMSpec(Session Region:[%s])", Region)
 	var vMSpecInfoList []*irs.VMSpecInfo
-
-	request := ecs.CreateDescribeInstanceTypesRequest()
-	request.Scheme = "https"
-	request.RegionId = Region
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -132,9 +155,8 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 	}
 
 	callLogStart := call.Start()
-	resp, err := vmSpecHandler.Client.DescribeInstanceTypes(request)
+	instanceTypes, err := describeAllInstanceTypes(vmSpecHandler.Client, Region)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	cblogger.Debug(resp)
 
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -145,25 +167,18 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListVMSpec() ([]*irs.VMSpecInfo, erro
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	//cblogger.Debug(resp)
-	cblogger.Info("Number of Retrieved Instance Types : ", len(resp.InstanceTypes.InstanceType))
-	for _, curInstance := range resp.InstanceTypes.InstanceType {
+	cblogger.Info("Number of Retrieved Instance Types : ", len(instanceTypes))
+	for _, curInstance := range instanceTypes {
 		cblogger.Infof("[%s] VM Retrieve Specification Information", curInstance.InstanceTypeFamily)
 		vMSpecInfo := ExtractVMSpecInfo(Region, curInstance)
 		vMSpecInfoList = append(vMSpecInfoList, &vMSpecInfo)
 	}
-	//cblogger.Debug(vMSpecInfoList)
 	return vMSpecInfoList, nil
 }
 
 func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInfo, error) {
 	Region := vmSpecHandler.Region.Region
 	cblogger.Infof("Start GetVMSpec(Session Region:[%s], Name:[%s])", Region, Name)
-
-	request := ecs.CreateDescribeInstanceTypesRequest()
-	request.Scheme = "https"
-	request.RegionId = Region
-	//request.InstanceTypeFamily = Name
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -178,9 +193,8 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 	}
 
 	callLogStart := call.Start()
-	resp, err := vmSpecHandler.Client.DescribeInstanceTypes(request)
+	instanceTypes, err := describeAllInstanceTypes(vmSpecHandler.Client, Region)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	cblogger.Debug(resp)
 
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -191,17 +205,16 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetVMSpec(Name string) (irs.VMSpecInf
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	cblogger.Info("Number of Retrieved Instance Types : ", len(resp.InstanceTypes.InstanceType))
-	//	cblogger.Debug(resp)
+	cblogger.Info("Number of Retrieved Instance Types : ", len(instanceTypes))
 
-	if len(resp.InstanceTypes.InstanceType) < 1 {
+	if len(instanceTypes) < 1 {
 		return irs.VMSpecInfo{}, errors.New("Notfound: '" + Name + "'Cannot find Spec information for the specified item.")
 	}
 
 	var vMSpecInfo irs.VMSpecInfo
 	//인스턴스 타입으로 필터가 안되기 때문에 직접 처리함.
 	//속도를 고려하면 조회 대상을 전체로 설정하지 말고 InstanceTypeFamily을 이용해서 패밀리 그룹을 제한할 수는 있음.
-	for _, curInstance := range resp.InstanceTypes.InstanceType {
+	for _, curInstance := range instanceTypes {
 		cblogger.Debugf("[%s]", curInstance.InstanceTypeId)
 		if Name == curInstance.InstanceTypeId {
 			cblogger.Debugf("===> [%s]", curInstance.InstanceTypeId)
@@ -219,10 +232,6 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec() (string, error) {
 	Region := vmSpecHandler.Region.Region
 	cblogger.Infof("Start ListOrgVMSpec(Session Region:[%s])", Region)
 
-	request := ecs.CreateDescribeInstanceTypesRequest()
-	request.Scheme = "https"
-	request.RegionId = Region
-
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
 	callLogInfo := call.CLOUDLOGSCHEMA{
@@ -236,9 +245,8 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec() (string, error) {
 	}
 
 	callLogStart := call.Start()
-	resp, err := vmSpecHandler.Client.DescribeInstanceTypes(request)
+	instanceTypes, err := describeAllInstanceTypes(vmSpecHandler.Client, Region)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	cblogger.Debug(resp)
 
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -249,8 +257,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec() (string, error) {
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	//jsonString, errJson := ConvertJsonString(resp.InstanceTypes.InstanceType)
-	jsonString, errJson := ConvertJsonString(resp.InstanceTypes)
+	jsonString, errJson := ConvertJsonString(ecs.InstanceTypesInDescribeInstanceTypes{InstanceType: instanceTypes})
 	if errJson != nil {
 		cblogger.Error(errJson)
 	}
@@ -260,9 +267,6 @@ func (vmSpecHandler *AlibabaVmSpecHandler) ListOrgVMSpec() (string, error) {
 func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Name string) (string, error) {
 	Region := vmSpecHandler.Region.Region
 	cblogger.Infof("Start GetOrgVMSpec(Session Region:[%s], Name:[%s])", Region, Name)
-	request := ecs.CreateDescribeInstanceTypesRequest()
-	request.Scheme = "https"
-	request.RegionId = Region
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -277,9 +281,8 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 	}
 
 	callLogStart := call.Start()
-	resp, err := vmSpecHandler.Client.DescribeInstanceTypes(request)
+	instanceTypes, err := describeAllInstanceTypes(vmSpecHandler.Client, Region)
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	cblogger.Debug(resp)
 
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -290,10 +293,9 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	cblogger.Info("Number of Retrieved Instance Types : ", len(resp.InstanceTypes.InstanceType))
-	//	cblogger.Debug(resp)
+	cblogger.Info("Number of Retrieved Instance Types : ", len(instanceTypes))
 
-	if len(resp.InstanceTypes.InstanceType) < 1 {
+	if len(instanceTypes) < 1 {
 		return "", errors.New(Name + "Cannot find Spec information for the specified item.")
 	}
 
@@ -301,7 +303,7 @@ func (vmSpecHandler *AlibabaVmSpecHandler) GetOrgVMSpec(Name string) (string, er
 	var errJson error
 	//인스턴스 타입으로 필터가 안되기 때문에 직접 처리함.
 	//속도를 고려하면 조회 대상을 전체로 설정하지 말고 InstanceTypeFamily을 이용해서 패밀리 그룹을 제한할 수는 있음.
-	for _, curInstance := range resp.InstanceTypes.InstanceType {
+	for _, curInstance := range instanceTypes {
 		cblogger.Debugf("[%s]", curInstance.InstanceTypeId)
 		if Name == curInstance.InstanceTypeId {
 			cblogger.Debugf("===> [%s]", curInstance.InstanceTypeId)

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VPCHandler.go
@@ -220,6 +220,8 @@ func (VPCHandler *AlibabaVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 
 	request := vpc.CreateDescribeVpcsRequest()
 	request.Scheme = "https"
+	request.PageNumber = requests.NewInteger(1)
+	request.PageSize = requests.NewInteger(50)
 
 	// logger for HisCall
 	callogger := call.GetLogger("HISCALL")
@@ -232,32 +234,42 @@ func (VPCHandler *AlibabaVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 		ElapsedTime:  "",
 		ErrorMSG:     "",
 	}
-	callLogStart := call.Start()
-
-	result, err := VPCHandler.Client.DescribeVpcs(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-	cblogger.Debug(result)
-	//cblogger.Debug(result)
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Info(call.String(callLogInfo))
-		return nil, err
-	}
-	callogger.Info(call.String(callLogInfo))
 
 	var vpcInfoList []*irs.VPCInfo
-	for _, curVpc := range result.Vpcs.Vpc {
-		cblogger.Infof("[%s] VPC information retrieval", curVpc.VpcId)
-		//vpcInfo := ExtractVpcDescribeInfo(&curVpc)
-		vpcInfo, vpcErr := VPCHandler.GetVPC(irs.IID{SystemId: curVpc.VpcId})
+	var vpcIds []string
+	curPage := 1
+	callLogStart := call.Start()
+	for {
+		result, err := VPCHandler.Client.DescribeVpcs(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Info(call.String(callLogInfo))
+			return nil, err
+		}
+
+		for _, curVpc := range result.Vpcs.Vpc {
+			vpcIds = append(vpcIds, curVpc.VpcId)
+		}
+
+		if len(vpcIds) >= result.TotalCount {
+			break
+		}
+		curPage++
+		request.PageNumber = requests.NewInteger(curPage)
+	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	callogger.Info(call.String(callLogInfo))
+
+	for _, vpcId := range vpcIds {
+		cblogger.Infof("[%s] VPC information retrieval", vpcId)
+		vpcInfo, vpcErr := VPCHandler.GetVPC(irs.IID{SystemId: vpcId})
 		if vpcErr != nil {
 			return nil, vpcErr
 		}
 		vpcInfoList = append(vpcInfoList, &vpcInfo)
 	}
 
-	cblogger.Debug(result)
-	//cblogger.Debug(vpcInfoList)
 	return vpcInfoList, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/FileSystemHandler.go
@@ -92,7 +92,33 @@ func (fileSystemHandler *AwsFileSystemHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := GetCallLogScheme(fileSystemHandler.Region, call.FILESYSTEM, "ListIID", "DescribeFileSystems()")
 	start := call.Start()
 
-	result, err := fileSystemHandler.Client.DescribeFileSystems(input)
+	var iidList []*irs.IID
+	err := fileSystemHandler.Client.DescribeFileSystemsPages(input, func(page *efs.DescribeFileSystemsOutput, lastPage bool) bool {
+		for _, fs := range page.FileSystems {
+			if fs == nil {
+				continue
+			}
+
+			var nameId, systemId string
+
+			// Safely handle Name
+			if fs.Name != nil {
+				nameId = *fs.Name
+			}
+
+			// Safely handle FileSystemId
+			if fs.FileSystemId != nil {
+				systemId = *fs.FileSystemId
+			}
+
+			iid := irs.IID{
+				NameId:   nameId,
+				SystemId: systemId,
+			}
+			iidList = append(iidList, &iid)
+		}
+		return !lastPage
+	})
 
 	if err != nil {
 		cblogger.Error(err)
@@ -100,31 +126,6 @@ func (fileSystemHandler *AwsFileSystemHandler) ListIID() ([]*irs.IID, error) {
 		return nil, err
 	}
 	LoggingInfo(hiscallInfo, start)
-
-	var iidList []*irs.IID
-	for _, fs := range result.FileSystems {
-		if fs == nil {
-			continue
-		}
-
-		var nameId, systemId string
-
-		// Safely handle Name
-		if fs.Name != nil {
-			nameId = *fs.Name
-		}
-
-		// Safely handle FileSystemId
-		if fs.FileSystemId != nil {
-			systemId = *fs.FileSystemId
-		}
-
-		iid := irs.IID{
-			NameId:   nameId,
-			SystemId: systemId,
-		}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/NLBHandler.go
@@ -689,10 +689,12 @@ func (NLBHandler *AwsNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	}
 	callLogStart := call.Start()
 
-	result, err := NLBHandler.Client.DescribeLoadBalancers(input)
+	var loadBalancers []*elbv2.LoadBalancer
+	err := NLBHandler.Client.DescribeLoadBalancersPages(input, func(page *elbv2.DescribeLoadBalancersOutput, lastPage bool) bool {
+		loadBalancers = append(loadBalancers, page.LoadBalancers...)
+		return !lastPage
+	})
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-
-	cblogger.Debug(result)
 
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -715,7 +717,7 @@ func (NLBHandler *AwsNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 	callogger.Info(call.String(callLogInfo))
 
 	var results []*irs.NLBInfo
-	for _, curNLB := range result.LoadBalancers {
+	for _, curNLB := range loadBalancers {
 		if !strings.EqualFold(*curNLB.Type, "network") {
 			cblogger.Infof("%s Load balancer is not under management, so it is skipped - [%s]", *curNLB.Type, *curNLB.LoadBalancerName)
 			continue
@@ -1796,7 +1798,18 @@ func (NLBHandler *AwsNLBHandler) ListIID() ([]*irs.IID, error) {
 	callLogInfo := GetCallLogScheme(NLBHandler.Region, call.NLB, "ListIID", "DescribeLoadBalancers()")
 	start := call.Start()
 
-	result, err := NLBHandler.Client.DescribeLoadBalancers(input)
+	err := NLBHandler.Client.DescribeLoadBalancersPages(input, func(page *elbv2.DescribeLoadBalancersOutput, lastPage bool) bool {
+		for _, curNLB := range page.LoadBalancers {
+			// if !strings.EqualFold(*curNLB.Type, "network") {
+			// 	cblogger.Infof("%s Load balancer is not under management, so it is skipped - [%s]", *curNLB.Type, *curNLB.LoadBalancerName)
+			// 	continue
+			// }
+
+			iid := irs.IID{SystemId: *curNLB.LoadBalancerArn}
+			iidList = append(iidList, &iid)
+		}
+		return !lastPage
+	})
 	callLogInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -1805,16 +1818,6 @@ func (NLBHandler *AwsNLBHandler) ListIID() ([]*irs.IID, error) {
 		return nil, err
 	}
 	calllogger.Info(call.String(callLogInfo))
-
-	for _, curNLB := range result.LoadBalancers {
-		// if !strings.EqualFold(*curNLB.Type, "network") {
-		// 	cblogger.Infof("%s Load balancer is not under management, so it is skipped - [%s]", *curNLB.Type, *curNLB.LoadBalancerName)
-		// 	continue
-		// }
-
-		iid := irs.IID{SystemId: *curNLB.LoadBalancerArn}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/TagHandler.go
@@ -353,19 +353,23 @@ func (tagHandler *AwsTagHandler) GetAllEFSTags() ([]*irs.TagInfo, error) {
 	// Step 1: List all file systems
 	input := &efs.DescribeFileSystemsInput{}
 
-	result, err := tagHandler.EFSClient.DescribeFileSystems(input)
+	var fileSystems []*efs.FileSystemDescription
+	err := tagHandler.EFSClient.DescribeFileSystemsPages(input, func(page *efs.DescribeFileSystemsOutput, lastPage bool) bool {
+		fileSystems = append(fileSystems, page.FileSystems...)
+		return !lastPage
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe file systems: %w", err)
 	}
 
-	if len(result.FileSystems) == 0 {
+	if len(fileSystems) == 0 {
 		return nil, fmt.Errorf("no file systems found")
 	}
 
 	// Step 2: Get tags for each file system
 	var allTagInfos []*irs.TagInfo
 
-	for _, fs := range result.FileSystems {
+	for _, fs := range fileSystems {
 		resIID := irs.IID{
 			NameId:   aws.StringValue(fs.Name),
 			SystemId: aws.StringValue(fs.FileSystemId),

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/RegionZoneHandler.go
@@ -83,6 +83,7 @@ func (regionZoneHandler *AzureRegionZoneHandler) ListRegionZone() ([]*irs.Region
 					if err != nil {
 						zoneErrorOccurred = true
 						wait.Done()
+						return
 					}
 
 					for _, sku := range page.Value {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/AnyCallHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/AnyCallHandler.go
@@ -636,33 +636,33 @@ func listDLVM(anyCallHandler *GCPAnyCallHandler, callInfo irs.AnyCallInfo) (irs.
 	// Initialize the Compute Engine client
 	vmClient := anyCallHandler.Client
 
-	// Fetch the list of VM Instances
-	resp, err := vmClient.Instances.List(anyCallHandler.Credential.ProjectID, zoneId).Context(anyCallHandler.Ctx).Do()
+	// Fetch the list of VM Instances, filtering for those with a Jupyter Lab token label
+	err := vmClient.Instances.List(anyCallHandler.Credential.ProjectID, zoneId).Context(anyCallHandler.Ctx).Pages(anyCallHandler.Ctx, func(resp *compute.InstanceList) error {
+		for _, instance := range resp.Items {
+			// Check if the Jupyter Lab token label exists
+			jupyterToken, hasToken := instance.Labels["cb_spider_tpu_vm_jupyter_token"]
+			if !hasToken {
+				continue // Skip VMs without the Jupyter Lab token label
+			}
+
+			// Get VM information
+			vmInfo, err := getInstanceInfo(anyCallHandler, zoneId, instance.Name)
+			if err != nil {
+				cblogger.Errorf("Failed to get VM info for %s: %v", instance.Name, err)
+				continue
+			}
+
+			// Append VM information, including Jupyter Lab token from the label, to OKeyValueList
+			vmInfoWithToken := fmt.Sprintf("%s, Jupyter Lab token: %s", vmInfo, jupyterToken)
+			callInfo.OKeyValueList = append(callInfo.OKeyValueList, irs.KeyValue{
+				Key:   instance.Name,
+				Value: vmInfoWithToken,
+			})
+		}
+		return nil
+	})
 	if err != nil {
 		return callInfo, fmt.Errorf("failed to list VM instances in zone %s: %v", zoneId, err)
-	}
-
-	// Filter and populate OKeyValueList with details of VMs having the Jupyter Lab token label
-	for _, instance := range resp.Items {
-		// Check if the Jupyter Lab token label exists
-		jupyterToken, hasToken := instance.Labels["cb_spider_tpu_vm_jupyter_token"]
-		if !hasToken {
-			continue // Skip VMs without the Jupyter Lab token label
-		}
-
-		// Get VM information
-		vmInfo, err := getInstanceInfo(anyCallHandler, zoneId, instance.Name)
-		if err != nil {
-			cblogger.Errorf("Failed to get VM info for %s: %v", instance.Name, err)
-			continue
-		}
-
-		// Append VM information, including Jupyter Lab token from the label, to OKeyValueList
-		vmInfoWithToken := fmt.Sprintf("%s, Jupyter Lab token: %s", vmInfo, jupyterToken)
-		callInfo.OKeyValueList = append(callInfo.OKeyValueList, irs.KeyValue{
-			Key:   instance.Name,
-			Value: vmInfoWithToken,
-		})
 	}
 
 	return callInfo, nil

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
@@ -131,22 +131,23 @@ func (DiskHandler *GCPDiskHandler) ListDisk() ([]*irs.DiskInfo, error) {
 		for _, zoneItem := range regionZoneInfo.ZoneList {
 			// get Disks by Zone
 			hiscallInfo.ElapsedTime = call.Elapsed(start)
-			diskList, err := DiskHandler.Client.Disks.List(projectID, zoneItem.Name).Do()
+			err := DiskHandler.Client.Disks.List(projectID, zoneItem.Name).Pages(DiskHandler.Ctx, func(diskList *compute.DiskList) error {
+				for _, disk := range diskList.Items {
+					diskInfo, err := convertDiskInfo(disk)
+					if err != nil {
+						cblogger.Error(err)
+						return err
+					}
+					diskInfoList = append(diskInfoList, &diskInfo)
+				}
+				return nil
+			})
 			if err != nil {
 				cblogger.Error(err)
 				LoggingError(hiscallInfo, err)
 				return nil, err
 			}
 			calllogger.Info(call.String(hiscallInfo))
-
-			for _, disk := range diskList.Items {
-				diskInfo, err := convertDiskInfo(disk)
-				if err != nil {
-					cblogger.Error(err)
-					return nil, err
-				}
-				diskInfoList = append(diskInfoList, &diskInfo)
-			}
 		}
 
 	}
@@ -567,17 +568,18 @@ func (DiskHandler *GCPDiskHandler) ListIID() ([]*irs.IID, error) {
 	var iidList []*irs.IID
 
 	for _, zoneItem := range regionZoneInfo.ZoneList {
-		diskList, err := DiskHandler.Client.Disks.List(projectID, zoneItem.Name).Do()
+		err := DiskHandler.Client.Disks.List(projectID, zoneItem.Name).Pages(DiskHandler.Ctx, func(diskList *compute.DiskList) error {
+			for _, disk := range diskList.Items {
+				iid := irs.IID{NameId: disk.Name, SystemId: disk.Name}
+				iidList = append(iidList, &iid)
+			}
+			return nil
+		})
 
 		if err != nil {
 			cblogger.Error(err)
 			LoggingError(hiscallInfo, err)
 			return nil, err
-		}
-
-		for _, disk := range diskList.Items {
-			iid := irs.IID{NameId: disk.Name, SystemId: disk.Name}
-			iidList = append(iidList, &iid)
 		}
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/MyImageHandler.go
@@ -68,7 +68,17 @@ func (MyImageHandler *GCPMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, erro
 
 	projectID := MyImageHandler.Credential.ProjectID
 
-	myImageList, err := MyImageHandler.Client.MachineImages.List(projectID).Do()
+	err := MyImageHandler.Client.MachineImages.List(projectID).Pages(MyImageHandler.Ctx, func(myImageList *compute.MachineImageList) error {
+		for _, myImage := range myImageList.Items {
+			myImageInfo, err := MyImageHandler.convertMyImageInfo(myImage)
+			if err != nil {
+				cblogger.Error(err)
+				continue
+			}
+			myImageInfoList = append(myImageInfoList, &myImageInfo)
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		cblogger.Error(err)
@@ -76,15 +86,6 @@ func (MyImageHandler *GCPMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, erro
 		return nil, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
-
-	for _, myImage := range myImageList.Items {
-		myImageInfo, err := MyImageHandler.convertMyImageInfo(myImage)
-		if err != nil {
-			cblogger.Error(err)
-			continue
-		}
-		myImageInfoList = append(myImageInfoList, &myImageInfo)
-	}
 
 	return myImageInfoList, nil
 }
@@ -216,7 +217,16 @@ func (ImageHandler *GCPMyImageHandler) ListIID() ([]*irs.IID, error) {
 
 	projectID := ImageHandler.Credential.ProjectID
 
-	myImageList, err := ImageHandler.Client.MachineImages.List(projectID).Do()
+	var iidList []*irs.IID
+
+	err := ImageHandler.Client.MachineImages.List(projectID).Pages(ImageHandler.Ctx, func(myImageList *compute.MachineImageList) error {
+		for _, myImage := range myImageList.Items {
+			iid := irs.IID{NameId: myImage.Name, SystemId: myImage.Name}
+
+			iidList = append(iidList, &iid)
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		cblogger.Error(err)
@@ -224,14 +234,6 @@ func (ImageHandler *GCPMyImageHandler) ListIID() ([]*irs.IID, error) {
 		return nil, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
-
-	var iidList []*irs.IID
-
-	for _, myImage := range myImageList.Items {
-		iid := irs.IID{NameId: myImage.Name, SystemId: myImage.Name}
-
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NICHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NICHandler.go
@@ -47,17 +47,19 @@ func (h *GCPNICHandler) ListNIC() ([]*irs.NICInfo, error) {
 	hiscallInfo := GetCallLogScheme(h.Region, call.NIC, "All", "instances.list()")
 	start := call.Start()
 	projectID := h.Credential.ProjectID
-	result, err := h.Client.Instances.List(projectID, h.Region.Zone).Context(h.Ctx).Do()
+	var list []*irs.NICInfo
+	err := h.Client.Instances.List(projectID, h.Region.Zone).Pages(h.Ctx, func(result *compute.InstanceList) error {
+		for _, inst := range result.Items {
+			for i, ni := range inst.NetworkInterfaces {
+				info := extractGCPNICInfo(inst.Name, i, ni)
+				list = append(list, &info)
+			}
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil { cblogger.Error(err); LoggingError(hiscallInfo, err); return nil, err }
 	LoggingInfo(hiscallInfo, start)
-	var list []*irs.NICInfo
-	for _, inst := range result.Items {
-		for i, ni := range inst.NetworkInterfaces {
-			info := extractGCPNICInfo(inst.Name, i, ni)
-			list = append(list, &info)
-		}
-	}
 	if list == nil { list = []*irs.NICInfo{} }
 	return list, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/NLBHandler.go
@@ -1436,14 +1436,18 @@ func (nlbHandler *GCPNLBHandler) listRegionAddresses(regionID string, filter str
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.Addresses.List(projectID, regionID).Do()
+	var allItems []*compute.Address
+	err := nlbHandler.Client.Addresses.List(projectID, regionID).Pages(nlbHandler.Ctx, func(resp *compute.AddressList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 	}
-	return resp, nil
+	return &compute.AddressList{Items: allItems}, nil
 }
 
 // Address 등록 : LB의 시작점
@@ -1512,14 +1516,18 @@ func (nlbHandler *GCPNLBHandler) listGlobalAddresses(filter string) (*compute.Ad
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.GlobalAddresses.List(projectID).Do()
+	var allItems []*compute.Address
+	err := nlbHandler.Client.GlobalAddresses.List(projectID).Pages(nlbHandler.Ctx, func(resp *compute.AddressList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 	}
-	return resp, nil
+	return &compute.AddressList{Items: allItems}, nil
 }
 
 // Region ForwardingRule 등록
@@ -1644,7 +1652,11 @@ func (nlbHandler *GCPNLBHandler) listRegionForwardingRules(regionID string, filt
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.ForwardingRules.List(projectID, regionID).Do()
+	var allItems []*compute.ForwardingRule
+	err := nlbHandler.Client.ForwardingRules.List(projectID, regionID).Pages(nlbHandler.Ctx, func(resp *compute.ForwardingRuleList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		cblogger.Error(err)
 		return nil, err
@@ -1655,7 +1667,7 @@ func (nlbHandler *GCPNLBHandler) listRegionForwardingRules(regionID string, filt
 
 		responseForwardingRule := compute.ForwardingRuleList{}
 		forwardingRuleList := []*compute.ForwardingRule{}
-		for _, item := range resp.Items {
+		for _, item := range allItems {
 			forwardingRuleUrlArr := strings.Split(item.SelfLink, StringSeperator_Slash)
 
 			itemForwardingRule := forwardingRuleUrlArr[len(forwardingRuleUrlArr)-1]
@@ -1668,7 +1680,7 @@ func (nlbHandler *GCPNLBHandler) listRegionForwardingRules(regionID string, filt
 		responseForwardingRule.Items = forwardingRuleList
 		return &responseForwardingRule, nil
 	}
-	return resp, nil
+	return &compute.ForwardingRuleList{Items: allItems}, nil
 
 }
 
@@ -1724,15 +1736,19 @@ func (nlbHandler *GCPNLBHandler) listGlobalForwardingRules(filter string) (*comp
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.GlobalForwardingRules.List(projectID).Do()
+	var allItems []*compute.ForwardingRule
+	err := nlbHandler.Client.GlobalForwardingRules.List(projectID).Pages(nlbHandler.Ctx, func(resp *compute.ForwardingRuleList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 	}
 
-	return resp, nil
+	return &compute.ForwardingRuleList{Items: allItems}, nil
 }
 
 // Region BackendService 등록
@@ -1791,14 +1807,19 @@ func (nlbHandler *GCPNLBHandler) getRegionBackendServices(region string, regionB
 func (nlbHandler *GCPNLBHandler) listRegionBackendServices(region string, filter string) (*compute.BackendServiceList, error) {
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.RegionBackendServices.List(projectID, region).Do()
+	var allItems []*compute.BackendService
+	err := nlbHandler.Client.RegionBackendServices.List(projectID, region).Pages(nlbHandler.Ctx, func(resp *compute.BackendServiceList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
+	resp := &compute.BackendServiceList{Items: allItems}
 	//cblogger.Info(resp)
 	printToJson(resp)
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 		//if strings.EqualFold(item.Group,   // instance group or network endpoint group(NEG)
 	}
@@ -1864,19 +1885,23 @@ func (nlbHandler *GCPNLBHandler) getGlobalBackendServices(backendServiceName str
 func (nlbHandler *GCPNLBHandler) listGlobalBackendServices(filter string) (*compute.BackendServiceList, error) {
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.BackendServices.List(projectID).Do()
+	var allItems []*compute.BackendService
+	err := nlbHandler.Client.BackendServices.List(projectID).Pages(nlbHandler.Ctx, func(resp *compute.BackendServiceList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 		//if strings.EqualFold(item.Group,   // instance group or network endpoint group(NEG)
 	}
 	//// item.group // instance group or network endpoint group
 	//cblogger.Info(backServices)
 	//return backServices, nil
-	return resp, nil
+	return &compute.BackendServiceList{Items: allItems}, nil
 }
 
 // RegionalHealthCheck 등록 : 미사용
@@ -2050,16 +2075,20 @@ func (nlbHandler *GCPNLBHandler) listHttpHealthChecks(filter string) (*compute.H
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.HttpHealthChecks.List(projectID).Do()
+	var allItems []*compute.HttpHealthCheck
+	err := nlbHandler.Client.HttpHealthChecks.List(projectID).Pages(nlbHandler.Ctx, func(resp *compute.HttpHealthCheckList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	for _, item := range resp.Items {
+	for _, item := range allItems {
 		cblogger.Debug(item)
 	}
 
-	return resp, nil
+	return &compute.HttpHealthCheckList{Items: allItems}, nil
 }
 
 // TargetPool Insert
@@ -2115,17 +2144,22 @@ func (nlbHandler *GCPNLBHandler) listTargetPools(regionID string, filter string)
 	// path param
 	projectID := nlbHandler.Credential.ProjectID
 
-	resp, err := nlbHandler.Client.TargetPools.List(projectID, regionID).Do()
+	var allItems []*compute.TargetPool
+	err := nlbHandler.Client.TargetPools.List(projectID, regionID).Pages(nlbHandler.Ctx, func(resp *compute.TargetPoolList) error {
+		allItems = append(allItems, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		cblogger.Error("TargetPools.List ", err)
 		return &compute.TargetPoolList{}, err
 	}
-	printToJson(resp)
-	for _, item := range resp.Items {
+	result := &compute.TargetPoolList{Items: allItems}
+	printToJson(result)
+	for _, item := range allItems {
 		cblogger.Debug(item)
 	}
 
-	return resp, nil
+	return result, nil
 }
 
 // nlbHandler.Client.TargetPools.AggregatedList(projectID) : 해당 project의 모든 region 에 대해 region별  target pool 목록

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/RDBMSHandler.go
@@ -284,7 +284,17 @@ func (handler *GCPRDBMSHandler) ListIID() ([]*irs.IID, error) {
 	// In CB-Spider, the ProjectID is often stored in the credential
 	projectId = handler.getProjectId()
 
-	resp, err := handler.Client.Instances.List(projectId).Do()
+	var iidList []*irs.IID
+	err := handler.Client.Instances.List(projectId).Pages(context.Background(), func(resp *sqladmin.InstancesListResponse) error {
+		for _, instance := range resp.Items {
+			iid := &irs.IID{
+				NameId:   instance.Name,
+				SystemId: instance.Name,
+			}
+			iidList = append(iidList, iid)
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		cblogger.Error(err)
@@ -292,15 +302,6 @@ func (handler *GCPRDBMSHandler) ListIID() ([]*irs.IID, error) {
 		return nil, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
-
-	var iidList []*irs.IID
-	for _, instance := range resp.Items {
-		iid := &irs.IID{
-			NameId:   instance.Name,
-			SystemId: instance.Name,
-		}
-		iidList = append(iidList, iid)
-	}
 
 	return iidList, nil
 }
@@ -552,7 +553,14 @@ func (handler *GCPRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 	start := call.Start()
 
 	projectId := handler.getProjectId()
-	resp, err := handler.Client.Instances.List(projectId).Do()
+	var rdbmsList []*irs.RDBMSInfo
+	err := handler.Client.Instances.List(projectId).Pages(context.Background(), func(resp *sqladmin.InstancesListResponse) error {
+		for _, instance := range resp.Items {
+			rdbmsInfo := handler.convertToRDBMSInfo(instance)
+			rdbmsList = append(rdbmsList, &rdbmsInfo)
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 	if err != nil {
 		cblogger.Error(err)
@@ -560,12 +568,6 @@ func (handler *GCPRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 		return nil, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
-
-	var rdbmsList []*irs.RDBMSInfo
-	for _, instance := range resp.Items {
-		rdbmsInfo := handler.convertToRDBMSInfo(instance)
-		rdbmsList = append(rdbmsList, &rdbmsInfo)
-	}
 
 	return rdbmsList, nil
 }
@@ -880,18 +882,19 @@ func (handler *GCPRDBMSHandler) DeleteDatabase(rdbmsSystemId, dbEngine, dbName s
 // This is used to determine if a Service Networking Peering can be safely deleted (only when no instances remain).
 func (handler *GCPRDBMSHandler) listInstancesInVPC(vpcNetwork string) ([]*sqladmin.DatabaseInstance, error) {
 	projectId := handler.getProjectId()
-	resp, err := handler.Client.Instances.List(projectId).Do()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list Cloud SQL instances: %w", err)
-	}
-
 	var instances []*sqladmin.DatabaseInstance
-	for _, instance := range resp.Items {
-		if instance.Settings != nil && instance.Settings.IpConfiguration != nil {
-			if instance.Settings.IpConfiguration.PrivateNetwork == vpcNetwork {
-				instances = append(instances, instance)
+	err := handler.Client.Instances.List(projectId).Pages(context.Background(), func(resp *sqladmin.InstancesListResponse) error {
+		for _, instance := range resp.Items {
+			if instance.Settings != nil && instance.Settings.IpConfiguration != nil {
+				if instance.Settings.IpConfiguration.PrivateNetwork == vpcNetwork {
+					instances = append(instances, instance)
+				}
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Cloud SQL instances: %w", err)
 	}
 	return instances, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/SecurityHandler.go
@@ -1962,7 +1962,11 @@ func (securityHandler *GCPSecurityHandler) firewallList(tag string) ([]compute.F
 	}
 	callLogStart := call.Start()
 
-	result, err := securityHandler.Client.Firewalls.List(projectID).Do()
+	var allItems []*compute.Firewall
+	err := securityHandler.Client.Firewalls.List(projectID).Pages(securityHandler.Ctx, func(page *compute.FirewallList) error {
+		allItems = append(allItems, page.Items...)
+		return nil
+	})
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	if err != nil {
 		callLogInfo.ErrorMSG = err.Error()
@@ -1972,7 +1976,7 @@ func (securityHandler *GCPSecurityHandler) firewallList(tag string) ([]compute.F
 	}
 	callogger.Info(call.String(callLogInfo))
 
-	firewallList := extractFirewallList(*result, tag) // 그룹으로 묶기
+	firewallList := extractFirewallList(compute.FirewallList{Items: allItems}, tag) // 그룹으로 묶기
 	return firewallList, nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/TagHandler.go
@@ -83,11 +83,15 @@ func (t *GCPTagHandler) getCloudSQLInstance(resIID irs.IID) (*sqladmin.DatabaseI
 }
 
 func (t *GCPTagHandler) getRDBMSInstances() ([]*sqladmin.DatabaseInstance, error) {
-	resp, err := t.SQLAdminClient.Instances.List(t.Credential.ProjectID).Do()
+	var instances []*sqladmin.DatabaseInstance
+	err := t.SQLAdminClient.Instances.List(t.Credential.ProjectID).Pages(t.Ctx, func(resp *sqladmin.InstancesListResponse) error {
+		instances = append(instances, resp.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return resp.Items, nil
+	return instances, nil
 }
 
 func (t *GCPTagHandler) AddTag(resType irs.RSType, resIID irs.IID, tag irs.KeyValue) (irs.KeyValue, error) {
@@ -491,20 +495,28 @@ func (t *GCPTagHandler) RemoveTag(resType irs.RSType, resIID irs.IID, key string
 	}
 }
 func (t *GCPTagHandler) getVms() ([]*compute.Instance, error) {
-	vms, err := t.ComputeClient.Instances.List(t.Credential.ProjectID, t.Region.Zone).Do()
+	var vms []*compute.Instance
+	err := t.ComputeClient.Instances.List(t.Credential.ProjectID, t.Region.Zone).Pages(t.Ctx, func(page *compute.InstanceList) error {
+		vms = append(vms, page.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	return vms.Items, nil
+	return vms, nil
 }
 
 func (t *GCPTagHandler) getDisks() ([]*compute.Disk, error) {
-	disks, err := t.ComputeClient.Disks.List(t.Credential.ProjectID, t.Region.Zone).Do()
+	var disks []*compute.Disk
+	err := t.ComputeClient.Disks.List(t.Credential.ProjectID, t.Region.Zone).Pages(t.Ctx, func(page *compute.DiskList) error {
+		disks = append(disks, page.Items...)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	return disks.Items, nil
+	return disks, nil
 }
 
 func (t *GCPTagHandler) getClusters() ([]*container.Cluster, error) {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -906,28 +906,29 @@ func (vmHandler *GCPVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 	for _, zoneItem := range regionZoneInfo.ZoneList {
 		cblogger.Infof("Fetching VM instances in zone: %s", zoneItem.Name)
 
-		serverList, err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Do()
+		err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Pages(vmHandler.Ctx, func(serverList *compute.InstanceList) error {
+			for _, s := range serverList.Items {
+				if s.Name != "" {
+					vmId := s.Name
+					status, _ := vmHandler.GetVMStatus(irs.IID{NameId: vmId, SystemId: vmId})
+					vmStatusInfo := irs.VMStatusInfo{
+						IId: irs.IID{
+							NameId:   vmId,
+							SystemId: vmId,
+						},
+						VmStatus: status,
+					}
+					vmStatusList = append(vmStatusList, &vmStatusInfo)
+				}
+			}
+			return nil
+		})
 		callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 		if err != nil {
 			callLogInfo.ErrorMSG = err.Error()
 			callogger.Info(call.String(callLogInfo))
 			cblogger.Error(err)
 			continue // skip to next zone
-		}
-
-		for _, s := range serverList.Items {
-			if s.Name != "" {
-				vmId := s.Name
-				status, _ := vmHandler.GetVMStatus(irs.IID{NameId: vmId, SystemId: vmId})
-				vmStatusInfo := irs.VMStatusInfo{
-					IId: irs.IID{
-						NameId:   vmId,
-						SystemId: vmId,
-					},
-					VmStatus: status,
-				}
-				vmStatusList = append(vmStatusList, &vmStatusInfo)
-			}
 		}
 		callogger.Info(call.String(callLogInfo))
 	}
@@ -1043,16 +1044,17 @@ func (vmHandler *GCPVMHandler) ListVM() ([]*irs.VMInfo, error) {
 	for _, zoneItem := range regionZoneInfo.ZoneList {
 		cblogger.Infof("Fetching VM instances in zone: %s", zoneItem.Name)
 
-		serverList, err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Do()
+		err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Pages(vmHandler.Ctx, func(serverList *compute.InstanceList) error {
+			for _, server := range serverList.Items {
+				vmInfo := vmHandler.mappingServerInfo(server)
+				vmList = append(vmList, &vmInfo)
+			}
+			return nil
+		})
 		callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 		if err != nil {
 			cblogger.Errorf("Error fetching VM instances in zone %s: %v", zoneItem.Name, err)
 			continue // try next zone
-		}
-
-		for _, server := range serverList.Items {
-			vmInfo := vmHandler.mappingServerInfo(server)
-			vmList = append(vmList, &vmInfo)
 		}
 
 		callogger.Info(call.String(callLogInfo))
@@ -1530,20 +1532,21 @@ func (vmHandler *GCPVMHandler) ListIID() ([]*irs.IID, error) {
 	for _, zoneItem := range regionZoneInfo.ZoneList {
 		cblogger.Infof("Fetching VM instances in zone: %s", zoneItem.Name)
 
-		serverList, err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Do()
+		err := vmHandler.Client.Instances.List(projectID, zoneItem.Name).Pages(vmHandler.Ctx, func(serverList *compute.InstanceList) error {
+			for _, server := range serverList.Items {
+				iid := irs.IID{
+					NameId:   server.Name,
+					SystemId: server.Name,
+				}
+				iidList = append(iidList, &iid)
+			}
+			return nil
+		})
 		hiscallInfo.ElapsedTime = call.Elapsed(start)
 
 		if err != nil {
 			cblogger.Errorf("Error fetching VM instances in zone %s: %v", zoneItem.Name, err)
 			continue // try next zone
-		}
-
-		for _, server := range serverList.Items {
-			iid := irs.IID{
-				NameId:   server.Name,
-				SystemId: server.Name,
-			}
-			iidList = append(iidList, &iid)
 		}
 
 		calllogger.Info(call.String(hiscallInfo))

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VPCHandler.go
@@ -393,7 +393,43 @@ func (vVPCHandler *GCPVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 	}
 	callLogStart := call.Start()
 
-	vpcList, err := vVPCHandler.Client.Networks.List(projectID).Do()
+	var vpcInfo []*irs.VPCInfo
+
+	err := vVPCHandler.Client.Networks.List(projectID).Pages(vVPCHandler.Ctx, func(vpcList *compute.NetworkList) error {
+		for _, item := range vpcList.Items {
+			// Use Networks.List() result directly instead of calling GetVPC()
+			subnetInfoList := []irs.SubnetInfo{}
+
+			// Get subnet information if subnets exist
+			if item.Subnetworks != nil {
+				for _, subnetURL := range item.Subnetworks {
+					str := strings.Split(subnetURL, "/")
+					region := str[len(str)-3]
+					subnet := str[len(str)-1]
+					infoSubnet, err := vVPCHandler.Client.Subnetworks.Get(projectID, region, subnet).Do()
+					if err != nil {
+						cblogger.Error(err)
+						return err
+					}
+					subnetInfoList = append(subnetInfoList, mappingSubnet(infoSubnet))
+				}
+			}
+
+			networkInfo := irs.VPCInfo{
+				IId: irs.IID{
+					NameId:   item.Name,
+					SystemId: item.Name,
+				},
+				IPv4_CIDR:      "GCP VPC does not support IPv4_CIDR",
+				SubnetInfoList: subnetInfoList,
+			}
+			// Use StructToKeyValueList for VPC metadata
+			networkInfo.KeyValueList = irs.StructToKeyValueList(item)
+
+			vpcInfo = append(vpcInfo, &networkInfo)
+		}
+		return nil
+	})
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 
 	if err != nil {
@@ -401,44 +437,9 @@ func (vVPCHandler *GCPVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 
 		callogger.Info(call.String(callLogInfo))
 
-		return nil, err
+		return vpcInfo, err
 	}
 	callogger.Info(call.String(callLogInfo))
-
-	var vpcInfo []*irs.VPCInfo
-
-	for _, item := range vpcList.Items {
-		// Use Networks.List() result directly instead of calling GetVPC()
-		subnetInfoList := []irs.SubnetInfo{}
-
-		// Get subnet information if subnets exist
-		if item.Subnetworks != nil {
-			for _, subnetURL := range item.Subnetworks {
-				str := strings.Split(subnetURL, "/")
-				region := str[len(str)-3]
-				subnet := str[len(str)-1]
-				infoSubnet, err := vVPCHandler.Client.Subnetworks.Get(projectID, region, subnet).Do()
-				if err != nil {
-					cblogger.Error(err)
-					return vpcInfo, err
-				}
-				subnetInfoList = append(subnetInfoList, mappingSubnet(infoSubnet))
-			}
-		}
-
-		networkInfo := irs.VPCInfo{
-			IId: irs.IID{
-				NameId:   item.Name,
-				SystemId: item.Name,
-			},
-			IPv4_CIDR:      "GCP VPC does not support IPv4_CIDR",
-			SubnetInfoList: subnetInfoList,
-		}
-		// Use StructToKeyValueList for VPC metadata
-		networkInfo.KeyValueList = irs.StructToKeyValueList(item)
-
-		vpcInfo = append(vpcInfo, &networkInfo)
-	}
 
 	return vpcInfo, nil
 }
@@ -767,7 +768,19 @@ func (vpcHandler *GCPVPCHandler) ListIID() ([]*irs.IID, error) {
 
 	projectID := vpcHandler.Credential.ProjectID
 
-	vpcList, err := vpcHandler.Client.Networks.List(projectID).Do()
+	var iidList []*irs.IID
+
+	err := vpcHandler.Client.Networks.List(projectID).Pages(vpcHandler.Ctx, func(vpcList *compute.NetworkList) error {
+		for _, item := range vpcList.Items {
+			iid := irs.IID{
+				NameId:   item.Name,
+				SystemId: item.Name,
+			}
+
+			iidList = append(iidList, &iid)
+		}
+		return nil
+	})
 	hiscallInfo.ElapsedTime = call.Elapsed(start)
 
 	if err != nil {
@@ -776,17 +789,6 @@ func (vpcHandler *GCPVPCHandler) ListIID() ([]*irs.IID, error) {
 		return nil, err
 	}
 	calllogger.Info(call.String(hiscallInfo))
-
-	var iidList []*irs.IID
-
-	for _, item := range vpcList.Items {
-		iid := irs.IID{
-			NameId:   item.Name,
-			SystemId: item.Name,
-		}
-
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -614,6 +615,98 @@ func (ic *IbmClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {
 	return true, nil
 }
 
+// getEndpointGatewayNextHref extracts the "start" cursor from an endpoint gateway list page's Next link.
+func getEndpointGatewayNextHref(next *vpcv1.PageLink) (string, error) {
+	if next != nil {
+		href := *next.Href
+		u, err := url.Parse(href)
+		if err != nil {
+			return "", err
+		}
+		paramMap, _ := url.ParseQuery(u.RawQuery)
+		if paramMap != nil {
+			safe := paramMap["start"]
+			if safe != nil && len(safe) > 0 {
+				return safe[0], nil
+			}
+		}
+	}
+	return "", errors.New("NOT NEXT")
+}
+
+// getAllEndpointGateways fetches every endpoint gateway in the resource group, following pagination.
+func getAllEndpointGateways(vpcService *vpcv1.VpcV1, resourceGroupId string) ([]vpcv1.EndpointGateway, error) {
+	options := &vpcv1.ListEndpointGatewaysOptions{
+		ResourceGroupID: core.StringPtr(resourceGroupId),
+	}
+	result, _, err := vpcService.ListEndpointGateways(options)
+	if err != nil {
+		return nil, err
+	}
+
+	var allGateways []vpcv1.EndpointGateway
+	for {
+		allGateways = append(allGateways, result.EndpointGateways...)
+		nextstr, _ := getEndpointGatewayNextHref(result.Next)
+		if nextstr == "" {
+			break
+		}
+		options := &vpcv1.ListEndpointGatewaysOptions{
+			ResourceGroupID: core.StringPtr(resourceGroupId),
+			Start:           core.StringPtr(nextstr),
+		}
+		result, _, err = vpcService.ListEndpointGateways(options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list endpoint gateways during pagination: %w", err)
+		}
+	}
+	return allGateways, nil
+}
+
+// getPublicGatewayNextHref extracts the "start" cursor from a public gateway list page's Next link.
+func getPublicGatewayNextHref(next *vpcv1.PageLink) (string, error) {
+	if next != nil {
+		href := *next.Href
+		u, err := url.Parse(href)
+		if err != nil {
+			return "", err
+		}
+		paramMap, _ := url.ParseQuery(u.RawQuery)
+		if paramMap != nil {
+			safe := paramMap["start"]
+			if safe != nil && len(safe) > 0 {
+				return safe[0], nil
+			}
+		}
+	}
+	return "", errors.New("NOT NEXT")
+}
+
+// getAllPublicGateways fetches every public gateway in the account, following pagination.
+func getAllPublicGateways(vpcService *vpcv1.VpcV1, ctx context.Context) ([]vpcv1.PublicGateway, error) {
+	options := vpcService.NewListPublicGatewaysOptions()
+	result, _, err := vpcService.ListPublicGatewaysWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var allGateways []vpcv1.PublicGateway
+	for {
+		allGateways = append(allGateways, result.PublicGateways...)
+		nextstr, _ := getPublicGatewayNextHref(result.Next)
+		if nextstr == "" {
+			break
+		}
+		options := vpcService.NewListPublicGatewaysOptions()
+		options.SetStart(nextstr)
+		result, _, err = vpcService.ListPublicGatewaysWithContext(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list public gateways during pagination: %w", err)
+		}
+	}
+	return allGateways, nil
+}
+
 func (ic *IbmClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqInfo irs.NodeGroupInfo) (irs.NodeGroupInfo, error) {
 	hiscallInfo := GetCallLogScheme(ic.Region, call.CLUSTER, clusterIID.NameId, "AddNodeGroup()")
 	start := call.Start()
@@ -646,9 +739,7 @@ func (ic *IbmClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqInfo i
 	}
 
 	// Get Network.Subnet Info
-	rawVpeList, _, getRawVpeListErr := ic.VpcService.ListEndpointGateways(&vpcv1.ListEndpointGatewaysOptions{
-		ResourceGroupID: core.StringPtr(resourceGroupId),
-	})
+	endpointGateways, getRawVpeListErr := getAllEndpointGateways(ic.VpcService, resourceGroupId)
 	if getRawVpeListErr != nil {
 		cblogger.Error(getRawVpeListErr)
 		LoggingError(hiscallInfo, getRawVpeListErr)
@@ -656,7 +747,7 @@ func (ic *IbmClusterHandler) AddNodeGroup(clusterIID irs.IID, nodeGroupReqInfo i
 	}
 
 	var target vpcv1.EndpointGateway
-	for _, rawVpe := range rawVpeList.EndpointGateways {
+	for _, rawVpe := range endpointGateways {
 		if *rawVpe.Name == fmt.Sprintf("iks-%s", irsCluster.IId.SystemId) {
 			target = rawVpe
 		}
@@ -1800,15 +1891,13 @@ func (ic *IbmClusterHandler) setClusterInfo(rawCluster kubernetesserviceapiv1.Ge
 	}
 
 	// Get Network.Subnet Info
-	rawVpeList, _, getRawVpeListErr := ic.VpcService.ListEndpointGateways(&vpcv1.ListEndpointGatewaysOptions{
-		ResourceGroupID: core.StringPtr(resourceGroupId),
-	})
+	endpointGateways, getRawVpeListErr := getAllEndpointGateways(ic.VpcService, resourceGroupId)
 	if getRawVpeListErr != nil {
 		return irs.ClusterInfo{}, getRawVpeListErr
 	}
 
 	var target vpcv1.EndpointGateway
-	for _, rawVpe := range rawVpeList.EndpointGateways {
+	for _, rawVpe := range endpointGateways {
 		if *rawVpe.Name == fmt.Sprintf("iks-%s", rawCluster.Id) {
 			target = rawVpe
 		}
@@ -2277,15 +2366,14 @@ func (ic *IbmClusterHandler) ensureSubnetPublicGateway(subnetId, vpcId string) e
 
 	// Check for existing public gateway in the same zone
 	var publicGatewayId string
-	listPublicGatewaysOptions := ic.VpcService.NewListPublicGatewaysOptions()
-	publicGateways, _, listErr := ic.VpcService.ListPublicGatewaysWithContext(ic.Ctx, listPublicGatewaysOptions)
+	publicGateways, listErr := getAllPublicGateways(ic.VpcService, ic.Ctx)
 	if listErr != nil {
 		cblogger.Errorf("Failed to list public gateways: %v", listErr)
 		return fmt.Errorf("failed to list public gateways: %w", listErr)
 	}
 
 	// Look for an existing public gateway in the same zone and VPC
-	for _, gw := range publicGateways.PublicGateways {
+	for _, gw := range publicGateways {
 		if gw.Zone != nil && gw.Zone.Name != nil && subnet.Zone != nil && subnet.Zone.Name != nil &&
 			*gw.Zone.Name == *subnet.Zone.Name &&
 			gw.VPC != nil && gw.VPC.ID != nil && *gw.VPC.ID == vpcId {

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/FileSystemHandler.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
-	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
+	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
@@ -81,18 +83,84 @@ func (filesystemHandler *IbmFileSystemHandler) GetMetaInfo() (irs.FileSystemMeta
 	return metaInfo, nil
 }
 
+// getShareNextHref extracts the "start" cursor from a share list page's Next link.
+func getShareNextHref(next *vpcv1.PageLink) (string, error) {
+	if next != nil {
+		href := *next.Href
+		u, err := url.Parse(href)
+		if err != nil {
+			return "", err
+		}
+		paramMap, _ := url.ParseQuery(u.RawQuery)
+		if paramMap != nil {
+			safe := paramMap["start"]
+			if safe != nil && len(safe) > 0 {
+				return safe[0], nil
+			}
+		}
+	}
+	return "", errors.New("NOT NEXT")
+}
+
+// getAllShares fetches every file share in the account, following pagination.
+func getAllShares(vpcService *vpcv1.VpcV1, ctx context.Context) ([]vpcv1.Share, error) {
+	options := &vpcv1.ListSharesOptions{}
+	result, _, err := vpcService.ListSharesWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var allShares []vpcv1.Share
+	for {
+		allShares = append(allShares, result.Shares...)
+		nextstr, _ := getShareNextHref(result.Next)
+		if nextstr == "" {
+			break
+		}
+		options := &vpcv1.ListSharesOptions{Start: core.StringPtr(nextstr)}
+		result, _, err = vpcService.ListSharesWithContext(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list shares during pagination: %w", err)
+		}
+	}
+	return allShares, nil
+}
+
+// getAllSubnets fetches every subnet in the account, following pagination.
+func getAllSubnets(vpcService *vpcv1.VpcV1, ctx context.Context) ([]vpcv1.Subnet, error) {
+	options := &vpcv1.ListSubnetsOptions{}
+	result, _, err := vpcService.ListSubnetsWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var allSubnets []vpcv1.Subnet
+	for {
+		allSubnets = append(allSubnets, result.Subnets...)
+		nextstr, _ := getSubnetNextHref(result.Next)
+		if nextstr == "" {
+			break
+		}
+		options := &vpcv1.ListSubnetsOptions{Start: core.StringPtr(nextstr)}
+		result, _, err = vpcService.ListSubnetsWithContext(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list subnets during pagination: %w", err)
+		}
+	}
+	return allSubnets, nil
+}
+
 func (filesystemHandler *IbmFileSystemHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := GetCallLogScheme(filesystemHandler.Region, call.FILESYSTEM, "FILESYSTEM", "ListIID()")
 	start := call.Start()
 
-	options := &vpcv1.ListSharesOptions{}
-	res, _, err := filesystemHandler.VpcService.ListSharesWithContext(filesystemHandler.Ctx, options)
+	shares, err := getAllShares(filesystemHandler.VpcService, filesystemHandler.Ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var iidList []*irs.IID
-	for _, share := range res.Shares {
+	for _, share := range shares {
 		if share.Zone != nil && share.Zone.Name != nil && *share.Zone.Name == filesystemHandler.Region.Zone {
 			iid := &irs.IID{
 				NameId:   *share.Name,
@@ -107,11 +175,11 @@ func (filesystemHandler *IbmFileSystemHandler) ListIID() ([]*irs.IID, error) {
 }
 
 func (filesystemHandler *IbmFileSystemHandler) findSubnetIDByName(name string) (string, error) {
-	subnets, _, err := filesystemHandler.VpcService.ListSubnetsWithContext(filesystemHandler.Ctx, &vpcv1.ListSubnetsOptions{})
+	subnets, err := getAllSubnets(filesystemHandler.VpcService, filesystemHandler.Ctx)
 	if err != nil {
 		return "", err
 	}
-	for _, subnet := range subnets.Subnets {
+	for _, subnet := range subnets {
 		if subnet.Name != nil && *subnet.Name == name {
 			return *subnet.ID, nil
 		}
@@ -120,13 +188,13 @@ func (filesystemHandler *IbmFileSystemHandler) findSubnetIDByName(name string) (
 }
 
 func (filesystemHandler *IbmFileSystemHandler) findSubnetsByVPC(vpcIID irs.IID) ([]irs.IID, error) {
-	subnets, _, err := filesystemHandler.VpcService.ListSubnetsWithContext(filesystemHandler.Ctx, &vpcv1.ListSubnetsOptions{})
+	subnets, err := getAllSubnets(filesystemHandler.VpcService, filesystemHandler.Ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var subnetList []irs.IID
-	for _, subnet := range subnets.Subnets {
+	for _, subnet := range subnets {
 		if subnet.VPC != nil {
 			vpcMatch := false
 			if vpcIID.SystemId != "" && subnet.VPC.ID != nil && *subnet.VPC.ID == vpcIID.SystemId {
@@ -205,12 +273,12 @@ func (filesystemHandler *IbmFileSystemHandler) getSubnetCIDR(subnetID string) (s
 }
 
 func (filesystemHandler *IbmFileSystemHandler) findSubnetByCIDR(cidr string) (*irs.IID, error) {
-	subnets, _, err := filesystemHandler.VpcService.ListSubnetsWithContext(filesystemHandler.Ctx, &vpcv1.ListSubnetsOptions{})
+	subnets, err := getAllSubnets(filesystemHandler.VpcService, filesystemHandler.Ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, subnet := range subnets.Subnets {
+	for _, subnet := range subnets {
 		if subnet.Ipv4CIDRBlock != nil && *subnet.Ipv4CIDRBlock == cidr {
 			subnetIID := &irs.IID{}
 			if subnet.Name != nil {
@@ -460,14 +528,13 @@ func (filesystemHandler *IbmFileSystemHandler) ListFileSystem() ([]*irs.FileSyst
 	hiscallInfo := GetCallLogScheme(filesystemHandler.Region, call.FILESYSTEM, filesystemHandler.Region.Region, "ListFileSystem()")
 	start := call.Start()
 
-	options := &vpcv1.ListSharesOptions{}
-	res, _, err := filesystemHandler.VpcService.ListSharesWithContext(filesystemHandler.Ctx, options)
+	shares, err := getAllShares(filesystemHandler.VpcService, filesystemHandler.Ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var list []*irs.FileSystemInfo
-	for _, share := range res.Shares {
+	for _, share := range shares {
 		if share.Zone != nil && share.Zone.Name != nil && *share.Zone.Name == filesystemHandler.Region.Zone {
 			info, err := filesystemHandler.setterFileSystemInfo(&share)
 			if err != nil {
@@ -490,13 +557,13 @@ func (filesystemHandler *IbmFileSystemHandler) GetFileSystem(iid irs.IID) (irs.F
 	if iid.SystemId != "" {
 		shareID = iid.SystemId
 	} else if iid.NameId != "" {
-		shares, _, err := filesystemHandler.VpcService.ListSharesWithContext(filesystemHandler.Ctx, &vpcv1.ListSharesOptions{})
+		shares, err := getAllShares(filesystemHandler.VpcService, filesystemHandler.Ctx)
 		if err != nil {
 			LoggingError(hiscallInfo, err)
 			return irs.FileSystemInfo{}, fmt.Errorf("failed to list shares: %v", err)
 		}
 
-		for _, share := range shares.Shares {
+		for _, share := range shares {
 			if *share.Name == iid.NameId {
 				shareID = *share.ID
 				break
@@ -632,12 +699,12 @@ func (filesystemHandler *IbmFileSystemHandler) setterFileSystemInfo(share *vpcv1
 func (filesystemHandler *IbmFileSystemHandler) DeleteFileSystem(iid irs.IID) (bool, error) {
 	shareID := iid.SystemId
 	if shareID == "" && iid.NameId != "" {
-		shares, _, err := filesystemHandler.VpcService.ListSharesWithContext(filesystemHandler.Ctx, &vpcv1.ListSharesOptions{})
+		shares, err := getAllShares(filesystemHandler.VpcService, filesystemHandler.Ctx)
 		if err != nil {
 			return false, fmt.Errorf("failed to list shares: %v", err)
 		}
 
-		for _, share := range shares.Shares {
+		for _, share := range shares {
 			if *share.Name == iid.NameId {
 				shareID = *share.ID
 				break

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/MyImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/MyImageHandler.go
@@ -4,15 +4,61 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/globalsearchv2"
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	"strings"
-	"time"
 )
+
+// getSnapshotNextHref extracts the "start" cursor from a snapshot list page's Next link.
+func getSnapshotNextHref(next *vpcv1.PageLink) (string, error) {
+	if next != nil {
+		href := *next.Href
+		u, err := url.Parse(href)
+		if err != nil {
+			return "", err
+		}
+		paramMap, _ := url.ParseQuery(u.RawQuery)
+		if paramMap != nil {
+			safe := paramMap["start"]
+			if safe != nil && len(safe) > 0 {
+				return safe[0], nil
+			}
+		}
+	}
+	return "", errors.New("NOT NEXT")
+}
+
+// getAllSnapshots fetches every snapshot in the account, following pagination.
+func getAllSnapshots(vpcService *vpcv1.VpcV1, ctx context.Context) ([]vpcv1.Snapshot, error) {
+	options := &vpcv1.ListSnapshotsOptions{}
+	result, _, err := vpcService.ListSnapshotsWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	var allSnapshots []vpcv1.Snapshot
+	for {
+		allSnapshots = append(allSnapshots, result.Snapshots...)
+		nextstr, _ := getSnapshotNextHref(result.Next)
+		if nextstr == "" {
+			break
+		}
+		options := &vpcv1.ListSnapshotsOptions{Start: core.StringPtr(nextstr)}
+		result, _, err = vpcService.ListSnapshotsWithContext(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list snapshots during pagination: %w", err)
+		}
+	}
+	return allSnapshots, nil
+}
 
 type IbmMyImageHandler struct {
 	CredentialInfo idrv.CredentialInfo
@@ -115,7 +161,7 @@ func (myImageHandler *IbmMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, erro
 	hiscallInfo := GetCallLogScheme(myImageHandler.Region, call.MYIMAGE, "MYIMAGE", "ListMyImage()")
 
 	start := call.Start()
-	snapshotList, _, listSnapshotErr := myImageHandler.VpcService.ListSnapshotsWithContext(myImageHandler.Ctx, &vpcv1.ListSnapshotsOptions{})
+	snapshots, listSnapshotErr := getAllSnapshots(myImageHandler.VpcService, myImageHandler.Ctx)
 	if listSnapshotErr != nil {
 		createErr := errors.New(fmt.Sprintf("Failed to List MyImage. err = %s", listSnapshotErr.Error()))
 		cblogger.Error(createErr.Error())
@@ -124,7 +170,7 @@ func (myImageHandler *IbmMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, erro
 	}
 
 	groupByImageResult := make(map[string][]vpcv1.Snapshot)
-	for _, snapshot := range snapshotList.Snapshots {
+	for _, snapshot := range snapshots {
 		if strings.Contains(*snapshot.Name, DEV) {
 			groupByKey := strings.Split(*snapshot.Name, DEV)[0]
 			groupByImageResult[groupByKey] = append(groupByImageResult[groupByKey], snapshot)
@@ -164,14 +210,14 @@ func (myImageHandler *IbmMyImageHandler) ListMyImage() ([]*irs.MyImageInfo, erro
 }
 
 func (myImageHandler *IbmMyImageHandler) GetRawMyImage(myImageIID irs.IID) (*vpcv1.Snapshot, error) {
-	snapshotList, _, err := myImageHandler.VpcService.ListSnapshotsWithContext(myImageHandler.Ctx, &vpcv1.ListSnapshotsOptions{})
+	snapshots, err := getAllSnapshots(myImageHandler.VpcService, myImageHandler.Ctx)
 	if err != nil {
 		err = errors.New(fmt.Sprintf("Failed to List MyImage. err = %s", err.Error()))
 		return nil, err
 	}
 
 	groupByImageResult := make(map[string][]vpcv1.Snapshot)
-	for _, snapshot := range snapshotList.Snapshots {
+	for _, snapshot := range snapshots {
 		if strings.Contains(*snapshot.Name, DEV) {
 			groupByKey := strings.Split(*snapshot.Name, DEV)[0]
 			groupByImageResult[groupByKey] = append(groupByImageResult[groupByKey], snapshot)
@@ -340,7 +386,7 @@ func (myImageHandler *IbmMyImageHandler) getMyImageIID(snapshotList []vpcv1.Snap
 }
 
 func (myImageHandler *IbmMyImageHandler) cleanSnapshotByMyImage(myImageIID irs.IID) error {
-	snapshotList, _, listSnapshotErr := myImageHandler.VpcService.ListSnapshotsWithContext(myImageHandler.Ctx, &vpcv1.ListSnapshotsOptions{})
+	snapshots, listSnapshotErr := getAllSnapshots(myImageHandler.VpcService, myImageHandler.Ctx)
 	if listSnapshotErr != nil {
 		return listSnapshotErr
 	}
@@ -349,7 +395,7 @@ func (myImageHandler *IbmMyImageHandler) cleanSnapshotByMyImage(myImageIID irs.I
 	if myImageIID.NameId != "" {
 		myImageNameId = myImageIID.NameId
 	} else {
-		for _, snapshot := range snapshotList.Snapshots {
+		for _, snapshot := range snapshots {
 			if *snapshot.ID == myImageIID.SystemId {
 				myImageNameId = strings.Split(*snapshot.Name, DEV)[0]
 			}
@@ -357,7 +403,7 @@ func (myImageHandler *IbmMyImageHandler) cleanSnapshotByMyImage(myImageIID irs.I
 	}
 
 	if myImageNameId != "" {
-		for _, snapshot := range snapshotList.Snapshots {
+		for _, snapshot := range snapshots {
 			parsed := strings.Split(*snapshot.Name, DEV)[0]
 			if parsed == myImageNameId {
 				deleteSnapshotOptions := vpcv1.DeleteSnapshotOptions{
@@ -416,7 +462,7 @@ func (myImageHandler *IbmMyImageHandler) ListIID() ([]*irs.IID, error) {
 	hiscallInfo := GetCallLogScheme(myImageHandler.Region, call.MYIMAGE, "MYIMAGE", "ListIID()")
 
 	start := call.Start()
-	snapshotList, _, err := myImageHandler.VpcService.ListSnapshotsWithContext(myImageHandler.Ctx, &vpcv1.ListSnapshotsOptions{})
+	snapshots, err := getAllSnapshots(myImageHandler.VpcService, myImageHandler.Ctx)
 	if err != nil {
 		err = errors.New(fmt.Sprintf("Failed to List MyImage. err = %s", err.Error()))
 		cblogger.Error(err.Error())
@@ -425,7 +471,7 @@ func (myImageHandler *IbmMyImageHandler) ListIID() ([]*irs.IID, error) {
 	}
 
 	groupByImageResult := make(map[string][]vpcv1.Snapshot)
-	for _, snapshot := range snapshotList.Snapshots {
+	for _, snapshot := range snapshots {
 		if strings.Contains(*snapshot.Name, DEV) {
 			groupByKey := strings.Split(*snapshot.Name, DEV)[0]
 			groupByImageResult[groupByKey] = append(groupByImageResult[groupByKey], snapshot)

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/NICHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/NICHandler.go
@@ -209,22 +209,13 @@ func (h *IbmNICHandler) CreateNIC(nicReqInfo irs.NICReqInfo) (irs.NICInfo, error
 	// Resolve subnet SystemId if not provided
 	subnetID := nicReqInfo.SubnetIID.SystemId
 	if subnetID == "" {
-		subnets, _, err := h.VpcService.ListSubnetsWithContext(h.Ctx, &vpcv1.ListSubnetsOptions{})
+		subnet, err := getRawSubnet(irs.IID{NameId: nicReqInfo.SubnetIID.NameId}, h.VpcService, h.Ctx)
 		if err != nil {
-			LoggingError(hiscallInfo, err)
-			return irs.NICInfo{}, fmt.Errorf("failed to list subnets: %w", err)
-		}
-		for _, sn := range subnets.Subnets {
-			if sn.Name != nil && *sn.Name == nicReqInfo.SubnetIID.NameId {
-				subnetID = *sn.ID
-				break
-			}
-		}
-		if subnetID == "" {
 			err := fmt.Errorf("subnet not found: %s", nicReqInfo.SubnetIID.NameId)
 			LoggingError(hiscallInfo, err)
 			return irs.NICInfo{}, err
 		}
+		subnetID = *subnet.ID
 	}
 
 	createOpts := &vpcv1.CreateVirtualNetworkInterfaceOptions{
@@ -243,22 +234,13 @@ func (h *IbmNICHandler) CreateNIC(nicReqInfo irs.NICReqInfo) (irs.NICInfo, error
 			sgID := sgIID.SystemId
 			if sgID == "" {
 				// lookup by name
-				sgs, _, err := h.VpcService.ListSecurityGroupsWithContext(h.Ctx, &vpcv1.ListSecurityGroupsOptions{})
+				sg, err := getRawSecurityGroup(irs.IID{NameId: sgIID.NameId}, h.VpcService, h.Ctx)
 				if err != nil {
-					LoggingError(hiscallInfo, err)
-					return irs.NICInfo{}, fmt.Errorf("failed to list security groups: %w", err)
-				}
-				for _, sg := range sgs.SecurityGroups {
-					if sg.Name != nil && *sg.Name == sgIID.NameId {
-						sgID = *sg.ID
-						break
-					}
-				}
-				if sgID == "" {
 					err := fmt.Errorf("security group not found: %s", sgIID.NameId)
 					LoggingError(hiscallInfo, err)
 					return irs.NICInfo{}, err
 				}
+				sgID = *sg.ID
 			}
 			sgIdentities = append(sgIdentities, &vpcv1.SecurityGroupIdentityByID{ID: core.StringPtr(sgID)})
 		}

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/NLBHandler.go
@@ -1210,17 +1210,18 @@ func (nlbHandler *IbmNLBHandler) getMatchedResourceIds(vmIIDs *[]irs.IID, vpcIID
 		}
 
 		// Get VPC subnets
-		listSubnetOptions := &vpcv1.ListSubnetsOptions{}
-		subnets, _, err := nlbHandler.VpcService.ListSubnetsWithContext(nlbHandler.Ctx, listSubnetOptions)
+		vpc, err := GetRawVPC(vpcIID, nlbHandler.VpcService, nlbHandler.Ctx)
+		if err != nil {
+			return []irs.IID{}, "", errors.New(fmt.Sprintf("Failed to get VPC: %s", err.Error()))
+		}
+		subnets, err := getVPCRawSubnets(vpc, nlbHandler.VpcService, nlbHandler.Ctx)
 		if err != nil {
 			return []irs.IID{}, "", errors.New(fmt.Sprintf("Failed to get VPC subnets: %s", err.Error()))
 		}
 
 		// Find first subnet in the specified VPC
-		for _, subnet := range subnets.Subnets {
-			if subnet.VPC != nil && *subnet.VPC.ID == vpcIID.SystemId {
-				return []irs.IID{}, *subnet.ID, nil
-			}
+		if len(subnets) > 0 {
+			return []irs.IID{}, *subnets[0].ID, nil
 		}
 
 		return []irs.IID{}, "", errors.New(fmt.Sprintf("No subnets found in VPC %s. Please create at least one subnet in the VPC before creating NLB", vpcIID.NameId))

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/RDBMSHandler.go
@@ -809,13 +809,25 @@ func (handler *IbmRDBMSHandler) listResourceInstances(serviceID string) ([]resou
 		ResourceID: &serviceID,
 	}
 
-	result, _, err := handler.ResourceController.ListResourceInstances(listOpts)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		result, _, err := handler.ResourceController.ListResourceInstances(listOpts)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			break
+		}
 
-	if result != nil && result.Resources != nil {
 		allInstances = append(allInstances, result.Resources...)
+
+		if result.NextURL == nil || *result.NextURL == "" {
+			break
+		}
+		next, err := core.GetQueryParam(result.NextURL, "start")
+		if err != nil || next == nil || *next == "" {
+			break
+		}
+		listOpts.Start = next
 	}
 
 	return allInstances, nil

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/TagHandler.go
@@ -611,109 +611,119 @@ func (tagHandler *IbmTagHandler) FindTag(resType irs.RSType, keyword string) ([]
 
 	var tagInfo []*irs.TagInfo
 
-	scanResult, _, err := tagHandler.SearchService.Search(searchOptions)
-	if err != nil {
-		getErr := fmt.Errorf("Failed to list tag. err = %s", err)
-		cblogger.Error(getErr.Error())
-		LoggingError(hiscallInfo, getErr)
-		return tagInfo, err
-	}
-
-	if len(scanResult.Items) == 0 {
-		return []*irs.TagInfo{}, errors.New("resource not found")
-	}
-
-	searchOptions.SearchCursor = scanResult.SearchCursor
-
-	for _, item := range scanResult.Items {
-		var tagFound bool
-
-		tags, ok := item.GetProperty("tags").([]interface{})
-		if !ok {
-			cblogger.Error("Tags are not in expected format")
-			continue
+	firstPage := true
+	for {
+		scanResult, _, err := tagHandler.SearchService.Search(searchOptions)
+		if err != nil {
+			getErr := fmt.Errorf("Failed to list tag. err = %s", err)
+			cblogger.Error(getErr.Error())
+			LoggingError(hiscallInfo, getErr)
+			return tagInfo, err
 		}
-		for _, tag := range tags {
-			tagStr, ok := tag.(string)
+
+		if len(scanResult.Items) == 0 {
+			if firstPage {
+				return []*irs.TagInfo{}, errors.New("resource not found")
+			}
+			break
+		}
+		firstPage = false
+
+		for _, item := range scanResult.Items {
+			var tagFound bool
+
+			tags, ok := item.GetProperty("tags").([]interface{})
 			if !ok {
-				cblogger.Errorf("Tag is not a string (%v)", tag)
+				cblogger.Error("Tags are not in expected format")
 				continue
 			}
-			if strings.Contains(tagStr, keyword) {
-				tagFound = true
-				break
-			}
-		}
-
-		if tagFound {
-			var tagKeyValue []irs.KeyValue
 			for _, tag := range tags {
 				tagStr, ok := tag.(string)
 				if !ok {
 					cblogger.Errorf("Tag is not a string (%v)", tag)
 					continue
 				}
-				parts := strings.SplitN(tagStr, ":", 2)
-				if parts[0] == ibmMasterUserTagKey {
+				if strings.Contains(tagStr, keyword) {
+					tagFound = true
+					break
+				}
+			}
+
+			if tagFound {
+				var tagKeyValue []irs.KeyValue
+				for _, tag := range tags {
+					tagStr, ok := tag.(string)
+					if !ok {
+						cblogger.Errorf("Tag is not a string (%v)", tag)
+						continue
+					}
+					parts := strings.SplitN(tagStr, ":", 2)
+					if parts[0] == ibmMasterUserTagKey {
+						continue
+					}
+					value := ""
+					if len(parts) > 1 {
+						value = parts[1]
+					}
+					tagKeyValue = append(tagKeyValue, irs.KeyValue{
+						Key:   parts[0],
+						Value: value,
+					})
+				}
+
+				rType, ok := item.GetProperty("type").(string)
+				if !ok {
+					cblogger.Error("type is not a string")
 					continue
 				}
-				value := ""
-				if len(parts) > 1 {
-					value = parts[1]
-				}
-				tagKeyValue = append(tagKeyValue, irs.KeyValue{
-					Key:   parts[0],
-					Value: value,
-				})
-			}
-
-			rType, ok := item.GetProperty("type").(string)
-			if !ok {
-				cblogger.Error("type is not a string")
-				continue
-			}
-			rsType, err := ibmTypeToRSType(rType)
-			if err != nil {
-				cblogger.Error(err)
-				continue
-			}
-
-			name, ok := item.GetProperty("name").(string)
-			if !ok {
-				cblogger.Error("name is not a string")
-				continue
-			}
-			resourceId, ok := item.GetProperty("resource_id").(string)
-			if !ok {
-				cblogger.Error("resource_id is not a string")
-				continue
-			}
-
-			if rsType == irs.CLUSTER {
-				clusterHandler := &IbmClusterHandler{
-					CredentialInfo: tagHandler.CredentialInfo,
-					Region:         tagHandler.Region,
-					Ctx:            tagHandler.Ctx,
-					VpcService:     tagHandler.VpcService,
-					ClusterService: tagHandler.ClusterService,
-					TaggingService: tagHandler.TaggingService,
-					SearchService:  tagHandler.SearchService,
-				}
-				rawCluster, err := clusterHandler.getRawCluster(irs.IID{NameId: name})
+				rsType, err := ibmTypeToRSType(rType)
 				if err != nil {
 					cblogger.Error(err)
 					continue
 				}
-				resourceId = rawCluster.Id
-			}
 
-			tagInfo = append(tagInfo, &irs.TagInfo{
-				ResType:      rsType,
-				ResIId:       irs.IID{NameId: name, SystemId: resourceId},
-				TagList:      tagKeyValue,
-				KeyValueList: []irs.KeyValue{}, // reserved for optional usage
-			})
+				name, ok := item.GetProperty("name").(string)
+				if !ok {
+					cblogger.Error("name is not a string")
+					continue
+				}
+				resourceId, ok := item.GetProperty("resource_id").(string)
+				if !ok {
+					cblogger.Error("resource_id is not a string")
+					continue
+				}
+
+				if rsType == irs.CLUSTER {
+					clusterHandler := &IbmClusterHandler{
+						CredentialInfo: tagHandler.CredentialInfo,
+						Region:         tagHandler.Region,
+						Ctx:            tagHandler.Ctx,
+						VpcService:     tagHandler.VpcService,
+						ClusterService: tagHandler.ClusterService,
+						TaggingService: tagHandler.TaggingService,
+						SearchService:  tagHandler.SearchService,
+					}
+					rawCluster, err := clusterHandler.getRawCluster(irs.IID{NameId: name})
+					if err != nil {
+						cblogger.Error(err)
+						continue
+					}
+					resourceId = rawCluster.Id
+				}
+
+				tagInfo = append(tagInfo, &irs.TagInfo{
+					ResType:      rsType,
+					ResIId:       irs.IID{NameId: name, SystemId: resourceId},
+					TagList:      tagKeyValue,
+					KeyValueList: []irs.KeyValue{}, // reserved for optional usage
+				})
+			}
 		}
+
+		if scanResult.SearchCursor == nil || *scanResult.SearchCursor == "" {
+			break
+		}
+		searchOptions.SearchCursor = scanResult.SearchCursor
 	}
 
 	LoggingInfo(hiscallInfo, start)

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/VMHandler.go
@@ -207,13 +207,13 @@ func (vmHandler *IbmVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 	}
 
 	if vmReqInfo.ImageType == irs.MyImage {
-		snapshotList, _, listSnapshotErr := vmHandler.VpcService.ListSnapshotsWithContext(vmHandler.Ctx, &vpcv1.ListSnapshotsOptions{})
+		snapshots, listSnapshotErr := getAllSnapshots(vmHandler.VpcService, vmHandler.Ctx)
 		if listSnapshotErr != nil {
 			return irs.VMInfo{}, errors.New(fmt.Sprintf("Failed to Get MyImage. err = %s", listSnapshotErr.Error()))
 		}
 
 		var associatedSnapshots []vpcv1.Snapshot
-		for _, snapshot := range snapshotList.Snapshots {
+		for _, snapshot := range snapshots {
 			if strings.Split(*snapshot.Name, DEV)[0] == myImage.IId.NameId {
 				associatedSnapshots = append(associatedSnapshots, snapshot)
 			}

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/NLBHandler.go
@@ -1405,20 +1405,21 @@ func (nlbHandler *KTVpcNLBHandler) ListIID() ([]*irs.IID, error) {
 		Size: 2000, // Max page size, to list all data in a single page
 	}
 	start := call.Start()
-	firstPage, err := ktvpclb.List(nlbHandler.NLBClient, listOpts).FirstPage() // Not 'NetworkClient', Not 'AllPages()'
+	var nlbList []ktvpclb.LoadBalancer
+	err := ktvpclb.List(nlbHandler.NLBClient, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		loadBalancers, err := ktvpclb.ExtractLoadBalancers(page)
+		if err != nil {
+			return false, fmt.Errorf("Failed to Extract NLB List : [%v]", err)
+		}
+		nlbList = append(nlbList, loadBalancers...)
+		return true, nil
+	})
 	if err != nil {
 		newErr := fmt.Errorf("Failed to Get NLB List from KT Cloud : [%v]", err)
 		cblogger.Error(newErr.Error())
 		return nil, newErr
 	}
 	loggingInfo(callLogInfo, start)
-
-	nlbList, err := ktvpclb.ExtractLoadBalancers(firstPage)
-	if err != nil {
-		newErr := fmt.Errorf("Failed to Extract NLB List : [%v]", err)
-		cblogger.Error(newErr.Error())
-		return nil, newErr
-	}
 
 	if len(nlbList) < 1 {
 		cblogger.Info("### There is No NLB!!")

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/FileSystemHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/FileSystemHandler.go
@@ -43,6 +43,56 @@ func getTokenFromCredential(cred idrv.CredentialInfo) (string, error) {
 	return provider.TokenID, nil
 }
 
+// nhnListAllNASVolumes fetches every NAS volume in the region, following the
+// NHN NAS API's page-based pagination (limit/page request params, paging.totalCount
+// response field). See: https://docs.nhncloud.com/en/Storage/NAS/en/api-guide/
+func nhnListAllNASVolumes(authToken, region string) ([]map[string]interface{}, error) {
+	const pageSize = 100
+	var allVolumes []map[string]interface{}
+	page := 1
+
+	for {
+		url := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes?limit=%d&page=%d", region, pageSize, page)
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %v", err)
+		}
+		req.Header.Add("X-Auth-Token", authToken)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch NAS list: %v", err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read NAS list response: %v", readErr)
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("failed to list NAS volumes [%d]: %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Volumes []map[string]interface{} `json:"volumes"`
+			Paging  struct {
+				TotalCount int `json:"totalCount"`
+			} `json:"paging"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, fmt.Errorf("failed to parse NAS response: %w", err)
+		}
+
+		allVolumes = append(allVolumes, result.Volumes...)
+		if len(result.Volumes) == 0 || len(allVolumes) >= result.Paging.TotalCount {
+			break
+		}
+		page++
+	}
+
+	return allVolumes, nil
+}
+
 func (nf *NhnCloudFileSystemHandler) ListIID() ([]*irs.IID, error) {
 	cblogger.Info("Cloud driver: called ListIID()")
 
@@ -57,41 +107,17 @@ func (nf *NhnCloudFileSystemHandler) ListIID() ([]*irs.IID, error) {
 	}
 
 	region := strings.ToLower(nf.RegionInfo.Region)
-	url := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes", region)
-
-	req, err := http.NewRequest("GET", url, nil)
+	volumes, err := nhnListAllNASVolumes(authToken, region)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %v", err)
-	}
-	req.Header.Add("X-Auth-Token", authToken)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch NAS list: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to parse NAS response [%d]: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("failed to list NAS volumes: %w", err)
 	}
 
-	var result struct {
-		Volumes []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"volumes"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		cblogger.Errorf("Failed to parse NAS response: %v", err)
-		return nil, fmt.Errorf("failed to parse NAS response: %w", err)
-	}
-
-	for _, vol := range result.Volumes {
+	for _, vol := range volumes {
+		id, _ := vol["id"].(string)
+		name, _ := vol["name"].(string)
 		iidList = append(iidList, &irs.IID{
-			NameId:   vol.Name,
-			SystemId: vol.ID,
+			NameId:   name,
+			SystemId: id,
 		})
 	}
 
@@ -142,46 +168,13 @@ func (nf *NhnCloudFileSystemHandler) getRawFileSystem(nameId string) (map[string
 	}
 
 	region := strings.ToLower(nf.RegionInfo.Region)
-	url := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes", region)
-	req, err := http.NewRequest("GET", url, nil)
+	volumes, err := nhnListAllNASVolumes(authToken, region)
 	if err != nil {
-		cblogger.Errorf("Failed to create HTTP request: %v", err)
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
-	}
-	req.Header.Add("X-Auth-Token", authToken)
-
-	client := http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		cblogger.Errorf("Failed to query NAS list: %v", err)
-		return nil, fmt.Errorf("failed to query NAS list: %w", err)
-	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			cblogger.Errorf("Error closing response body: %v", closeErr)
-		}
-	}()
-
-	body, readErr := io.ReadAll(resp.Body)
-	if readErr != nil {
-		cblogger.Errorf("Failed to read NAS list response body: %v", readErr)
-		return nil, fmt.Errorf("failed to read NAS list response body: %w", readErr)
+		cblogger.Errorf("Failed to list NAS volumes: %v", err)
+		return nil, fmt.Errorf("failed to list NAS volumes: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		cblogger.Errorf("NAS list API failed with status [%d]: %s", resp.StatusCode, string(body))
-		return nil, fmt.Errorf("NAS list API failed with status [%d]: %s", resp.StatusCode, string(body))
-	}
-
-	var result struct {
-		Volumes []map[string]interface{} `json:"volumes"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		cblogger.Errorf("Failed to parse JSON response: %v", err)
-		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
-	}
-
-	for _, vol := range result.Volumes {
+	for _, vol := range volumes {
 		if name, ok := vol["name"].(string); ok && name == nameId {
 			cblogger.Infof("Found raw FileSystem for NameId '%s'.", nameId)
 			return vol, nil
@@ -345,35 +338,14 @@ func (nf *NhnCloudFileSystemHandler) ListFileSystem() ([]*irs.FileSystemInfo, er
 	}
 
 	region := strings.ToLower(nf.RegionInfo.Region)
-	url := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes", region)
-
-	req, _ := http.NewRequest("GET", url, nil)
-	req.Header.Add("X-Auth-Token", authToken)
-
-	client := http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	volumes, err := nhnListAllNASVolumes(authToken, region)
 	if err != nil {
-		cblogger.Errorf("Failed to request NAS list: %v", err)
-		return nil, fmt.Errorf("failed to request NAS list: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		cblogger.Errorf("Failed to get NAS list: %s", string(body))
-		return nil, fmt.Errorf("failed to get NAS list (status: %d): %s", resp.StatusCode, string(body))
-	}
-
-	var result struct {
-		Volumes []map[string]interface{} `json:"volumes"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		cblogger.Errorf("Failed to parse NAS list response: %v", err)
-		return nil, fmt.Errorf("failed to parse NAS list response: %v", err)
+		cblogger.Errorf("Failed to list NAS volumes: %v", err)
+		return nil, fmt.Errorf("failed to list NAS volumes: %w", err)
 	}
 
 	var fsList []*irs.FileSystemInfo
-	for _, raw := range result.Volumes {
+	for _, raw := range volumes {
 		fs, err := nf.setterFileSystemInfo(raw)
 		if err != nil {
 			cblogger.Warnf("Failed to convert NAS entry (skipped): %v", err)
@@ -483,41 +455,15 @@ func (nf *NhnCloudFileSystemHandler) DeleteFileSystem(iid irs.IID) (bool, error)
 	}
 
 	region := strings.ToLower(nf.RegionInfo.Region)
-	url := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes", region)
-
-	req, err := http.NewRequest("GET", url, nil)
+	volumes, err := nhnListAllNASVolumes(authToken, region)
 	if err != nil {
-		return false, fmt.Errorf("failed to create list request: %v", err)
-	}
-	req.Header.Add("X-Auth-Token", authToken)
-	req.Header.Add("Content-Type", "application/json")
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, fmt.Errorf("failed to send list request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return false, fmt.Errorf("failed to list NAS volumes: %s", string(body))
-	}
-
-	var result struct {
-		Volumes []struct {
-			ID   string `json:"id"`
-			Name string `json:"name"`
-		} `json:"volumes"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return false, fmt.Errorf("failed to decode NAS list response: %v", err)
+		return false, fmt.Errorf("failed to list NAS volumes: %w", err)
 	}
 
 	var volumeID string
-	for _, v := range result.Volumes {
-		if v.Name == iid.NameId {
-			volumeID = v.ID
+	for _, v := range volumes {
+		if name, ok := v["name"].(string); ok && name == iid.NameId {
+			volumeID, _ = v["id"].(string)
 			break
 		}
 	}
@@ -525,6 +471,7 @@ func (nf *NhnCloudFileSystemHandler) DeleteFileSystem(iid irs.IID) (bool, error)
 		return false, fmt.Errorf("NAS not found with name: %s", iid.NameId)
 	}
 
+	client := &http.Client{}
 	deleteURL := fmt.Sprintf("https://%s-api-nas-infrastructure.nhncloudservice.com/v1/volumes/%s", region, volumeID)
 	deleteReq, err := http.NewRequest("DELETE", deleteURL, nil)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -140,14 +140,15 @@ func (clusterHandler *TencentClusterHandler) ListCluster() ([]*irs.ClusterInfo, 
 	}
 	calllogger.Info(call.String(callLogInfo))
 
-	cluster_info_list := make([]*irs.ClusterInfo, *res.Response.TotalCount)
-	for i, cluster := range res.Response.Clusters {
-		cluster_info_list[i], err = getClusterInfo(clusterHandler.CredentialInfo.ClientId, clusterHandler.CredentialInfo.ClientSecret, clusterHandler.RegionInfo.Region, *cluster.ClusterId)
+	cluster_info_list := make([]*irs.ClusterInfo, 0, len(res.Response.Clusters))
+	for _, cluster := range res.Response.Clusters {
+		clusterInfo, err := getClusterInfo(clusterHandler.CredentialInfo.ClientId, clusterHandler.CredentialInfo.ClientSecret, clusterHandler.RegionInfo.Region, *cluster.ClusterId)
 		if err != nil {
 			err := fmt.Errorf("Failed to Get ClusterInfo :  %v", err)
 			cblogger.Error(err)
 			return nil, err
 		}
+		cluster_info_list = append(cluster_info_list, clusterInfo)
 	}
 
 	return cluster_info_list, nil

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/CommonHandler.go
@@ -17,19 +17,32 @@ import (
 )
 
 func DescribeDisks(client *cbs.Client, diskIIDs []irs.IID) ([]*cbs.Disk, error) {
-	request := cbs.NewDescribeDisksRequest()
+	var allDisks []*cbs.Disk
+	var offset uint64 = 0
+	limit := uint64(100)
 
-	if diskIIDs != nil {
-		request.DiskIds = common.StringPtrs([]string{diskIIDs[0].SystemId})
+	for {
+		request := cbs.NewDescribeDisksRequest()
+		if diskIIDs != nil {
+			request.DiskIds = common.StringPtrs([]string{diskIIDs[0].SystemId})
+		}
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := client.DescribeDisks(request)
+		if err != nil {
+			cblogger.Error(err)
+			return nil, err
+		}
+
+		allDisks = append(allDisks, response.Response.DiskSet...)
+		if response.Response.TotalCount == nil || uint64(len(allDisks)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
 
-	response, err := client.DescribeDisks(request)
-	if err != nil {
-		cblogger.Error(err)
-		return nil, err
-	}
-
-	return response.Response.DiskSet, nil
+	return allDisks, nil
 }
 
 func DescribeDisksByDiskID(client *cbs.Client, diskIID irs.IID) (cbs.Disk, error) {
@@ -302,24 +315,40 @@ func ListSubnet(client *vpc.Client, reqVpcId string) ([]irs.SubnetInfo, error){
 		ErrorMSG:     "",
 	}
 
-	request := vpc.NewDescribeSubnetsRequest()
-	request.Filters = []*vpc.Filter{
-		&vpc.Filter{
-			Name:   common.StringPtr("vpc-id"),
-			Values: common.StringPtrs([]string{reqVpcId}),
-		},
-	}
+	var subnetSet []*vpc.Subnet
+	var offset uint64 = 0
+	limit := uint64(100)
 
 	callLogStart := call.Start()
-	response, err := client.DescribeSubnets(request)
+	for {
+		request := vpc.NewDescribeSubnetsRequest()
+		request.Filters = []*vpc.Filter{
+			&vpc.Filter{
+				Name:   common.StringPtr("vpc-id"),
+				Values: common.StringPtrs([]string{reqVpcId}),
+			},
+		}
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
+
+		response, err := client.DescribeSubnets(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callogger.Info(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+
+		subnetSet = append(subnetSet, response.Response.SubnetSet...)
+		if response.Response.TotalCount == nil || uint64(len(subnetSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
+	}
 	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
-	if err != nil {
-		cblogger.Error(err)
-		return nil, err
-	}
-	
-	for _, curSubnet := range response.Response.SubnetSet {
+
+	for _, curSubnet := range subnetSet {
 		cblogger.Infof("[%s] Check Subnet Information", *curSubnet.SubnetId)
 		resSubnetInfo := irs.SubnetInfo{
 			IId:       irs.IID{SystemId: *curSubnet.SubnetId, NameId: *curSubnet.SubnetName},

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ImageHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ImageHandler.go
@@ -98,26 +98,37 @@ func (imageHandler *TencentImageHandler) ListImage() ([]*irs.ImageInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeImagesRequest()
-	request.Limit = common.Uint64Ptr(100) //default : 20 / max : 100
+	var imageSet []*cvm.Image
+	var offset uint64 = 0
+	limit := uint64(100) //default : 20 / max : 100
 
 	callLogStart := call.Start()
-	response, err := imageHandler.Client.DescribeImages(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := cvm.NewDescribeImagesRequest()
+		request.Offset = &offset
+		request.Limit = &limit
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
+		response, err := imageHandler.Client.DescribeImages(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
 
-		cblogger.Error(err)
-		return nil, err
+			cblogger.Error(err)
+			return nil, err
+		}
+
+		imageSet = append(imageSet, response.Response.ImageSet...)
+		if response.Response.TotalCount == nil || int64(len(imageSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
-	//cblogger.Debug(response)
-	//cblogger.Debug(response.ToJsonString())
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 
 	//cnt := 0
-	for _, curImage := range response.Response.ImageSet {
+	for _, curImage := range imageSet {
 		cblogger.Debugf("[%s] AMI information processing", *curImage.ImageId)
 		imageInfo := ExtractImageDescribeInfo(curImage)
 		imageInfoList = append(imageInfoList, &imageInfo)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/KeyPairHandler.go
@@ -33,24 +33,37 @@ func (keyPairHandler *TencentKeyPairHandler) ListKey() ([]*irs.KeyPairInfo, erro
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeKeyPairsRequest()
+	var keyPairSet []*cvm.KeyPair
+	var offset int64 = 0
+	limit := int64(100)
 
 	callLogStart := call.Start()
-	response, err := keyPairHandler.Client.DescribeKeyPairs(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := cvm.NewDescribeKeyPairsRequest()
+		request.Offset = &offset
+		request.Limit = &limit
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
+		response, err := keyPairHandler.Client.DescribeKeyPairs(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
 
-		cblogger.Error(err)
-		return nil, err
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
+		keyPairSet = append(keyPairSet, response.Response.KeyPairSet...)
+		if response.Response.TotalCount == nil || int64(len(keyPairSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
-	//cblogger.Debug(response)
-	cblogger.Debug(response.ToJsonString())
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 
-	for _, pair := range response.Response.KeyPairSet {
+	for _, pair := range keyPairSet {
 		keyPairInfo, errKeyPair := ExtractKeyPairDescribeInfo(pair)
 		if errKeyPair != nil {
 			// 2021-10-27 이슈#480에 의해 Local Key 로직 제거
@@ -441,23 +454,37 @@ func (keyPairHandler *TencentKeyPairHandler) ListIID() ([]*irs.IID, error) {
 
 	callLogInfo := GetCallLogScheme(keyPairHandler.Region, call.VMKEYPAIR, "ListIID", "DescribeKeyPairs()")
 
-	request := cvm.NewDescribeKeyPairsRequest()
+	var offset int64 = 0
+	limit := int64(100)
 
 	start := call.Start()
-	response, err := keyPairHandler.Client.DescribeKeyPairs(request)
+	for {
+		request := cvm.NewDescribeKeyPairsRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := keyPairHandler.Client.DescribeKeyPairs(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(start)
+			callLogInfo.ErrorMSG = err.Error()
+			calllogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug("keyPair Count : ", *response.Response.TotalCount)
+
+		for _, pair := range response.Response.KeyPairSet {
+			iid := irs.IID{SystemId: *pair.KeyId}
+			iidList = append(iidList, &iid)
+		}
+
+		if response.Response.TotalCount == nil || int64(len(iidList)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
+	}
 	callLogInfo.ElapsedTime = call.Elapsed(start)
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		calllogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
-	}
 	calllogger.Debug(call.String(callLogInfo))
-	cblogger.Debug("keyPair Count : ", *response.Response.TotalCount)
-	for _, pair := range response.Response.KeyPairSet {
-		iid := irs.IID{SystemId: *pair.KeyId}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/NLBHandler.go
@@ -279,35 +279,47 @@ func (NLBHandler *TencentNLBHandler) ListNLB() ([]*irs.NLBInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	request := clb.NewDescribeLoadBalancersRequest()
+	var loadBalancerSet []*clb.LoadBalancer
+	var offset int64 = 0
+	limit := int64(100)
+
 	callLogStart := call.Start()
-	response, err := NLBHandler.Client.DescribeLoadBalancers(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := clb.NewDescribeLoadBalancersRequest()
+		request.Offset = &offset
+		request.Limit = &limit
 
-	cblogger.Debug(response.ToJsonString())
+		response, err := NLBHandler.Client.DescribeLoadBalancers(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
+		loadBalancerSet = append(loadBalancerSet, response.Response.LoadBalancerSet...)
+		if response.Response.TotalCount == nil || uint64(len(loadBalancerSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Debug(call.String(callLogInfo))
 
-	cblogger.Debug("NLB count : ", *response.Response.TotalCount)
+	cblogger.Debug("NLB count : ", len(loadBalancerSet))
 
 	var nlbInfoList []*irs.NLBInfo
-	if *response.Response.TotalCount > 0 {
-		for _, curNLB := range response.Response.LoadBalancerSet {
-			cblogger.Debugf("[%s] NLB information retrieval - [%s]", *curNLB.LoadBalancerId, *curNLB.LoadBalancerName)
-			nlbInfo, nlbErr := NLBHandler.GetNLB(irs.IID{SystemId: *curNLB.LoadBalancerId})
+	for _, curNLB := range loadBalancerSet {
+		cblogger.Debugf("[%s] NLB information retrieval - [%s]", *curNLB.LoadBalancerId, *curNLB.LoadBalancerName)
+		nlbInfo, nlbErr := NLBHandler.GetNLB(irs.IID{SystemId: *curNLB.LoadBalancerId})
 
-			if nlbErr != nil {
-				cblogger.Error(nlbErr)
-				return nil, nlbErr
-			}
-			nlbInfoList = append(nlbInfoList, &nlbInfo)
+		if nlbErr != nil {
+			cblogger.Error(nlbErr)
+			return nil, nlbErr
 		}
+		nlbInfoList = append(nlbInfoList, &nlbInfo)
 	}
 
 	cblogger.Debugf("Number of returned result items: [%d]", len(nlbInfoList))
@@ -1103,24 +1115,36 @@ func (NLBHandler *TencentNLBHandler) ListIID() ([]*irs.IID, error) {
 
 	callLogInfo := GetCallLogScheme(NLBHandler.Region, call.CLUSTER, "ListIID", "DescribeLoadBalancers()")
 
-	request := clb.NewDescribeLoadBalancersRequest()
-	start := call.Start()
-	response, err := NLBHandler.Client.DescribeLoadBalancers(request)
-	callLogInfo.ElapsedTime = call.Elapsed(start)
+	var offset int64 = 0
+	limit := int64(100)
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		calllogger.Error(call.String(callLogInfo))
-		return nil, err
-	}
-	calllogger.Debug(call.String(callLogInfo))
-	cblogger.Debug("NLB count : ", *response.Response.TotalCount)
-	if *response.Response.TotalCount > 0 {
+	start := call.Start()
+	for {
+		request := clb.NewDescribeLoadBalancersRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := NLBHandler.Client.DescribeLoadBalancers(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(start)
+			callLogInfo.ErrorMSG = err.Error()
+			calllogger.Error(call.String(callLogInfo))
+			return nil, err
+		}
+		cblogger.Debug("NLB count : ", *response.Response.TotalCount)
+
 		for _, curNLB := range response.Response.LoadBalancerSet {
 			iid := irs.IID{SystemId: *curNLB.LoadBalancerId}
 			iidList = append(iidList, &iid)
 		}
+
+		if response.Response.TotalCount == nil || uint64(len(iidList)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Debug(call.String(callLogInfo))
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/SecurityHandler.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	taglib "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/tag/v20180813"
@@ -229,26 +230,38 @@ func (securityHandler *TencentSecurityHandler) ListSecurity() ([]*irs.SecurityIn
 		ErrorMSG:     "",
 	}
 
-	request := vpc.NewDescribeSecurityGroupsRequest()
-	request.Limit = common.StringPtr("100") //default : 20 / max : 100
+	var securityGroupSet []*vpc.SecurityGroup
+	var offset uint64 = 0
+	limit := uint64(100) //default : 20 / max : 100
 
 	callLogStart := call.Start()
-	response, err := securityHandler.Client.DescribeSecurityGroups(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := vpc.NewDescribeSecurityGroupsRequest()
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
+		response, err := securityHandler.Client.DescribeSecurityGroups(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
 
-		cblogger.Error(err)
-		return nil, err
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
+		securityGroupSet = append(securityGroupSet, response.Response.SecurityGroupSet...)
+		if response.Response.TotalCount == nil || uint64(len(securityGroupSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
-	//cblogger.Debug(response)
-	cblogger.Debug(response.ToJsonString())
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 
 	var results []*irs.SecurityInfo
-	for _, securityGroup := range response.Response.SecurityGroupSet {
+	for _, securityGroup := range securityGroupSet {
 		// 	securityInfo := ExtractSecurityInfo(securityGroup)
 		securityInfo, errSecurity := securityHandler.GetSecurity(irs.IID{NameId: *securityGroup.SecurityGroupName, SystemId: *securityGroup.SecurityGroupId})
 		if errSecurity != nil {
@@ -776,25 +789,37 @@ func (securityHandler *TencentSecurityHandler) ListIID() ([]*irs.IID, error) {
 
 	callLogInfo := GetCallLogScheme(securityHandler.Region, call.VPCSUBNET, "ListIID", "DescribeSecurityGroups()")
 
-	request := vpc.NewDescribeSecurityGroupsRequest()
-	request.Limit = common.StringPtr("100") //default : 20 / max : 100
+	var offset uint64 = 0
+	limit := uint64(100) //default : 20 / max : 100
 
 	start := call.Start()
-	response, err := securityHandler.Client.DescribeSecurityGroups(request)
-	callLogInfo.ElapsedTime = call.Elapsed(start)
+	for {
+		request := vpc.NewDescribeSecurityGroupsRequest()
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		calllogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
+		response, err := securityHandler.Client.DescribeSecurityGroups(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(start)
+			callLogInfo.ErrorMSG = err.Error()
+			calllogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug("SecurityGroup Count : ", *response.Response.TotalCount)
+
+		for _, securityGroup := range response.Response.SecurityGroupSet {
+			iid := irs.IID{SystemId: *securityGroup.SecurityGroupId}
+			iidList = append(iidList, &iid)
+		}
+
+		if response.Response.TotalCount == nil || uint64(len(iidList)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(start)
 	calllogger.Debug(call.String(callLogInfo))
-	cblogger.Debug("SecurityGroup Count : ", *response.Response.TotalCount)
-	for _, securityGroup := range response.Response.SecurityGroupSet {
-		iid := irs.IID{SystemId: *securityGroup.SecurityGroupId}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/TagHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/TagHandler.go
@@ -445,29 +445,35 @@ func (t *TencentTagHandler) FindTag(resType irs.RSType, keyword string) ([]*irs.
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	req := taglib.NewDescribeResourceTagsRequest()
-	if resType != irs.ALL {
-		serviceTypeStr, resourcePrefixStr := rsTypeToTencentTypeMapParse(rsTypeToTencentTypeMap[resType])
-		req.ServiceType = common.StringPtr(serviceTypeStr)
-		req.ResourcePrefix = common.StringPtr(resourcePrefixStr)
-	}
-	req.ResourceRegion = common.StringPtr(t.Region.Region)
-	req.Limit = common.Uint64Ptr(1)
+	var rows []*taglib.TagResource
+	var offset uint64 = 0
+	limit := uint64(100)
 
-	initRes, err := t.TagClient.DescribeResourceTags(req)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		req := taglib.NewDescribeResourceTagsRequest()
+		if resType != irs.ALL {
+			serviceTypeStr, resourcePrefixStr := rsTypeToTencentTypeMapParse(rsTypeToTencentTypeMap[resType])
+			req.ServiceType = common.StringPtr(serviceTypeStr)
+			req.ResourcePrefix = common.StringPtr(resourcePrefixStr)
+		}
+		req.ResourceRegion = common.StringPtr(t.Region.Region)
+		req.Offset = &offset
+		req.Limit = &limit
 
-	req.Limit = common.Uint64Ptr(*initRes.Response.TotalCount)
+		res, err := t.TagClient.DescribeResourceTags(req)
+		if err != nil {
+			return nil, err
+		}
 
-	res, err := t.TagClient.DescribeResourceTags(req)
-	if err != nil {
-		return nil, err
+		rows = append(rows, res.Response.Rows...)
+		if res.Response.TotalCount == nil || uint64(len(rows)) >= *res.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
 
 	tagInfoResIdArr := map[irs.RSType][]string{}
-	for _, tag := range res.Response.Rows {
+	for _, tag := range rows {
 		if strings.Contains(*tag.TagKey, keyword) || strings.Contains(*tag.TagValue, keyword) || keyword == "" || keyword == "*" {
 			resourceIdSplitArr := strings.Split(*tag.ResourceId, "-")
 			tagInfoResIdArr[resourceIdStartStrToRsType[resourceIdSplitArr[0]]] = append(tagInfoResIdArr[resourceIdStartStrToRsType[resourceIdSplitArr[0]]], *tag.ResourceId)

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -1006,26 +1006,38 @@ func (vmHandler *TencentVMHandler) ListVM() ([]*irs.VMInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeInstancesRequest()
-	request.Limit = common.Int64Ptr(100)
+	var instanceSet []*cvm.Instance
+	var offset int64 = 0
+	limit := int64(100)
 
 	callLogStart := call.Start()
-	response, err := vmHandler.Client.DescribeInstances(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := cvm.NewDescribeInstancesRequest()
+		request.Offset = &offset
+		request.Limit = &limit
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
+		response, err := vmHandler.Client.DescribeInstances(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
 
-		cblogger.Error(err)
-		return nil, err
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
+		instanceSet = append(instanceSet, response.Response.InstanceSet...)
+		if response.Response.TotalCount == nil || int64(len(instanceSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
-
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
-	cblogger.Debug(response.ToJsonString())
 
 	var vmInfoList []*irs.VMInfo
-	for _, curVm := range response.Response.InstanceSet {
+	for _, curVm := range instanceSet {
 		vmInfo, _ := vmHandler.GetVM(irs.IID{SystemId: *curVm.InstanceId})
 		vmInfoList = append(vmInfoList, &vmInfo)
 	}
@@ -1087,25 +1099,38 @@ func (vmHandler *TencentVMHandler) ListVMStatus() ([]*irs.VMStatusInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	request := cvm.NewDescribeInstancesStatusRequest()
-	request.Limit = common.Int64Ptr(100)
+	var instanceStatusSet []*cvm.InstanceStatus
+	var offset int64 = 0
+	limit := int64(100)
 
 	callLogStart := call.Start()
-	response, err := vmHandler.Client.DescribeInstancesStatus(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	for {
+		request := cvm.NewDescribeInstancesStatusRequest()
+		request.Offset = &offset
+		request.Limit = &limit
 
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
+		response, err := vmHandler.Client.DescribeInstancesStatus(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
 
-		cblogger.Error(err)
-		return nil, err
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
+		instanceStatusSet = append(instanceStatusSet, response.Response.InstanceStatusSet...)
+		if response.Response.TotalCount == nil || int64(len(instanceStatusSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
-	cblogger.Debug(response.ToJsonString())
 
 	var vmStatusList []*irs.VMStatusInfo
-	for _, curVm := range response.Response.InstanceStatusSet {
+	for _, curVm := range instanceStatusSet {
 		vmStatus, _ := ConvertVMStatusString(*curVm.InstanceState)
 
 		vmStatusInfo := irs.VMStatusInfo{
@@ -1409,26 +1434,38 @@ func (vmHandler *TencentVMHandler) ListIID() ([]*irs.IID, error) {
 
 	callLogInfo := GetCallLogScheme(vmHandler.Region, call.VMKEYPAIR, "ListIID", "DescribeInstances()")
 
-	request := cvm.NewDescribeInstancesRequest()
-	request.Limit = common.Int64Ptr(100)
+	var offset int64 = 0
+	limit := int64(100)
 
 	start := call.Start()
-	response, err := vmHandler.Client.DescribeInstances(request)
+	for {
+		request := cvm.NewDescribeInstancesRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := vmHandler.Client.DescribeInstances(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(start)
+			callLogInfo.ErrorMSG = err.Error()
+			calllogger.Error(call.String(callLogInfo))
+
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug("VM Count : ", *response.Response.TotalCount)
+
+		for _, curVm := range response.Response.InstanceSet {
+			iid := irs.IID{SystemId: *curVm.InstanceId}
+			iidList = append(iidList, &iid)
+		}
+
+		if response.Response.TotalCount == nil || int64(len(iidList)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
+	}
 	callLogInfo.ElapsedTime = call.Elapsed(start)
-
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		calllogger.Error(call.String(callLogInfo))
-
-		cblogger.Error(err)
-		return nil, err
-	}
 	calllogger.Debug(call.String(callLogInfo))
-	cblogger.Debug("VM Count : ", *response.Response.TotalCount)
-	for _, curVm := range response.Response.InstanceSet {
-		iid := irs.IID{SystemId: *curVm.InstanceId}
-		iidList = append(iidList, &iid)
-	}
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VPCHandler.go
@@ -12,6 +12,7 @@ package resources
 
 import (
 	"errors"
+	"strconv"
 
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
@@ -179,36 +180,48 @@ func (VPCHandler *TencentVPCHandler) ListVPC() ([]*irs.VPCInfo, error) {
 		ErrorMSG:     "",
 	}
 
-	request := vpc.NewDescribeVpcsRequest()
-	callLogStart := call.Start()
-	response, err := VPCHandler.Client.DescribeVpcs(request)
-	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+	var vpcSet []*vpc.Vpc
+	var offset uint64 = 0
+	limit := uint64(100)
 
-	cblogger.Debug(response.ToJsonString())
-	//cblogger.Debug(result)
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		callogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
+	callLogStart := call.Start()
+	for {
+		request := vpc.NewDescribeVpcsRequest()
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
+
+		response, err := VPCHandler.Client.DescribeVpcs(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+			callLogInfo.ErrorMSG = err.Error()
+			callogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
+		vpcSet = append(vpcSet, response.Response.VpcSet...)
+		if response.Response.TotalCount == nil || uint64(len(vpcSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
 	callogger.Info(call.String(callLogInfo))
 
-	cblogger.Info("VPC Count : ", *response.Response.TotalCount)
+	cblogger.Info("VPC Count : ", len(vpcSet))
 
 	var vpcInfoList []*irs.VPCInfo
-	if *response.Response.TotalCount > 0 {
-		for _, curVpc := range response.Response.VpcSet {
-			cblogger.Debugf("[%s] VPC Infomation reteive - [%s]", *curVpc.VpcId, *curVpc.VpcName)
-			vpcInfo, vpcErr := VPCHandler.GetVPC(irs.IID{SystemId: *curVpc.VpcId})
-			// cblogger.Info("==>조회 결과")
-			// cblogger.Debug(vpcInfo)
-			if vpcErr != nil {
-				cblogger.Error(vpcErr)
-				return nil, vpcErr
-			}
-			vpcInfoList = append(vpcInfoList, &vpcInfo)
+	for _, curVpc := range vpcSet {
+		cblogger.Debugf("[%s] VPC Infomation reteive - [%s]", *curVpc.VpcId, *curVpc.VpcName)
+		vpcInfo, vpcErr := VPCHandler.GetVPC(irs.IID{SystemId: *curVpc.VpcId})
+		// cblogger.Info("==>조회 결과")
+		// cblogger.Debug(vpcInfo)
+		if vpcErr != nil {
+			cblogger.Error(vpcErr)
+			return nil, vpcErr
 		}
+		vpcInfoList = append(vpcInfoList, &vpcInfo)
 	}
 
 	cblogger.Debugf("Number of Return Results List : [%d]", len(vpcInfoList))
@@ -344,29 +357,43 @@ func (VPCHandler *TencentVPCHandler) ListSubnet(reqVpcId string) ([]irs.SubnetIn
 		}
 	*/
 
-	request := vpc.NewDescribeSubnetsRequest()
-	request.Filters = []*vpc.Filter{
-		&vpc.Filter{
-			Name:   common.StringPtr("vpc-id"),
-			Values: common.StringPtrs([]string{reqVpcId}),
-		},
+	var subnetSet []*vpc.Subnet
+	var offset uint64 = 0
+	limit := uint64(100)
+
+	for {
+		request := vpc.NewDescribeSubnetsRequest()
+		request.Filters = []*vpc.Filter{
+			&vpc.Filter{
+				Name:   common.StringPtr("vpc-id"),
+				Values: common.StringPtrs([]string{reqVpcId}),
+			},
+		}
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
+
+		// callLogStart := call.Start()
+		response, err := VPCHandler.Client.DescribeSubnets(request)
+		// callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
+
+		//cblogger.Debug(response.ToJsonString())
+		cblogger.Debug(response)
+		if err != nil {
+			// callLogInfo.ErrorMSG = err.Error()
+			// callogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		// callogger.Info(call.String(callLogInfo))
+
+		subnetSet = append(subnetSet, response.Response.SubnetSet...)
+		if response.Response.TotalCount == nil || uint64(len(subnetSet)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
 
-	// callLogStart := call.Start()
-	response, err := VPCHandler.Client.DescribeSubnets(request)
-	// callLogInfo.ElapsedTime = call.Elapsed(callLogStart)
-
-	//cblogger.Debug(response.ToJsonString())
-	cblogger.Debug(response)
-	if err != nil {
-		// callLogInfo.ErrorMSG = err.Error()
-		// callogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
-	}
-	// callogger.Info(call.String(callLogInfo))
-
-	for _, curSubnet := range response.Response.SubnetSet {
+	for _, curSubnet := range subnetSet {
 		cblogger.Infof("[%s] Check Subnet Information", *curSubnet.SubnetId)
 		resSubnetInfo := irs.SubnetInfo{
 			IId:       irs.IID{SystemId: *curSubnet.SubnetId, NameId: *curSubnet.SubnetName},
@@ -553,29 +580,38 @@ func (vpcHandler *TencentVPCHandler) ListIID() ([]*irs.IID, error) {
 
 	callLogInfo := GetCallLogScheme(vpcHandler.Region, call.VPCSUBNET, "ListIID", "DescribeVpcs()")
 
-	request := vpc.NewDescribeVpcsRequest()
+	var offset uint64 = 0
+	limit := uint64(100)
 
 	start := call.Start()
-	response, err := vpcHandler.Client.DescribeVpcs(request)
-	callLogInfo.ElapsedTime = call.Elapsed(start)
+	for {
+		request := vpc.NewDescribeVpcsRequest()
+		request.Offset = common.StringPtr(strconv.FormatUint(offset, 10))
+		request.Limit = common.StringPtr(strconv.FormatUint(limit, 10))
 
-	cblogger.Debug(response.ToJsonString())
-	//cblogger.Debug(result)
-	if err != nil {
-		callLogInfo.ErrorMSG = err.Error()
-		calllogger.Error(call.String(callLogInfo))
-		cblogger.Error(err)
-		return nil, err
-	}
-	calllogger.Debug(call.String(callLogInfo))
-	cblogger.Debug("VPC Count : ", *response.Response.TotalCount)
-	if *response.Response.TotalCount > 0 {
+		response, err := vpcHandler.Client.DescribeVpcs(request)
+		if err != nil {
+			callLogInfo.ElapsedTime = call.Elapsed(start)
+			callLogInfo.ErrorMSG = err.Error()
+			calllogger.Error(call.String(callLogInfo))
+			cblogger.Error(err)
+			return nil, err
+		}
+		cblogger.Debug(response.ToJsonString())
+
 		for _, curVpc := range response.Response.VpcSet {
 			cblogger.Debugf("[%s] VPC information retrieval", *curVpc.VpcId)
 			iid := irs.IID{SystemId: *curVpc.VpcId}
 			iidList = append(iidList, &iid)
 		}
+
+		if response.Response.TotalCount == nil || uint64(len(iidList)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
+	callLogInfo.ElapsedTime = call.Elapsed(start)
+	calllogger.Debug(call.String(callLogInfo))
 
 	return iidList, nil
 }

--- a/cloud-control-manager/cloud-driver/drivers/tencent/utils/tencent/tencent_api.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/utils/tencent/tencent_api.go
@@ -41,13 +41,31 @@ func GetClusters(secret_id string, secret_key string, region_id string) (*tke.De
 	cpf.HttpProfile.Endpoint = "tke.tencentcloudapi.com"
 	client, _ := tke.NewClient(credential, region_id, cpf)
 
-	request := tke.NewDescribeClustersRequest()
-	response, err := client.DescribeClusters(request)
-	if err != nil {
-		return nil, err
+	var allClusters []*tke.Cluster
+	var offset int64 = 0
+	limit := int64(100)
+	var lastResponse *tke.DescribeClustersResponse
+
+	for {
+		request := tke.NewDescribeClustersRequest()
+		request.Offset = &offset
+		request.Limit = &limit
+
+		response, err := client.DescribeClusters(request)
+		if err != nil {
+			return nil, err
+		}
+		lastResponse = response
+
+		allClusters = append(allClusters, response.Response.Clusters...)
+		if response.Response.TotalCount == nil || int64(len(allClusters)) >= *response.Response.TotalCount {
+			break
+		}
+		offset += limit
 	}
 
-	return response, nil
+	lastResponse.Response.Clusters = allClusters
+	return lastResponse, nil
 }
 
 func GetCluster(secret_id string, secret_key string, region_id string, cluster_id string) (*tke.DescribeClustersResponse, error) {


### PR DESCRIPTION
**Problem**: As the number of created resources grows, missing pagination currently causes incomplete listings or failed deletions for many resource types.

**Test Note**: Basic CRUD testing was completed for all affected resources, but pagination testing itself was excluded due to practical constraints such as account quotas.

- GCP: Fix ListVMSpec() and VMHandler/NICHandler/AnyCallHandler/TagHandler/DiskHandler/SecurityHandler/VPCHandler/RDBMSHandler/NLBHandler/MyImageHandler to page through all zones via the Compute API's Pages() callback instead of a single unpaginated call
- AWS: Convert NLB ListNLB/ListIID to DescribeLoadBalancersPages, and EFS ListFileSystem/TagHandler to DescribeFileSystemsPages (EFS defaults to MaxItems=100 per call)
- Azure: Fix a WaitGroup double-Done() panic risk in ListRegionZone's zone-pager error branch (missing return after wg.Done())
- Alibaba: Add PageNumber/PageSize and NextToken pagination loops across VM/Image (ListVM, ListMyImage), ListVMStatus, ListVPC, ListSecurity, ListNLB, NAS ListIID, VMSpec, PriceInfoHandler, Cluster/NodeGroup/VSwitch queries, and ECS/VPC/Subnet tag-search helpers
- Tencent: Fix ListCluster()'s pre-sized-slice nil-pointer crash risk (slice was sized to TotalCount while only one page was fetched), and add Offset/Limit pagination to Disk, KeyPair, VPC/Subnet, NLB, VM, SecurityGroup, Image, and Tag handlers
- IBM: Add shared getAllSnapshots/getAllShares/getAllSubnets cursor-pagination helpers across MyImageHandler, VMHandler, FileSystemHandler, NICHandler, NLBHandler; fix RDBMS listResourceInstances() to loop via Start/NextURL; fix TagHandler.FindTag() to actually reuse its SearchCursor; add gateway-listing helpers to ClusterHandler
- NHN: Add nhnListAllNASVolumes() pagination helper for the NAS Volume list API, fixing 4 call sites that previously missed volumes beyond page one (causing false "not found" on by-name lookups)
- KT Cloud VPC: Fix NLB ListIID() to loop via EachPage() instead of FirstPage(), matching its sibling ListNLB()