### PR TITLE
Remove driver-side disk type/size validation (let the CSP decide)

### DIFF
--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/DiskHandler.go
@@ -476,174 +476,51 @@ Disk 생성시 validation check
   - DiskType 별 min/max capacity check
 */
 func validateCreateDisk(diskReqInfo *irs.DiskInfo, availableDiskTypesInThisZone []string) error {
-	// Check Disk Exists
-
 	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("ALIBABA")
-	//disktype: cloud / cloud_efficiency / cloud_ssd / cloud_essd
-	//disksize: cloud|5|2000|GB / cloud_efficiency|20|32768|GB / cloud_ssd|20|32768|GB / cloud_essd_PL0|40|32768|GB / cloud_essd_PL1|20|32768|GB / cloud_essd_PL2|461|32768|GB / cloud_essd_PL3|1261|32768|GB
-
-	arrDiskType := cloudOSMetaInfo.DiskType
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-	arrRootDiskSizeOfType := cloudOSMetaInfo.RootDiskSize
-	// Check Disk available
-	// Size :
-	// DiskCategory : cloud / cloud_efficiency / cloud_ssd / cloud_essd
-	// valid size : cloud 5 ~ 2000, cloud_efficiency 20 ~ 32768, cloud_ssd 20 ~ 32768, cloud_essd
-
-	reqDiskCategory := diskReqInfo.DiskType
-	diskSize := diskReqInfo.DiskSize
-
-	if reqDiskCategory == "" || reqDiskCategory == "default" {
-		for _, diskSizeOfType := range arrRootDiskSizeOfType {
-			diskSizeArr := strings.Split(diskSizeOfType, "|")
-			if ContainString(availableDiskTypesInThisZone, diskSizeArr[0]) { // check available disk type in this zone
-				reqDiskCategory = diskSizeArr[0]       // ESSD
-				diskReqInfo.DiskType = reqDiskCategory // set default value
-				break
-			}
-		}
-	}
-	// 정의된 type인지
-	if !ContainString(arrDiskType, reqDiskCategory) {
-		return errors.New("Disktype : " + reqDiskCategory + "' is not valid")
-	}
-
-	if diskSize == "" || diskSize == "default" {
-		for _, diskSizeOfType := range arrRootDiskSizeOfType {
-			diskSizeArr := strings.Split(diskSizeOfType, "|")
-			if ContainString(availableDiskTypesInThisZone, diskSizeArr[0]) { // check available disk type in this zone
-				diskSize = diskSizeArr[1]       // 20
-				diskReqInfo.DiskSize = diskSize // set default value
-				break
-			}
-		}
-	}
-
-	reqDiskSize, err := strconv.ParseInt(diskSize, 10, 64)
 	if err != nil {
+		cblogger.Error(err)
 		return err
 	}
-
-	diskSizeValue := DiskSize{}
-	isExists := false
-	for idx, _ := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(arrDiskSizeOfType[idx], "|")
-		reqDiskType := diskReqInfo.DiskType
-		switch reqDiskCategory {
-		case "cloud_essd":
-			// cloud_essd 는 performanceLevel(PL0, PL1, PL2, PL3) 에 따라 또 다시 min/max가 생김.
-			// cb-spider는 performanceLevel을 관리하지 않으므로 기본값인 PL2 를 사용한다.
-			// console 상 attach disk의 default는 PL1
-			reqDiskType += "_PL1"
+	if diskReqInfo.DiskType == "" || diskReqInfo.DiskType == "default" {
+		for _, diskSizeOfType := range cloudOSMetaInfo.RootDiskSize {
+			diskSizeArr := strings.Split(diskSizeOfType, "|")
+			if ContainString(availableDiskTypesInThisZone, diskSizeArr[0]) {
+				diskReqInfo.DiskType = diskSizeArr[0]
+				break
+			}
 		}
-
-		if strings.EqualFold(reqDiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
+		if (diskReqInfo.DiskType == "" || diskReqInfo.DiskType == "default") && len(availableDiskTypesInThisZone) > 0 {
+			diskReqInfo.DiskType = availableDiskTypesInThisZone[0]
 		}
 	}
-
-	if !isExists {
-		return errors.New("Invalid Disk Type : " + diskReqInfo.DiskType)
+	if diskReqInfo.DiskSize == "" || diskReqInfo.DiskSize == "default" {
+		diskReqInfo.DiskSize = "20"
+		for _, diskSizeOfType := range cloudOSMetaInfo.RootDiskSize {
+			diskSizeArr := strings.Split(diskSizeOfType, "|")
+			if strings.EqualFold(diskReqInfo.DiskType, diskSizeArr[0]) {
+				diskReqInfo.DiskSize = diskSizeArr[1]
+				break
+			}
+		}
 	}
-
-	if reqDiskSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", reqDiskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be at least the default size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
+	if _, err := strconv.ParseInt(diskReqInfo.DiskSize, 10, 64); err != nil {
+		return err
 	}
-
-	if reqDiskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", reqDiskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
-	// 실제로 diskType이 유효한지 check
-
 	return nil
 }
 
 func validateModifyDisk(diskReqInfo irs.DiskInfo, diskSize string) error {
-	// volume Size
 	orgDiskSize, err := strconv.ParseInt(diskReqInfo.DiskSize, 10, 64)
 	if err != nil {
 		return err
 	}
-
 	targetDiskSize, err := strconv.ParseInt(diskSize, 10, 64)
-
 	if err != nil {
 		return err
 	}
-
-	if orgDiskSize < targetDiskSize {
-	} else {
+	if orgDiskSize >= targetDiskSize {
 		return errors.New("Target DiskSize : " + diskSize + " must be greater than Original DiskSize " + diskReqInfo.DiskSize)
 	}
-
-	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("ALIBABA")
-	//arrDiskType := cloudOSMetaInfo.DiskType
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
-	//if !ContainString(arrDiskType, diskReqInfo.DiskType) {
-	//	return errors.New("Disktype : " + diskReqInfo.DiskType + "' is not valid")
-	//}
-
-	diskSizeValue := DiskSize{}
-	isExists := false
-	for idx, _ := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(arrDiskSizeOfType[idx], "|")
-		reqDiskType := diskReqInfo.DiskType
-		switch reqDiskType {
-		case "cloud_essd":
-			// cloud_essd 는 performanceLevel(PL0, PL1, PL2, PL3) 에 따라 또 다시 min/max가 생김.
-			// cb-spider는 performanceLevel을 관리하지 않으므로 기본값인 PL2 를 사용한다.
-			reqDiskType += "_PL2"
-		}
-
-		if strings.EqualFold(reqDiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
-		}
-	}
-
-	if !isExists {
-		return errors.New("Invalid Disk Type : " + diskReqInfo.DiskType)
-	}
-
-	if targetDiskSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", targetDiskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be at least the default size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
-	}
-
-	if targetDiskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", targetDiskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
 	return nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/VMHandler.go
@@ -337,8 +337,9 @@ func (vmHandler *AlibabaVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 			}
 		}
 
-		if found == false {
-			return irs.VMInfo{}, errors.New("The disktype you entered is not available for this instancetype.")
+		if !found {
+			cblogger.Warnf("RootDiskType [%s] is not in the zone's reported list %v; passing through.", vmReqInfo.RootDiskType, supportedDiskTypes)
+			useDiskType = vmReqInfo.RootDiskType
 		}
 
 		request.SystemDiskCategory = useDiskType

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/DiskHandler.go
@@ -508,264 +508,46 @@ Throughput
 	Valid Range: Minimum value of 125. Maximum value of 1000.
 */
 func validateCreateDisk(diskReqInfo *irs.DiskInfo) error {
-	// VolumeType
 	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("AWS")
-	arrDiskType := cloudOSMetaInfo.DiskType
-	arrRootDiskType := cloudOSMetaInfo.RootDiskType
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
-	cblogger.Debug(arrDiskType)
-	reqDiskType := diskReqInfo.DiskType
-	reqDiskSize := diskReqInfo.DiskSize
-	if reqDiskType == "" || reqDiskType == "default" {
-		reqDiskType = arrRootDiskType[0]
-		diskReqInfo.DiskType = arrRootDiskType[0]
+	if err != nil {
+		cblogger.Error(err)
+		return err
 	}
-
-	// 정의된 type인지
-	if !ContainString(arrDiskType, reqDiskType) {
-		return errors.New("Disktype : " + reqDiskType + " is not valid")
+	if diskReqInfo.DiskType == "" || diskReqInfo.DiskType == "default" {
+		if len(cloudOSMetaInfo.RootDiskType) > 0 {
+			diskReqInfo.DiskType = cloudOSMetaInfo.RootDiskType[0]
+		}
 	}
-
-	if reqDiskSize == "" || reqDiskSize == "default" {
-		for _, diskSizeInfo := range arrDiskSizeOfType {
+	if diskReqInfo.DiskSize == "" || diskReqInfo.DiskSize == "default" {
+		diskReqInfo.DiskSize = "50"
+		for _, diskSizeInfo := range cloudOSMetaInfo.DiskSize {
 			diskSizeArr := strings.Split(diskSizeInfo, "|")
-			if strings.EqualFold(reqDiskType, diskSizeArr[0]) {
-				diskMinSize, err := strconv.ParseInt(diskSizeArr[1], 10, 64)
-				if err != nil {
-					cblogger.Error(err)
-					return err
-				}
-
-				// default size를 50GB로 정하였으나,
-				// st1, sc1 type의 경우 minimum size가 50GB보다 큰 125GB이므로, 이 경우에는 minimum size를 default size로 사용함
-				if diskMinSize < 50 {
-					reqDiskSize = "50"
-					diskReqInfo.DiskSize = "50"
-				} else {
-					reqDiskSize = diskSizeArr[1]
-					diskReqInfo.DiskSize = diskSizeArr[1] // set default value
+			if strings.EqualFold(diskReqInfo.DiskType, diskSizeArr[0]) {
+				if diskMinSize, err := strconv.ParseInt(diskSizeArr[1], 10, 64); err == nil && diskMinSize > 50 {
+					diskReqInfo.DiskSize = diskSizeArr[1]
 				}
 				break
 			}
 		}
-
 	}
-
-	// volume Size
-	volumeSize, err := strconv.ParseInt(reqDiskSize, 10, 64)
-	if err != nil {
+	if _, err := strconv.ParseInt(diskReqInfo.DiskSize, 10, 64); err != nil {
 		return err
 	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-	isExists := false
-	for idx, _ := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(arrDiskSizeOfType[idx], "|")
-		if strings.EqualFold(diskReqInfo.DiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
-		}
-	}
-	if !isExists {
-		return errors.New("Invalid Root Disk Type : " + diskReqInfo.DiskType)
-	}
-
-	if volumeSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", volumeSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be at least the default size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
-	}
-
-	if volumeSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", volumeSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
-	//switch diskReqInfo.DiskType {
-	//case "standard":
-	//	if volumeSize < 1 || volumeSize > 1024 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 1 to 1024")
-	//	}
-	//case "gp2":
-	//	if volumeSize < 1 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 1 to 16384")
-	//	}
-	//case "gp3":
-	//	if volumeSize < 1 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 1 to 16384")
-	//	}
-	//
-	//	//throughput, err := strconv.ParseInt(diskReqInfo., 10, 64)
-	//	// min :125, max :  1000
-	//case "io1":
-	//	if volumeSize < 4 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 4 to 16384")
-	//	}
-	//case "io2":
-	//	if volumeSize < 4 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 4 to 16384")
-	//	}
-	//case "st1":
-	//	if volumeSize < 125 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 125 to 16384")
-	//	}
-	//case "sc1":
-	//	if volumeSize < 125 || volumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 125 to 16384")
-	//	}
-	//default:
-	//	return errors.New("Invalid DiskType : " + diskReqInfo.DiskType)
-	//}
-
-	// IOPS : gp3, io1, io2
-	//iopsSize, err := strconv.ParseInt(diskReqInfo.IOPS, 10, 64)
-	//if err != nil { return err }
-	//switch diskReqInfo.DiskType {
-	//gp3: 3,000-16,000 IOPS
-	//
-	//io1: 100-64,000 IOPS
-	//
-	//io2: 100-64,000 IOPS
-	//case "gp2":
-	//case "gp3":
-	//	if iopsSize < 3000 || iopsSize > 16000 {
-	//		return errors.New("IOPS : " + iopsSize + "' supports 3,000 to 16,000")
-	//	}
-	//
-	//case "io1":
-	//	if iopsSize < 100 || iopsSize > 64000 {
-	//		return errors.New("IOPS : " + iopsSize + "' supports 100 to 64000")
-	//	}
-	//case "io2":
-	//	if iopsSize < 100 || iopsSize > 64000 {
-	//		return errors.New("IOPS : " + iopsSize + "' supports 100 to 64000")
-	//	}
-	//}
-
-	// encryption 이 true 면 KmsKeyId set 해야 함
-
-	// MultiAttachEnabled
 	return nil
 }
 
 func validateModifyDisk(diskReqInfo irs.DiskInfo, diskSize string) error {
-
-	// volume Size
 	orgVolumeSize, err := strconv.ParseInt(diskReqInfo.DiskSize, 10, 64)
 	if err != nil {
 		return err
 	}
-
 	targetVolumeSize, err := strconv.ParseInt(diskSize, 10, 64)
 	if err != nil {
 		return err
 	}
-
-	if orgVolumeSize < targetVolumeSize {
-	} else {
+	if orgVolumeSize >= targetVolumeSize {
 		return errors.New("Target DiskSize : " + diskSize + " must be greater than Original DiskSize " + diskReqInfo.DiskSize)
 	}
-
-	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("AWS")
-	arrDiskType := cloudOSMetaInfo.DiskType
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
-	// 정의된 type인지
-	if !ContainString(arrDiskType, diskReqInfo.DiskType) {
-		return errors.New("Disktype : " + diskReqInfo.DiskType + " is not valid")
-	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-	isExists := false
-	for idx, _ := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(arrDiskSizeOfType[idx], "|")
-		if strings.EqualFold(diskReqInfo.DiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
-		}
-	}
-	if !isExists {
-		return errors.New("Invalid Root Disk Type : " + diskReqInfo.DiskType)
-	}
-
-	if targetVolumeSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", targetVolumeSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Root Disk Size must be at least the default size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
-	}
-
-	if targetVolumeSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", targetVolumeSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Root Disk Size must be smaller than the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
-	// VolumeType
-	// valid type : standard | io1 | io2 | gp2 | sc1 | st1 | gp3
-	//if !ContainString(arrDiskSizeOfType, diskReqInfo.DiskType) {
-	//	return errors.New("Disktype : " + diskReqInfo.DiskType + "' is not valid")
-	//}
-	//
-	//switch diskReqInfo.DiskType {
-	//case "gp3":
-	//	if targetVolumeSize < 1 || targetVolumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 1 to 16384")
-	//	}
-	//case "io1":
-	//	if targetVolumeSize < 4 || targetVolumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 4 to 16384")
-	//	}
-	//case "io2":
-	//	if targetVolumeSize < 4 || targetVolumeSize > 16384 {
-	//		return errors.New("Disktype : " + diskReqInfo.DiskType + "' supports 4 to 16384")
-	//	}
-	//default:
-	//	return errors.New("Invalid DiskType : " + diskReqInfo.DiskType)
-	//}
-
-	// MultiAttachEnabled
-
-	// Throughput : gp3 only, min 125, max 1000, default 125
-	//switch diskReqInfo.DiskType {
-	//case "gp3":
-	//
-	//}
 	return nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/VMHandler.go
@@ -197,10 +197,7 @@ func (vmHandler *AwsVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 			}
 
 			// 요청된 사이즈는 볼륨 사이즈 보다는 크거나 같아야 함.
-			if iChkDiskSize < imageVolumeSize {
-				cblogger.Errorf("The root volume must be larger than %dGB.", imageVolumeSize)
-				return irs.VMInfo{}, awserr.New(CUSTOM_ERR_CODE_BAD_REQUEST, "Root Disk Size must be at least the default size ("+strconv.FormatInt(imageVolumeSize, 10)+" GB).", nil)
-			}
+			cblogger.Infof("Requested root disk size %dGB (image default %dGB); size validation is delegated to AWS.", iChkDiskSize, imageVolumeSize)
 		}
 	}
 

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/CommonAzureFunc.go
@@ -237,8 +237,10 @@ func GetVMDiskTypeInitType(diskType string) armcompute.StorageAccountTypes {
 		return armcompute.StorageAccountTypesStandardSSDLRS
 	case StandardHDD:
 		return armcompute.StorageAccountTypesStandardLRS
-	default:
+	case "", "default":
 		return armcompute.StorageAccountTypesPremiumLRS
+	default:
+		return armcompute.StorageAccountTypes(diskType)
 	}
 }
 
@@ -274,7 +276,7 @@ func GetDiskTypeInitType(diskType string) (armcompute.DiskStorageAccountTypes, e
 	case StandardHDD:
 		return armcompute.DiskStorageAccountTypesStandardLRS, nil
 	default:
-		return "", errors.New(fmt.Sprintf("invalid DiskType %s, Please select one of %s, %s, %s", diskType, PremiumSSD, StandardSSD, StandardHDD))
+		return armcompute.DiskStorageAccountTypes(diskType), nil
 	}
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/DiskHandler.go
@@ -10,7 +10,6 @@ import (
 	call "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/call-log"
 	idrv "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces"
 	irs "github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/interfaces/resources"
-	cim "github.com/cloud-barista/cb-spider/cloud-info-manager"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -366,115 +365,27 @@ func (DiskHandler *GCPDiskHandler) DetachDisk(diskIID irs.IID, ownerVM irs.IID) 
 }
 
 func validateDiskSize(diskInfo irs.DiskInfo) error {
-	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("GCP")
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
-	diskSize, err := strconv.ParseInt(diskInfo.DiskSize, 10, 64)
-	if err != nil {
+	if _, err := strconv.ParseInt(diskInfo.DiskSize, 10, 64); err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-	isExists := false
-
-	for _, diskSizeInfo := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(diskSizeInfo, "|")
-		if strings.EqualFold(diskInfo.DiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
-		}
-	}
-
-	if !isExists {
-		return errors.New("Invalid Disk Type : " + diskInfo.DiskType)
-	}
-
-	if diskSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be at least the minimum size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
-	}
-
-	if diskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than or equal to the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
 	return nil
 }
 
 func validateChangeDiskSize(diskInfo irs.DiskInfo, newSize string) error {
-	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("GCP")
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
 	diskSize, err := strconv.ParseInt(diskInfo.DiskSize, 10, 64)
 	if err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
 	newDiskSize, err := strconv.ParseInt(newSize, 10, 64)
 	if err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
 	if diskSize >= newDiskSize {
 		return errors.New("Target Disk Size: " + newSize + " must be larger than existing Disk Size " + diskInfo.DiskSize)
 	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-
-	for _, diskSizeInfo := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(diskSizeInfo, "|")
-		if strings.EqualFold(diskInfo.DiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-		}
-	}
-
-	if newDiskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than or equal to the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
 	return nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/VMHandler.go
@@ -18,7 +18,6 @@ import (
 	_ "errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -374,52 +373,12 @@ func (vmHandler *GCPVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, err
 				// diskType = cloudOSMetaInfo.RootDiskType[0]
 			} else {
 				diskType = vmReqInfo.RootDiskType
-
-				// RootDiskType을 조회하여 diskSize의 min, max, default값 추출 한 뒤 입력된 diskSize가 있으면 비교시 사용
-				diskSizeResp, err := vmHandler.Client.DiskTypes.Get(projectID, zone, diskType).Do()
-				if err != nil {
-					cblogger.Error("Invalid Disk Type Error!!")
-					return irs.VMInfo{}, err
-				}
-
-				cblogger.Info("valid disk size: %#v\n", diskSizeResp.ValidDiskSize)
-
-				//valid disk size 정의
-				re := regexp.MustCompile("GB-?") //ex) 10GB-65536GB
-				diskSizeArr := re.Split(diskSizeResp.ValidDiskSize, -1)
-				diskMinSize, err := strconv.ParseInt(diskSizeArr[0], 10, 64)
-				if err != nil {
-					cblogger.Error(err)
-					return irs.VMInfo{}, err
-				}
-
-				diskMaxSize, err := strconv.ParseInt(diskSizeArr[1], 10, 64)
-				if err != nil {
-					cblogger.Error(err)
-					return irs.VMInfo{}, err
-				}
-
-				// diskUnit := "GB" // 기본 단위는 GB
-
-				if iDiskSize < diskMinSize {
-					cblogger.Error("Disk Size Error!!: ", iDiskSize)
-					//return irs.VMInfo{}, errors.New("Requested disk size cannot be smaller than the minimum disk size, invalid")
-					return irs.VMInfo{}, errors.New("Root Disk Size must be at least the default size (" + strconv.FormatInt(diskMinSize, 10) + " GB).")
-				}
-
-				if iDiskSize > diskMaxSize {
-					cblogger.Error("Disk Size Error!!: ", iDiskSize)
-					//return irs.VMInfo{}, errors.New("Requested disk size cannot be larger than the maximum disk size, invalid")
-					return irs.VMInfo{}, errors.New("Root Disk Size must be smaller than the maximum size (" + strconv.FormatInt(diskMaxSize, 10) + " GB).")
-				}
+				cblogger.Infof("Root disk type %s / size %dGB; validation is delegated to GCP.", diskType, iDiskSize)
 			}
 
 			//imageSize = imageResp.DiskSizeGb
 
-			if iDiskSize < imageSize {
-				cblogger.Error("Disk Size Error!!: ", iDiskSize)
-				return irs.VMInfo{}, errors.New("Root Disk Size must be larger then the image size (" + strconv.FormatInt(imageSize, 10) + " GB).")
-			}
+			cblogger.Infof("Requested root disk size %dGB (image %dGB); validation is delegated to GCP.", iDiskSize, imageSize)
 
 			instance.Disks[0].InitializeParams.DiskSizeGb = iDiskSize
 

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/DiskHandler.go
@@ -83,11 +83,6 @@ func (diskHandler *KTVpcDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.D
 		loggingError(callLogInfo, newErr)
 		return irs.DiskInfo{}, newErr
 	}
-	if reqDiskSizeInt < 10 || reqDiskSizeInt > 2000 { // 10~2000(GB)
-		newErr := fmt.Errorf("Invalid Disk Size. Disk Size Must be between 10 and 2000.")
-		cblogger.Error(newErr.Error())
-		return irs.DiskInfo{}, newErr
-	}
 
 	create0pts := volumes2.CreateOpts{
 		AvailabilityZone: diskHandler.RegionInfo.Zone,

--- a/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/kt/resources/VMHandler.go
@@ -219,12 +219,6 @@ func (vmHandler *KTVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 		}
 		if isPublicWindowsImage { // # Incase of Public Windows image
 			// Root Disk Size is supported at only 50GB for Linux and 100GB for Windows OS.
-			if !strings.EqualFold(vmReqInfo.RootDiskSize, "") && !strings.EqualFold(vmReqInfo.RootDiskSize, "default") && !strings.EqualFold(vmReqInfo.RootDiskSize, DefaultWinRootDiskSize) && !strings.EqualFold(vmReqInfo.RootDiskSize, DefaultWinRootDiskSize2) {
-				newErr := fmt.Errorf("Invalid RootDiskSize!! Root Disk Size is supported at only 50GB/100GB for Linux and 100GB/150GB for Windows OS.")
-				cblogger.Error(newErr.Error())
-				loggingError(callLogInfo, newErr)
-				return irs.VMInfo{}, newErr
-			}
 
 			// In case the Root Volume Size is not specified.
 			reqDiskSize := vmReqInfo.RootDiskSize
@@ -244,12 +238,6 @@ func (vmHandler *KTVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, e
 			}
 		} else { // # Incase of Public Linux image
 			// Root Disk Size is supported at only 50GB for Linux and 100GB for Windows OS.
-			if !strings.EqualFold(vmReqInfo.RootDiskSize, "") && !strings.EqualFold(vmReqInfo.RootDiskSize, "default") && !strings.EqualFold(vmReqInfo.RootDiskSize, DefaultDiskSize) && !strings.EqualFold(vmReqInfo.RootDiskSize, DefaultDiskSize2) {
-				newErr := fmt.Errorf("Invalid RootDiskSize!! Root Disk Size is supported at only 50GB/100GB for Linux and 100GB/150GB for Windows OS.")
-				cblogger.Error(newErr.Error())
-				loggingError(callLogInfo, newErr)
-				return irs.VMInfo{}, newErr
-			}
 
 			// In case the Root Volume Size is not specified.
 			reqDiskSize := vmReqInfo.RootDiskSize

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/DiskHandler.go
@@ -64,6 +64,8 @@ func (diskHandler *NcpVpcDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.
 		reqDiskTypeKVM = "FB1"
 	} else if strings.EqualFold(reqDiskType, "HDD") {
 		reqDiskTypeKVM = "CB1"
+	} else {
+		reqDiskTypeKVM = reqDiskType
 	}
 
 	if strings.EqualFold(reqDiskSizeGbStr, "") || strings.EqualFold(reqDiskSizeGbStr, "default") {
@@ -178,11 +180,6 @@ func (diskHandler *NcpVpcDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (irs.
 	}
 	reqDiskSizeInt := int32(i)
 
-	if reqDiskSizeInt < 10 || reqDiskSizeInt > 2000 {   // Range : 10~2000(GB)
-		newErr := fmt.Errorf("Invalid Disk Size. Disk Size Must be between 10 and 2000(GB).")
-		cblogger.Error(newErr.Error())
-		return irs.DiskInfo{}, newErr		
-	}
 
 	// For Zone-based control!!
 	var reqZoneId string

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/VMHandler.go
@@ -163,9 +163,9 @@ func (vmHandler *NcpVpcVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo, 
 		if strings.EqualFold(vmReqInfo.RootDiskType, "default") || strings.EqualFold(vmReqInfo.RootDiskType, "HDD") {
 			reqDiskType = KVMRootDiskType
 		} else if strings.EqualFold(vmReqInfo.RootDiskType, "SSD") {
-			newErr := fmt.Errorf("Invalid root disk type. KVM-based VMs only support root disks of the ‘HDD’ type.")
-			cblogger.Error(newErr.Error())
-			return irs.VMInfo{}, newErr
+			reqDiskType = "FB1"
+		} else {
+			reqDiskType = vmReqInfo.RootDiskType
 		}
 
 		instanceReq = vserver.CreateServerInstancesRequest{

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/DiskHandler.go
@@ -112,11 +112,6 @@ func (diskHandler *NhnCloudDiskHandler) CreateDisk(diskReqInfo irs.DiskInfo) (ir
 		LoggingError(callLogInfo, newErr)
 		return irs.DiskInfo{}, newErr
 	}
-	if reqDiskSizeInt < 10 || reqDiskSizeInt > 2000 { // 10~2000(GB)
-		newErr := fmt.Errorf("Invalid Disk Size. Disk Size Must be between 10 and 2000.")
-		cblogger.Error(newErr.Error())
-		return irs.DiskInfo{}, newErr
-	}
 
 	start := call.Start()
 	create0pts := volumes.CreateOpts{
@@ -253,11 +248,7 @@ func (diskHandler *NhnCloudDiskHandler) ChangeDiskSize(diskIID irs.IID, newDiskS
 		return false, newErr
 	}
 
-	if newDiskSizeInt < 10 || newDiskSizeInt > 2000 { // 10~2000(GB)
-		newErr := fmt.Errorf("Invalid Disk Size. Disk Size Must be between 10 and 2000.")
-		cblogger.Error(newErr.Error())
-		return false, newErr
-	} else if newDiskSizeInt <= curDiskSizeInt {
+	if newDiskSizeInt <= curDiskSizeInt {
 		newErr := fmt.Errorf("Invalid Disk Size. New Disk Size must be Greater than Current Disk Size.")
 		cblogger.Error(newErr.Error())
 		return false, newErr

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/VMHandler.go
@@ -331,49 +331,6 @@ func (vmHandler *NhnCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo
 	}
 
 	// When Volume Type is Incorrect
-	if strings.EqualFold(nhnVMSpecType, "u2") && !strings.EqualFold(reqDiskType, HDD) {
-		newErr := fmt.Errorf("Invalid RootDiskType!! Specified VMSpec [%s] supports only 'default' or 'General_HDD' RootDiskType!!", vmReqInfo.VMSpecName)
-		cblogger.Error(newErr.Error())
-		LoggingError(callLogInfo, newErr)
-		return irs.VMInfo{}, newErr
-	}
-
-	if strings.EqualFold(nhnVMSpecType, "u2") && (!strings.EqualFold(reqDiskSize, "") && !strings.EqualFold(reqDiskSize, "default")) {
-
-		vmSpecHandler := NhnCloudVMSpecHandler{
-			RegionInfo: vmHandler.RegionInfo,
-			VMClient:   vmHandler.VMClient,
-		}
-		vmSpec, err := vmSpecHandler.GetVMSpec(vmReqInfo.VMSpecName) // Check vmSpec info.
-		if err != nil {
-			newErr := fmt.Errorf("Failed to Get VMSpec Info. with the name : %v", err)
-			cblogger.Error(newErr.Error())
-			LoggingError(callLogInfo, newErr)
-			return irs.VMInfo{}, newErr
-		}
-
-		// Use Key/Value info of the vmSpec Info.
-		var localDisk string
-		for _, keyInfo := range vmSpec.KeyValueList {
-			if strings.EqualFold(keyInfo.Key, "LocalDiskSize(GB)") {
-				localDisk = keyInfo.Value
-				break
-			}
-		}
-
-		if reqDiskSize != localDisk {
-			newErr := fmt.Errorf("Invalid RootDiskSize!! Specified VMSpec [%s] supports only [%s](GB)!!", vmReqInfo.VMSpecName, localDisk)
-			cblogger.Error(newErr.Error())
-			return irs.VMInfo{}, newErr
-		}
-	}
-
-	if nhnVMSpecType != "u2" && (reqDiskType != HDD && reqDiskType != SSD) {
-		newErr := fmt.Errorf("Invalid RootDiskType!! Must be 'default', 'General_HDD' or 'General_SSD'")
-		cblogger.Error(newErr.Error())
-		LoggingError(callLogInfo, newErr)
-		return irs.VMInfo{}, newErr
-	}
 
 	var reqDiskSizeInt int
 	// Set VM RootDiskSize
@@ -398,12 +355,6 @@ func (vmHandler *NhnCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo
 		}
 
 		// Volume Size must be more than 50GB and less than 1000GB (for Windows OS)
-		if nhnVMSpecType != "u2" && (reqDiskSizeInt < 50 || reqDiskSizeInt > 1000) {
-			newErr := fmt.Errorf("Invalid RootDiskSize!! RootDiskSize range should be 50 to 1000(GB) for Windows OS!!")
-			cblogger.Error(newErr.Error())
-			LoggingError(callLogInfo, newErr)
-			return irs.VMInfo{}, newErr
-		}
 	} else {
 		if strings.EqualFold(reqDiskSize, "") || strings.EqualFold(reqDiskSize, "default") {
 			reqDiskSize = DefaultDiskSize
@@ -417,12 +368,6 @@ func (vmHandler *NhnCloudVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo
 		}
 
 		// Volume Size must be more than 20GB and less than 1000GB (for Linux OS)
-		if nhnVMSpecType != "u2" && (reqDiskSizeInt < 20 || reqDiskSizeInt > 1000) {
-			newErr := fmt.Errorf("Invalid RootDiskSize!! RootDiskSize range should be 20 to 1000(GB) for Linux OS!!")
-			cblogger.Error(newErr.Error())
-			LoggingError(callLogInfo, newErr)
-			return irs.VMInfo{}, newErr
-		}
 	}
 
 	start := call.Start()

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/DiskHandler.go
@@ -299,135 +299,44 @@ func convertTenStatusToDiskStatus(diskInfo *cbs.Disk) irs.DiskStatus {
 
 func validateDisk(diskReqInfo *irs.DiskInfo) error {
 	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("TENCENT")
-	arrDiskType := cloudOSMetaInfo.DiskType
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-	arrRootDiskSizeOfType := cloudOSMetaInfo.RootDiskSize
-
-	reqDiskType := diskReqInfo.DiskType
-	reqDiskSize := diskReqInfo.DiskSize
-
-	if reqDiskType == "" || reqDiskType == "default" {
-		diskSizeArr := strings.Split(arrRootDiskSizeOfType[0], "|")
-		reqDiskType = diskSizeArr[0]          //
-		diskReqInfo.DiskType = diskSizeArr[0] // set default value
-	}
-	// 정의된 type인지
-	if !ContainString(arrDiskType, reqDiskType) {
-		return errors.New("Disktype : " + reqDiskType + "' is not valid")
-	}
-
-	if reqDiskSize == "" || reqDiskSize == "default" {
-		diskSizeArr := strings.Split(arrRootDiskSizeOfType[0], "|")
-		reqDiskSize = diskSizeArr[1]
-		diskReqInfo.DiskSize = diskSizeArr[1] // set default value
-	}
-
-	diskSize, err := strconv.ParseInt(reqDiskSize, 10, 64)
 	if err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-	isExists := false
-
-	for _, diskSizeInfo := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(diskSizeInfo, "|")
-		if strings.EqualFold(reqDiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-			isExists = true
+	defaultType, defaultSize := "CLOUD_PREMIUM", "50"
+	if len(cloudOSMetaInfo.RootDiskSize) > 0 {
+		diskSizeArr := strings.Split(cloudOSMetaInfo.RootDiskSize[0], "|")
+		if len(diskSizeArr) > 1 {
+			defaultType, defaultSize = diskSizeArr[0], diskSizeArr[1]
 		}
 	}
-
-	if !isExists {
-		return errors.New("Invalid Disk Type : " + reqDiskType)
+	if diskReqInfo.DiskType == "" || diskReqInfo.DiskType == "default" {
+		diskReqInfo.DiskType = defaultType
 	}
-
-	if diskSize < diskSizeValue.diskMinSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be at least the minimum size (" + strconv.FormatInt(diskSizeValue.diskMinSize, 10) + " GB).")
+	if diskReqInfo.DiskSize == "" || diskReqInfo.DiskSize == "default" {
+		diskReqInfo.DiskSize = defaultSize
 	}
-
-	if diskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than or equal to the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
+	if _, err := strconv.ParseInt(diskReqInfo.DiskSize, 10, 64); err != nil {
+		cblogger.Error(err)
+		return err
 	}
-
 	return nil
 }
 
 func validateChangeDiskSize(diskInfo irs.DiskInfo, newSize string) error {
-	cloudOSMetaInfo, err := cim.GetCloudOSMetaInfo("TENCENT")
-	arrDiskSizeOfType := cloudOSMetaInfo.DiskSize
-
 	diskSize, err := strconv.ParseInt(diskInfo.DiskSize, 10, 64)
 	if err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
 	newDiskSize, err := strconv.ParseInt(newSize, 10, 64)
 	if err != nil {
 		cblogger.Error(err)
 		return err
 	}
-
 	if diskSize >= newDiskSize {
 		return errors.New("Target Disk Size: " + newSize + " must be larger than existing Disk Size " + diskInfo.DiskSize)
 	}
-
-	type diskSizeModel struct {
-		diskType    string
-		diskMinSize int64
-		diskMaxSize int64
-		unit        string
-	}
-
-	diskSizeValue := diskSizeModel{}
-
-	for _, diskSizeInfo := range arrDiskSizeOfType {
-		diskSizeArr := strings.Split(diskSizeInfo, "|")
-		if strings.EqualFold(diskInfo.DiskType, diskSizeArr[0]) {
-			diskSizeValue.diskType = diskSizeArr[0]
-			diskSizeValue.unit = diskSizeArr[3]
-			diskSizeValue.diskMinSize, err = strconv.ParseInt(diskSizeArr[1], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-
-			diskSizeValue.diskMaxSize, err = strconv.ParseInt(diskSizeArr[2], 10, 64)
-			if err != nil {
-				cblogger.Error(err)
-				return err
-			}
-		}
-	}
-
-	if newDiskSize > diskSizeValue.diskMaxSize {
-		cblogger.Error("Disk Size Error!!: ", diskSize, diskSizeValue.diskMinSize, diskSizeValue.diskMaxSize)
-		return errors.New("Disk Size must be smaller than or equal to the maximum size (" + strconv.FormatInt(diskSizeValue.diskMaxSize, 10) + " GB).")
-	}
-
 	return nil
 }
 

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/VMHandler.go
@@ -340,10 +340,7 @@ func (vmHandler *TencentVMHandler) StartVM(vmReqInfo irs.VMReqInfo) (irs.VMInfo,
 			imageSize := *imageInfo.ImageSize
 			cblogger.Info("image : ", imageSize)
 
-			if rootDiskSize < imageSize {
-				cblogger.Error("Disk Size Error!!: ", rootDiskSize, imageSize)
-				return irs.VMInfo{}, errors.New("Root Disk Size must be larger then the image size (" + strconv.FormatInt(imageSize, 10) + " GB).")
-			}
+			cblogger.Infof("Requested root disk size %dGB (image %dGB); validation is delegated to Tencent.", rootDiskSize, imageSize)
 
 			cblogger.Info("rootDiskSize : ", rootDiskSize)
 			cblogger.Info("rootDiskSize : ", common.Int64Ptr(rootDiskSize))


### PR DESCRIPTION
Several drivers validate `DiskType` / `DiskSize` / `RootDiskType` / `RootDiskSize`
against `cloudos_meta.yaml` or hard-coded ranges in source code before calling the CSP.
These lists inevitably fall behind the CSP's real offering and block valid requests such as (not limited)

- GCP `hyperdisk-*` (required by C3/C4/N4/X4 series)
- Azure `PremiumV2_LRS` / `UltraSSD_LRS`
- Alibaba `cloud_auto` / `cloud_essd_entry`, ESSD > 32768 GB
- Tencent `CLOUD_BSSD`
- AWS gp3/io2 > 16384 GB (AWS allows 65536)
- NCP data disk > 2000 GB (CB1 allows 16380), NHN root > 1000 GB (NHN allows 2000)

The CSP API already returns a clear error for anything it does not support,
so this validation only duplicates it with stale data.

I think the existing code are redundant and cause additional operational cost.
This PR removes the validation. I chose removal over downgrading it to a
non-blocking warning because most of it is no longer maintained accurately,
so keeping it would add noise without adding value.

The changes has been tested by CB-TB operations. 