### PR TITLE
[NHN/RDBMS] Feat: Add NHNAutoOpenDBSecurityGroup option (driver, REST API, AdminWeb)

### DIFF
--- a/api-runtime/common-runtime/RDBMSManager.go
+++ b/api-runtime/common-runtime/RDBMSManager.go
@@ -414,31 +414,46 @@ func CreateRDBMS(connectionName string, rsType string, reqInfo cres.RDBMSInfo, I
 	//+++++++++++++++++++++++++++++++++++++++++++
 
 	// SecurityGroupIIDs translation
-	for idx, sgIID := range reqInfo.SecurityGroupIIDs {
-		sgSPLock.RLock(connectionName, sgIID.NameId)
-		defer sgSPLock.RUnlock(connectionName, sgIID.NameId)
-		var sgIIdInfo SGIIDInfo
-		if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
-			var iidInfoList []*SGIIDInfo
-			err := getAuthIIDInfoList(connectionName, &iidInfoList)
-			if err != nil {
-				cblog.Error(err)
-				return nil, err
+	//
+	// NHN Cloud RDBMS does not use SecurityGroupNames/SecurityGroupIIDs at all
+	// (see RDBMSInfo.NHNAutoOpenDBSecurityGroup instead): NHN Cloud RDS DB
+	// Security Groups are a resource type separate from the VPC/Neutron
+	// security group this loop resolves, so a name given here would never
+	// correspond to a real registered SecurityGroup and resolution would
+	// always fail with "not found". Skip translation entirely for NHN so any
+	// value the caller sent is simply ignored, matching the driver's behavior.
+	providerName, err := ccm.GetProviderNameByConnectionName(connectionName)
+	if err != nil {
+		cblog.Error(err)
+		return nil, err
+	}
+	if !strings.EqualFold(providerName, "NHN") {
+		for idx, sgIID := range reqInfo.SecurityGroupIIDs {
+			sgSPLock.RLock(connectionName, sgIID.NameId)
+			defer sgSPLock.RUnlock(connectionName, sgIID.NameId)
+			var sgIIdInfo SGIIDInfo
+			if os.Getenv("PERMISSION_BASED_CONTROL_MODE") != "" {
+				var iidInfoList []*SGIIDInfo
+				err := getAuthIIDInfoList(connectionName, &iidInfoList)
+				if err != nil {
+					cblog.Error(err)
+					return nil, err
+				}
+				castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, sgIID.NameId)
+				if err != nil {
+					cblog.Error(err)
+					return nil, err
+				}
+				sgIIdInfo = *castedIIDInfo.(*SGIIDInfo)
+			} else {
+				err = infostore.GetByConditions(&sgIIdInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, sgIID.NameId)
+				if err != nil {
+					cblog.Error(err)
+					return nil, err
+				}
 			}
-			castedIIDInfo, err := getAuthIIDInfo(&iidInfoList, sgIID.NameId)
-			if err != nil {
-				cblog.Error(err)
-				return nil, err
-			}
-			sgIIdInfo = *castedIIDInfo.(*SGIIDInfo)
-		} else {
-			err = infostore.GetByConditions(&sgIIdInfo, CONNECTION_NAME_COLUMN, connectionName, NAME_ID_COLUMN, sgIID.NameId)
-			if err != nil {
-				cblog.Error(err)
-				return nil, err
-			}
+			reqInfo.SecurityGroupIIDs[idx] = getDriverIID(cres.IID{NameId: sgIIdInfo.NameId, SystemId: sgIIdInfo.SystemId})
 		}
-		reqInfo.SecurityGroupIIDs[idx] = getDriverIID(cres.IID{NameId: sgIIdInfo.NameId, SystemId: sgIIdInfo.SystemId})
 	}
 	//+++++++++++++++++++++++++++++++++++++++++++
 

--- a/api-runtime/rest-runtime/RDBMSRest.go
+++ b/api-runtime/rest-runtime/RDBMSRest.go
@@ -135,6 +135,16 @@ type RDBMSCreateRequest struct {
 		PublicAccess       bool `json:"PublicAccess,omitempty" default:"false"`
 		DeletionProtection bool `json:"DeletionProtection,omitempty" default:"false"`
 
+		// NHNAutoOpenDBSecurityGroup (NHN Cloud only): requires PublicAccess=true.
+		// When true, CB-Spider auto-creates and attaches a fully-open (0.0.0.0/0)
+		// NHN Cloud RDS DB Security Group, and deletes it automatically when the
+		// instance is deleted. Ignored by every other CSP. NHN Cloud RDBMS does
+		// not use SecurityGroupNames at all (see NHNAutoOpenDBSecurityGroup
+		// instead); if this flag is false (default), create and attach a DB
+		// Security Group yourself via the NHN Cloud console/API for external
+		// SQL access.
+		NHNAutoOpenDBSecurityGroup bool `json:"NHNAutoOpenDBSecurityGroup,omitempty" default:"false"`
+
 		TagList []cres.KeyValue `json:"TagList,omitempty" validate:"omitempty"`
 	} `json:"ReqInfo" validate:"required"`
 }
@@ -202,6 +212,8 @@ func CreateRDBMS(c echo.Context) error {
 		PublicAccess:       req.ReqInfo.PublicAccess,
 		DeletionProtection: req.ReqInfo.DeletionProtection,
 		// Encryption is not configurable at creation (CSP default)
+
+		NHNAutoOpenDBSecurityGroup: req.ReqInfo.NHNAutoOpenDBSecurityGroup,
 
 		TagList: req.ReqInfo.TagList,
 	}

--- a/api-runtime/rest-runtime/admin-web/html/rdbms.html
+++ b/api-runtime/rest-runtime/admin-web/html/rdbms.html
@@ -894,6 +894,14 @@
         vertical-align: middle;
     }
 
