### PR TITLE
[Test:OpenStack:MariaDB] Fix: Correct MariaDB DBEngineVersion mismatch in test scripts and update docs

### DIFF
--- a/test/rdbms-mariadb-test/README.md
+++ b/test/rdbms-mariadb-test/README.md
@@ -47,7 +47,7 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 |-----|------------|---------|------|------|
 | AWS | ✅ | ✅ | `10.6` | Amazon RDS for MariaDB |
 | Alibaba | ✅ | ✅ | `10.6` | AliCloud RDS for MariaDB |
-| OpenStack | ⚠️ | ❌ | `10.6` | **현재 이 환경은 MariaDB Trove datastore 구축 전 상태** (설치되면 정상 동작 예상) — 시험 스크립트는 그대로 유지 |
+| OpenStack | ✅ | ❌ | `10.4` | Trove for OpenStack |
 | NHN | ✅ | ❌ | `MARIADB_V101118` | NHN RDS for MariaDB |
 
 
@@ -59,7 +59,7 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 |-----|--------|---------|------|---------|
 | AWS | mariadb | 10.6 | db.t3.medium | 100GB |
 | Alibaba | mariadb | 10.6 | metainfo 동적 조회 (예: `mariadb.n2.medium.2c`, 조회 실패 시 `rds.mariadb.s4.large`로 폴백) | 20GB |
-| OpenStack | mariadb | 10.6 | m1.small | 20GB (Trove 구축 후 정상 동작 예상) |
+| OpenStack | mariadb | 10.4 | m1.small | 20GB |
 | NHN | mariadb | MARIADB_V101118 | m2.c2m4 | 20GB |
 
 ## Usage
@@ -157,24 +157,22 @@ rdbms-mariadb-test/
 
 ## 시험 결과
 
-### 2026-08-10
+시험 날짜: 2026-08-18
 
-`./all_test.sh` 전체 시험 수트 실행 결과입니다 (Step 2/4/5/7은 하위 시험 또는 OpenStack MariaDB Trove datastore 미구축으로 인한 실패 — 상세는 각 하위 디렉토리 README 참고).
+`./all_test.sh` 전체 시험 수트 실행 결과, 4개 CSP(AWS/Alibaba/OpenStack/NHN) 전 Step PASS했습니다.
 
 ```
  PASS | Step 1: Network Prepare (VPC/Subnet/SG)
- FAIL | Step 2: StorageType Validation Test (exit code: 1)
+ PASS | Step 2: StorageType Validation Test
  PASS | Step 3: Delete StorageType RDBMS Instances
- FAIL | Step 4: RDBMS Instance Create (all CSPs) (exit code: 1)
- FAIL | Step 5: Database Management Test (CRUD inside instance) (exit code: 1)
+ PASS | Step 4: RDBMS Instance Create (all CSPs)
+ PASS | Step 5: Database Management Test (CRUD inside instance)
  PASS | Step 6: Tag Management Test (SupportsTag=true CSPs)
- FAIL | Step 7: RDBMS Instance Delete (all CSPs) (exit code: 1)
+ PASS | Step 7: RDBMS Instance Delete (all CSPs)
  PASS | Step 8: Network Cleanup (VPC/Subnet/SG)
 
- Total: 4 PASS, 4 FAIL
+ Total: 8 PASS, 0 FAIL
 ```
-
-OpenStack을 제외한 3개 CSP(AWS/Alibaba/NHN)는 Create부터 Delete까지 전 단계 PASS했습니다. OpenStack은 이 환경에 MariaDB Trove datastore가 아직 구축되지 않아 `Datastore version '10.6' cannot be found` 오류로 인스턴스 생성에 실패했고, 이로 인해 이후 DB 관리 시험(Step 5) 및 삭제(Step 7)에서도 OpenStack만 실패로 이어졌습니다 (인스턴스 부재로 인한 연쇄 실패이며, datastore 구축 후 정상 동작 예상).
 
 **RDBMS Instance Create (Step 4) 상세:**
 
@@ -184,26 +182,26 @@ OpenStack을 제외한 3개 CSP(AWS/Alibaba/NHN)는 Create부터 Delete까지 �
 =================================================================================================================================================================================
 CSP          | Status      | Engine   | Version      | Spec                     | Storage                  | Endpoint                                 | PublicAccess | Elapsed
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-AWS          | Available   | mariadb  | 10.6.27      | db.t3.medium             | 100GB|gp2                | cb-spider-mariadb-test-***.ap-southeast-2.rds.amazonaws.com:3306        | true         | 4m44s
-ALIBABA      | Available   | mariadb  | 10.6         | mariadb.n2.medium.2c     | 20GB|cloud_essd          | *.*.*.*:3306                             | true         | 3m20s
-OPENSTACK    | CREATE_ERROR | Datastore version '10.6' cannot be found. |              |                          |                                          |              | -
-NHN          | Available   | mariadb  | MARIADB_V101118 | m2.c2m4                  | 20GB|General SSD         | ***.external.kr1.mariadb.rds.nhncloudservice.com:3306                   | true         | 10m8s
+AWS          | Available   | mariadb  | 10.6.27      | db.t3.medium             | 100GB|gp2                | cb-spider-mariadb-test-***.ap-southeast-2.rds.amazonaws.com:3306        | true         | 4m40s
+ALIBABA      | Available   | mariadb  | 10.6         | mariadb.n2.medium.2c     | 20GB|cloud_essd          | *.*.*.*:3306                             | true         | 3m28s
+OPENSTACK    | Available   | mariadb  | 10.4         | m1.small                 | 20GB|NA                  | *.*.*.*:3306                              | true         | 3m58s
+NHN          | Available   | mariadb  | MARIADB_V101118 | m2.c2m4                  | 20GB|General SSD         | ***.external.kr1.mariadb.rds.nhncloudservice.com:3306                   | true         | 9m53s
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-Failed : 1
+Failed : 0
 ```
 
 **RDBMS Instance Delete (Step 7) 상세:**
 
 ```
 ============================================================
