### PR TITLE
Fix: Return stored SystemId in S3 bucket JSON responses

### DIFF
--- a/api-runtime/common-runtime/S3Manager.go
+++ b/api-runtime/common-runtime/S3Manager.go
@@ -612,6 +612,15 @@ func GetS3Bucket(connectionName, bucketName string) (*minio.BucketInfo, error) {
 	return &bucketInfo, nil
 }
 
+// GetS3BucketSystemId returns the CSP-side bucket name stored for the connection; falls back to bucketName.
+func GetS3BucketSystemId(connectionName, bucketName string) string {
+	var iidInfo S3BucketIIDInfo
+	if err := infostore.GetByConditions(&iidInfo, "connection_name", connectionName, "name_id", bucketName); err != nil || iidInfo.SystemId == "" {
+		return bucketName
+	}
+	return iidInfo.SystemId
+}
+
 func GetS3BucketRegionInfo(connectionName, bucketName string) (string, error) {
 	cblog.Info("call GetS3BucketRegionInfo()")
 	var iidInfo S3BucketIIDInfo

--- a/api-runtime/rest-runtime/S3Rest.go
+++ b/api-runtime/rest-runtime/S3Rest.go
@@ -951,7 +951,7 @@ func listObjectVersions(c echo.Context) error {
 	// JSON response: use IID format for bucket name
 	if isJSONResponse(c) {
 		jsonResp := ListVersionsResultJSON{
-			IId:           BucketIID{NameId: bucketName, SystemId: bucketName},
+			IId:           BucketIID{NameId: bucketName, SystemId: cmrt.GetS3BucketSystemId(conn, bucketName)},
 			Prefix:        prefix,
 			MaxKeys:       1000,
 			IsTruncated:   false,
@@ -1488,7 +1488,7 @@ func GetS3BucketUsage(c echo.Context) error {
 	// JSON response: use IID format for bucket name
 	if isJSONResponse(c) {
 		jsonResp := BucketUsageJSON{
-			IId:                 BucketIID{NameId: bucketName, SystemId: bucketName},
+			IId:                 BucketIID{NameId: bucketName, SystemId: cmrt.GetS3BucketSystemId(conn, bucketName)},
 			CurrentSize:         currentSize,
 			DeletedVersionsSize: deletedVersionsSize,
 			TotalSize:           currentSize + deletedVersionsSize,
@@ -1806,7 +1806,7 @@ func ListS3Objects(c echo.Context) error {
 				cpJSON = append(cpJSON, CommonPrefixJSON{Prefix: cp.Prefix})
 			}
 			jsonResp := ListBucketResultWithPrefixJSON{
-				IId:            BucketIID{NameId: bucket, SystemId: bucket},
+				IId:            BucketIID{NameId: bucket, SystemId: cmrt.GetS3BucketSystemId(conn, bucket)},
 				Prefix:         prefix,
 				Delimiter:      delimiter,
 				Marker:         "",
@@ -1864,7 +1864,7 @@ func ListS3Objects(c echo.Context) error {
 	// JSON response: use IID format for bucket name
 	if isJSONResponse(c) {
 		jsonResp := ListBucketResultJSON{
-			IId:         BucketIID{NameId: bucket, SystemId: bucket},
+			IId:         BucketIID{NameId: bucket, SystemId: cmrt.GetS3BucketSystemId(conn, bucket)},
 			Prefix:      prefix,
 			Marker:      "",
 			MaxKeys:     1000,
@@ -2489,7 +2489,7 @@ func initiateMultipartUpload(c echo.Context) error {
 	// JSON response: use IID format for bucket name
 	if isJSONResponse(c) {
 		jsonResp := InitiateMultipartUploadResultJSON{
-			IId:      BucketIID{NameId: bucket, SystemId: bucket},
+			IId:      BucketIID{NameId: bucket, SystemId: cmrt.GetS3BucketSystemId(conn, bucket)},
 			Key:      decodedKey,
 			UploadId: uploadID,
 		}
@@ -2589,7 +2589,7 @@ func completeMultipartUpload(c echo.Context) error {
 	if isJSONResponse(c) {
 		jsonResp := CompleteMultipartUploadResultJSON{
 			Location: location,
-			IId:      BucketIID{NameId: bucket, SystemId: bucket},
+			IId:      BucketIID{NameId: bucket, SystemId: cmrt.GetS3BucketSystemId(conn, bucket)},
 			Key:      decodedKey,
 			ETag:     etag,
 		}
@@ -2875,7 +2875,7 @@ func postObject(c echo.Context) error {
 			Key string    `json:"Key"`
 		}
 		return c.JSON(http.StatusOK, UploadResultJSON{
-			IId: BucketIID{NameId: bucket, SystemId: bucket},
+			IId: BucketIID{NameId: bucket, SystemId: cmrt.GetS3BucketSystemId(conn, bucket)},
 			Key: key,
 		})
 	}
@@ -3429,7 +3429,7 @@ func listParts(c echo.Context) error {
 			})
 		}
 		jsonResp := ListPartsResultJSON{
-			IId:                  BucketIID{NameId: result.Bucket, SystemId: result.Bucket},
+			IId:                  BucketIID{NameId: result.Bucket, SystemId: cmrt.GetS3BucketSystemId(conn, result.Bucket)},
 			Key:                  result.Key,
 			UploadID:             result.UploadID,
 			PartNumberMarker:     result.PartNumberMarker,
@@ -3498,7 +3498,7 @@ func listMultipartUploads(c echo.Context) error {
 			})
 		}
 		jsonResp := ListMultipartUploadsResultJSON{
-			IId:                BucketIID{NameId: result.Bucket, SystemId: result.Bucket},
+			IId:                BucketIID{NameId: result.Bucket, SystemId: cmrt.GetS3BucketSystemId(conn, result.Bucket)},
 			KeyMarker:          result.KeyMarker,
 			UploadIDMarker:     result.UploadIDMarker,
 			NextKeyMarker:      result.NextKeyMarker,


### PR DESCRIPTION
### Problem

Per-bucket S3 JSON responses (get bucket, object versions, usage, multipart, POST object) set both `NameId` and `SystemId` to the requested bucket name instead of reading the stored IID. Tencent COS bucket names carry an `-<AppId>` suffix on the CSP side, so the `SystemId` in these responses did not exist on the CSP, while the bucket list API returned the correct value. Registered buckets with a distinct `SystemId` were affected the same way.

Consumers such as CB-Tumblebug store the single-bucket response, so `cspResourceId` ended up without the AppId and direct COS access with that name failed.

### Fix

- Add `GetS3BucketSystemId(connectionName, bucketName)` in `S3Manager.go`, which returns the stored `SystemId` and falls back to the given name when no metadata exists.
- Use it for the `SystemId` field in the 9 hardcoded `BucketIID{...}` literals in `S3Rest.go`.

Providers without an AppId concept keep identical `NameId` and `SystemId`, so their responses are unchanged.

### Verification

Live cluster, buckets created through CB-Tumblebug.

**Tencent** (`tencent-ap-seoul`, bucket `tb6el18av13e3t6bp789`)

| API | Before | After |
|---|---|---|
| `GET /s3/{bucket}` SystemId | `tb6el18av13e3t6bp789` | `tb6el18av13e3t6bp789-1383606637` |
| `GET /s3` (list) SystemId | `tb6el18av13e3t6bp789-1383606637` | `tb6el18av13e3t6bp789-1383606637` |
| CB-TB `cspResourceId` | `tb6el18av13e3t6bp789` | `tb6el18av13e3t6bp789-1383606637` |

**AWS** (`aws-ap-northeast-2`, bucket `tbpfhvsu7i9cq54ht09k`)

| API | Before | After |
|---|---|---|
| `GET /s3/{bucket}` SystemId | `tbpfhvsu7i9cq54ht09k` | `tbpfhvsu7i9cq54ht09k` |
| CB-TB `cspResourceId` | `tbpfhvsu7i9cq54ht09k` | `tbpfhvsu7i9cq54ht09k` |

A Tencent bucket created before the fix picked up the corrected `SystemId` on the next single-bucket GET without any change on the CB-Tumblebug side.