+    /* Disabled state for Subnets/Security Groups dropdowns (CSPs that don't use them) */
+    .sg-custom-select.disabled .sg-selected-display {
+        background-color: #eee;
+        color: #999;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+
     /* MetaInfo Reference Panel */
     #metaInfoPanel {
         background-color: #f0f7ff;
@@ -1106,6 +1114,12 @@
                             <th>Public</th>
                             <td>{{if $rdbms.PublicAccess}}Yes{{else}}No{{end}}</td>
                         </tr>
+                        {{if eq $.ProviderName "NHN"}}
+                        <tr>
+                            <th>Auto-open DB SG</th>
+                            <td>{{if $rdbms.NHNAutoOpenDBSecurityGroup}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                        {{end}}
                     </table>
                 </td>
 
@@ -1423,6 +1437,19 @@
                             <div class="sg-dropdown-list" id="sgDropdownList"></div>
                         </div>
                     </div>
+                    <div id="nhnAutoOpenDBSecurityGroupGroup" style="display:none;">
+                        <div class="form-group">
+                            <label for="nhnAutoOpenDBSecurityGroup">Auto-open DB SG:</label>
+                            <select id="nhnAutoOpenDBSecurityGroup" name="nhnAutoOpenDBSecurityGroup" style="background-color: #E6E6FA; width: 65%;">
+                                <option value="false">No</option>
+                                <option value="true" selected>Yes</option>
+                            </select>
+                        </div>
+                        <div class="form-group" style="margin-top: -6px;">
+                            <label></label>
+                            <small style="flex: 2; text-align: left; color: #666;">NHN only. Requires Public Access = Yes. Auto-creates a fully-open (0.0.0.0/0) DB Security Group and deletes it automatically when the instance is deleted.</small>
+                        </div>
+                    </div>
                 </fieldset>
 
                 <!-- Authentication -->
@@ -1450,7 +1477,7 @@
                     </div>
                     <div class="form-group">
                         <label for="publicAccess">Public Access:</label>
-                        <select id="publicAccess" name="publicAccess" style="background-color: #E6E6FA; width: 65%;">
+                        <select id="publicAccess" name="publicAccess" style="background-color: #E6E6FA; width: 65%;" onchange="updateSubnetFieldAvailability(); updateNHNAutoOpenSGAvailability()">
                             <option value="false">No</option>
                             <option value="true" selected>Yes</option>
                         </select>
@@ -1553,6 +1580,10 @@
 
     let currentRequiresSubnet = false;
     let currentRequiresSecurityGroup = false;
+    // RequiresSubnet from the last-applied RDBMSMetaInfo, kept around so the
+    // Subnet field's disabled/required state can be recomputed on demand
+    // (e.g. when Public Access changes for Azure) without re-fetching MetaInfo.
+    let lastMetaInfoRequiresSubnet = false;
 
     // Helper function to create fetch options with Basic Auth if credentials are set
     function createFetchOptions(options = {}) {
@@ -1747,6 +1778,15 @@
             }
         }
 
+        const nhnAutoOpenDBSecurityGroupEl = document.getElementById('nhnAutoOpenDBSecurityGroup');
+        if (isNHNProvider() && nhnAutoOpenDBSecurityGroupEl && nhnAutoOpenDBSecurityGroupEl.value === 'true') {
+            const publicAccess = document.getElementById('publicAccess').value === 'true';
+            if (!publicAccess) {
+                alert("Auto-open DB Security Group requires Public Access = Yes.");
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -1788,6 +1828,10 @@
             Value: tagInput.querySelector('.rdbms-tag-value').value
         }));
 