-     RDBMS DELETE SUMMARY - ALL CSPs (MariaDB)
+      RDBMS DELETE SUMMARY - ALL CSPs (MariaDB)
 ============================================================
 CSP          | Result         | Detail               | Elapsed
 ------------------------------------------------------------
-AWS          | DELETED        | ok                   | 3m56s
+AWS          | DELETED        | ok                   | 3m49s
 ALIBABA      | DELETED        | ok                   | 23s
-OPENSTACK    | NOT_FOUND      | Relational Database 'cb-spider-mariadb-test' does not exist in connection 'openstack-config01' | -
-NHN          | DELETED        | ok                   | 19s
+OPENSTACK    | DELETED        | ok                   | 20s
+NHN          | DELETED        | ok                   | 18s
 ------------------------------------------------------------
-Failed : 1
+Failed : 0
 ```

--- a/test/rdbms-mariadb-test/database-test/README.md
+++ b/test/rdbms-mariadb-test/database-test/README.md
@@ -180,24 +180,24 @@ tail -f /tmp/rdbms_mgmt_logs_<PID>/log_aws.txt
 
 | CSP | Note |
 |-----|------|
-| OpenStack | 이 환경은 MariaDB Trove datastore 구축 전 상태로, 상위 create 시험(Step 4)이 실패하면 인스턴스가 없어 본 시험도 FAIL로 이어짐. Trove datastore 구성 후 정상 동작 예상 |
+| OpenStack | 상위 create 시험(Step 4)이 실패하면 인스턴스가 없어 본 시험도 FAIL로 이어짐 |
 
 ## 시험 결과
 
-### 2026-08-10
+시험 날짜: 2026-08-18
 
-상위 디렉토리 create 시험(Step 4)에서 OpenStack 인스턴스 생성이 `DBEngineVersion '10.6'` 미지원으로 실패하여, 본 시험에서도 OpenStack만 FAIL로 나타남 (인스턴스 부재).
+4개 CSP 전부 PASS했습니다.
 
 ```
 =======================================================================================================
-            RDBMS DATABASE MANAGEMENT TEST SUMMARY - ALL CSPs (MariaDB)
+             RDBMS DATABASE MANAGEMENT TEST SUMMARY - ALL CSPs (MariaDB)
 =======================================================================================================
 CSP          | CreateDB   | ListDB   | FoundInList  | DeleteDB   | VerifyDeleted | Elapsed
 -------------------------------------------------------------------------------------------------------
-AWS          | PASS       | PASS     | FOUND        | PASS       | PASS          | 17s
-ALIBABA      | PASS       | PASS     | FOUND        | PASS       | PASS          | 21s
-OPENSTACK    | FAIL       | FAIL     | NOT_FOUND    | FAIL       | FAIL          | 4s
-NHN          | PASS       | PASS     | FOUND        | PASS       | PASS          | 31s
+AWS          | PASS       | PASS     | FOUND        | PASS       | PASS          | 8s
+ALIBABA      | PASS       | PASS     | FOUND        | PASS       | PASS          | 17s
+OPENSTACK    | PASS       | PASS     | FOUND        | PASS       | PASS          | 28s
+NHN          | PASS       | PASS     | FOUND        | PASS       | PASS          | 33s
 -------------------------------------------------------------------------------------------------------
