### PR TITLE
feat(k8s): propagate cluster token expiration time

### DIFF
--- a/api-runtime/common-runtime/ClusterManager.go
+++ b/api-runtime/common-runtime/ClusterManager.go
@@ -1203,36 +1203,36 @@ func GetCluster(connectionName string, rsType string, clusterName string, kubeco
 // Generate Token for Cluster Authentication
 // (1) get IID(NameId)
 // (2) generate token using driver
-func GenerateClusterToken(connectionName string, clusterName string) (string, error) {
+func GenerateClusterToken(connectionName string, clusterName string) (cres.ClusterToken, error) {
 	cblog.Info("call GenerateClusterToken()")
 
 	// check empty and trim user inputs
 	connectionName, err := EmptyCheckAndTrim("connectionName", connectionName)
 	if err != nil {
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	if err := checkCapability(connectionName, CLUSTER_HANDLER); err != nil {
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	clusterName, err = EmptyCheckAndTrim("clusterName", clusterName)
 	if err != nil {
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	cldConn, err := ccm.GetCloudConnection(connectionName)
 	if err != nil {
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	handler, err := cldConn.CreateClusterHandler()
 	if err != nil {
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	clusterSPLock.RLock(connectionName, clusterName)
@@ -1244,13 +1244,13 @@ func GenerateClusterToken(connectionName string, clusterName string) (string, er
 		err = getAuthIIDInfoList(connectionName, &iidInfoList)
 		if err != nil {
 			cblog.Error(err)
-			return "", err
+			return cres.ClusterToken{}, err
 		}
 	} else {
 		err = infostore.ListByCondition(&iidInfoList, CONNECTION_NAME_COLUMN, connectionName)
 		if err != nil {
 			cblog.Error(err)
-			return "", err
+			return cres.ClusterToken{}, err
 		}
 	}
 	var iidInfo *ClusterIIDInfo
@@ -1265,14 +1265,14 @@ func GenerateClusterToken(connectionName string, clusterName string) (string, er
 	if bool_ret == false {
 		err := fmt.Errorf("%s '%s' does not exist in connection '%s'", RSTypeString(CLUSTER), clusterName, connectionName)
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	// (2) generate token using driver
 	token, err := handler.GenerateClusterToken(getDriverIID(cres.IID{NameId: iidInfo.NameId, SystemId: iidInfo.SystemId}))
 	if err != nil {
 		cblog.Error(err)
-		return "", err
+		return cres.ClusterToken{}, err
 	}
 
 	return token, nil

--- a/api-runtime/rest-runtime/ClusterRest.go
+++ b/api-runtime/rest-runtime/ClusterRest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"strconv"
+	"time"
 )
 
 //================ Cluster Handler
@@ -755,8 +756,15 @@ type ClusterTokenResponse struct {
 	Status     ClusterTokenStatus `json:"status"`
 }
 
+// ClusterTokenStatus mirrors the Kubernetes ExecCredentialStatus
+// (client.authentication.k8s.io/v1).
 type ClusterTokenStatus struct {
 	Token string `json:"token" example:"k8s-aws-v1.aHR0cHM6Ly9zdHMuYXA..."`
+
+	// ExpirationTimestamp is when the token stops being accepted, in RFC3339.
+	// It is omitted when the CSP provides no expiry information, which the spec allows:
+	// clients then keep the credential until a 401 forces a refresh.
+	ExpirationTimestamp *string `json:"expirationTimestamp,omitempty" example:"2026-09-02T05:15:00Z"`
 }
 
 // getClusterToken godoc
@@ -788,7 +796,7 @@ func GetClusterToken(c echo.Context) error {
 	}
 
 	// Get cluster info first to validate cluster exists and get token
-	token, err := cmrt.GenerateClusterToken(connectionName, clusterName)
+	clusterToken, err := cmrt.GenerateClusterToken(connectionName, clusterName)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -798,9 +806,22 @@ func GetClusterToken(c echo.Context) error {
 		ApiVersion: "client.authentication.k8s.io/v1",
 		Kind:       "ExecCredential",
 		Status: ClusterTokenStatus{
-			Token: token,
+			Token:               clusterToken.Token,
+			ExpirationTimestamp: rfc3339OrNil(clusterToken.ExpiresAt),
 		},
 	}
 
 	return c.JSON(http.StatusOK, response)
+}
+
+// rfc3339OrNil renders a token expiry for the ExecCredential response, or nil when it is
+// unknown. A zero time means the driver could not determine the expiry; emitting it as a
+// timestamp would tell clients the credential is long expired, so the field is omitted
+// instead -- expirationTimestamp is optional in the spec.
+func rfc3339OrNil(t time.Time) *string {
+	if t.IsZero() {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339)
+	return &s
 }

--- a/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/alibaba/resources/ClusterHandler.go
@@ -289,8 +289,8 @@ func (ach *AlibabaClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInf
 
 // GenerateClusterToken generates a token for cluster authentication
 // Alibaba Cloud does not support dynamic token generation yet
-func (ach *AlibabaClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
-	return "", fmt.Errorf("GenerateClusterToken is not supported for Alibaba Cloud clusters yet")
+func (ach *AlibabaClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
+	return irs.ClusterToken{}, fmt.Errorf("GenerateClusterToken is not supported for Alibaba Cloud clusters yet")
 }
 
 func (ach *AlibabaClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/aws/resources/ClusterHandler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"strconv"
@@ -614,7 +615,7 @@ func (ClusterHandler *AwsClusterHandler) getStaticKubeConfig(clusterDesc *eks.De
 	cluster := clusterDesc.Cluster
 
 	// create kubeconfig with EKS token
-	token, err := ClusterHandler.generateEKSToken(*cluster.Name)
+	token, _, err := ClusterHandler.generateEKSToken(*cluster.Name)
 	if err != nil {
 		cblogger.Errorf("Failed to generate EKS token: %v", err)
 		// empty token when error occurs
@@ -686,9 +687,20 @@ users:
 }
 
 // create EKS token using AWS STS
-func (ClusterHandler *AwsClusterHandler) generateEKSToken(clusterName string) (string, error) {
+// generateEKSToken returns the EKS bearer token and the time it stops being accepted.
+//
+// The expiry is derived from the presigned URL itself (X-Amz-Date + X-Amz-Expires) rather
+// than from time.Now(), so it tracks the value STS actually enforces even if the duration
+// constant changes. One minute is subtracted for cushion, mirroring the official
+// aws-iam-authenticator, so that a request started just before the boundary does not
+// arrive after it (clock skew, network latency, signing-time drift).
+// Ref: kubernetes-sigs/aws-iam-authenticator pkg/token/token.go
+//
+// A zero expiry is returned when it cannot be determined; callers must treat that as
+// "unknown" rather than "expired".
+func (ClusterHandler *AwsClusterHandler) generateEKSToken(clusterName string) (string, time.Time, error) {
 	if ClusterHandler.StsClient == nil {
-		return "", fmt.Errorf("STS client not available")
+		return "", time.Time{}, fmt.Errorf("STS client not available")
 	}
 
 	// create request for GetCallerIdentity
@@ -702,7 +714,7 @@ func (ClusterHandler *AwsClusterHandler) generateEKSToken(clusterName string) (s
 	presignedURL, err := req.Presign(duration)
 	if err != nil {
 		cblogger.Errorf("Failed to create presigned URL: %v", err)
-		return "", fmt.Errorf("failed to create presigned URL: %w", err)
+		return "", time.Time{}, fmt.Errorf("failed to create presigned URL: %w", err)
 	}
 
 	encodedURL := base64.RawURLEncoding.EncodeToString([]byte(presignedURL))
@@ -710,12 +722,50 @@ func (ClusterHandler *AwsClusterHandler) generateEKSToken(clusterName string) (s
 	// prepend "k8s-aws-v1." to the encoded URL
 	token := "k8s-aws-v1." + encodedURL
 
-	return token, nil
+	return token, eksTokenExpiry(presignedURL), nil
+}
+
+// eksTokenExpiryCushion is subtracted from the presigned URL expiry so that a request
+// started just before the boundary is not rejected on arrival. The official
+// aws-iam-authenticator uses the same one-minute cushion.
+const eksTokenExpiryCushion = 1 * time.Minute
+
+// eksTokenExpiry reads X-Amz-Date and X-Amz-Expires from a presigned STS URL and returns
+// when the derived token stops being usable. It returns the zero time when the URL cannot
+// be parsed, which callers treat as "expiry unknown".
+func eksTokenExpiry(presignedURL string) time.Time {
+	u, err := url.Parse(presignedURL)
+	if err != nil {
+		cblogger.Errorf("Failed to parse presigned URL for token expiry: %v", err)
+		return time.Time{}
+	}
+
+	q := u.Query()
+	// X-Amz-Date is the signing time in the SigV4 basic format (e.g. 20260902T051500Z).
+	signedAt, err := time.Parse("20060102T150405Z", q.Get("X-Amz-Date"))
+	if err != nil {
+		cblogger.Errorf("Failed to parse X-Amz-Date for token expiry: %v", err)
+		return time.Time{}
+	}
+
+	secs, err := strconv.ParseInt(q.Get("X-Amz-Expires"), 10, 64)
+	if err != nil || secs <= 0 {
+		cblogger.Errorf("Failed to parse X-Amz-Expires for token expiry: %v", err)
+		return time.Time{}
+	}
+
+	expiresAt := signedAt.Add(time.Duration(secs) * time.Second).Add(-eksTokenExpiryCushion)
+	if !expiresAt.After(signedAt) {
+		// Duration shorter than the cushion; reporting a past time would be worse than
+		// reporting nothing, so treat it as unknown.
+		return time.Time{}
+	}
+	return expiresAt
 }
 
 // GenerateClusterToken generates a token for cluster authentication
 // This implements the ClusterHandler interface
-func (ClusterHandler *AwsClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+func (ClusterHandler *AwsClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
 	cblogger.Info("call GenerateClusterToken()")
 
 	// For EKS, we need the cluster name to generate token
@@ -725,17 +775,17 @@ func (ClusterHandler *AwsClusterHandler) GenerateClusterToken(clusterIID irs.IID
 	}
 
 	if clusterName == "" {
-		return "", fmt.Errorf("cluster name is required for token generation")
+		return irs.ClusterToken{}, fmt.Errorf("cluster name is required for token generation")
 	}
 
 	// Generate EKS token using existing function
-	token, err := ClusterHandler.generateEKSToken(clusterName)
+	token, expiresAt, err := ClusterHandler.generateEKSToken(clusterName)
 	if err != nil {
 		cblogger.Errorf("Failed to generate cluster token: %v", err)
-		return "", fmt.Errorf("failed to generate cluster token: %w", err)
+		return irs.ClusterToken{}, fmt.Errorf("failed to generate cluster token: %w", err)
 	}
 
-	return token, nil
+	return irs.ClusterToken{Token: token, ExpiresAt: expiresAt}, nil
 }
 
 func (ClusterHandler *AwsClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/azure/resources/ClusterHandler.go
@@ -299,8 +299,8 @@ func (ac *AzureClusterHandler) GetCluster(clusterIID irs.IID) (info irs.ClusterI
 
 // GenerateClusterToken generates a token for cluster authentication
 // Azure AKS uses different authentication method, this is not supported yet
-func (ac *AzureClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
-	return "", errors.New("GenerateClusterToken is not supported for Azure AKS clusters yet")
+func (ac *AzureClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
+	return irs.ClusterToken{}, errors.New("GenerateClusterToken is not supported for Azure AKS clusters yet")
 }
 
 func (ac *AzureClusterHandler) DeleteCluster(clusterIID irs.IID) (deleteResult bool, delErr error) {

--- a/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/gcp/resources/ClusterHandler.go
@@ -1680,7 +1680,7 @@ func (ClusterHandler *GCPClusterHandler) hasActiveOperations(projectID, zone, cl
 
 // GenerateClusterToken generates a token for cluster authentication
 // GCP uses OAuth2 access token for GKE cluster access
-func (ClusterHandler *GCPClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+func (ClusterHandler *GCPClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
 	cblogger.Info("call GenerateClusterToken()")
 
 	// Create JWT config from credential info
@@ -1693,7 +1693,7 @@ func (ClusterHandler *GCPClusterHandler) GenerateClusterToken(clusterIID irs.IID
 	res, err := json.Marshal(data)
 	if err != nil {
 		cblogger.Errorf("Failed to marshal credential data: %v", err)
-		return "", fmt.Errorf("failed to marshal credential data: %w", err)
+		return irs.ClusterToken{}, fmt.Errorf("failed to marshal credential data: %w", err)
 	}
 
 	// Use cloud-platform scope for GKE access
@@ -1701,7 +1701,7 @@ func (ClusterHandler *GCPClusterHandler) GenerateClusterToken(clusterIID irs.IID
 	conf, err := goo.JWTConfigFromJSON(res, authURL)
 	if err != nil {
 		cblogger.Errorf("Failed to create JWT config: %v", err)
-		return "", fmt.Errorf("failed to create JWT config: %w", err)
+		return irs.ClusterToken{}, fmt.Errorf("failed to create JWT config: %w", err)
 	}
 
 	// Get token using the JWT config
@@ -1709,10 +1709,11 @@ func (ClusterHandler *GCPClusterHandler) GenerateClusterToken(clusterIID irs.IID
 	token, err := tokenSource.Token()
 	if err != nil {
 		cblogger.Errorf("Failed to get access token: %v", err)
-		return "", fmt.Errorf("failed to get access token: %w", err)
+		return irs.ClusterToken{}, fmt.Errorf("failed to get access token: %w", err)
 	}
 
-	return token.AccessToken, nil
+	// oauth2.Token already carries the server-provided expiry; do not discard it.
+	return irs.ClusterToken{Token: token.AccessToken, ExpiresAt: token.Expiry}, nil
 }
 
 func (ClusterHandler *GCPClusterHandler) createK8sClientFromKubeconfig(kubeconfigContent string) (*kubernetes.Clientset, error) {
@@ -1721,11 +1722,11 @@ func (ClusterHandler *GCPClusterHandler) createK8sClientFromKubeconfig(kubeconfi
 		return nil, fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
 	}
 
-	token, err := ClusterHandler.GenerateClusterToken(irs.IID{})
+	clusterToken, err := ClusterHandler.GenerateClusterToken(irs.IID{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cluster token: %w", err)
 	}
-	config.BearerToken = token
+	config.BearerToken = clusterToken.Token
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ibm/resources/ClusterHandler.go
@@ -551,8 +551,8 @@ func (ic *IbmClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInfo, er
 
 // GenerateClusterToken generates a token for cluster authentication
 // IBM does not support dynamic token generation yet
-func (ic *IbmClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
-	return "", fmt.Errorf("GenerateClusterToken is not supported for IBM clusters yet")
+func (ic *IbmClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
+	return irs.ClusterToken{}, fmt.Errorf("GenerateClusterToken is not supported for IBM clusters yet")
 }
 
 func (ic *IbmClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/mock/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/mock/resources/ClusterHandler.go
@@ -209,12 +209,15 @@ func (clusterHandler *MockClusterHandler) GetCluster(iid irs.IID) (irs.ClusterIn
 
 // GenerateClusterToken generates a token for cluster authentication
 // Mock implementation returns a fake token
-func (clusterHandler *MockClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+func (clusterHandler *MockClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
 	cblogger := cblog.GetLogger("CB-SPIDER")
 	cblogger.Info("Mock Driver: called GenerateClusterToken()!")
 
 	// Return a mock token for testing purposes
-	return "mock-token-k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5", nil
+	return irs.ClusterToken{
+		Token:     "mock-token-k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8_QWN0aW9uPUdldENhbGxlcklkZW50aXR5",
+		ExpiresAt: time.Now().Add(15 * time.Minute),
+	}, nil
 }
 
 func (clusterHandler *MockClusterHandler) DeleteCluster(iid irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/ncp/resources/ClusterHandler.go
@@ -760,7 +760,7 @@ func (nvch *NcpVpcClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterInf
 // GenerateClusterToken generates a bearer token string for cluster authentication.
 // Returns an NCP IAM HMAC token (k8s-ncp-v1.xxx) — NOT a full kubeconfig YAML.
 // This token is used by the REST API's ExecCredential response (ClusterTokenResponse.Status.Token).
-func (nvch *NcpVpcClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
+func (nvch *NcpVpcClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err := fmt.Errorf("PANIC!!\n%v\n%v", r, string(debug.Stack()))
@@ -783,7 +783,7 @@ func (nvch *NcpVpcClusterHandler) GenerateClusterToken(clusterIID irs.IID) (stri
 	clusterList, err := ncpClustersGet(nvch.ClusterClient, nvch.Ctx)
 	if err != nil {
 		tokenErr = fmt.Errorf("failed to get cluster list: %w", err)
-		return "", tokenErr
+		return irs.ClusterToken{}, tokenErr
 	}
 
 	var targetCluster *vnks.Cluster
@@ -796,20 +796,22 @@ func (nvch *NcpVpcClusterHandler) GenerateClusterToken(clusterIID irs.IID) (stri
 	}
 	if targetCluster == nil || targetCluster.Uuid == nil {
 		tokenErr = fmt.Errorf("cluster not found or UUID is missing")
-		return "", tokenErr
+		return irs.ClusterToken{}, tokenErr
 	}
 
 	ncpRegion := nvch.normalizeRegionCode(nvch.RegionInfo.Region)
 	clusterUUID := ncloud.StringValue(targetCluster.Uuid)
 
+	// Capture the issue time before signing: the validity window is measured from it.
+	issuedAt := time.Now()
 	token, err := generateNCPIAMToken(nvch.CredentialInfo.ClientId, nvch.CredentialInfo.ClientSecret, clusterUUID, ncpRegion)
 	if err != nil {
 		tokenErr = fmt.Errorf("failed to generate NCP IAM token: %w", err)
-		return "", tokenErr
+		return irs.ClusterToken{}, tokenErr
 	}
 
 	LoggingInfo(hiscallInfo, start)
-	return token, nil
+	return irs.ClusterToken{Token: token, ExpiresAt: issuedAt.Add(ncpTokenValidity)}, nil
 }
 
 // getKubeConfig retrieves kubeconfig with exec-based dynamic token authentication
@@ -2483,6 +2485,14 @@ type ncpTokenClaim struct {
 	Signature string `json:"signature"`
 	Path      string `json:"path"`
 }
+
+// ncpTokenValidity is how long an NCP IAM token stays acceptable.
+//
+// NCP returns no expiry: the token is signed locally (HMAC-SHA256) with no API call, and
+// the claim carries only the issue timestamp. This mirrors the constant used by the
+// official ncp-iam-authenticator, so it must be revisited if NCP changes that window.
+// Ref: https://github.com/NaverCloudPlatform/ncp-iam-authenticator (pkg/token: tokenValidity)
+const ncpTokenValidity = 240 * time.Second
 
 // generateNCPIAMToken generates a presigned NCP IAM token for Kubernetes authentication
 // This token is used by Kubernetes API server to authenticate kubectl requests

--- a/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/nhn/resources/ClusterHandler.go
@@ -273,8 +273,8 @@ func (nch *NhnCloudClusterHandler) GetCluster(clusterIID irs.IID) (irs.ClusterIn
 
 // GenerateClusterToken generates a token for cluster authentication
 // NHN Cloud does not support dynamic token generation yet
-func (nch *NhnCloudClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
-	return "", fmt.Errorf("GenerateClusterToken is not supported for NHN Cloud clusters yet")
+func (nch *NhnCloudClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
+	return irs.ClusterToken{}, fmt.Errorf("GenerateClusterToken is not supported for NHN Cloud clusters yet")
 }
 
 func (nch *NhnCloudClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/drivers/tencent/resources/ClusterHandler.go
@@ -175,8 +175,8 @@ func (clusterHandler *TencentClusterHandler) GetCluster(clusterIID irs.IID) (irs
 
 // GenerateClusterToken generates a token for cluster authentication
 // Tencent Cloud does not support dynamic token generation yet
-func (clusterHandler *TencentClusterHandler) GenerateClusterToken(clusterIID irs.IID) (string, error) {
-	return "", fmt.Errorf("GenerateClusterToken is not supported for Tencent Cloud clusters yet")
+func (clusterHandler *TencentClusterHandler) GenerateClusterToken(clusterIID irs.IID) (irs.ClusterToken, error) {
+	return irs.ClusterToken{}, fmt.Errorf("GenerateClusterToken is not supported for Tencent Cloud clusters yet")
 }
 
 func (clusterHandler *TencentClusterHandler) DeleteCluster(clusterIID irs.IID) (bool, error) {

--- a/cloud-control-manager/cloud-driver/interfaces/resources/ClusterHandler.go
+++ b/cloud-control-manager/cloud-driver/interfaces/resources/ClusterHandler.go
@@ -104,6 +104,20 @@ type AddonsInfo struct {
 	KeyValueList []KeyValue `json:"KeyValueList,omitempty" validate:"omitempty"`
 }
 
+// ClusterToken is a short-lived credential issued by the CSP for cluster access.
+// It is a CSP domain value: the REST layer maps it into a Kubernetes ExecCredential
+// (client.authentication.k8s.io/v1), so this type intentionally carries no
+// Kubernetes-specific wire format.
+// @description Short-lived Cluster Access Token
+type ClusterToken struct {
+	Token string `json:"Token" example:"k8s-aws-v1.aHR0cHM6Ly9zdHMuYXA..."`
+
+	// ExpiresAt is when the token stops being accepted.
+	// Zero means the CSP provides no expiry information; callers must treat it as unknown
+	// rather than as "already expired" or "never expires".
+	ExpiresAt time.Time `json:"ExpiresAt,omitempty" example:"2026-09-02T05:15:00Z"`
+}
+
 // -------- Cluster API
 type ClusterHandler interface {
 
@@ -115,7 +129,7 @@ type ClusterHandler interface {
 	DeleteCluster(clusterIID IID) (bool, error)
 
 	//------ Token Management
-	GenerateClusterToken(clusterIID IID) (string, error)
+	GenerateClusterToken(clusterIID IID) (ClusterToken, error)
 
 	//------ NodeGroup Management
 	AddNodeGroup(clusterIID IID, nodeGroupReqInfo NodeGroupInfo) (NodeGroupInfo, error)


### PR DESCRIPTION
## Summary

`GenerateClusterToken` now returns `ClusterToken{Token, ExpiresAt}` instead of a bare string, 
so drivers can carry the expiry up to the REST layer. 

`ClusterTokenStatus` gains `expirationTimestamp` (RFC3339), 
completing the  `ExecCredentialStatus` shape it already declares itself to mirror. 

Expiry is derived per CSP:
- GCP from `oauth2.Token.Expiry`
- AWS by reading the signing time and validity seconds that SigV4 embeds in the presigned STS URL (`X-Amz-Date` / `X-Amz-Expires`), minus a 1-minute cushion (mirroring `aws-iam-authenticator`), 
- NCP from the 240s constant used by `ncp-iam-authenticator`.

Drivers that do not issue tokens (Azure, Alibaba, Tencent, IBM, NHN) only change their return type; behavior is unchanged.

Fixes #1827
