### PR TITLE
[AdminWeb] Fix: Restore original page after re-login and hide dashboard title in fullscreen mode

### DIFF
--- a/api-runtime/rest-runtime/admin-web/AdminWeb-Main.go
+++ b/api-runtime/rest-runtime/admin-web/AdminWeb-Main.go
@@ -11,8 +11,10 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
+	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -149,14 +151,23 @@ func AdminWebSessionMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 }
 
 func redirectToLogin(c echo.Context) error {
+	// Preserve the originally requested path+query so the user can be sent
+	// back to it (instead of always the home page) after logging back in.
+	reqURI := c.Request().URL.RequestURI()
+	target := "/spider/adminweb/"
+	if reqURI != "/spider/adminweb/" && reqURI != "/spider/adminweb" {
+		target = "/spider/adminweb/?redirect=" + url.QueryEscape(reqURI)
+	}
+	targetJS := fmt.Sprintf("%q", target)
+
 	// If loaded in iframe, redirect the top-level window
 	return c.HTML(http.StatusUnauthorized, `<!DOCTYPE html>
 <html><head><title>Session Required</title></head>
 <body><script>
 if (window.top !== window.self) {
-    window.top.location.href = '/spider/adminweb/';
+    window.top.location.href = `+targetJS+`;
 } else {
-    window.location.href = '/spider/adminweb/';
+    window.location.href = `+targetJS+`;
 }
 </script></body></html>`)
 }

--- a/api-runtime/rest-runtime/admin-web/html/dashboard.html
+++ b/api-runtime/rest-runtime/admin-web/html/dashboard.html
@@ -114,6 +114,9 @@
     .content {
         margin-top: 100px;
     }
+    .fixed-header.dashboard-fullscreen h1 {
+        display: none;
+    }
     .connection-status-banner {
         display: none;
         position: fixed;
@@ -327,29 +330,54 @@
         }, '*');
     }
 
-    var isAppFullscreen = false;
+    var FULLSCREEN_STORAGE_KEY = 'dashboardFullscreen';
+    // "Show Empty Connections" reloads this page via window.location.href, which
+    // re-runs this script from scratch. Track fullscreen state in sessionStorage
+    // (not just a JS var) so it survives that reload - the parent frame's own
+    // fullscreen state (left-menu/top-menu hidden) already survives it since
+    // main.html itself isn't reloaded, so without this the title would pop back
+    // while the rest of the layout stayed expanded.
+    var isAppFullscreen = sessionStorage.getItem(FULLSCREEN_STORAGE_KEY) === '1';
     var FULLSCREEN_ENTER_ICON_PATH = 'M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z';
     var FULLSCREEN_EXIT_ICON_PATH = 'M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z';
 
-    function toggleFullscreen() {
-        isAppFullscreen = !isAppFullscreen;
-        window.parent.postMessage({ type: 'toggleAppFullscreen' }, '*');
+    function syncContentOffset() {
+        var header = document.querySelector('.fixed-header');
+        var content = document.querySelector('.content');
+        if (header && content) {
+            content.style.marginTop = header.offsetHeight + 'px';
+        }
+    }
 
+    function applyFullscreenState() {
         var btn = document.getElementById('fullscreenBtn');
         var icon = document.getElementById('fullscreenIconPath');
+        var header = document.querySelector('.fixed-header');
         if (isAppFullscreen) {
             icon.setAttribute('d', FULLSCREEN_EXIT_ICON_PATH);
             btn.title = 'Exit Full Screen';
+            header.classList.add('dashboard-fullscreen');
         } else {
             icon.setAttribute('d', FULLSCREEN_ENTER_ICON_PATH);
             btn.title = 'Full Screen';
+            header.classList.remove('dashboard-fullscreen');
         }
+        syncContentOffset();
+    }
+
+    function toggleFullscreen() {
+        isAppFullscreen = !isAppFullscreen;
+        sessionStorage.setItem(FULLSCREEN_STORAGE_KEY, isAppFullscreen ? '1' : '0');
+        window.parent.postMessage({ type: 'toggleAppFullscreen' }, '*');
+        applyFullscreenState();
     }
 
     document.addEventListener('DOMContentLoaded', function() {
         lastSuccessfulRefresh = new Date();
         toggleRefresh();
+        applyFullscreenState();
     });
+    window.addEventListener('resize', syncContentOffset);
 </script>
 </head>
 <body>

--- a/api-runtime/rest-runtime/admin-web/html/main.html
+++ b/api-runtime/rest-runtime/admin-web/html/main.html
@@ -722,6 +722,7 @@
                     document.getElementById('authArea').style.display = 'flex';
                     document.getElementById('authUsernameText').textContent = result.data.username || username;
                     hideAboutOverlay(true);
+                    goToPendingRedirect();
                 } else {
                     loginBtn.disabled = false;
                     loginBtn.textContent = 'Login';
@@ -745,8 +746,39 @@
             window.location.href = '/spider/adminweb/logout';
         }
 
+        // Only ever redirect back into our own adminweb body_frame paths -
+        // never treat the redirect value as an arbitrary/external URL.
+        function isSafeAdminwebRedirect(path) {
+            return typeof path === 'string' &&
+                path.indexOf('/spider/adminweb/') === 0 &&
+                path.indexOf('//') !== 0 &&
+                path.toLowerCase().indexOf('javascript:') === -1;
+        }
+
+        // Navigate the body_frame iframe back to the page the user was on
+        // before being sent to the login screen, if any.
+        function goToPendingRedirect() {
+            var redirect = sessionStorage.getItem('pendingRedirect');
+            sessionStorage.removeItem('pendingRedirect');
+            if (redirect && isSafeAdminwebRedirect(redirect)) {
+                var iframe = document.querySelector('iframe[name="body_frame"]');
+                if (iframe) {
+                    iframe.src = redirect;
+                }
+            }
+        }
+
         // On page load: check auth status via server-side session
         window.addEventListener('load', function() {
+            var redirectParam = new URLSearchParams(window.location.search).get('redirect');
+            if (redirectParam && isSafeAdminwebRedirect(redirectParam)) {
+                sessionStorage.setItem('pendingRedirect', redirectParam);
+                // Clean the query string from the visible URL
+                window.history.replaceState({}, document.title, '/spider/adminweb/');
+            } else if (redirectParam) {
+                window.history.replaceState({}, document.title, '/spider/adminweb/');
+            }
+
             fetch('/spider/adminweb/authinfo')
                 .then(function(response) { return response.json(); })
                 .then(function(data) {
@@ -756,6 +788,7 @@
                             sessionStorage.removeItem('skipAbout');
                             document.getElementById('authArea').style.display = 'flex';
                             document.getElementById('authUsernameText').textContent = data.username;
+                            goToPendingRedirect();
                         } else {
                             // No valid server session - show login
                             showAboutOverlay('login');


### PR DESCRIPTION
- Preserve and restore the originally requested page after a session-expiry re-login, instead of always landing on the home page
- Hide the dashboard title in fullscreen mode, and keep it hidden across the "Show Empty Connections" reload