-Total: 3 PASS, 1 FAIL
+Total: 4 PASS, 0 FAIL
 ```

--- a/test/rdbms-mariadb-test/openstack-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/openstack-rdbms-test.sh
@@ -16,7 +16,7 @@ export CREATE_JSON='{
     "Name": "cb-spider-mariadb-test",
     "VPCName": "vpc-01",
     "DBEngine": "mariadb",
-    "DBEngineVersion": "10.6",
+    "DBEngineVersion": "10.4",
     "DBSpec": "m1.small",
     "StorageSize": "20",
     "MasterUserName": "myadmin",

--- a/test/rdbms-mariadb-test/storage-type-test/README.md
+++ b/test/rdbms-mariadb-test/storage-type-test/README.md
@@ -217,14 +217,11 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 
 | 항목 | 값 |
 |------|-----|
-| DBEngine / Version | `mariadb` / `10.6` |
+| DBEngine / Version | `mariadb` / `10.4` |
 | DBSpec | `m1.small` |
 | StorageSize | `20 GB` |
 | Connection | `openstack-config01` |
 | Region / Zone | `RegionOne` / `nova` |
-
-**특이사항**
-- MariaDB Trove datastore가 구축전 상태
 
 ---
 
@@ -242,27 +239,27 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 
 ## 시험 결과
 
-### 2026-08-10
+시험 날짜: 2026-08-18
 
-OpenStack은 이 환경에 MariaDB Trove datastore가 아직 구축되지 않아 `DBEngineVersion '10.6' cannot be found` 오류로 CREATE_ERROR 발생 (datastore 구축 후 정상 동작 예상).
+전체 11건 PASS했습니다.
 
 ```
 ================================================================================================================================
-                          RDBMS StorageType Test Summary - All CSPs (MariaDB)
+                           RDBMS StorageType Test Summary - All CSPs (MariaDB)
 ================================================================================================================================
 CSP          | StorageType(Req)     | StorageType(Ret)   | Result | DB Status      | Elapsed    | Reason
 --------------------------------------------------------------------------------------------------------------------------------
-AWS          | gp2                  | gp2                | PASS   | Available      | 4m41s      | -
-AWS          | gp3                  | gp3                | PASS   | Available      | 4m41s      | -
-AWS          | io1                  | io1                | PASS   | Available      | 4m41s      | -
-AWS          | io2                  | io2                | PASS   | Available      | 4m42s      | -
-ALIBABA      | cloud_essd           | cloud_essd         | PASS   | Available      | 3m26s      | -
-ALIBABA      | cloud_essd2          | cloud_essd2        | PASS   | Available      | 3m6s       | -
-ALIBABA      | cloud_essd3          | cloud_essd3        | PASS   | Available      | 3m36s      | -
-OPENSTACK    | __DEFAULT__          | N/A                | FAIL   | CREATE_ERROR   | 1s         | -
-OPENSTACK    | RBD                  | N/A                | FAIL   | CREATE_ERROR   | 1s         | -
-NHN          | General HDD          | General HDD        | PASS   | Available      | 9m22s      | -
-NHN          | General SSD          | General SSD        | PASS   | Available      | 10m20s     | -
+AWS          | gp2                  | gp2                | PASS   | Available      | 5m14s      | -
+AWS          | gp3                  | gp3                | PASS   | Available      | 4m42s      | -
+AWS          | io1                  | io1                | PASS   | Available      | 5m15s      | -
+AWS          | io2                  | io2                | PASS   | Available      | 5m14s      | -
+ALIBABA      | cloud_essd           | cloud_essd         | PASS   | Available      | 3m39s      | -
+ALIBABA      | cloud_essd2          | cloud_essd2        | PASS   | Available      | 3m23s      | -
+ALIBABA      | cloud_essd3          | cloud_essd3        | PASS   | Available      | 3m24s      | -
+OPENSTACK    | __DEFAULT__          | NA                 | PASS   | Available      | 4m28s      | OpenStack Trove does not expose StorageType post-creation; Available=PASS
+OPENSTACK    | RBD                  | NA                 | PASS   | Available      | 4m58s      | OpenStack Trove does not expose StorageType post-creation; Available=PASS
+NHN          | General HDD          | General HDD        | PASS   | Available      | 10m36s     | -
+NHN          | General SSD          | General SSD        | PASS   | Available      | 10m21s     | -
 --------------------------------------------------------------------------------------------------------------------------------
-Total: 11  PASS: 9  FAIL: 2  SKIP: 0
+Total: 11  PASS: 11  FAIL: 0  SKIP: 0
 ```

--- a/test/rdbms-mariadb-test/storage-type-test/openstack-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/openstack-storage-type-test.sh
@@ -64,7 +64,7 @@ while IFS= read -r storage_type; do
     \"Name\": \"${rdbms_name}\",
     \"VPCName\": \"vpc-01\",
     \"DBEngine\": \"mariadb\",
-    \"DBEngineVersion\": \"10.6\",
+    \"DBEngineVersion\": \"10.4\",
     \"DBSpec\": \"m1.small\",
     \"StorageType\": \"${storage_type}\",
     \"StorageSize\": \"20\",


### PR DESCRIPTION
- Fix storage-type-test/openstack-storage-type-test.sh requesting DBEngineVersion: "10.6", which doesn't exist on this environment's Trove (Datastore version '10.6' cannot be found, confirmed via /spider/rdbmsmetainfo?DBEngine=mariadb); changed to 10.4, the actual registered version
- Update test/rdbms-mariadb-test/README.md, storage-type-test/README.md, database-test/README.md to reflect the fix: OpenStack MariaDB support marked as fully working (version 10.4), stale "Trove datastore not yet provisioned" notes removed, and results refreshed to the latest all-PASS run (8/8, 11/11, 4/4)