+        // NHN-only convenience option (hidden/reset to false for all other providers)
+        const nhnAutoOpenDBSecurityGroupEl = document.getElementById('nhnAutoOpenDBSecurityGroup');
+        const nhnAutoOpenDBSecurityGroup = !!nhnAutoOpenDBSecurityGroupEl && nhnAutoOpenDBSecurityGroupEl.value === 'true';
+
         const data = {
             ConnectionName: connConfig,
             ReqInfo: {
@@ -1804,6 +1848,7 @@
                 MasterUserPassword: masterUserPassword,
                 HighAvailability: highAvailability,
                 PublicAccess: publicAccess,
+                NHNAutoOpenDBSecurityGroup: nhnAutoOpenDBSecurityGroup || undefined,
                 Encryption: encryption,
                 DeletionProtection: deletionProtection,
                 BackupRetentionDays: backupRetentionDays,
@@ -2174,21 +2219,44 @@
             if (cacheBadge) cacheBadge.style.display = isCached ? '' : 'none';
 
             // Update Subnet/SG label required status
-            const subnetLabel = document.getElementById('subnetLabel');
             const sgLabel = document.getElementById('sgLabel');
-            if (metaInfo.RequiresSubnet) {
-                subnetLabel.innerHTML = 'Subnets: <span style="color: red;">*</span>';
-                currentRequiresSubnet = true;
-            } else {
-                subnetLabel.innerHTML = 'Subnets: <span style="color: #999;">(optional)</span>';
-                currentRequiresSubnet = false;
-            }
-            if (metaInfo.RequiresSecurityGroup) {
-                sgLabel.innerHTML = 'Security Groups: <span style="color: red;">*</span>';
-                currentRequiresSecurityGroup = true;
-            } else {
-                sgLabel.innerHTML = 'Security Groups: <span style="color: #999;">(optional)</span>';
+
+            lastMetaInfoRequiresSubnet = !!metaInfo.RequiresSubnet;
+            updateSubnetFieldAvailability();
+
+            const sgWrapper = document.getElementById('securityGroupSelectWrapper');
+            if (isSecurityGroupUnusedProvider()) {
+                // SecurityGroupNames has no effect on this CSP's RDBMS create
+                // API — the driver never reads it, so disable the field
+                // instead of letting users interact with an input that does
+                // nothing.
+                if (sgWrapper) sgWrapper.classList.add('disabled');
+                document.getElementById('sgSelectedText').textContent = 'Not used by this CSP';
+                document.getElementById('sgDropdownList').innerHTML = '';
+                sgLabel.innerHTML = 'Security Groups: <span style="color: #999;">(not used)</span>';
                 currentRequiresSecurityGroup = false;
+            } else {
+                if (sgWrapper) sgWrapper.classList.remove('disabled');
+                if (metaInfo.RequiresSecurityGroup) {
+                    sgLabel.innerHTML = 'Security Groups: <span style="color: red;">*</span>';
+                    currentRequiresSecurityGroup = true;
+                } else {
+                    sgLabel.innerHTML = 'Security Groups: <span style="color: #999;">(optional)</span>';
+                    currentRequiresSecurityGroup = false;
+                }
+            }
+
+            // NHN-only convenience option: auto-create/attach a fully-open
+            // DB Security Group (see RDBMSInfo.NHNAutoOpenDBSecurityGroup).
+            const nhnSGGroup = document.getElementById('nhnAutoOpenDBSecurityGroupGroup');
+            if (nhnSGGroup) {
+                if (isNHNProvider()) {
+                    nhnSGGroup.style.display = '';
+                    updateNHNAutoOpenSGAvailability();
+                } else {
+                    nhnSGGroup.style.display = 'none';
+                    document.getElementById('nhnAutoOpenDBSecurityGroup').value = 'false';
+                }
             }
 
             // Populate Version select
@@ -2617,9 +2685,14 @@
         const vpcSelect = document.getElementById('vpcName');
         const subnetDropdownList = document.getElementById('subnetDropdownList');
         const subnetSelectedText = document.getElementById('subnetSelectedText');
-        
+
         subnetDropdownList.innerHTML = '';
-        
+
+        if (isSubnetUnusedProvider()) {
+            subnetSelectedText.textContent = 'Not used by this CSP';
+            return;
+        }
+
         if (!vpcSelect.value) {
             subnetSelectedText.textContent = 'Select VPC first';
             return;
@@ -2694,7 +2767,13 @@
         const sgDropdownList = document.getElementById('sgDropdownList');
         const sgSelectedText = document.getElementById('sgSelectedText');
         const vpcSelect = document.getElementById('vpcName');
-        
+
+        if (isSecurityGroupUnusedProvider()) {
+            sgDropdownList.innerHTML = '';
+            sgSelectedText.textContent = 'Not used by this CSP';
+            return;
+        }
+
         if (!vpcSelect.value) {
             sgSelectedText.textContent = 'Select VPC first';
             sgDropdownList.innerHTML = '';
@@ -3077,6 +3156,107 @@
     // SQL password is still needed for table/row operations on all CSPs.
     const CSP_NATIVE_DB_PROVIDERS = ['NCP', 'NHN', 'GCP', 'ALIBABA', 'TENCENT', 'OPENSTACK', 'KT', 'AZURE'];
 
+    // CSPs whose RDBMS create API never reads SecurityGroupNames — the field
+    // is silently ignored. The Add-RDBMS form keeps it visible but disables
+    // it for these providers, instead of hiding it or letting users interact
+    // with an input that does nothing. AWS requires a Security Group;
+    // Tencent optionally uses one (shares the VM's SG) — both stay enabled.
+    const RDBMS_SG_UNUSED_PROVIDERS = ['ALIBABA', 'AZURE', 'GCP', 'IBM', 'NCP', 'OPENSTACK', 'NHN'];
+
+    // CSPs whose RDBMS create API never reads SubnetNames, under any
+    // PublicAccess setting. AWS/Alibaba/Tencent/NCP/NHN require a subnet and
+    // stay enabled. Azure is NOT in this static list — it's handled
+    // dynamically in isSubnetUnusedProvider() since it only uses SubnetIIDs
+    // for its VPC-private mode (PublicAccess=false).
+    const RDBMS_SUBNET_UNUSED_PROVIDERS = ['GCP', 'IBM', 'OPENSTACK'];
+
+    function isSecurityGroupUnusedProvider() {
+        const provider = (document.getElementById('currentProviderName').value || '').toUpperCase();
+        return RDBMS_SG_UNUSED_PROVIDERS.indexOf(provider) >= 0;
+    }
+
+    function isSubnetUnusedProvider() {
+        const provider = (document.getElementById('currentProviderName').value || '').toUpperCase();
+        if (provider === 'AZURE') {
+            // Azure only uses SubnetIIDs for its VPC-private mode
+            // (PublicAccess=false); with PublicAccess=true (the default) the
+            // field has no effect. Re-evaluated live via updateSubnetFieldAvailability().
+            const publicAccessEl = document.getElementById('publicAccess');
+            return !publicAccessEl || publicAccessEl.value !== 'false';
+        }
+        return RDBMS_SUBNET_UNUSED_PROVIDERS.indexOf(provider) >= 0;
+    }
+
+    // Recomputes the Subnets field's disabled/required state. Called on
+    // MetaInfo load and whenever Public Access changes (Azure's Subnet usage
+    // depends on it — see isSubnetUnusedProvider). Re-populates the dropdown
+    // if the field just became enabled and a VPC is already selected.
+    function updateSubnetFieldAvailability() {
+        const subnetLabel = document.getElementById('subnetLabel');
+        const subnetWrapper = document.getElementById('subnetSelectWrapper');
+        const wasDisabled = !!(subnetWrapper && subnetWrapper.classList.contains('disabled'));
+
+        if (isSubnetUnusedProvider()) {
+            if (subnetWrapper) subnetWrapper.classList.add('disabled');
+            document.getElementById('subnetSelectedText').textContent = 'Not used by this CSP';
+            document.getElementById('subnetDropdownList').innerHTML = '';
+            subnetLabel.innerHTML = 'Subnets: <span style="color: #999;">(not used)</span>';
+            currentRequiresSubnet = false;
+            return;
+        }
+
+        if (subnetWrapper) subnetWrapper.classList.remove('disabled');
+
+        // Azure's requirement is dynamic (only required in VPC-private mode)
+        // and isn't reflected in the static RequiresSubnet MetaInfo flag.
+        const azurePrivateModeRequiresSubnet = isAzureProvider() &&
+            document.getElementById('publicAccess').value === 'false';
+
+        if (lastMetaInfoRequiresSubnet || azurePrivateModeRequiresSubnet) {
+            subnetLabel.innerHTML = 'Subnets: <span style="color: red;">*</span>';
+            currentRequiresSubnet = true;
+        } else {
+            subnetLabel.innerHTML = 'Subnets: <span style="color: #999;">(optional)</span>';
+            currentRequiresSubnet = false;
+        }
+
+        // The dropdown was cleared while disabled — repopulate it now that
+        // it's usable again (no-ops if no VPC is selected yet).
+        if (wasDisabled) {
+            updateSubnets();
+        }
+    }
+
+    function isAzureProvider() {
+        const provider = (document.getElementById('currentProviderName').value || '').toUpperCase();
+        return provider === 'AZURE';
+    }
+
+    function isNHNProvider() {
+        const provider = (document.getElementById('currentProviderName').value || '').toUpperCase();
+        return provider === 'NHN';
+    }
+
+    // NHNAutoOpenDBSecurityGroup requires PublicAccess=true (enforced by the
+    // backend too — see validateForm()). Keep the control in sync with
+    // Public Access so users can't set an invalid combination in the first
+    // place: force it to No and lock it while Public Access=No, and hand
+    // control back (defaulting to Yes again) once Public Access=Yes.
+    function updateNHNAutoOpenSGAvailability() {
+        if (!isNHNProvider()) return;
+        const select = document.getElementById('nhnAutoOpenDBSecurityGroup');
+        if (!select) return;
+
+        const publicAccess = document.getElementById('publicAccess').value === 'true';
+        if (publicAccess) {
+            select.disabled = false;
+            select.value = 'true';
+        } else {
+            select.disabled = true;
+            select.value = 'false';
+        }
+    }
+
     function isNativeDBProvider() {
         const provider = (document.getElementById('currentProviderName').value || '').toUpperCase();
         return CSP_NATIVE_DB_PROVIDERS.indexOf(provider) >= 0;
@@ -3153,20 +3333,11 @@
             return;
         }
 
-        // For CSP-native providers, skip SQL connect test (DB management uses CSP API).
-        // Password is still stored for table/row SQL operations.
-        if (isNativeDBProvider()) {
-            currentDBPassword = password;
-            currentDBName = null;
-            statusEl.textContent = '✓ Connected — Select a database below';
-            statusEl.className = 'db-connect-status connected';
-            document.getElementById('db-database-panel').style.display = 'block';
-            document.getElementById('db-table-panel').style.display = 'none';
-            document.getElementById('db-row-panel').style.display = 'none';
-            loadDatabases();
-            return;
-        }
-
+        // Always verify the password with a real SQL connection before
+        // proceeding, on every CSP (including CSP-native DB-management
+        // providers) — Table browsing needs a real SQL connection regardless
+        // of provider, so a wrong password should fail here, not silently
+        // succeed and only surface an error later when opening a table.
         statusEl.textContent = 'Connecting...';
         statusEl.className = 'db-connect-status';
 

--- a/api/docs.go
+++ b/api/docs.go
@@ -15704,6 +15704,11 @@ const docTemplate = `{
                     "description": "Master user password (for Create request only)",
                     "type": "string"
                 },
+                "NHNAutoOpenDBSecurityGroup": {
+                    "description": "NHNAutoOpenDBSecurityGroup (NHN Cloud only): when true together with\nPublicAccess=true, CB-Spider auto-creates a fully-open (0.0.0.0/0) NHN\nCloud RDS DB Security Group, attaches it at creation, and deletes it\nautomatically when the instance is deleted. Ignored by every other CSP.\nSecurityGroupNames/SecurityGroupIIDs is not used for NHN Cloud RDBMS at\nall: NHN Cloud RDS DB Security Groups are a resource type separate from\nthe VPC/Neutron security group CB-Spider manages, so when this flag is\nfalse (the default), you must create one yourself via the NHN Cloud\nconsole or API and attach it to the instance for external SQL access.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "PublicAccess": {
                     "description": "Access",
                     "type": "boolean",
@@ -19070,6 +19075,11 @@ const docTemplate = `{
                         "MasterUserPassword": {
                             "type": "string",
                             "example": "password123!"
+                        },
+                        "NHNAutoOpenDBSecurityGroup": {
+                            "description": "NHNAutoOpenDBSecurityGroup (NHN Cloud only): requires PublicAccess=true.\nWhen true, CB-Spider auto-creates and attaches a fully-open (0.0.0.0/0)\nNHN Cloud RDS DB Security Group, and deletes it automatically when the\ninstance is deleted. Ignored by every other CSP. NHN Cloud RDBMS does\nnot use SecurityGroupNames at all (see NHNAutoOpenDBSecurityGroup\ninstead); if this flag is false (default), create and attach a DB\nSecurity Group yourself via the NHN Cloud console/API for external\nSQL access.",
+                            "type": "boolean",
+                            "default": false
                         },
                         "Name": {
                             "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -15701,6 +15701,11 @@
                     "description": "Master user password (for Create request only)",
                     "type": "string"
                 },
+                "NHNAutoOpenDBSecurityGroup": {
+                    "description": "NHNAutoOpenDBSecurityGroup (NHN Cloud only): when true together with\nPublicAccess=true, CB-Spider auto-creates a fully-open (0.0.0.0/0) NHN\nCloud RDS DB Security Group, attaches it at creation, and deletes it\nautomatically when the instance is deleted. Ignored by every other CSP.\nSecurityGroupNames/SecurityGroupIIDs is not used for NHN Cloud RDBMS at\nall: NHN Cloud RDS DB Security Groups are a resource type separate from\nthe VPC/Neutron security group CB-Spider manages, so when this flag is\nfalse (the default), you must create one yourself via the NHN Cloud\nconsole or API and attach it to the instance for external SQL access.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "PublicAccess": {
                     "description": "Access",
                     "type": "boolean",
@@ -19067,6 +19072,11 @@
                         "MasterUserPassword": {
                             "type": "string",
                             "example": "password123!"
+                        },
+                        "NHNAutoOpenDBSecurityGroup": {
+                            "description": "NHNAutoOpenDBSecurityGroup (NHN Cloud only): requires PublicAccess=true.\nWhen true, CB-Spider auto-creates and attaches a fully-open (0.0.0.0/0)\nNHN Cloud RDS DB Security Group, and deletes it automatically when the\ninstance is deleted. Ignored by every other CSP. NHN Cloud RDBMS does\nnot use SecurityGroupNames at all (see NHNAutoOpenDBSecurityGroup\ninstead); if this flag is false (default), create and attach a DB\nSecurity Group yourself via the NHN Cloud console/API for external\nSQL access.",
+                            "type": "boolean",
+                            "default": false
                         },
                         "Name": {
                             "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1482,6 +1482,19 @@ definitions:
       MasterUserPassword:
         description: Master user password (for Create request only)
         type: string
+      NHNAutoOpenDBSecurityGroup:
+        default: false
+        description: |-
+          NHNAutoOpenDBSecurityGroup (NHN Cloud only): when true together with
+          PublicAccess=true, CB-Spider auto-creates a fully-open (0.0.0.0/0) NHN
+          Cloud RDS DB Security Group, attaches it at creation, and deletes it
+          automatically when the instance is deleted. Ignored by every other CSP.
+          SecurityGroupNames/SecurityGroupIIDs is not used for NHN Cloud RDBMS at
+          all: NHN Cloud RDS DB Security Groups are a resource type separate from
+          the VPC/Neutron security group CB-Spider manages, so when this flag is
+          false (the default), you must create one yourself via the NHN Cloud
+          console or API and attach it to the instance for external SQL access.
+        type: boolean
       PublicAccess:
         default: false
         description: Access
@@ -3902,6 +3915,18 @@ definitions:
           MasterUserPassword:
             example: password123!
             type: string
+          NHNAutoOpenDBSecurityGroup:
+            default: false
+            description: |-
+              NHNAutoOpenDBSecurityGroup (NHN Cloud only): requires PublicAccess=true.
+              When true, CB-Spider auto-creates and attaches a fully-open (0.0.0.0/0)
+              NHN Cloud RDS DB Security Group, and deletes it automatically when the
+              instance is deleted. Ignored by every other CSP. NHN Cloud RDBMS does
+              not use SecurityGroupNames at all (see NHNAutoOpenDBSecurityGroup
+              instead); if this flag is false (default), create and attach a DB
+              Security Group yourself via the NHN Cloud console/API for external
+              SQL access.
+            type: boolean
           Name:
             example: rdbms-01
             type: string

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/RDBMSHandler.go
@@ -206,6 +206,7 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSInstanceOptions(engineNames []alib
 	for _, eng := range engineNames {
 		instanceSpecSet := map[string]bool{}
 		seenLookup := map[string]bool{}
+		firstCall := true
 		for _, lookup := range storageLookups[eng.aliName] {
 			if lookup.engineVersion != latestVersionByEngine[eng.aliName] {
 				continue
@@ -215,6 +216,17 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSInstanceOptions(engineNames []alib
 				continue
 			}
 			seenLookup[lookupKey] = true
+
+			// A single GetMetaInfo() call can require one DescribeAvailableClasses
+			// request per (category, storageType) combination — for engines with
+			// several categories (Basic/HighAvailability/AlwaysOn/Finance) and
+			// storage types this can easily reach 10-20+ sequential calls. Pace
+			// them instead of firing back-to-back, or Alibaba's per-user rate
+			// limit rejects the burst with a "Throttling.User" error.
+			if !firstCall {
+				time.Sleep(describeAvailableClassesPacingDelay)
+			}
+			firstCall = false
 
 			classesReq := rds.CreateDescribeAvailableClassesRequest()
 			classesReq.Engine = eng.aliName
@@ -259,14 +271,22 @@ func (handler *AlibabaRDBMSHandler) fetchRDBMSInstanceOptions(engineNames []alib
 	return instanceSpecOptions, irs.StorageSizeRange{Min: minStorage, Max: maxStorage}, nil
 }
 
+// describeAvailableClassesPacingDelay is slept between successive
+// DescribeAvailableClasses calls within a single GetMetaInfo() request (see
+// fetchRDBMSInstanceOptions) so the (category, storageType) combinations for
+// an engine version are queried as a paced sequence rather than a burst,
+// which is what triggers Alibaba's per-user "Throttling.User" rate limit.
+const describeAvailableClassesPacingDelay = 400 * time.Millisecond
+
 func (handler *AlibabaRDBMSHandler) describeAvailableClasses(request *rds.DescribeAvailableClassesRequest) (*rds.DescribeAvailableClassesResponse, error) {
 	type describeAvailableClassesResult struct {
 		response *rds.DescribeAvailableClassesResponse
 		err      error
 	}
 
-	const maxThrottleRetry = 5
-	const throttleWait = 5 * time.Second
+	const maxThrottleRetry = 6
+	const throttleBaseWait = 5 * time.Second
+	const throttleMaxWait = 60 * time.Second
 
 	for attempt := 0; ; attempt++ {
 		resultChan := make(chan describeAvailableClassesResult, 1)
@@ -281,9 +301,18 @@ func (handler *AlibabaRDBMSHandler) describeAvailableClasses(request *rds.Descri
 			timer.Stop()
 			if result.err != nil {
 				if strings.Contains(result.err.Error(), "ErrorCode: Throttling") && attempt < maxThrottleRetry {
-					cblogger.Warnf("Throttling error for DescribeAvailableClasses (engine=%s, version=%s, zone=%s): %v. Waiting %s before retrying...",
-						request.Engine, request.EngineVersion, request.ZoneId, result.err, throttleWait)
-					time.Sleep(throttleWait)
+					// Exponential backoff (5s, 10s, 20s, 40s, 60s, 60s...): a fixed
+					// 5s retry proved too short against Alibaba's observed
+					// recommended cooldown (X-Acs-Retry-After up to ~14s) for this
+					// API, so back off further on repeated throttling instead of
+					// hammering it at the same short interval.
+					wait := throttleBaseWait << attempt
+					if wait > throttleMaxWait || wait <= 0 {
+						wait = throttleMaxWait
+					}
+					cblogger.Warnf("Throttling error for DescribeAvailableClasses (engine=%s, version=%s, zone=%s): %v. Waiting %s before retrying (attempt %d/%d)...",
+						request.Engine, request.EngineVersion, request.ZoneId, result.err, wait, attempt+1, maxThrottleRetry)
+					time.Sleep(wait)
 					continue
 				}
 				return nil, result.err

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/RDBMSHandler.go
@@ -196,9 +196,28 @@ type nhnRDSDBSecurityGroupDetail struct {
 	Description         string `json:"description"`
 }
 
+// nhnRDSDBSecurityGroupDetailResponse decodes the response of
+// GET /v3.0/db-security-groups/{id}. The exact response shape for this
+// specific endpoint isn't confirmed (NHN's public API guide is truncated
+// before this section, and a live call returned an empty name/description
+// when decoded flat) — LIST db-security-groups is confirmed to nest its
+// items under a "dbSecurityGroups" array, so this also accepts a "dbSecurityGroup"
+// singular-object shape for the single-item GET, in addition to a flat
+// top-level shape, and Detail() returns whichever was actually populated.
 type nhnRDSDBSecurityGroupDetailResponse struct {
 	Header nhnRDSResponseHeader `json:"header"`
 	nhnRDSDBSecurityGroupDetail
+	Nested *nhnRDSDBSecurityGroupDetail `json:"dbSecurityGroup,omitempty"`
+}
+
+// Detail returns the populated DB security group fields regardless of
+// whether the response was flat or nested under "dbSecurityGroup" (see
+// nhnRDSDBSecurityGroupDetailResponse).
+func (r nhnRDSDBSecurityGroupDetailResponse) Detail() nhnRDSDBSecurityGroupDetail {
+	if r.Nested != nil && (r.Nested.DBSecurityGroupId != "" || r.Nested.DBSecurityGroupName != "" || r.Nested.Description != "") {
+		return *r.Nested
+	}
+	return r.nhnRDSDBSecurityGroupDetail
 }
 
 type nhnRDSCreateInstanceRequest struct {
@@ -616,6 +635,8 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 		return irs.RDBMSInfo{}, errors.New("MasterUserName is required")
 	case rdbmsReqInfo.MasterUserPassword == "":
 		return irs.RDBMSInfo{}, errors.New("MasterUserPassword is required")
+	case rdbmsReqInfo.NHNAutoOpenDBSecurityGroup && !rdbmsReqInfo.PublicAccess:
+		return irs.RDBMSInfo{}, errors.New("NHNAutoOpenDBSecurityGroup requires PublicAccess=true")
 	}
 
 	storageSize, err := strconv.Atoi(rdbmsReqInfo.StorageSize)
@@ -679,24 +700,32 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 		return irs.RDBMSInfo{}, newErr
 	}
 
-	// Build DB Security Group IDs.
-	// If SecurityGroupIIDs are provided, use their SystemIds (NHN RDS DB SG UUIDs).
-	// Otherwise auto-create a permissive SG that allows inbound on DB_PORT from 0.0.0.0/0.
-	var dbSGIds []string
-	if len(rdbmsReqInfo.SecurityGroupIIDs) > 0 {
-		for _, sg := range rdbmsReqInfo.SecurityGroupIIDs {
-			if sg.SystemId != "" {
-				dbSGIds = append(dbSGIds, sg.SystemId)
-			}
-		}
-	}
-	if len(dbSGIds) == 0 {
-		// Resolve subnet CIDR for private-access restriction (best-effort)
-		subnetCidr := ""
-		if !rdbmsReqInfo.PublicAccess && subnetId != "" {
-			subnetCidr = handler.fetchSubnetCidr(ctx, subnetId)
-		}
-		autoSGId, sgErr := handler.createDefaultDBSecurityGroup(ctx, endpointFn, rdbmsReqInfo.IId.NameId, rdbmsReqInfo.PublicAccess, subnetCidr)
+	// DB Security Group handling.
+	//
+	// Officially, CB-Spider does NOT manage NHN Cloud RDS DB Security Groups
+	// by default (same as Alibaba/Azure/GCP/IBM/NCP/OpenStack) —
+	// SecurityGroupNames/SecurityGroupIIDs is not used for NHN Cloud RDBMS at
+	// all. NHN Cloud's DB SG is a separate resource type from the VPC/Neutron
+	// security group Spider manages, so the user must create a DB Security
+	// Group with the desired access rules via the NHN Cloud console or API
+	// and attach it to the DB instance themselves (independently of Spider)
+	// for external SQL access.
+	//
+	// Setting NHNAutoOpenDBSecurityGroup=true (requires PublicAccess=true,
+	// validated above) is an official convenience option: CB-Spider then
+	// auto-creates a fully-open (0.0.0.0/0) DB Security Group, attaches it at
+	// creation, and deletes it automatically when the instance is deleted
+	// (see DeleteRDBMS).
+	//
+	// dbSGIds must stay a non-nil (possibly empty) slice: the NHN API docs
+	// mark dbSecurityGroupIds as optional, but a Go nil slice marshals to
+	// JSON `null`, and NHN's backend appears to fault (500) on a null value
+	// for this field rather than treating it like an omitted/empty one — the
+	// same reason UserGroupIds below is always set to []string{} rather than
+	// left nil.
+	dbSGIds := []string{}
+	if rdbmsReqInfo.NHNAutoOpenDBSecurityGroup {
+		autoSGId, sgErr := handler.createDefaultDBSecurityGroup(ctx, endpointFn, rdbmsReqInfo.IId.NameId)
 		if sgErr != nil {
 			LoggingError(callLogInfo, sgErr)
 			return irs.RDBMSInfo{}, sgErr
@@ -813,6 +842,10 @@ func (handler *NhnCloudRDBMSHandler) CreateRDBMS(rdbmsReqInfo irs.RDBMSInfo) (ir
 	if strings.HasPrefix(strings.ToUpper(rdbmsReqInfo.DBEngineVersion), "MARIADB_") {
 		result.DBEngine = "mariadb"
 	}
+	// We already know whether this instance's DB Security Group was just
+	// auto-created (validated at the top of this function), so reflect it
+	// directly rather than re-deriving it via a live SG lookup.
+	result.NHNAutoOpenDBSecurityGroup = rdbmsReqInfo.NHNAutoOpenDBSecurityGroup
 	return result, nil
 }
 
@@ -877,6 +910,11 @@ func (handler *NhnCloudRDBMSHandler) ListRDBMS() ([]*irs.RDBMSInfo, error) {
 			if strings.HasPrefix(strings.ToUpper(detail.DBVersion), "MARIADB_") {
 				info.DBEngine = "mariadb"
 			}
+			// See the matching comment in GetRDBMS: re-derive live from the
+			// attached SG's description tag.
+			if autoSGIds := handler.collectAutoCBSpiderSGIdsWithEndpoint(ctx, endpointFn, detail.DBSecurityGroupIds); len(autoSGIds) > 0 {
+				info.NHNAutoOpenDBSecurityGroup = true
+			}
 			rdbmsList = append(rdbmsList, &info)
 		}
 	}
@@ -932,6 +970,13 @@ func (handler *NhnCloudRDBMSHandler) GetRDBMS(rdbmsIID irs.IID) (irs.RDBMSInfo, 
 		if strings.HasPrefix(strings.ToUpper(result.DBVersion), "MARIADB_") {
 			info.DBEngine = "mariadb"
 		}
+		// Surface whether the currently attached DB SG(s) include one CB-Spider
+		// auto-created (see NHNAutoOpenDBSecurityGroup), so this is visible on
+		// GetRDBMS/ListRDBMS even though CB-Spider never stores that choice
+		// anywhere itself — it's re-derived live from the SG's description tag.
+		if autoSGIds := handler.collectAutoCBSpiderSGIdsWithEndpoint(ctx, endpointFn, result.DBSecurityGroupIds); len(autoSGIds) > 0 {
+			info.NHNAutoOpenDBSecurityGroup = true
+		}
 		return info, nil
 	}
 
@@ -961,10 +1006,16 @@ func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error)
 	}
 
 	// Collect DB security group IDs before deleting the instance so we can
-	// clean up any SGs that were auto-created by CB-Spider.
+	// clean up any SGs that were auto-created by CB-Spider (identified by
+	// their description tag, see createDefaultDBSecurityGroup). This only
+	// ever finds anything for an instance that was created with
+	// NHNAutoOpenDBSecurityGroup=true — user-managed DB Security Groups never
+	// carry that description tag, so they are left untouched.
 	var getInstResp nhnRDSGetInstanceResponse
-	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &getInstResp); err == nil {
-		_ = checkRDSResponseHeader(getInstResp.Header) // ignore header error here
+	if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-instances/"+dbInstanceId, &getInstResp); err != nil {
+		cblogger.Warnf("[NHN RDS] failed to fetch instance '%s' before delete (auto-created DB SG cleanup will be skipped): %v", dbInstanceId, err)
+	} else if hdrErr := checkRDSResponseHeader(getInstResp.Header); hdrErr != nil {
+		cblogger.Warnf("[NHN RDS] error response fetching instance '%s' before delete (auto-created DB SG cleanup will be skipped): %v", dbInstanceId, hdrErr)
 	}
 	autoSGIds := handler.collectAutoCBSpiderSGIdsWithEndpoint(ctx, endpointFn, getInstResp.DBSecurityGroupIds)
 
@@ -979,12 +1030,30 @@ func (handler *NhnCloudRDBMSHandler) DeleteRDBMS(rdbmsIID irs.IID) (bool, error)
 		return false, err
 	}
 
-	// Delete auto-created DB SGs (best-effort; log but do not fail)
-	for _, sgId := range autoSGIds {
-		if delErr := handler.deleteRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-security-groups/"+sgId, nil); delErr != nil {
-			cblogger.Warnf("[NHN RDS] failed to delete auto-created DB security group '%s': %v", sgId, delErr)
+	// Delete auto-created DB SGs (best-effort; log but do not fail the
+	// instance deletion itself). NHN Cloud RDS instance deletion is
+	// asynchronous (deleteResp is a job, not a completed operation), and NHN
+	// rejects deleting a DB Security Group that is still attached to an
+	// instance that hasn't finished deleting yet — so we must wait for the
+	// deletion job to actually reach COMPLETED before attempting SG cleanup,
+	// otherwise the SG delete call fails silently and the SG is orphaned.
+	// autoSGIds is always empty unless the instance was created with
+	// NHNAutoOpenDBSecurityGroup=true, so user-managed DB Security Groups are
+	// never touched — and ordinary deletes (the vast majority) skip this
+	// extra wait entirely since there's nothing to clean up.
+	if len(autoSGIds) > 0 {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer waitCancel()
+		if err := handler.waitForRDSJobCompletion(waitCtx, endpointFn, deleteResp.JobId); err != nil {
+			cblogger.Warnf("[NHN RDS] instance deletion accepted, but failed waiting for it to complete before cleaning up auto-created DB security group(s) (they may need manual cleanup): %v", err)
 		} else {
-			cblogger.Infof("[NHN RDS] deleted auto-created DB security group '%s'", sgId)
+			for _, sgId := range autoSGIds {
+				if delErr := handler.deleteRDSWithEndpoint(waitCtx, endpointFn, "/v3.0/db-security-groups/"+sgId, nil); delErr != nil {
+					cblogger.Warnf("[NHN RDS] failed to delete auto-created DB security group '%s': %v", sgId, delErr)
+				} else {
+					cblogger.Infof("[NHN RDS] deleted auto-created DB security group '%s'", sgId)
+				}
+			}
 		}
 	}
 
@@ -1041,48 +1110,6 @@ func (handler *NhnCloudRDBMSHandler) postRDSWithEndpoint(ctx context.Context, en
 	return nil
 }
 
-// collectAutoCBSpiderSGIds inspects the given DB SG IDs and returns those
-// that were auto-created by CB-Spider (identified by description prefix).
-func (handler *NhnCloudRDBMSHandler) collectAutoCBSpiderSGIds(ctx context.Context, sgIds []string) []string {
-	var auto []string
-	for _, id := range sgIds {
-		var detail nhnRDSDBSecurityGroupDetailResponse
-		if err := handler.getRDS(ctx, "/v3.0/db-security-groups/"+id, &detail); err != nil {
-			continue
-		}
-		if checkRDSResponseHeader(detail.Header) != nil {
-			continue
-		}
-		if strings.HasPrefix(detail.Description, "Auto-created by CB-Spider:") {
-			auto = append(auto, id)
-		}
-	}
-	return auto
-}
-
-// fetchSubnetCidr retrieves the CIDR of the given subnet ID from the NHN RDS subnet list.
-// Returns empty string on any error (best-effort).
-func (handler *NhnCloudRDBMSHandler) fetchSubnetCidr(ctx context.Context, subnetId string) string {
-	type nhnRDSSubnet struct {
-		SubnetId   string `json:"subnetId"`
-		SubnetCidr string `json:"subnetCidr"`
-	}
-	type nhnRDSSubnetListResponse struct {
-		Header  nhnRDSResponseHeader `json:"header"`
-		Subnets []nhnRDSSubnet       `json:"subnets"`
-	}
-	var resp nhnRDSSubnetListResponse
-	if err := handler.getRDS(ctx, "/v3.0/network/subnets", &resp); err != nil {
-		return ""
-	}
-	for _, s := range resp.Subnets {
-		if s.SubnetId == subnetId {
-			return s.SubnetCidr
-		}
-	}
-	return ""
-}
-
 // putRDS sends a PUT request to the NHN RDS for MySQL API.
 func (handler *NhnCloudRDBMSHandler) putRDS(ctx context.Context, path string, body interface{}, v interface{}) error {
 	endpoint, err := handler.rdsEndpoint()
@@ -1127,24 +1154,16 @@ func (handler *NhnCloudRDBMSHandler) putRDS(ctx context.Context, path string, bo
 	return nil
 }
 
-// createDefaultDBSecurityGroup creates a NHN Cloud RDS DB Security Group and returns its ID.
-// endpointFn selects the correct RDS endpoint (MySQL or MariaDB) for the DB instance being created.
-// If publicAccess is true, allows inbound DB port from 0.0.0.0/0.
-// If publicAccess is false and subnetCidr is non-empty, restricts inbound to the subnet CIDR only.
-func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Context, endpointFn func() (string, error), name string, publicAccess bool, subnetCidr string) (string, error) {
-	cidr := "0.0.0.0/0"
-	if !publicAccess && subnetCidr != "" {
-		cidr = subnetCidr
-	}
-	var desc string
-	if publicAccess {
-		desc = "Auto-created by CB-Spider: allow inbound DB port from 0.0.0.0/0"
-	} else {
-		desc = "Auto-created by CB-Spider: allow inbound DB port from subnet " + cidr
-	}
+// createDefaultDBSecurityGroup creates a fully-open (0.0.0.0/0) NHN Cloud RDS
+// DB Security Group for the RDBMSInfo.NHNAutoOpenDBSecurityGroup convenience
+// option and returns its ID. endpointFn selects the correct RDS endpoint
+// (MySQL or MariaDB) for the DB instance being created. Callers must ensure
+// PublicAccess=true before calling this (validated in CreateRDBMS).
+func (handler *NhnCloudRDBMSHandler) createDefaultDBSecurityGroup(ctx context.Context, endpointFn func() (string, error), name string) (string, error) {
+	const cidr = "0.0.0.0/0"
 	reqBody := nhnRDSCreateDBSecurityGroupRequest{
 		DBSecurityGroupName: name + "-sg",
-		Description:         desc,
+		Description:         "Auto-created by CB-Spider: allow inbound DB port from 0.0.0.0/0 (NHNAutoOpenDBSecurityGroup=true)",
 		Rules: []nhnRDSDBSecurityGroupRule{
 			{
 				Direction: "INGRESS",
@@ -1269,6 +1288,36 @@ func (handler *NhnCloudRDBMSHandler) pollRDSJobWithEndpoint(ctx context.Context,
 	}
 }
 
+// waitForRDSJobCompletion polls an NHN Cloud RDS async job until it reaches a
+// terminal state (COMPLETED or FAILED). Unlike pollRDSJobWithEndpoint, it
+// does not require a particular resourceRelations entry — it's for callers
+// (e.g. DeleteRDBMS) that only need to know the job finished, not extract a
+// created resource's ID.
+func (handler *NhnCloudRDBMSHandler) waitForRDSJobCompletion(ctx context.Context, endpointFn func() (string, error), jobId string) error {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for NHN Cloud RDS job %s", jobId)
+		case <-ticker.C:
+			var jobResp nhnRDSJobResponse
+			if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/jobs/"+jobId, &jobResp); err != nil {
+				return fmt.Errorf("failed to poll NHN Cloud RDS job %s: %w", jobId, err)
+			}
+			switch jobResp.JobStatus {
+			case "COMPLETED":
+				return nil
+			case "FAILED":
+				return fmt.Errorf("NHN Cloud RDS job %s failed", jobId)
+			default:
+				cblogger.Infof("[NHN RDS] job %s status: %s (waiting...)", jobId, jobResp.JobStatus)
+			}
+		}
+	}
+}
+
 // findRDSInstanceIDByNameWithEndpoint finds a DB instance UUID by name at the given endpoint.
 func (handler *NhnCloudRDBMSHandler) findRDSInstanceIDByNameWithEndpoint(ctx context.Context, endpointFn func() (string, error), name string) (string, error) {
 	var result nhnRDSListInstancesResponse
@@ -1380,12 +1429,14 @@ func (handler *NhnCloudRDBMSHandler) collectAutoCBSpiderSGIdsWithEndpoint(ctx co
 	for _, id := range sgIds {
 		var detail nhnRDSDBSecurityGroupDetailResponse
 		if err := handler.getRDSWithEndpoint(ctx, endpointFn, "/v3.0/db-security-groups/"+id, &detail); err != nil {
+			cblogger.Warnf("[NHN RDS] failed to fetch detail for DB security group '%s' (skipping auto-created check): %v", id, err)
 			continue
 		}
-		if checkRDSResponseHeader(detail.Header) != nil {
+		if hdrErr := checkRDSResponseHeader(detail.Header); hdrErr != nil {
+			cblogger.Warnf("[NHN RDS] error response fetching detail for DB security group '%s' (skipping auto-created check): %v", id, hdrErr)
 			continue
 		}
-		if strings.HasPrefix(detail.Description, "Auto-created by CB-Spider:") {
+		if strings.HasPrefix(detail.Detail().Description, "Auto-created by CB-Spider:") {
 			auto = append(auto, id)
 		}
 	}

--- a/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/RDBMSHandler.go
@@ -212,6 +212,17 @@ type RDBMSInfo struct {
 	PublicAccess bool   `json:"PublicAccess,omitempty" default:"false"` // Whether publicly accessible
 	Endpoint     string `json:"Endpoint,omitempty"`                     // Connection endpoint (for response)
 
+	// NHNAutoOpenDBSecurityGroup (NHN Cloud only): when true together with
+	// PublicAccess=true, CB-Spider auto-creates a fully-open (0.0.0.0/0) NHN
+	// Cloud RDS DB Security Group, attaches it at creation, and deletes it
+	// automatically when the instance is deleted. Ignored by every other CSP.
+	// SecurityGroupNames/SecurityGroupIIDs is not used for NHN Cloud RDBMS at
+	// all: NHN Cloud RDS DB Security Groups are a resource type separate from
+	// the VPC/Neutron security group CB-Spider manages, so when this flag is
+	// false (the default), you must create one yourself via the NHN Cloud
+	// console or API and attach it to the instance for external SQL access.
+	NHNAutoOpenDBSecurityGroup bool `json:"NHNAutoOpenDBSecurityGroup,omitempty" default:"false"`
+
 	// Encryption - read-only, CSP-managed. Not configurable at creation via Spider.
 	Encryption bool `json:"Encryption,omitempty" default:"false"` // Storage encryption enabled (CSP default)
 

--- a/test/rdbms-mariadb-test/README.md
+++ b/test/rdbms-mariadb-test/README.md
@@ -62,6 +62,8 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 | OpenStack | mariadb | 10.4 | m1.small | 20GB |
 | NHN | mariadb | MARIADB_V101118 | m2.c2m4 | 20GB |
 
+> **NHN 참고**: NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능합니다. `nhn-rdbms-test.sh`는 `"NHNAutoOpenDBSecurityGroup": true`를 설정해 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성하고, 인스턴스 삭제 시 함께 자동 삭제되도록 합니다 — 시험 편의를 위한 옵션이며, 운영 환경에서는 NHN 콘솔/API로 특정 CIDR만 허용하는 DB Security Group을 직접 구성하는 것을 권장합니다.
+
 ## Usage
 
 ### Quick Start (Full Test Suite)

--- a/test/rdbms-mariadb-test/nhn-rdbms-test.sh
+++ b/test/rdbms-mariadb-test/nhn-rdbms-test.sh
@@ -15,6 +15,7 @@ export CREATE_JSON='{
     "Name": "cb-spider-mariadb-test",
     "VPCName": "vpc-01",
     "SubnetNames": ["subnet-01"],
+    "NHNAutoOpenDBSecurityGroup": true,
     "DBEngine": "mariadb",
     "DBEngineVersion": "MARIADB_V101118",
     "DBSpec": "m2.c2m4",

--- a/test/rdbms-mariadb-test/storage-type-test/README.md
+++ b/test/rdbms-mariadb-test/storage-type-test/README.md
@@ -236,6 +236,8 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 | Region / Zone | `KR1` / `kr-pub-a` |
 | SubnetNames | `subnet-01` |
 
+`NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능하므로, 시험 편의를 위해 이 옵션으로 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성/삭제합니다. 운영 환경에서는 사용을 권장하지 않습니다.
+
 
 ## 시험 결과
 

--- a/test/rdbms-mariadb-test/storage-type-test/nhn-storage-type-test.sh
+++ b/test/rdbms-mariadb-test/storage-type-test/nhn-storage-type-test.sh
@@ -66,6 +66,7 @@ while IFS= read -r storage_type; do
     \"Name\": \"${rdbms_name}\",
     \"VPCName\": \"vpc-01\",
     \"SubnetNames\": [\"subnet-01\"],
+    \"NHNAutoOpenDBSecurityGroup\": true,
     \"DBEngine\": \"mariadb\",
     \"DBEngineVersion\": \"MARIADB_V101118\",
     \"DBSpec\": \"m2.c2m4\",

--- a/test/rdbms-mysql-test/README.md
+++ b/test/rdbms-mysql-test/README.md
@@ -112,6 +112,8 @@ StorageType은 지정하지 않으며, CSP 기본값으로 생성됩니다. 결�
 | NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | CSP 관리 | ✅ |
 | NHN | MYSQL_V8408 | m2.c2m4 | 20GB | ✅ |
 
+> **NHN 참고**: NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능합니다. `nhn-rdbms-test.sh`는 `"NHNAutoOpenDBSecurityGroup": true`를 설정해 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성하고, 인스턴스 삭제 시 함께 자동 삭제되도록 합니다 — 시험 편의를 위한 옵션이며, 운영 환경에서는 NHN 콘솔/API로 특정 CIDR만 허용하는 DB Security Group을 직접 구성하는 것을 권장합니다.
+
 ## Configuration
 
 테스트 실행 전에 CB-Spider 접속 정보를 환경변수로 설정하거나, `run-all-csp-rdbms-tests.sh` / `delete-all-csp-rdbms.sh` 파일 내부의 기본값을 직접 수정합니다.

--- a/test/rdbms-mysql-test/common-network-cleanup.sh
+++ b/test/rdbms-mysql-test/common-network-cleanup.sh
@@ -23,8 +23,8 @@ SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"
 # by the just-deleted RDBMS instance asynchronously, so a delete attempted right
 # after RDBMS deletion can hit a transient DependencyViolation/ResourceInUse-type
 # error. Retry with backoff before giving up.
-RETRY_COUNT="${NETWORK_DELETE_RETRIES:-5}"
-RETRY_INTERVAL="${NETWORK_DELETE_RETRY_INTERVAL:-15}"
+RETRY_COUNT="${NETWORK_DELETE_RETRIES:-10}"
+RETRY_INTERVAL="${NETWORK_DELETE_RETRY_INTERVAL:-20}"
 
 mkdir -p "$(dirname "${RESULT_FILE}")"
 

--- a/test/rdbms-mysql-test/nhn-rdbms-test.sh
+++ b/test/rdbms-mysql-test/nhn-rdbms-test.sh
@@ -15,6 +15,7 @@ export CREATE_JSON='{
     "Name": "cb-spider-mysql-test",
     "VPCName": "vpc-01",
     "SubnetNames": ["subnet-01"],
+    "NHNAutoOpenDBSecurityGroup": true,
     "DBEngine": "mysql",
     "DBEngineVersion": "MYSQL_V8408",
     "DBSpec": "m2.c2m4",

--- a/test/rdbms-mysql-test/storage-type-test/README.md
+++ b/test/rdbms-mysql-test/storage-type-test/README.md
@@ -315,6 +315,7 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - Connection: `nhn-korea-pangyo1-config`
 - Region: `KR1` / Zone: `kr-pub-a`
 - SubnetNames: `subnet-01`
+- `NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능하므로, 시험 편의를 위해 이 옵션으로 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성/삭제합니다. 운영 환경에서는 사용을 권장하지 않습니다.
 
 ---
 

--- a/test/rdbms-mysql-test/storage-type-test/nhn-storage-type-test.sh
+++ b/test/rdbms-mysql-test/storage-type-test/nhn-storage-type-test.sh
@@ -55,6 +55,7 @@ while IFS= read -r storage_type; do
     \"Name\": \"${rdbms_name}\",
     \"VPCName\": \"vpc-01\",
     \"SubnetNames\": [\"subnet-01\"],
+    \"NHNAutoOpenDBSecurityGroup\": true,
     \"DBEngine\": \"mysql\",
     \"DBEngineVersion\": \"MYSQL_V8408\",
     \"DBSpec\": \"m2.c2m4\",


### PR DESCRIPTION
- Add NHNAutoOpenDBSecurityGroup option for NHN RDBMS: auto-creates/deletes a fully-open (0.0.0.0/0) DB Security Group when enabled with PublicAccess=true
- SecurityGroupNames is now ignored for NHN RDBMS, matching other CSPs
- Fix bugs blocking the feature: JSON null-vs-empty encoding, async delete timing, DB SG response parsing
- AdminWeb: show the new option in the Add RDBMS form and instance list; disable (not hide) unused Subnet/SG fields; always verify password on Connect
- Update NHN test scripts/READMEs and regenerate Swagger docs
- Pace Alibaba DescribeAvailableClasses calls + backoff to avoid API throttling
- Extend network cleanup retry window for Tencent's delayed VPC IP release

**Breaking Change:**

- NHN RDBMS create requests no longer honor SecurityGroupNames — it's now silently ignored. Instances created without NHNAutoOpenDBSecurityGroup: true no longer get any DB Security Group auto-created (previous behavior auto-created one whenever SecurityGroupNames was empty). Existing callers relying on that implicit auto-create must set NHNAutoOpenDBSecurityGroup: true, or attach a DB Security Group manually via the NHN console/API for external SQL access.