### PR TITLE
[Test/README] Sync S3/RDBMS test suite READMEs with current scripts and translate to English

### DIFF
--- a/test/rdbms-mariadb-test/README.md
+++ b/test/rdbms-mariadb-test/README.md
@@ -2,9 +2,9 @@
 
 Automated test suite for CB-Spider RDBMS API — creates MariaDB instances across CSPs in parallel, waits until each becomes available, then collects and displays a unified result table.
 
-**대상 CSP: MariaDB를 지원하는 AWS · Alibaba · OpenStack · NHN **
-**미지원 CSP: Azure / GCP / IBM / NCP / Tencent **
-  - Tencent: 가이드에는 제공, 실제 API 호출시 "Not Supported" 관련 에러 반환으로 현재는 지원하지 않음
+**Target CSPs: AWS, Alibaba, OpenStack, and NHN (the CSPs that support MariaDB)**
+**Unsupported: Azure / GCP / IBM / NCP / Tencent**
+  - Tencent: listed as available in the CSP's own guide, but the driver rejects `mariadb` as the requested engine with a "Not Supported" error at API call time, so it is not supported in practice.
 
 ## Prerequisites
 
@@ -25,11 +25,11 @@ Before running tests, register connection names for each CSP in CB-Spider.
 | OpenStack | `openstack-config01` | `RegionOne` | `nova` |
 | NHN | `nhn-korea-pangyo1-config` | `KR1` | `kr-pub-a` |
 
-> Azure / GCP / IBM / NCP / Tencent는 MariaDB 미지원으로 이 테스트 스위트에서 제외되어 커넥션 등록이 필요 없습니다.
+> Azure / GCP / IBM / NCP / Tencent are excluded from this test suite since they don't support MariaDB, so no connection needs to be registered for them.
 
 ### Pre-created Network Resources
 
-RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야 합니다.
+Each CSP must already have a VPC and subnet created before an RDBMS instance can be created.
 
 ```bash
 ./run-all-csp-network-prepare.sh
@@ -43,62 +43,62 @@ RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야
 
 ## MariaDB Engine Support by CSP
 
-| CSP | MariaDB 지원 | Tag 지원 | 버전 | 비고 |
+| CSP | MariaDB Support | Tag Support | Version | Notes |
 |-----|------------|---------|------|------|
-| AWS | ✅ | ✅ | `10.6` | Amazon RDS for MariaDB |
-| Alibaba | ✅ | ✅ | `10.6` | AliCloud RDS for MariaDB |
-| OpenStack | ✅ | ❌ | `10.4` | Trove for OpenStack |
-| NHN | ✅ | ❌ | `MARIADB_V101118` | NHN RDS for MariaDB |
+| AWS | Yes | Yes | `10.6` | Amazon RDS for MariaDB |
+| Alibaba | Yes | Yes | `10.6` | AliCloud RDS for MariaDB |
+| OpenStack | Yes | No | `10.4` | Trove for OpenStack |
+| NHN | Yes | No | `MARIADB_V101118` | NHN RDS for MariaDB |
 
 
 ## RDBMS Instance Configuration
 
-인스턴스 이름은 `cb-spider-mariadb-test`입니다.
+The instance name used throughout is `cb-spider-mariadb-test`.
 
 | CSP | Engine | Version | Spec | Storage |
 |-----|--------|---------|------|---------|
 | AWS | mariadb | 10.6 | db.t3.medium | 100GB |
-| Alibaba | mariadb | 10.6 | metainfo 동적 조회 (예: `mariadb.n2.medium.2c`, 조회 실패 시 `rds.mariadb.s4.large`로 폴백) | 20GB |
+| Alibaba | mariadb | 10.6 | Resolved dynamically from metainfo (e.g. `mariadb.n2.medium.2c`; falls back to `rds.mariadb.s4.large` if the lookup fails) | 20GB |
 | OpenStack | mariadb | 10.4 | m1.small | 20GB |
 | NHN | mariadb | MARIADB_V101118 | m2.c2m4 | 20GB |
 
-> **NHN 참고**: NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능합니다. `nhn-rdbms-test.sh`는 `"NHNAutoOpenDBSecurityGroup": true`를 설정해 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성하고, 인스턴스 삭제 시 함께 자동 삭제되도록 합니다 — 시험 편의를 위한 옵션이며, 운영 환경에서는 NHN 콘솔/API로 특정 CIDR만 허용하는 DB Security Group을 직접 구성하는 것을 권장합니다.
+> **NHN note**: NHN Cloud RDS requires a dedicated "DB Security Group" — separate from the VPC Security Group — before external access is possible. `nhn-rdbms-test.sh` sets `"NHNAutoOpenDBSecurityGroup": true`, which auto-creates a fully open (`0.0.0.0/0`) DB Security Group and removes it automatically when the instance is deleted. This is purely a testing convenience; in production, configure a DB Security Group through the NHN console/API that allows only specific CIDRs.
 
 ## Usage
 
 ### Quick Start (Full Test Suite)
 
 ```bash
-# 전체 테스트 순차 실행 (네트워크 준비 → StorageType 검증 → RDBMS 생성 → DB 관리 → Tag → 삭제 → 네트워크 정리)
+# Runs the full suite sequentially (network prepare -> StorageType validation -> RDBMS create -> DB management -> Tag -> delete -> network cleanup)
 ./all_test.sh
 
-# 실패 시 즉시 중단
+# Abort immediately on the first failure
 STOP_ON_FAIL=1 ./all_test.sh
 ```
 
 ### Step-by-step
 
 ```bash
-# 1. 네트워크 사전 자원 생성
+# 1. Create prerequisite network resources
 ./run-all-csp-network-prepare.sh
 
-# 2. StorageType 검증 테스트
+# 2. StorageType validation test
 ./storage-type-test/run-all-csp-storage-type-tests.sh
 ./storage-type-test/delete-all-csp-storage-type-rdbms.sh
 
-# 3. RDBMS 인스턴스 생성 및 검증
+# 3. Create and verify RDBMS instances
 ./run-all-csp-rdbms-tests.sh
 
-# 4. DB 관리 테스트 (CreateDB / ListDB / DeleteDB)
+# 4. Database management test (CreateDB / ListDB / DeleteDB)
 ./database-test/run-all-csp-database-tests.sh
 
-# 5. Tag 관리 테스트
+# 5. Tag management test
 ./tag-test/run-all-csp-rdbms-tag-tests.sh
 
-# 6. RDBMS 인스턴스 삭제
+# 6. Delete RDBMS instances
 ./delete-all-csp-rdbms.sh
 
-# 7. 네트워크 자원 삭제
+# 7. Delete network resources
 ./delete-all-csp-network.sh
 ```
 
@@ -113,55 +113,55 @@ STOP_ON_FAIL=1 ./all_test.sh
 
 ### Configuration
 
-| 환경변수 | 기본값 | 설명 |
+| Environment Variable | Default | Description |
 |---------|--------|------|
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
 | `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
-| `MAX_WAIT_SEC` | `3600` | 인스턴스 Available 대기 최대 시간 (초) |
-| `POLL_INTERVAL` | `30` | 상태 폴링 간격 (초) |
-| `STOP_ON_FAIL` | `0` | `1`이면 첫 번째 실패 시 중단 |
-| `VERBOSE` | `0` | `1`이면 CSP별 상세 로그 출력 |
+| `MAX_WAIT_SEC` | `3600` | Max seconds to wait for an instance to become Available |
+| `POLL_INTERVAL` | `30` | Status polling interval (seconds) |
+| `STOP_ON_FAIL` | `0` | If `1`, abort on the first failure |
+| `VERBOSE` | `0` | If `1`, print detailed per-CSP logs |
 
 ## Script Structure
 
 ```
 rdbms-mariadb-test/
-├── all_test.sh                          # 전체 테스트 수트
-├── common-rdbms-test.sh                 # 공통: Create → Poll → Get Info
-├── common-rdbms-delete.sh               # 공통: Delete → Poll until gone
-├── common-network-prepare.sh            # 공통: VPC/Subnet/SG 생성
-├── common-network-cleanup.sh            # 공통: VPC/Subnet/SG 삭제
-├── run-all-csp-rdbms-tests.sh           # 전체 CSP 병렬 RDBMS 생성
-├── delete-all-csp-rdbms.sh              # 전체 CSP 병렬 RDBMS 삭제
-├── run-all-csp-network-prepare.sh       # 전체 CSP 네트워크 사전 준비
-├── delete-all-csp-network.sh            # 전체 CSP 네트워크 정리
-├── aws-rdbms-test.sh / alibaba-rdbms-test.sh / openstack-rdbms-test.sh / nhn-rdbms-test.sh   # MariaDB 지원 4개 CSP만 존재
+├── all_test.sh                          # Full test suite
+├── common-rdbms-test.sh                 # Common: Create -> Poll -> Get Info
+├── common-rdbms-delete.sh               # Common: Delete -> Poll until gone
+├── common-network-prepare.sh            # Common: VPC/Subnet/SG create
+├── common-network-cleanup.sh            # Common: VPC/Subnet/SG delete
+├── run-all-csp-rdbms-tests.sh           # Create RDBMS on all CSPs in parallel
+├── delete-all-csp-rdbms.sh              # Delete RDBMS on all CSPs in parallel
+├── run-all-csp-network-prepare.sh       # Prepare network prerequisites on all CSPs
+├── delete-all-csp-network.sh            # Clean up network resources on all CSPs
+├── aws-rdbms-test.sh / alibaba-rdbms-test.sh / openstack-rdbms-test.sh / nhn-rdbms-test.sh   # Only the 4 CSPs that support MariaDB
 ├── database-test/
 │   ├── common-database-test.sh
-│   ├── run-all-csp-database-tests.sh          # 실행 대상: AWS/Alibaba/OpenStack/NHN
+│   ├── run-all-csp-database-tests.sh          # Targets: AWS/Alibaba/OpenStack/NHN
 │   └── aws-database-test.sh / alibaba-database-test.sh / openstack-database-test.sh / nhn-database-test.sh
 ├── storage-type-test/
 │   ├── common-storage-type-test.sh
-│   ├── run-all-csp-storage-type-tests.sh      # 실행 대상: AWS/Alibaba/OpenStack/NHN
+│   ├── run-all-csp-storage-type-tests.sh      # Targets: AWS/Alibaba/OpenStack/NHN
 │   ├── delete-all-csp-storage-type-rdbms.sh
 │   └── aws-storage-type-test.sh / alibaba-storage-type-test.sh / openstack-storage-type-test.sh / nhn-storage-type-test.sh
 └── tag-test/
     ├── common-rdbms-tag-test.sh
-    ├── run-all-csp-rdbms-tag-tests.sh          # 실행 대상: AWS/Alibaba (SupportsTag=true AND MariaDB 지원)
+    ├── run-all-csp-rdbms-tag-tests.sh          # Targets: AWS/Alibaba (SupportsTag=true AND MariaDB supported)
     └── aws-rdbms-tag-test.sh / alibaba-rdbms-tag-test.sh
 ```
 
-각 시험 시나리오(StorageType 검증, DB 관리, Tag 관리)에 대한 상세 내용과 개별 시험 결과는 해당 하위 디렉토리의 README.md를 참고하세요.
+For the detailed scenario and individual results of each test suite (StorageType validation, database management, tag management), see the README in the corresponding subdirectory:
 
 - [storage-type-test/README.md](storage-type-test/README.md)
 - [database-test/README.md](database-test/README.md)
 - [tag-test/README.md](tag-test/README.md)
 
-## 시험 결과
+## Test Results
 
-시험 날짜: 2026-08-18
+Test Date: 2026-08-18
 
-`./all_test.sh` 전체 시험 수트 실행 결과, 4개 CSP(AWS/Alibaba/OpenStack/NHN) 전 Step PASS했습니다.
+A full run of `./all_test.sh` passed every step for all 4 CSPs (AWS/Alibaba/OpenStack/NHN).
 
 ```
  PASS | Step 1: Network Prepare (VPC/Subnet/SG)
@@ -176,7 +176,7 @@ rdbms-mariadb-test/
  Total: 8 PASS, 0 FAIL
 ```
 
-**RDBMS Instance Create (Step 4) 상세:**
+**RDBMS Instance Create (Step 4) detail:**
 
 ```
 =================================================================================================================================================================================
@@ -192,7 +192,7 @@ NHN          | Available   | mariadb  | MARIADB_V101118 | m2.c2m4               
 Failed : 0
 ```
 
-**RDBMS Instance Delete (Step 7) 상세:**
+**RDBMS Instance Delete (Step 7) detail:**
 
 ```
 ============================================================

--- a/test/rdbms-mariadb-test/database-test/README.md
+++ b/test/rdbms-mariadb-test/database-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS Database Management Test (MariaDB)
 
-RDBMS 인스턴스 내부의 Database CRUD API를 검증하는 테스트 스위트입니다. MariaDB를 지원하는 4개 CSP(AWS, Alibaba, OpenStack, NHN)에 대해 병렬로 실행하며, RDBMS 인스턴스 안에서 데이터베이스를 생성/조회/삭제하는 전체 흐름을 검증합니다.
+A test suite that validates the Database CRUD API inside an RDBMS instance. It runs in parallel against the 4 CSPs that support MariaDB (AWS, Alibaba, OpenStack, NHN), verifying the full flow of creating, listing, and deleting a database inside an RDBMS instance.
 
 ## Prerequisites
 
@@ -10,13 +10,13 @@ RDBMS 인스턴스 내부의 Database CRUD API를 검증하는 테스트 스위�
 cd ./bin; ./start.sh
 ```
 
-### RDBMS 인스턴스 사전 생성
+### RDBMS Instance Must Already Exist
 
-이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+This test assumes an RDBMS instance has already been created. First run the network prerequisite prepare and the create test from the parent directory.
 
 ```bash
 cd ..
-./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-network-prepare.sh   # Create VPC/Subnet/SG prerequisites (once)
 ./run-all-csp-rdbms-tests.sh
 ```
 
@@ -28,24 +28,24 @@ cd ..
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 Database CRUD를 검증합니다:
+For each CSP, Database CRUD is validated in this order:
 
-1. **CreateDatabase** — `POST /spider/rdbms/{Name}/databases` — `spidertestdb` 데이터베이스 생성
-2. **ListDatabases** — `GET /spider/rdbms/{Name}/databases` — 데이터베이스 목록 조회 성공 확인
-3. **FoundInList** — 목록에서 `spidertestdb` 존재 확인
-4. **DeleteDatabase** — `DELETE /spider/rdbms/{Name}/databases/spidertestdb` — 데이터베이스 삭제
-5. **VerifyDeleted** — `GET /spider/rdbms/{Name}/databases` — 삭제 후 목록에서 제거 확인
+1. **CreateDatabase** — `POST /spider/rdbms/{Name}/databases` — creates the `spidertestdb` database
+2. **ListDatabases** — `GET /spider/rdbms/{Name}/databases` — confirms the database list can be retrieved
+3. **FoundInList** — confirms `spidertestdb` is present in the list
+4. **DeleteDatabase** — `DELETE /spider/rdbms/{Name}/databases/spidertestdb` — deletes the database
+5. **VerifyDeleted** — `GET /spider/rdbms/{Name}/databases` — confirms it is gone from the list after deletion
 
-### 구현 방식
+### Implementation
 
-CB-Spider는 다음 두 가지 방식으로 Database 관리를 지원합니다:
+CB-Spider supports database management through two mechanisms:
 
-| 방식 | 조건 | 설명 |
+| Mechanism | Condition | Description |
 |------|------|------|
-| **CSP 네이티브 API** | 드라이버가 `rdbmsDatabaseManager` 인터페이스 구현 | 각 CSP의 데이터베이스 관리 API 직접 호출 |
-| **SQL 직접 실행** | 드라이버 미구현 시 자동 폴백 | `MasterUserPassword`로 접속하여 SQL 실행 (`CREATE/DROP DATABASE`) |
+| **CSP native API** | The driver implements the `rdbmsDatabaseManager` interface | Calls the CSP's own database management API directly |
+| **Direct SQL execution** | Automatic fallback when the driver doesn't implement it | Connects using `MasterUserPassword` and runs SQL (`CREATE/DROP DATABASE`) |
 
-`MasterUserPassword`는 SQL 폴백 경로에서 필요하므로 항상 포함합니다.
+`MasterUserPassword` is required for the SQL fallback path, so it is always included in the request.
 
 ## Configuration
 
@@ -54,7 +54,7 @@ export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
 export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
 ```
 
-테스트 DB 이름을 변경하려면:
+To change the test database name:
 
 ```bash
 export DB_NAME=mydb ./aws-database-test.sh
@@ -68,8 +68,8 @@ export DB_NAME=mydb ./aws-database-test.sh
 ./run-all-csp-database-tests.sh
 ```
 
-- MariaDB 지원 4개 CSP(AWS/Alibaba/OpenStack/NHN)에 대해 병렬로 Database CRUD 검증 실행
-- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+- Runs Database CRUD validation in parallel against the 4 CSPs that support MariaDB (AWS/Alibaba/OpenStack/NHN)
+- Prints a unified result table and PASS/FAIL summary when complete
 
 **Example output:**
 ```
@@ -89,7 +89,7 @@ Total: 4 PASS, 0 FAIL
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-database-test.sh
@@ -98,14 +98,14 @@ Total: 4 PASS, 0 FAIL
 ./nhn-database-test.sh
 ```
 
-단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_mgmt_results`)이 사용됩니다.
+For a standalone run, the result file location is controlled by the `RESULT_DIR` environment variable, defaulting to `/tmp/rdbms_mgmt_results`.
 
 ## Script Structure
 
 ```
 database-test/
-├── run-all-csp-database-tests.sh   # Orchestrator: 전체 병렬 실행, PASS/FAIL 집계
-├── common-database-test.sh         # Common: CreateDB → ListDB → DeleteDB → VerifyDeleted
+├── run-all-csp-database-tests.sh   # Orchestrator: runs all CSPs in parallel, aggregates PASS/FAIL
+├── common-database-test.sh         # Common: CreateDB -> ListDB -> DeleteDB -> VerifyDeleted
 ├── aws-database-test.sh
 ├── alibaba-database-test.sh
 ├── openstack-database-test.sh
@@ -118,9 +118,9 @@ database-test/
 |----------|---------|-------------|
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
 | `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
-| `DB_NAME` | `spidertestdb` | 생성/삭제할 테스트 데이터베이스 이름 |
+| `DB_NAME` | `spidertestdb` | Name of the test database to create/delete |
 | `RESULT_DIR` | `/tmp/rdbms_mgmt_results` | Result file output directory |
-| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+| `VERBOSE` | `0` | If set to `1`, dumps the full per-CSP log |
 
 ```bash
 # Example: verbose output
@@ -129,21 +129,21 @@ VERBOSE=1 ./run-all-csp-database-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 7개 필드:
+The result file (`result_<csp>.txt`) has 7 pipe(`|`)-separated fields:
 
 ```
 CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `CreateDB` | 데이터베이스 생성 결과 (`PASS` / `FAIL`) |
-| `ListDB` | 데이터베이스 목록 조회 결과 |
-| `FoundInList` | 생성된 DB가 목록에 존재 (`FOUND` / `NOT_FOUND`) |
-| `DeleteDB` | 데이터베이스 삭제 결과 |
-| `VerifyDeleted` | 삭제 후 목록에서 제거 확인 결과 |
-| `Elapsed` | 경과 시간 |
+| `CSP` | CSP name (e.g. AWS) |
+| `CreateDB` | Database creation result (`PASS` / `FAIL`) |
+| `ListDB` | Database list retrieval result |
+| `FoundInList` | Whether the created database was found in the list (`FOUND` / `NOT_FOUND`) |
+| `DeleteDB` | Database deletion result |
+| `VerifyDeleted` | Whether the database was confirmed gone from the list after deletion |
+| `Elapsed` | Elapsed time |
 
 ## API Reference
 
@@ -153,7 +153,7 @@ CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
 | ListDatabases | `GET` | `/spider/rdbms/{Name}/databases` |
 | DeleteDatabase | `DELETE` | `/spider/rdbms/{Name}/databases/{DBName}` |
 
-모든 요청의 body:
+Request body for all calls:
 ```json
 {
   "ConnectionName": "<connection-name>",
@@ -161,7 +161,7 @@ CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
   "MasterUserPassword": "<password>"
 }
 ```
-(`DatabaseName`은 CreateDatabase 전용, `MasterUserPassword`는 SQL 폴백 경로에 필요)
+(`DatabaseName` is only used for CreateDatabase; `MasterUserPassword` is needed for the SQL fallback path)
 
 ## Logs & Results
 
@@ -170,7 +170,7 @@ CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
 /tmp/rdbms_mgmt_logs_<PID>/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/rdbms_mgmt_logs_<PID>/log_aws.txt
@@ -180,13 +180,13 @@ tail -f /tmp/rdbms_mgmt_logs_<PID>/log_aws.txt
 
 | CSP | Note |
 |-----|------|
-| OpenStack | 상위 create 시험(Step 4)이 실패하면 인스턴스가 없어 본 시험도 FAIL로 이어짐 |
+| OpenStack | If the create test in the parent suite (Step 4) fails, no instance exists, so this test fails as well |
 
-## 시험 결과
+## Test Results
 
-시험 날짜: 2026-08-18
+Test Date: 2026-08-18
 
-4개 CSP 전부 PASS했습니다.
+All 4 CSPs passed.
 
 ```
 =======================================================================================================

--- a/test/rdbms-mariadb-test/storage-type-test/README.md
+++ b/test/rdbms-mariadb-test/storage-type-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS StorageType Test (MariaDB)
 
-MariaDB를 지원하는 각 CSP(AWS, Alibaba, OpenStack, NHN)의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트입니다. 각 CSP의 `rdbmsmetainfo` API에서 지원 StorageType 목록을 동적으로 조회한 뒤, 옵션별로 인스턴스를 병렬 생성하고 반환된 StorageType이 요청과 일치하는지 검증합니다.
+A parallel test suite that creates and validates an RDBMS instance for each StorageType supported by each MariaDB-capable CSP (AWS, Alibaba, OpenStack, NHN). It dynamically fetches the list of supported StorageTypes from each CSP's `rdbmsmetainfo` API, creates one instance per option in parallel, and verifies that the returned StorageType matches what was requested.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ cd ./bin; ./start.sh
 
 ### Pre-created Network Resources
 
-RDBMS 생성 전에 각 CSP에 VPC/Subnet(및 AWS의 Security Group)이 미리 생성되어 있어야 합니다.
+Each CSP must already have a VPC/Subnet (and, for AWS, a Security Group) created before an RDBMS instance can be created.
 
 ```bash
 cd ..
@@ -27,22 +27,22 @@ cd ..
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 StorageType별 검증을 수행합니다:
+For each CSP, StorageType validation proceeds in this order:
 
-1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=...` — 지원하는 StorageType 목록을 동적으로 조회
-2. **CreateRDBMS** (StorageType별 병렬) — `POST /spider/rdbms` — 옵션별로 `cb-mariadb-st-<type>` 인스턴스 생성
-3. **Poll Available** — `GET /spider/rdbms/{Name}` — Available 상태가 될 때까지 폴링 (기본 30초 간격, 최대 3600초)
-4. **VerifyStorageType** — 반환된 StorageType이 요청과 일치하는지 확인 (`Result` 필드에 `PASS`/`FAIL` 기록)
-5. **(옵션) AutoDelete** — `AUTO_DELETE=true`이면 검증 직후 인스턴스 자동 삭제. 기본값(`false`)에서는 `delete-all-csp-storage-type-rdbms.sh`로 별도 정리
+1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mariadb&ConnectionName=...` — dynamically retrieves the list of supported StorageTypes
+2. **CreateRDBMS** (in parallel, per StorageType) — `POST /spider/rdbms` — creates a `cb-mariadb-st-<type>` instance for each option
+3. **Poll Available** — `GET /spider/rdbms/{Name}` — polls until the instance becomes Available (every 30s by default, up to 3600s)
+4. **VerifyStorageType** — confirms the returned StorageType matches what was requested (recorded as `PASS`/`FAIL` in the `Result` field)
+5. **(Optional) AutoDelete** — if `AUTO_DELETE=true`, the instance is deleted immediately after verification. With the default (`false`), clean up separately with `delete-all-csp-storage-type-rdbms.sh`
 
-### StorageType 선택 가능 여부
+### StorageType Selection Support
 
-| CSP | SupportsStorageTypeSelection | 비고 |
+| CSP | SupportsStorageTypeSelection | Notes |
 |-----|------------------------------|------|
-| AWS | ✅ | gp2, gp3, io1, io2 |
-| Alibaba | ✅ | cloud_essd, cloud_essd2, cloud_essd3 |
-| OpenStack | ✅ | `__DEFAULT__`, `RBD` (MariaDB Trove datastore 구축 필요) |
-| NHN | ✅ | General HDD, General SSD |
+| AWS | Yes | gp2, gp3, io1, io2 |
+| Alibaba | Yes | cloud_essd, cloud_essd2, cloud_essd3 |
+| OpenStack | Yes | `__DEFAULT__`, `RBD` (requires a MariaDB Trove datastore to be configured) |
+| NHN | Yes | General HDD, General SSD |
 
 ## Configuration
 
@@ -59,8 +59,8 @@ export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
 ./run-all-csp-storage-type-tests.sh
 ```
 
-- MariaDB 지원 4개 CSP(AWS/Alibaba/OpenStack/NHN)에 대해 병렬로 StorageType별 검증 실행
-- 완료 후 통합 결과 테이블 및 PASS/FAIL/SKIP 집계 출력
+- Runs StorageType validation in parallel against the 4 CSPs that support MariaDB (AWS/Alibaba/OpenStack/NHN)
+- Prints a unified result table and PASS/FAIL/SKIP summary when complete
 
 **Example output:**
 ```
@@ -80,7 +80,7 @@ Total: 4  PASS: 3  FAIL: 1  SKIP: 0
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-storage-type-test.sh
@@ -89,7 +89,7 @@ Total: 4  PASS: 3  FAIL: 1  SKIP: 0
 ./nhn-storage-type-test.sh
 ```
 
-단독 실행 시 결과/로그 디렉토리는 `RESULT_DIR` / `LOG_DIR` 환경변수로 지정하거나 기본값(`/tmp/st_results_<PID>`, `/tmp/st_logs_<PID>`)이 사용됩니다.
+For a standalone run, the result/log directories are controlled by the `RESULT_DIR` / `LOG_DIR` environment variables, defaulting to `/tmp/st_results_<PID>` and `/tmp/st_logs_<PID>`.
 
 ### Delete All Instances
 
@@ -97,15 +97,15 @@ Total: 4  PASS: 3  FAIL: 1  SKIP: 0
 ./delete-all-csp-storage-type-rdbms.sh
 ```
 
-- StorageTypeOptions를 다시 조회해 `cb-mariadb-st-<type>` 이름의 인스턴스를 유추한 뒤 전체 CSP 병렬 삭제
+- Re-fetches the StorageTypeOptions to derive each `cb-mariadb-st-<type>` instance name, then deletes them all in parallel across CSPs
 
 ## Script Structure
 
 ```
 storage-type-test/
-├── run-all-csp-storage-type-tests.sh    # Orchestrator: 전체 CSP 병렬 실행 (AWS/Alibaba/OpenStack/NHN)
-├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: 전체 CSP 병렬 삭제
-├── common-storage-type-test.sh          # Common: Create → Poll Available → Get Info → Verify → (옵션) Delete
+├── run-all-csp-storage-type-tests.sh    # Orchestrator: runs all CSPs in parallel (AWS/Alibaba/OpenStack/NHN)
+├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: deletes all CSPs in parallel
+├── common-storage-type-test.sh          # Common: Create -> Poll Available -> Get Info -> Verify -> (optional) Delete
 ├── aws-storage-type-test.sh
 ├── alibaba-storage-type-test.sh
 ├── openstack-storage-type-test.sh
@@ -120,8 +120,8 @@ storage-type-test/
 | `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
 | `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per instance (seconds) |
 | `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
-| `AUTO_DELETE` | `false` | `true`이면 검증 완료 직후 인스턴스 자동 삭제 |
-| `VERBOSE` | `0` | `1`로 설정 시 CSP별 전체 로그 덤프 출력 |
+| `AUTO_DELETE` | `false` | If `true`, the instance is deleted automatically right after verification |
+| `VERBOSE` | `0` | If set to `1`, dumps the full per-CSP log |
 
 ```bash
 # Example: verbose output
@@ -130,21 +130,21 @@ VERBOSE=1 ./run-all-csp-storage-type-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>_<storagetype>.txt`)은 파이프(|) 구분 7개 필드:
+The result file (`result_<csp>_<storagetype>.txt`) has 7 pipe(`|`)-separated fields:
 
 ```
 CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `StorageType(Requested)` | 요청한 StorageType 값 |
-| `StorageType(Returned)` | 생성 후 조회된 StorageType 값 (`N/A`는 생성 실패) |
+| `CSP` | CSP name (e.g. AWS) |
+| `StorageType(Requested)` | The StorageType value requested |
+| `StorageType(Returned)` | The StorageType value read back after creation (`N/A` if creation failed) |
 | `Result` | `PASS` / `FAIL` / `SKIP` |
-| `DB_Status` | 인스턴스 상태 (`Available`, `CREATE_ERROR`, `TIMEOUT` 등) |
-| `Elapsed` | 경과 시간 |
-| `Reason` | 특이사항 (예: OpenStack은 StorageType 미제공으로 Available만으로 PASS 처리) |
+| `DB_Status` | Instance status (`Available`, `CREATE_ERROR`, `TIMEOUT`, etc.) |
+| `Elapsed` | Elapsed time |
+| `Reason` | Notes (e.g. OpenStack doesn't expose StorageType post-creation, so it's marked PASS based on Available status alone) |
 
 ## API Reference
 
@@ -162,13 +162,13 @@ CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
 /tmp/st_test_<PID>/logs/log_<csp>.txt
 ```
 
-전체 삭제 실행 시:
+When running the full delete:
 ```
 /tmp/st_del_<PID>/results/result_<csp>_<storagetype>.txt
 /tmp/st_del_<PID>/logs/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/st_test_<PID>/logs/log_aws.txt
@@ -178,44 +178,44 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 
 ### AWS
 
-`StorageTypeOptions`는 metainfo API에서 동적으로 조회되며, 각 타입에 대해 아래 설정으로 인스턴스를 생성합니다.
+`StorageTypeOptions` is fetched dynamically from the metainfo API, and an instance is created for each type with the settings below.
 
-| 항목 | 값 |
+| Item | Value |
 |------|-----|
 | DBEngine / Version | `mariadb` / `10.6` |
 | DBSpec | `db.t3.medium` |
-| StorageSize | `100 GB` (io1/io2 포함 전 타입 동일) |
+| StorageSize | `100 GB` (same for every type, including io1/io2) |
 | Connection | `aws-config01` |
 | Region / Zone | `ap-southeast-2` / `ap-southeast-2a` |
-| SubnetNames | `subnet-01`, `subnet-02` (서로 다른 AZ, SubnetGroup 생성 필수) |
+| SubnetNames | `subnet-01`, `subnet-02` (different AZs; a SubnetGroup must exist) |
 | SecurityGroupNames | `sg-01` |
 
-**특이사항**
-- io1/io2: `Iops: "3000"` 필드 필수
+**Special notes**
+- io1/io2: requires the `Iops: "3000"` field
 
 ---
 
 ### Alibaba
 
-`StorageTypeOptions`와 `DBSpecOptions`를 모두 metainfo API에서 동적으로 조회하며, 지역/존에 유효한 스펙을 자동 선택합니다(하드코딩된 스펙은 StorageType과 호환되지 않을 수 있음).
+Both `StorageTypeOptions` and `DBSpecOptions` are fetched dynamically from the metainfo API, automatically selecting a spec valid for the target region/zone (a hardcoded spec may not be compatible with the requested StorageType).
 
-| 항목 | 값 |
+| Item | Value |
 |------|-----|
 | DBEngine / Version | `mariadb` / `10.6` |
-| DBSpec | metainfo `DBSpecOptions[0]` (조회 실패 시 `rds.mariadb.s4.large`로 폴백) |
-| StorageSize | 기본 `20 GB`, `cloud_essd2`는 `500 GB`, `cloud_essd3`는 `1500 GB` |
+| DBSpec | metainfo `DBSpecOptions[0]` (falls back to `rds.mariadb.s4.large` if the lookup fails) |
+| StorageSize | `20 GB` by default; `500 GB` for `cloud_essd2`; `1500 GB` for `cloud_essd3` |
 | Connection | `alibaba-beijing-config` |
 | Region / Zone | `cn-beijing` / `cn-beijing-f` |
 | SubnetNames | `subnet-01` |
 
-**특이사항**
-- cloud_essd2/cloud_essd3는 최소 StorageSize 요건이 있어 스크립트에서 자동으로 크기를 늘려 요청
+**Special notes**
+- `cloud_essd2`/`cloud_essd3` have a minimum StorageSize requirement, so the script automatically requests a larger size for them
 
 ---
 
 ### OpenStack
 
-| 항목 | 값 |
+| Item | Value |
 |------|-----|
 | DBEngine / Version | `mariadb` / `10.4` |
 | DBSpec | `m1.small` |
@@ -227,7 +227,7 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 
 ### NHN
 
-| 항목 | 값 |
+| Item | Value |
 |------|-----|
 | DBEngine / Version | `mariadb` / `MARIADB_V101118` |
 | DBSpec | `m2.c2m4` |
@@ -236,14 +236,14 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 | Region / Zone | `KR1` / `kr-pub-a` |
 | SubnetNames | `subnet-01` |
 
-`NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능하므로, 시험 편의를 위해 이 옵션으로 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성/삭제합니다. 운영 환경에서는 사용을 권장하지 않습니다.
+`NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS requires a dedicated "DB Security Group", separate from the VPC Security Group, before external access is possible. For testing convenience this option auto-creates and auto-deletes a fully open (`0.0.0.0/0`) DB Security Group. This is not recommended for production use.
 
 
-## 시험 결과
+## Test Results
 
-시험 날짜: 2026-08-18
+Test Date: 2026-08-18
 
-전체 11건 PASS했습니다.
+All 11 cases passed.
 
 ```
 ================================================================================================================================

--- a/test/rdbms-mariadb-test/tag-test/README.md
+++ b/test/rdbms-mariadb-test/tag-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS Tag Management Test (MariaDB)
 
-RDBMS 리소스의 Tag CRUD API를 검증하는 테스트 스위트입니다. `RDBMSMetaInfo.SupportsTag=true`이면서 MariaDB를 지원하는 CSP(AWS, Alibaba)에 대해서만 실행됩니다. OpenStack/NHN은 MariaDB는 지원하지만 SupportsTag=false이므로 시험 대상에서 제외됩니다.
+A test suite that validates the Tag CRUD API for RDBMS resources. It runs only against CSPs that both support MariaDB and have `RDBMSMetaInfo.SupportsTag=true` (AWS, Alibaba). OpenStack and NHN support MariaDB but have `SupportsTag=false`, so they are excluded from this test.
 
 ## Prerequisites
 
@@ -10,13 +10,13 @@ RDBMS 리소스의 Tag CRUD API를 검증하는 테스트 스위트입니다. `R
 cd ./bin; ./start.sh
 ```
 
-### RDBMS 인스턴스 사전 생성
+### RDBMS Instance Must Already Exist
 
-이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+This test assumes an RDBMS instance has already been created. First run the network prerequisite prepare and the create test from the parent directory.
 
 ```bash
 cd ..
-./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-network-prepare.sh   # Create VPC/Subnet/SG prerequisites (once)
 ./run-all-csp-rdbms-tests.sh
 ```
 
@@ -28,28 +28,28 @@ cd ..
 
 ## Supported CSPs
 
-MariaDB 지원 여부와 `RDBMSMetaInfo.SupportsTag` 값을 모두 만족해야 시험 대상이 됩니다.
+A CSP is included in this test only if it supports MariaDB **and** has `RDBMSMetaInfo.SupportsTag=true`.
 
-| CSP | MariaDB 지원 | SupportsTag | 시험 대상 |
+| CSP | MariaDB Support | SupportsTag | Tested |
 |-----|------------|-------------|---------|
-| AWS | ✅ | `true` | ✅ |
-| Alibaba | ✅ | `true` | ✅ |
-| OpenStack | ⚠️ | `false` | ❌ |
-| NHN | ✅ | `false` | ❌ |
+| AWS | Yes | `true` | Yes |
+| Alibaba | Yes | `true` | Yes |
+| OpenStack | Partial | `false` | No |
+| NHN | Yes | `false` | No |
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 Tag CRUD를 검증합니다:
+For each CSP, Tag CRUD is validated in this order:
 
-1. **AddTag(1)** — `POST /spider/tag` — 첫 번째 태그 추가 (`spider-rdbms-tag` / `rdbms-tag-value`)
-2. **ListTag** — `GET /spider/tag?...` — 목록에서 첫 번째 태그 존재 확인
-3. **GetTag** — `GET /spider/tag/{Key}?...` — 태그 값 일치 확인
-4. **AddTag(2)** — `POST /spider/tag` — 두 번째 태그 추가 (`spider-rdbms-tag2` / `rdbms-tag-value2`)
-5. **RemoveTag** — `DELETE /spider/tag/{Key}` — 첫 번째 태그 삭제
-6. **VerifyRemoved** — `GET /spider/tag?...` — 첫 번째 태그가 목록에서 제거되었는지 확인
-7. **Cleanup** — 두 번째 태그 삭제 (정리)
+1. **AddTag(1)** — `POST /spider/tag` — adds the first tag (`spider-rdbms-tag` / `rdbms-tag-value`)
+2. **ListTag** — `GET /spider/tag?...` — confirms the first tag is present in the list
+3. **GetTag** — `GET /spider/tag/{Key}?...` — confirms the tag value matches
+4. **AddTag(2)** — `POST /spider/tag` — adds a second tag (`spider-rdbms-tag2` / `rdbms-tag-value2`)
+5. **RemoveTag** — `DELETE /spider/tag/{Key}` — removes the first tag
+6. **VerifyRemoved** — `GET /spider/tag?...` — confirms the first tag is gone from the list
+7. **Cleanup** — removes the second tag (housekeeping)
 
-모든 단계가 PASS여야 해당 CSP가 전체 PASS로 판정됩니다.
+A CSP is judged an overall PASS only if every step passes.
 
 ## Configuration
 
@@ -66,8 +66,8 @@ export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
 ./run-all-csp-rdbms-tag-tests.sh
 ```
 
-- SupportsTag=true이면서 MariaDB를 지원하는 2개 CSP(AWS, Alibaba)에 대해 병렬로 Tag CRUD 검증 실행
-- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+- Runs Tag CRUD validation in parallel against the 2 CSPs that support MariaDB and have SupportsTag=true (AWS, Alibaba)
+- Prints a unified result table and PASS/FAIL summary when complete
 
 **Example output:**
 ```
@@ -85,21 +85,21 @@ Total: 2 PASS, 0 FAIL
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-rdbms-tag-test.sh
 ./alibaba-rdbms-tag-test.sh
 ```
 
-단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_tag_results`)이 사용됩니다.
+For a standalone run, the result file location is controlled by the `RESULT_DIR` environment variable, defaulting to `/tmp/rdbms_tag_results`.
 
 ## Script Structure
 
 ```
 tag-test/
-├── run-all-csp-rdbms-tag-tests.sh   # Orchestrator: AWS/Alibaba 병렬 실행, PASS/FAIL 집계
-├── common-rdbms-tag-test.sh         # Common: AddTag → ListTag → GetTag → AddTag2 → RemoveTag → VerifyRemoved
+├── run-all-csp-rdbms-tag-tests.sh   # Orchestrator: runs AWS/Alibaba in parallel, aggregates PASS/FAIL
+├── common-rdbms-tag-test.sh         # Common: AddTag -> ListTag -> GetTag -> AddTag2 -> RemoveTag -> VerifyRemoved
 ├── aws-rdbms-tag-test.sh
 └── alibaba-rdbms-tag-test.sh
 ```
@@ -111,7 +111,7 @@ tag-test/
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
 | `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
 | `RESULT_DIR` | `/tmp/rdbms_tag_results` | Result file output directory |
-| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+| `VERBOSE` | `0` | If set to `1`, dumps the full per-CSP log |
 
 ```bash
 # Example: verbose output
@@ -120,22 +120,22 @@ VERBOSE=1 ./run-all-csp-rdbms-tag-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 8개 필드:
+The result file (`result_<csp>.txt`) has 8 pipe(`|`)-separated fields:
 
 ```
 CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `AddTag` | 첫 번째 태그 추가 결과 (`PASS` / `FAIL`) |
-| `ListTag` | 태그 목록 조회 및 존재 확인 결과 |
-| `GetTag` | 특정 태그 조회 및 값 일치 확인 결과 |
-| `AddTag2` | 두 번째 태그 추가 결과 |
-| `RemoveTag` | 첫 번째 태그 삭제 결과 |
-| `VerifyRemoved` | 삭제 후 목록에서 제거 확인 결과 |
-| `Elapsed` | 경과 시간 |
+| `CSP` | CSP name (e.g. AWS) |
+| `AddTag` | Result of adding the first tag (`PASS` / `FAIL`) |
+| `ListTag` | Result of listing tags and confirming presence |
+| `GetTag` | Result of fetching a specific tag and confirming its value |
+| `AddTag2` | Result of adding the second tag |
+| `RemoveTag` | Result of deleting the first tag |
+| `VerifyRemoved` | Whether the tag was confirmed gone from the list after deletion |
+| `Elapsed` | Elapsed time |
 
 ## Logs & Results
 
@@ -144,7 +144,7 @@ CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
 /tmp/rdbms_tag_logs_<PID>/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/rdbms_tag_logs_<PID>/log_aws.txt
@@ -159,7 +159,7 @@ tail -f /tmp/rdbms_tag_logs_<PID>/log_aws.txt
 | GetTag | `GET` | `/spider/tag/{Key}?ConnectionName=&ResourceType=rdbms&ResourceName=` |
 | RemoveTag | `DELETE` | `/spider/tag/{Key}` |
 
-## 시험 결과
+## Test Results
 
 ### 2026-08-10
 

--- a/test/rdbms-mysql-test/README.md
+++ b/test/rdbms-mysql-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS API Test
 
-Automated test suite for CB-Spider RDBMS API — creates MySQL instances across 9 CSPs in parallel, waits until each becomes available, then collects and displays a unified result table.
+Automated test suite for CB-Spider's RDBMS API — creates MySQL instances across 9 CSPs in parallel, waits until each becomes available, then collects and displays a unified result table.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ cd ./bin; ./start.sh
 
 ### CSP Connection Configuration
 
-Before running tests, register connection names for each CSP in CB-Spider.
+Before running the tests, register a connection name for each CSP in CB-Spider.
 
 | CSP | Connection Name | Region | Zone |
 |-----|----------------|--------|------|
@@ -28,38 +28,39 @@ Before running tests, register connection names for each CSP in CB-Spider.
 
 ### Pre-created Network Resources
 
-RDBMS 생성 전에 각 CSP에 VPC와 서브넷이 미리 생성되어 있어야 합니다. AWS는 Security Group도 미리 생성되어 있어야 합니다.
+Each CSP needs a VPC and subnet created ahead of time before an RDBMS instance can be created. AWS also needs a security group created ahead of time.
 
-| CSP | VPC | Subnet | Security Group | 비고 |
+| CSP | VPC | Subnet | Security Group | Notes |
 |-----|-----|--------|-----------------|------|
-| AWS | `vpc-01` | `subnet-01`, `subnet-02` | `sg-01` | 서로 다른 AZ의 서브넷 2개 필수 (SubnetGroup 요건) |
-| Azure | `vpc-01` | `subnet-01` | | 서브넷 미사용 |
-| GCP | `vpc-01` | `subnet-01` | | 서브넷 미사용 |
+| AWS | `vpc-01` | `subnet-01`, `subnet-02` | `sg-01` | Requires 2 subnets in different AZs (SubnetGroup requirement) |
+| Azure | `vpc-01` | `subnet-01` | | Subnet not actually used |
+| GCP | `vpc-01` | `subnet-01` | | Subnet not actually used |
 | Alibaba | `vpc-01` | `subnet-01` | | |
 | Tencent | `vpc-01` | `subnet-01` | | |
-| IBM | `vpc-01` | `subnet-01` | | 서브넷 미사용 |
-| OpenStack | `vpc-01` | `subnet-01` | | 서브넷 미사용 |
+| IBM | `vpc-01` | `subnet-01` | | Subnet not actually used |
+| OpenStack | `vpc-01` | `subnet-01` | | Subnet not actually used |
 | NCP | `vpc-01` | `subnet-01` | | |
 | NHN | `vpc-01` | `subnet-01` | | |
 
-아래 스크립트로 9개 CSP의 VPC/Subnet(및 AWS의 Security Group)을 한 번에 생성/삭제할 수 있습니다. 두 스크립트 모두 이미 존재하는 자원은 건너뛰므로(idempotent) 반복 실행해도 안전합니다.
+The scripts below create/delete the VPC/Subnet (and, for AWS, the security group) for all 9 CSPs in one shot. Both scripts are idempotent — they skip resources that already exist, so it's safe to run them repeatedly.
 
 ```bash
-# 전체 CSP 사전 자원 생성 (병렬)
+# Create pre-requisite resources for all CSPs (in parallel)
 ./run-all-csp-network-prepare.sh
 
-# 전체 CSP 사전 자원 삭제 (병렬)
-# RDBMS 인스턴스가 먼저 삭제된 이후에 실행해야 합니다 (VPC/SG가 사용 중이면 삭제 실패)
+# Delete pre-requisite resources for all CSPs (in parallel)
+# Run this only after the RDBMS instances have been deleted
+# (VPC/SG deletion fails while they're still in use)
 ./delete-all-csp-network.sh
 ```
 
-특정 CSP만 단독 실행하려면 `<csp>-network-prepare.sh`를 직접 실행합니다 (예: `./aws-network-prepare.sh`). AWS의 AZ는 `AWS_AZ1`/`AWS_AZ2` 환경변수로 override 가능합니다 (기본값: `ap-southeast-2a`/`ap-southeast-2b`).
+To run a single CSP on its own, invoke `<csp>-network-prepare.sh` directly (e.g. `./aws-network-prepare.sh`). AWS's AZs can be overridden with the `AWS_AZ1`/`AWS_AZ2` environment variables (default: `ap-southeast-2a`/`ap-southeast-2b`).
 
-내부적으로는 다음과 같이 CB-Spider REST API를 호출합니다:
+Under the hood, these scripts call the CB-Spider REST API like this:
 
 ```bash
-# VPC 생성 예시 (AWS)
-curl -u admin:***** -sX POST http://localhost:1024/spider/vpc \
+# Create VPC (AWS example)
+curl -u admin:**** -sX POST http://localhost:1024/spider/vpc \
   -H 'Content-Type: application/json' \
   -d '{
     "ConnectionName": "aws-config01",
@@ -73,8 +74,8 @@ curl -u admin:***** -sX POST http://localhost:1024/spider/vpc \
     }
   }' | jq .
 
-# Security Group 생성 예시 (AWS, MySQL 3306 인바운드 허용)
-curl -u admin:***** -sX POST http://localhost:1024/spider/securitygroup \
+# Create Security Group (AWS example, allows inbound MySQL 3306)
+curl -u admin:**** -sX POST http://localhost:1024/spider/securitygroup \
   -H 'Content-Type: application/json' \
   -d '{
     "ConnectionName": "aws-config01",
@@ -96,47 +97,47 @@ curl -u admin:***** -sX POST http://localhost:1024/spider/securitygroup \
 
 ## RDBMS Instance Configuration
 
-All CSPs create a MySQL instance named `cb-spider-mysql-test`.
+Every CSP creates a MySQL instance named `cb-spider-mysql-test`.
 
-StorageType은 지정하지 않으며, CSP 기본값으로 생성됩니다. 결과 테이블의 Storage 컬럼에 `크기|타입` 형태로 표시됩니다 (예: `100GB|gp2`).
+StorageType is not specified for this test, so each CSP falls back to its own default. The result table's Storage column shows this as `size|type` (e.g. `100GB|gp2`).
 
 | CSP | Engine Version | Instance Spec | Storage | Subnet Required |
 |-----|---------------|---------------|---------|-----------------|
-| AWS | 8.0 | db.t3.medium | 100GB | ✅ (2개, 다른 AZ) |
-| Azure | 8.0.21 | Standard_B1ms | 20GB | 미사용 |
-| GCP | 8.0 | db-custom-2-8192 | 20GB | 미사용 |
-| Alibaba | 8.0 | mysql.n4.large.1 | 20GB | ✅ |
-| Tencent | 8.0 | 8000 (MB) | 50GB | ✅ |
-| IBM | 8.4 | multitenant | 30GB | 미사용 |
-| OpenStack | 5.7.29 | m1.small | 20GB | 미사용 |
-| NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | CSP 관리 | ✅ |
-| NHN | MYSQL_V8408 | m2.c2m4 | 20GB | ✅ |
+| AWS | 8.0 | db.t3.medium | 100GB | Yes (2, in different AZs) |
+| Azure | 8.0.21 | Standard_B1ms | 20GB | Not used |
+| GCP | 8.0 | db-custom-2-8192 | 20GB | Not used |
+| Alibaba | 8.0 | mysql.n4.large.1 | 20GB | Yes |
+| Tencent | 8.0 | 8000 (MB) | 50GB | Yes |
+| IBM | 8.4 | multitenant | 30GB | Not used |
+| OpenStack | 5.7.29 | m1.small | 20GB | Not used |
+| NCP | 8.0.36 | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | Managed by CSP | Yes |
+| NHN | MYSQL_V8408 | m2.c2m4 | 20GB | Yes |
 
-> **NHN 참고**: NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능합니다. `nhn-rdbms-test.sh`는 `"NHNAutoOpenDBSecurityGroup": true`를 설정해 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성하고, 인스턴스 삭제 시 함께 자동 삭제되도록 합니다 — 시험 편의를 위한 옵션이며, 운영 환경에서는 NHN 콘솔/API로 특정 CIDR만 허용하는 DB Security Group을 직접 구성하는 것을 권장합니다.
+> **NHN note**: NHN Cloud RDS requires a dedicated "DB Security Group" — separate from the VPC security group — before external access is possible. `nhn-rdbms-test.sh` sets `"NHNAutoOpenDBSecurityGroup": true`, which auto-creates a fully open (`0.0.0.0/0`) DB Security Group and auto-deletes it along with the instance. This is purely a convenience for testing; in production, configure a DB Security Group that allows only specific CIDRs via the NHN console/API.
 
 ## Configuration
 
-테스트 실행 전에 CB-Spider 접속 정보를 환경변수로 설정하거나, `run-all-csp-rdbms-tests.sh` / `delete-all-csp-rdbms.sh` 파일 내부의 기본값을 직접 수정합니다.
+Before running the tests, set CB-Spider's connection details as environment variables, or edit the defaults directly inside `run-all-csp-rdbms-tests.sh` / `delete-all-csp-rdbms.sh`.
 
-**방법 1) 환경변수 설정**
+**Option 1) Environment variables**
 ```bash
 export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
-export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+export SPIDER_AUTH=admin:****             # Basic auth (admin:<password>)
 ```
 
-**방법 2) 스크립트 파일 직접 수정** (`run-all-csp-rdbms-tests.sh`, `delete-all-csp-rdbms.sh`)
+**Option 2) Edit the script defaults directly** (`run-all-csp-rdbms-tests.sh`, `delete-all-csp-rdbms.sh`)
 ```bash
 export SPIDER_URL="${SPIDER_URL:-http://localhost:1024}"
-export SPIDER_AUTH="${SPIDER_AUTH:-admin:*****}"   # <-- 비밀번호 변경
+export SPIDER_AUTH="${SPIDER_AUTH:-admin:****}"   # <-- change the password here
 ```
 
-> `SPIDER_AUTH`의 비밀번호는 CB-Spider 기동 시 설정한 값으로 변경하세요.
+> Change the password portion of `SPIDER_AUTH` to whatever was set when CB-Spider started up.
 
 ## How to Run Tests
 
 ### 0. Prepare Network Prerequisites (VPC/Subnet, AWS Security Group)
 
-RDBMS 생성 테스트를 실행하기 전에 먼저 실행합니다 (1회만 실행하면 됨, idempotent):
+Run this before the RDBMS creation tests (only needs to be run once — it's idempotent):
 
 ```bash
 ./run-all-csp-network-prepare.sh
@@ -148,9 +149,9 @@ RDBMS 생성 테스트를 실행하기 전에 먼저 실행합니다 (1회만 �
 ./run-all-csp-rdbms-tests.sh
 ```
 
-- 9개 CSP에 동시 RDBMS 생성 (백그라운드 병렬 실행)
-- 각 CSP별 Available 상태까지 대기 (최대 60분)
-- 완료 후 통합 결과 테이블 출력
+- Creates an RDBMS instance on all 9 CSPs concurrently (background parallel execution)
+- Waits for each CSP's instance to reach Available (up to 60 minutes)
+- Prints a unified result table when done
 
 **Example output:**
 ```
@@ -168,8 +169,8 @@ GCP          | Available   | mysql    | 8.0          | db-custom-2-8192         
 ./delete-all-csp-rdbms.sh
 ```
 
-- 9개 CSP의 RDBMS 인스턴스 동시 삭제
-- 인스턴스 완전 삭제 확인 후 결과 테이블 출력
+- Deletes the RDBMS instance on all 9 CSPs concurrently
+- Prints a result table after confirming full deletion
 
 **Example output:**
 ```
@@ -183,7 +184,7 @@ GCP          | DELETED        | ok                   | 2m9s
 
 ### Run Individual CSP Test
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 # Prepare network prerequisites
@@ -209,16 +210,40 @@ GCP          | DELETED        | ok                   | 2m9s
 ./nhn-rdbms-test.sh
 ```
 
-단독 실행 시에는 `RESULT_DIR` 환경변수를 지정하거나 기본값(`/tmp/rdbms_results`, network prepare/cleanup은 `/tmp/rdbms_network_results`)이 사용됩니다.
+When run individually, results are written to the `RESULT_DIR` you specify, or to the defaults (`/tmp/rdbms_results` for creation, `/tmp/rdbms_network_results` for network prepare/cleanup).
+
+### Full Suite: All Steps in Sequence
+
+```bash
+./all_test.sh
+```
+
+`all_test.sh` runs the complete lifecycle end to end, in order:
+
+1. Network Prepare — create VPC/Subnet/SG for all CSPs
+2. StorageType Test — validate StorageType options per CSP (`storage-type-test/`)
+3. Delete StorageType RDBMS instances created by step 2
+4. RDBMS Create — create the instance on all 9 CSPs
+5. Database Test — validate Database CRUD inside each instance (`database-test/`)
+6. Tag Test — validate Tag CRUD for SupportsTag=true CSPs (`tag-test/`)
+7. RDBMS Delete — delete the instance on all 9 CSPs
+8. Network Cleanup — delete VPC/Subnet/SG for all CSPs
+
+Each step runs as a separate script; a per-step PASS/FAIL summary is printed at the end. By default, a failed step doesn't stop the run — set `STOP_ON_FAIL=1` to abort on the first failure instead.
+
+```bash
+STOP_ON_FAIL=1 ./all_test.sh
+```
 
 ## Script Structure
 
 ```
 .
-├── run-all-csp-network-prepare.sh  # Orchestrator: 전체 VPC/Subnet/SG 사전 생성 (병렬)
-├── delete-all-csp-network.sh       # Orchestrator: 전체 VPC/Subnet/SG 사전 자원 삭제 (병렬)
-├── common-network-prepare.sh       # Common: VPC/Subnet 생성 → (옵션) SG 생성
-├── common-network-cleanup.sh       # Common: (옵션) SG 삭제 → VPC/Subnet 삭제
+├── all_test.sh                     # Orchestrator: full lifecycle, all 8 steps in sequence
+├── run-all-csp-network-prepare.sh  # Orchestrator: create VPC/Subnet/SG for all CSPs (parallel)
+├── delete-all-csp-network.sh       # Orchestrator: delete VPC/Subnet/SG for all CSPs (parallel)
+├── common-network-prepare.sh       # Common: create VPC/Subnet -> (optional) create SG
+├── common-network-cleanup.sh       # Common: (optional) delete SG -> delete VPC/Subnet
 ├── aws-network-prepare.sh
 ├── azure-network-prepare.sh
 ├── gcp-network-prepare.sh
@@ -228,10 +253,10 @@ GCP          | DELETED        | ok                   | 2m9s
 ├── openstack-network-prepare.sh
 ├── ncp-network-prepare.sh
 ├── nhn-network-prepare.sh
-├── run-all-csp-rdbms-tests.sh   # Orchestrator: 전체 생성 테스트 (병렬)
-├── delete-all-csp-rdbms.sh      # Orchestrator: 전체 삭제 (병렬)
-├── common-rdbms-test.sh         # Common: Create → Poll Available → Get Info
-├── common-rdbms-delete.sh       # Common: Verify → Delete → Poll Removed
+├── run-all-csp-rdbms-tests.sh   # Orchestrator: create on all CSPs (parallel)
+├── delete-all-csp-rdbms.sh      # Orchestrator: delete on all CSPs (parallel)
+├── common-rdbms-test.sh         # Common: Create -> Poll Available -> Get Info
+├── common-rdbms-delete.sh       # Common: Verify -> Delete -> Poll Removed
 ├── aws-rdbms-test.sh
 ├── azure-rdbms-test.sh
 ├── gcp-rdbms-test.sh
@@ -240,7 +265,10 @@ GCP          | DELETED        | ok                   | 2m9s
 ├── ibm-rdbms-test.sh
 ├── openstack-rdbms-test.sh
 ├── ncp-rdbms-test.sh
-└── nhn-rdbms-test.sh
+├── nhn-rdbms-test.sh
+├── database-test/               # Database CRUD test suite (see database-test/README.md)
+├── storage-type-test/           # StorageType validation test suite (see storage-type-test/README.md)
+└── tag-test/                    # Tag CRUD test suite (see tag-test/README.md)
 ```
 
 ## Environment Variables
@@ -248,11 +276,12 @@ GCP          | DELETED        | ok                   | 2m9s
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
-| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
 | `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per CSP (seconds) |
 | `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
-| `VERBOSE` | `0` | Set to `1` for per-CSP full log dump |
+| `VERBOSE` | `0` | Set to `1` for a per-CSP full log dump |
 | `AWS_AZ1` / `AWS_AZ2` | `ap-southeast-2a` / `ap-southeast-2b` | AZs used for AWS `subnet-01`/`subnet-02` in `aws-network-prepare.sh` |
+| `STOP_ON_FAIL` | `0` | (`all_test.sh` only) Set to `1` to abort the full suite on the first failed step |
 
 ```bash
 # Example: custom Spider URL
@@ -264,29 +293,41 @@ VERBOSE=1 ./run-all-csp-rdbms-tests.sh
 
 ## Logs & Results
 
-각 실행마다 PID 기반 임시 디렉토리에 로그와 결과 파일이 저장됩니다.
+Each run writes logs and result files to a PID-scoped temporary directory.
 
 ```
 /tmp/rdbms_results_<PID>/result_<csp>.txt   # pipe-separated result line
 /tmp/rdbms_logs_<PID>/log_<csp>.txt         # per-CSP full output
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/rdbms_logs_<PID>/log_aws.txt
 ```
 
+## Related Test Suites
+
+These sibling test suites assume the RDBMS instances created above already exist, and each covers a different subset of the 9 CSPs (only the CSPs where the underlying capability applies):
+
+| Suite | Directory | CSPs Covered | What It Validates |
+|-------|-----------|--------------|--------------------|
+| Database Management | `database-test/` | All 9 (AWS, Azure, GCP, Alibaba, Tencent, IBM, OpenStack, NCP, NHN) | Database CRUD (Create/List/Delete) inside an instance |
+| StorageType | `storage-type-test/` | All 9 (Azure, IBM, NCP auto-SKIP; the other 6 run) | Per-StorageType instance creation and verification |
+| Tag Management | `tag-test/` | 6 with `SupportsTag=true` (AWS, Azure, GCP, Alibaba, Tencent, IBM) | Tag CRUD (Add/List/Get/Remove) on an RDBMS resource |
+
+See each subdirectory's README for full details.
+
 ## CSP-Specific Notes
 
 | CSP | Note |
 |-----|------|
-| AWS | SubnetGroup 생성을 위해 **다른 AZ의 서브넷 2개 이상** 필요. Security Group `sg-01` 사전 생성 필요 |
-| Tencent | `DBSpec`은 메모리 크기(MB) 지정 (예: `8000` = 8GB) |
-| IBM | StorageType 지정 불가 (SupportsStorageTypeSelection=false). |
-| NCP | StorageSize/StorageType 지정 불가 (CSP 자동 관리). G3(KVM) generation만 지원. Public 도메인은 생성 후 콘솔에서 별도 신청 필요 |
+| AWS | SubnetGroup creation requires **2 or more subnets in different AZs**. The `sg-01` security group must be pre-created |
+| Tencent | `DBSpec` specifies memory size in MB (e.g. `8000` = 8GB) |
+| IBM | StorageType cannot be specified (SupportsStorageTypeSelection=false) |
+| NCP | StorageSize/StorageType cannot be specified (managed automatically by the CSP). Only the G3 (KVM) generation is supported. A public domain must be requested separately via the console after creation |
 
-## 시험 결과
+## Test Results
 
 ### 2026-08-03
 

--- a/test/rdbms-mysql-test/database-test/README.md
+++ b/test/rdbms-mysql-test/database-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS Database Management Test
 
-RDBMS 인스턴스 내부의 Database CRUD API를 검증하는 테스트 스위트입니다. 9개 CSP에 대해 병렬로 실행하며, RDBMS 인스턴스 안에서 데이터베이스를 생성/조회/삭제하는 전체 흐름을 검증합니다.
+Test suite that validates the Database CRUD API inside an RDBMS instance. It runs in parallel across 9 CSPs, exercising the full flow of creating, listing, and deleting a database inside an already-running RDBMS instance.
 
 ## Prerequisites
 
@@ -10,13 +10,13 @@ RDBMS 인스턴스 내부의 Database CRUD API를 검증하는 테스트 스위�
 cd ./bin; ./start.sh
 ```
 
-### RDBMS 인스턴스 사전 생성
+### RDBMS Instance Must Already Exist
 
-이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+This test assumes the RDBMS instance already exists. First run the network prerequisites and the create test in the parent directory:
 
 ```bash
 cd ..
-./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-network-prepare.sh   # VPC/Subnet/SG prerequisites (one-time)
 ./run-all-csp-rdbms-tests.sh
 ```
 
@@ -28,33 +28,33 @@ cd ..
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 Database CRUD를 검증합니다:
+For each CSP, Database CRUD is validated in this order:
 
-1. **CreateDatabase** — `POST /spider/rdbms/{Name}/databases` — `spidertestdb` 데이터베이스 생성
-2. **ListDatabases** — `GET /spider/rdbms/{Name}/databases` — 데이터베이스 목록 조회 성공 확인
-3. **FoundInList** — 목록에서 `spidertestdb` 존재 확인
-4. **DeleteDatabase** — `DELETE /spider/rdbms/{Name}/databases/spidertestdb` — 데이터베이스 삭제
-5. **VerifyDeleted** — `GET /spider/rdbms/{Name}/databases` — 삭제 후 목록에서 제거 확인
+1. **CreateDatabase** — `POST /spider/rdbms/{Name}/databases` — creates the `spidertestdb` database
+2. **ListDatabases** — `GET /spider/rdbms/{Name}/databases` — confirms the database list can be retrieved
+3. **FoundInList** — confirms `spidertestdb` is present in the list
+4. **DeleteDatabase** — `DELETE /spider/rdbms/{Name}/databases/spidertestdb` — deletes the database
+5. **VerifyDeleted** — `GET /spider/rdbms/{Name}/databases` — confirms it's gone from the list after deletion
 
-### 구현 방식
+### Implementation Approach
 
-CB-Spider는 다음 두 가지 방식으로 Database 관리를 지원합니다:
+CB-Spider supports database management through two mechanisms:
 
-| 방식 | 조건 | 설명 |
+| Mechanism | Condition | Description |
 |------|------|------|
-| **CSP 네이티브 API** | 드라이버가 `rdbmsDatabaseManager` 인터페이스 구현 | 각 CSP의 데이터베이스 관리 API 직접 호출 |
-| **SQL 직접 실행** | 드라이버 미구현 시 자동 폴백 | `MasterUserPassword`로 접속하여 SQL 실행 (`CREATE/DROP DATABASE`) |
+| **CSP-native API** | The driver implements the `rdbmsDatabaseManager` interface | Calls the CSP's own database management API directly |
+| **Direct SQL execution** | Automatic fallback when the driver doesn't implement it | Connects using `MasterUserPassword` and runs SQL (`CREATE/DROP DATABASE`) |
 
-`MasterUserPassword`는 SQL 폴백 경로에서 필요하므로 항상 포함합니다.
+`MasterUserPassword` is always included in requests, since it's required by the SQL fallback path.
 
 ## Configuration
 
 ```bash
 export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
-export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+export SPIDER_AUTH=admin:****             # Basic auth (admin:<password>)
 ```
 
-테스트 DB 이름을 변경하려면:
+To change the test database name:
 
 ```bash
 export DB_NAME=mydb ./aws-database-test.sh
@@ -68,8 +68,8 @@ export DB_NAME=mydb ./aws-database-test.sh
 ./run-all-csp-database-tests.sh
 ```
 
-- 9개 CSP에 대해 병렬로 Database CRUD 검증 실행
-- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+- Runs Database CRUD validation on all 9 CSPs in parallel
+- Prints a unified result table and a PASS/FAIL tally when done
 
 **Example output:**
 ```
@@ -94,7 +94,7 @@ Total: 9 PASS, 0 FAIL
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-database-test.sh
@@ -108,14 +108,14 @@ Total: 9 PASS, 0 FAIL
 ./nhn-database-test.sh
 ```
 
-단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_database_results`)이 사용됩니다.
+When run individually, the result file goes to the `RESULT_DIR` you specify, or to the default (`/tmp/rdbms_mgmt_results`).
 
 ## Script Structure
 
 ```
 database-test/
-├── run-all-csp-database-tests.sh   # Orchestrator: 전체 병렬 실행, PASS/FAIL 집계
-├── common-database-test.sh         # Common: CreateDB → ListDB → DeleteDB → VerifyDeleted
+├── run-all-csp-database-tests.sh   # Orchestrator: full parallel run, PASS/FAIL tally
+├── common-database-test.sh         # Common: CreateDB -> ListDB -> DeleteDB -> VerifyDeleted
 ├── aws-database-test.sh
 ├── azure-database-test.sh
 ├── gcp-database-test.sh
@@ -132,10 +132,10 @@ database-test/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
-| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
-| `DB_NAME` | `spidertestdb` | 생성/삭제할 테스트 데이터베이스 이름 |
-| `RESULT_DIR` | `/tmp/rdbms_database_results` | Result file output directory |
-| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
+| `DB_NAME` | `spidertestdb` | Name of the test database to create/delete |
+| `RESULT_DIR` | `/tmp/rdbms_mgmt_results` | Result file output directory (single-CSP runs) |
+| `VERBOSE` | `0` | Set to `1` for a per-CSP full log dump |
 
 ```bash
 # Example: verbose output
@@ -144,21 +144,21 @@ VERBOSE=1 ./run-all-csp-database-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 7개 필드:
+Each result file (`result_<csp>.txt`) has 7 pipe-separated fields:
 
 ```
 CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `CreateDB` | 데이터베이스 생성 결과 (`PASS` / `FAIL`) |
-| `ListDB` | 데이터베이스 목록 조회 결과 |
-| `FoundInList` | 생성된 DB가 목록에 존재 (`FOUND` / `NOT_FOUND`) |
-| `DeleteDB` | 데이터베이스 삭제 결과 |
-| `VerifyDeleted` | 삭제 후 목록에서 제거 확인 결과 |
-| `Elapsed` | 경과 시간 |
+| `CSP` | CSP name (e.g. AWS) |
+| `CreateDB` | Result of creating the database (`PASS` / `FAIL`) |
+| `ListDB` | Result of listing databases |
+| `FoundInList` | Whether the created database appears in the list (`FOUND` / `NOT_FOUND`) |
+| `DeleteDB` | Result of deleting the database |
+| `VerifyDeleted` | Result of confirming it's gone from the list after deletion |
+| `Elapsed` | Elapsed time |
 
 ## API Reference
 
@@ -168,7 +168,7 @@ CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
 | ListDatabases | `GET` | `/spider/rdbms/{Name}/databases` |
 | DeleteDatabase | `DELETE` | `/spider/rdbms/{Name}/databases/{DBName}` |
 
-모든 요청의 body:
+Request body for all calls:
 ```json
 {
   "ConnectionName": "<connection-name>",
@@ -176,22 +176,22 @@ CSP|CreateDB|ListDB|FoundInList|DeleteDB|VerifyDeleted|Elapsed
   "MasterUserPassword": "<password>"
 }
 ```
-(`DatabaseName`은 CreateDatabase 전용, `MasterUserPassword`는 SQL 폴백 경로에 필요)
+(`DatabaseName` is only used for CreateDatabase; `MasterUserPassword` is required by the SQL fallback path)
 
 ## Logs & Results
 
 ```
-/tmp/rdbms_database_results_<PID>/result_<csp>.txt
-/tmp/rdbms_database_logs_<PID>/log_<csp>.txt
+/tmp/rdbms_mgmt_results_<PID>/result_<csp>.txt
+/tmp/rdbms_mgmt_logs_<PID>/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
-tail -f /tmp/rdbms_database_logs_<PID>/log_aws.txt
+tail -f /tmp/rdbms_mgmt_logs_<PID>/log_aws.txt
 ```
 
-## 시험 결과
+## Test Results
 
 ### 2026-08-03
 

--- a/test/rdbms-mysql-test/storage-type-test/README.md
+++ b/test/rdbms-mysql-test/storage-type-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS StorageType Test
 
-각 CSP의 StorageType별로 RDBMS 인스턴스를 생성·검증하는 병렬 테스트 스위트입니다. 각 CSP의 `rdbmsmetainfo` API에서 지원 StorageType 목록을 동적으로 조회한 뒤, 옵션별로 인스턴스를 병렬 생성하고 반환된 StorageType이 요청과 일치하는지 검증합니다.
+Parallel test suite that creates and verifies RDBMS instances for each CSP's supported StorageType values. For each CSP it dynamically queries the supported StorageType list from the `rdbmsmetainfo` API, creates one instance per option in parallel, and verifies that the returned StorageType matches what was requested.
 
 ## Prerequisites
 
@@ -12,7 +12,7 @@ cd ./bin; ./start.sh
 
 ### Pre-created Network Resources
 
-RDBMS 생성 전에 각 CSP에 VPC/Subnet(및 AWS의 Security Group)이 미리 생성되어 있어야 합니다.
+Each CSP needs a VPC/Subnet (and, for AWS, a security group) created ahead of time before an RDBMS instance can be created.
 
 ```bash
 cd ..
@@ -27,35 +27,35 @@ cd ..
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 StorageType별 검증을 수행합니다:
+For each CSP, StorageType validation runs in this order:
 
-1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=...` — 지원하는 StorageType 목록을 동적으로 조회
-2. **CreateRDBMS** (StorageType별 병렬) — `POST /spider/rdbms` — 옵션별로 `cb-mysql-st-<type>` 인스턴스 생성
-3. **Poll Available** — `GET /spider/rdbms/{Name}` — Available 상태가 될 때까지 폴링 (기본 30초 간격, 최대 3600초)
-4. **VerifyStorageType** — 반환된 StorageType이 요청과 일치하는지 확인 (`Result` 필드에 `PASS`/`FAIL` 기록)
-5. **(옵션) AutoDelete** — `AUTO_DELETE=true`이면 검증 직후 인스턴스 자동 삭제. 기본값(`false`)에서는 `delete-all-csp-storage-type-rdbms.sh`로 별도 정리
+1. **FetchStorageTypeOptions** — `GET /spider/rdbmsmetainfo?DBEngine=mysql&ConnectionName=...` — dynamically fetches the list of supported StorageTypes
+2. **CreateRDBMS** (one per StorageType, in parallel) — `POST /spider/rdbms` — creates a `cb-mysql-st-<type>` instance for each option
+3. **Poll Available** — `GET /spider/rdbms/{Name}` — polls until the instance becomes Available (every 30s by default, up to 3600s)
+4. **VerifyStorageType** — confirms the returned StorageType matches what was requested (recorded as `PASS`/`FAIL` in the `Result` field)
+5. **(Optional) AutoDelete** — if `AUTO_DELETE=true`, the instance is deleted immediately after verification. With the default (`false`), clean up separately with `delete-all-csp-storage-type-rdbms.sh`
 
-Azure/IBM/NCP는 `SupportsStorageTypeSelection=false`로 StorageType 지정이 불가능하여 스크립트 실행 시 즉시 SKIP 처리됩니다.
+Azure/IBM/NCP have `SupportsStorageTypeSelection=false` — StorageType cannot be specified for them, so their scripts SKIP immediately on execution.
 
-### StorageType 선택 가능 여부
+### StorageType Selectability
 
-| CSP | SupportsStorageTypeSelection | 비고 |
+| CSP | SupportsStorageTypeSelection | Notes |
 |-----|------------------------------|------|
-| AWS | ✅ | gp2, gp3, io1, io2 |
-| GCP | ✅ | 머신 시리즈에 따라 자동 결정 (직접 선택 아님) |
-| Alibaba | ✅ | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd |
-| Tencent | ✅ | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM |
-| OpenStack | ✅ | `__DEFAULT__`, `RBD` |
-| NHN | ✅ | General HDD, General SSD |
-| Azure | ❌ | SKIP |
-| IBM | ❌ | SKIP |
-| NCP | ❌ | SKIP |
+| AWS | Yes | gp2, gp3, io1, io2 |
+| GCP | Yes | Determined automatically by machine series (not a direct choice) |
+| Alibaba | Yes | cloud_auto, cloud_essd, cloud_essd2, cloud_essd3, local_ssd |
+| Tencent | Yes | local_ssd, CLOUD_HSSD, CLOUD_SSD, CLOUD_PREMIUM |
+| OpenStack | Yes | `__DEFAULT__`, `RBD` |
+| NHN | Yes | General HDD, General SSD |
+| Azure | No | SKIP |
+| IBM | No | SKIP |
+| NCP | No | SKIP |
 
 ## Configuration
 
 ```bash
 export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
-export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+export SPIDER_AUTH=admin:****             # Basic auth (admin:<password>)
 ```
 
 ## How to Run Tests
@@ -66,8 +66,8 @@ export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
 ./run-all-csp-storage-type-tests.sh
 ```
 
-- 9개 CSP에 대해 병렬로 StorageType별 검증 실행 (Azure/IBM/NCP는 자동 SKIP)
-- 완료 후 통합 결과 테이블 및 PASS/FAIL/SKIP 집계 출력
+- Runs StorageType validation on all 9 CSPs in parallel (Azure/IBM/NCP SKIP automatically)
+- Prints a unified result table and a PASS/FAIL/SKIP tally when done
 
 **Example output:**
 ```
@@ -87,21 +87,21 @@ Total: 22  PASS: 19  FAIL: 0  SKIP: 3
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-storage-type-test.sh
-./azure-storage-type-test.sh          # SKIP (StorageType 선택 불가)
+./azure-storage-type-test.sh          # SKIP (StorageType selection not supported)
 ./gcp-storage-type-test.sh
 ./alibaba-storage-type-test.sh
 ./tencent-storage-type-test.sh
-./ibm-storage-type-test.sh            # SKIP (StorageType 선택 불가)
+./ibm-storage-type-test.sh            # SKIP (StorageType selection not supported)
 ./openstack-storage-type-test.sh
-./ncp-storage-type-test.sh            # SKIP (StorageType 선택 불가)
+./ncp-storage-type-test.sh            # SKIP (StorageType selection not supported)
 ./nhn-storage-type-test.sh
 ```
 
-단독 실행 시 결과/로그 디렉토리는 `RESULT_DIR` / `LOG_DIR` 환경변수로 지정하거나 기본값(`/tmp/st_results_<PID>`, `/tmp/st_logs_<PID>`)이 사용됩니다.
+When run individually, results and logs go to the directories you specify via `RESULT_DIR` / `LOG_DIR`, or to the defaults (`/tmp/st_results_<PID>`, `/tmp/st_logs_<PID>`).
 
 ### Delete All Instances
 
@@ -109,24 +109,24 @@ Total: 22  PASS: 19  FAIL: 0  SKIP: 3
 ./delete-all-csp-storage-type-rdbms.sh
 ```
 
-- StorageTypeOptions를 다시 조회해 `cb-mysql-st-<type>` 이름의 인스턴스를 유추한 뒤 전체 CSP 병렬 삭제
+- Re-queries StorageTypeOptions to infer the `cb-mysql-st-<type>` instance names, then deletes them across all CSPs in parallel
 
 ## Script Structure
 
 ```
 storage-type-test/
-├── run-all-csp-storage-type-tests.sh    # Orchestrator: 전체 CSP 병렬 실행
-├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: 전체 CSP 병렬 삭제
-├── common-storage-type-test.sh          # Common: Create → Poll Available → Get Info → Verify → (옵션) Delete
+├── run-all-csp-storage-type-tests.sh    # Orchestrator: full parallel run across CSPs
+├── delete-all-csp-storage-type-rdbms.sh # Orchestrator: full parallel delete across CSPs
+├── common-storage-type-test.sh          # Common: Create -> Poll Available -> Get Info -> Verify -> (optional) Delete
 ├── aws-storage-type-test.sh
 ├── gcp-storage-type-test.sh
 ├── alibaba-storage-type-test.sh
 ├── tencent-storage-type-test.sh
 ├── nhn-storage-type-test.sh
 ├── openstack-storage-type-test.sh
-├── azure-storage-type-test.sh           # SKIP (StorageType 선택 불가)
-├── ibm-storage-type-test.sh             # SKIP (StorageType 선택 불가)
-└── ncp-storage-type-test.sh             # SKIP (StorageType 선택 불가)
+├── azure-storage-type-test.sh           # SKIP (StorageType selection not supported)
+├── ibm-storage-type-test.sh             # SKIP (StorageType selection not supported)
+└── ncp-storage-type-test.sh             # SKIP (StorageType selection not supported)
 ```
 
 ## Environment Variables
@@ -137,8 +137,8 @@ storage-type-test/
 | `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
 | `MAX_WAIT_SEC` | `3600` (create) / `1800` (delete) | Timeout per instance (seconds) |
 | `POLL_INTERVAL` | `30` (create) / `15` (delete) | Polling interval (seconds) |
-| `AUTO_DELETE` | `false` | `true`이면 검증 완료 직후 인스턴스 자동 삭제 |
-| `VERBOSE` | `0` | `1`로 설정 시 CSP별 전체 로그 덤프 출력 |
+| `AUTO_DELETE` | `false` | If `true`, delete the instance immediately after verification completes |
+| `VERBOSE` | `0` | Set to `1` for a per-CSP full log dump |
 
 ```bash
 # Example: verbose output
@@ -147,21 +147,21 @@ VERBOSE=1 ./run-all-csp-storage-type-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>_<storagetype>.txt`)은 파이프(|) 구분 7개 필드:
+Each result file (`result_<csp>_<storagetype>.txt`) has 7 pipe-separated fields:
 
 ```
 CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `StorageType(Requested)` | 요청한 StorageType 값 |
-| `StorageType(Returned)` | 생성 후 조회된 StorageType 값 (`N/A`는 생성 실패) |
+| `CSP` | CSP name (e.g. AWS) |
+| `StorageType(Requested)` | The StorageType value that was requested |
+| `StorageType(Returned)` | The StorageType read back after creation (`N/A` means creation failed) |
 | `Result` | `PASS` / `FAIL` / `SKIP` |
-| `DB_Status` | 인스턴스 상태 (`Available`, `CREATE_ERROR`, `TIMEOUT`, `NOT_APPLICABLE` 등) |
-| `Elapsed` | 경과 시간 |
-| `Reason` | 특이사항 (예: SupportsStorageTypeSelection=false, cloud_auto 자동 선택 등) |
+| `DB_Status` | Instance status (`Available`, `CREATE_ERROR`, `TIMEOUT`, `NOT_APPLICABLE`, etc.) |
+| `Elapsed` | Elapsed time |
+| `Reason` | Notes (e.g. SupportsStorageTypeSelection=false, cloud_auto auto-selection, etc.) |
 
 ## API Reference
 
@@ -179,13 +179,13 @@ CSP|StorageType(Requested)|StorageType(Returned)|Result|DB_Status|Elapsed|Reason
 /tmp/st_test_<PID>/logs/log_<csp>.txt
 ```
 
-전체 삭제 실행 시:
+When running the full delete script:
 ```
 /tmp/st_del_<PID>/results/result_<csp>_<storagetype>.txt
 /tmp/st_del_<PID>/logs/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/st_test_<PID>/logs/log_aws.txt
@@ -199,24 +199,24 @@ tail -f /tmp/st_test_<PID>/logs/log_aws.txt
 |-------------|---------------|-------------|------|
 | gp2 | db.t3.medium | 100 GB | - |
 | gp3 | db.t3.medium | 100 GB | - |
-| io1 | db.t3.medium | 100 GB | **3000 (필수)** |
-| io2 | db.t3.medium | 100 GB | **3000 (필수)** |
+| io1 | db.t3.medium | 100 GB | **3000 (required)** |
+| io2 | db.t3.medium | 100 GB | **3000 (required)** |
 
-- StorageTypeOptions: metainfo API에서 동적으로 조회
+- StorageTypeOptions: fetched dynamically from the metainfo API
 - Connection: `aws-config01`
 - Region: `ap-southeast-2` / Zone: `ap-southeast-2a`
-- SubnetNames: `subnet-01`, `subnet-02` (서로 다른 AZ, SubnetGroup 생성 필수)
+- SubnetNames: `subnet-01`, `subnet-02` (different AZs, required for SubnetGroup creation)
 - SecurityGroupNames: `sg-01`
 
-**특이사항**
-- io1/io2: `Iops` 필드 필수(Iops:AWS io1/io2 전용)
-- StorageSize: io1/io2는 최소 100 GB
+**Special notes**
+- io1/io2: the `Iops` field is required (Iops is AWS io1/io2-only)
+- StorageSize: io1/io2 require a minimum of 100 GB
 
 ---
 
 ### GCP
 
-GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 직접 지정.
+GCP's StorageType is fixed by machine series, so 5 combinations are explicitly specified.
 
 | StorageType | DBSpec | StorageSize | Edition | Machine Series |
 |-------------|---------------|-------------|---------|---------------|
@@ -230,33 +230,33 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - Region: `us-central1` / Zone: `us-central1-a`
 - VPCName: `vpc-01`
 
-**특이사항**
-- 머신 시리즈 ↔ StorageType 불일치 시 Spider 드라이버에서 에러 반환 (e.g. N2에 HYPERDISK_BALANCED 요청시 에러)
-- N2/C4A 머신 타입은 Edition=ENTERPRISE_PLUS 자동 설정 (드라이버 내부 처리)
-- N2(`db-perf-optimized-N-*`), C4A(`db-c4a-highmem-*`), N4(`db-custom-N4-*`): StorageType은 API에 전달하지 않음 (머신 시리즈에 의해 자동 결정)
-- GCP metainfo StorageTypeOptions에 HYPERDISK_BALANCED가 포함되나, 직접 지정이 아닌 머신 시리즈 선택으로 결정됨
-- HYPERDISK_BALANCED 최소 StorageSize: 20 GB
+**Special notes**
+- A mismatch between machine series and StorageType causes the Spider driver to return an error (e.g. requesting HYPERDISK_BALANCED on an N2 machine)
+- N2/C4A machine types automatically get Edition=ENTERPRISE_PLUS set (handled internally by the driver)
+- For N2 (`db-perf-optimized-N-*`), C4A (`db-c4a-highmem-*`), and N4 (`db-custom-N4-*`): StorageType is not passed to the API — it's determined automatically by the machine series
+- GCP's metainfo StorageTypeOptions includes HYPERDISK_BALANCED, but it's selected via machine series rather than direct specification
+- HYPERDISK_BALANCED requires a minimum StorageSize of 20 GB
 
 ---
 
 ### Alibaba
 
-| StorageType | DBSpec | StorageSize | 비고 |
+| StorageType | DBSpec | StorageSize | Notes |
 |-------------|---------------|-------------|------|
 | cloud_auto | mysql.n4.large.1 | 20 GB | |
 | cloud_essd | mysql.n4.large.1 | 20 GB | ESSD PL1 |
-| cloud_essd2 | mysql.n2.small.2c | **500 GB** | ESSD PL2, 최소 500 GB |
-| cloud_essd3 | mysql.n2.small.2c | **1500 GB** | ESSD PL3, 최소 1500 GB |
-| local_ssd | rds.mysql.t1.small | 20 GB | Premium Local SSD, rds.mysql.* 계열 전용 |
+| cloud_essd2 | mysql.n2.small.2c | **500 GB** | ESSD PL2, minimum 500 GB |
+| cloud_essd3 | mysql.n2.small.2c | **1500 GB** | ESSD PL3, minimum 1500 GB |
+| local_ssd | rds.mysql.t1.small | 20 GB | Premium Local SSD, only available on the rds.mysql.* family |
 
-- StorageTypeOptions: metainfo API에서 동적으로 조회
+- StorageTypeOptions: fetched dynamically from the metainfo API
 - Connection: `alibaba-beijing-config`
 - Region: `cn-beijing` / Zone: `cn-beijing-f`
 - SubnetNames: `subnet-01`
 
-**특이사항**
-- cloud_essd2/3는 mysql.n4.* 계열과 호환되지 않음 → mysql.n2.small.2c 사용
-- local_ssd는 rds.mysql.* 계열 전용 (mysql.n4.* 사용 시 InvalidInstanceLevel.DiskType 에러)
+**Special notes**
+- cloud_essd2/3 are incompatible with the mysql.n4.* family — mysql.n2.small.2c is used instead
+- local_ssd is only available on the rds.mysql.* family (using mysql.n4.* causes an InvalidInstanceLevel.DiskType error)
 
 ---
 
@@ -269,14 +269,14 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 | CLOUD_SSD | 8000 (MB) | 50 GB |
 | CLOUD_PREMIUM | 8000 (MB) | 50 GB |
 
-- StorageTypeOptions: metainfo API에서 동적으로 조회
+- StorageTypeOptions: fetched dynamically from the metainfo API
 - Connection: `tencent-beijing3-config`
 - Region: `ap-beijing` / Zone: `ap-beijing-3`
 - SubnetNames: `subnet-01`
-- DBSpec: 메모리 크기 MB 단위 지정 (8000 = 8 GB)
+- DBSpec: specifies memory size in MB (8000 = 8 GB)
 
-**특이사항**
-- 동시 주문 거부 발생 가능 (OperationDenied.OtherOderInProcess) → 드라이버 자동 재시도 처리
+**Special notes**
+- Concurrent order submission can be rejected (OperationDenied.OtherOderInProcess) — the driver retries automatically
 
 ---
 
@@ -286,8 +286,8 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - Connection: `ibm-us-east-1-config`
 - Region: `us-east` / Zone: `us-east-1`
 - DBEngineVersion: `8.4`
-- IBM Cloud Databases는 스토리지 타입 선택 기능 부재
-- 테스트 스크립트 실행 시 즉시 SKIP 처리
+- IBM Cloud Databases has no storage type selection feature
+- The test script SKIPs immediately on execution
 
 ---
 
@@ -301,6 +301,7 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - Connection: `openstack-config01`
 - Region: `RegionOne` / Zone: `nova`
 - DBEngineVersion: `5.7.29`
+- StorageTypeOptions are fetched dynamically from Cinder's volume type list, so the actual values available depend on how the target OpenStack deployment is configured
 
 ---
 
@@ -311,11 +312,11 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 | General HDD | m2.c2m4 | 20 GB |
 | General SSD | m2.c2m4 | 20 GB |
 
-- StorageTypeOptions: NHN Cloud RDS API에서 동적으로 조회
+- StorageTypeOptions: fetched dynamically from the NHN Cloud RDS API
 - Connection: `nhn-korea-pangyo1-config`
 - Region: `KR1` / Zone: `kr-pub-a`
 - SubnetNames: `subnet-01`
-- `NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS는 VPC Security Group과는 별개인 전용 "DB Security Group"이 있어야 외부 접속이 가능하므로, 시험 편의를 위해 이 옵션으로 전체 개방(`0.0.0.0/0`) DB Security Group을 자동 생성/삭제합니다. 운영 환경에서는 사용을 권장하지 않습니다.
+- `NHNAutoOpenDBSecurityGroup: true` — NHN Cloud RDS requires a dedicated "DB Security Group" separate from the VPC security group before external access is possible, so this option auto-creates/deletes a fully open (`0.0.0.0/0`) DB Security Group for testing convenience. Not recommended for production use.
 
 ---
 
@@ -324,8 +325,8 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - SupportsStorageTypeSelection=false
 - Connection: `azure-koreacentral-config`
 - Region: `koreacentral` / Zone: `1`
-- Azure MySQL Flexible Server의 storageSku는 read-only, Azure가 자동 설정
-- 테스트 스크립트 실행 시 즉시 SKIP 처리
+- Azure MySQL Flexible Server's storageSku is read-only and set automatically by Azure
+- The test script SKIPs immediately on execution
 
 ---
 
@@ -334,10 +335,10 @@ GCP는 머신 시리즈에 따라 StorageType이 고정되어 5개 케이스를 
 - SupportsStorageTypeSelection=false
 - Connection: `ncp-korea1-config`
 - Region: `KR` / Zone: `KR-1`
-- NCP MySQL G3은 SSD 자동 적용, DataStorageTypeCode 지정 불가
-- 테스트 스크립트 실행 시 즉시 SKIP 처리
+- NCP MySQL G3 applies SSD automatically; DataStorageTypeCode cannot be specified
+- The test script SKIPs immediately on execution
 
-## 시험 결과
+## Test Results
 
 ### 2026-08-03
 

--- a/test/rdbms-mysql-test/tag-test/README.md
+++ b/test/rdbms-mysql-test/tag-test/README.md
@@ -1,6 +1,6 @@
 # CB-Spider RDBMS Tag Management Test
 
-RDBMS 리소스의 Tag CRUD API를 검증하는 테스트 스위트입니다. `RDBMSMetaInfo.SupportsTag=true`인 CSP(AWS, Azure, GCP, Alibaba, Tencent, IBM)에 대해서만 실행됩니다.
+Test suite that validates the Tag CRUD API on RDBMS resources. It only runs against the CSPs where `RDBMSMetaInfo.SupportsTag=true` (AWS, Azure, GCP, Alibaba, Tencent, IBM).
 
 ## Prerequisites
 
@@ -10,13 +10,13 @@ RDBMS 리소스의 Tag CRUD API를 검증하는 테스트 스위트입니다. `R
 cd ./bin; ./start.sh
 ```
 
-### RDBMS 인스턴스 사전 생성
+### RDBMS Instance Must Already Exist
 
-이 시험은 RDBMS 인스턴스가 이미 생성되어 있다고 가정합니다. 먼저 상위 디렉토리의 네트워크 사전 준비 및 create 시험을 실행하세요.
+This test assumes the RDBMS instance already exists. First run the network prerequisites and the create test in the parent directory:
 
 ```bash
 cd ..
-./run-all-csp-network-prepare.sh   # VPC/Subnet/SG 사전 생성 (최초 1회)
+./run-all-csp-network-prepare.sh   # VPC/Subnet/SG prerequisites (one-time)
 ./run-all-csp-rdbms-tests.sh
 ```
 
@@ -28,39 +28,39 @@ cd ..
 
 ## Supported CSPs
 
-`RDBMSMetaInfo.SupportsTag` 값에 따라 시험 대상 CSP가 결정됩니다.
+Which CSPs are tested is determined by the `RDBMSMetaInfo.SupportsTag` value.
 
-| CSP | SupportsTag | 시험 대상 |
+| CSP | SupportsTag | Tested |
 |-----|-------------|---------|
-| AWS | `true` | ✅ |
-| Azure | `true` | ✅ |
-| GCP | `true` | ✅ |
-| Alibaba | `true` | ✅ |
-| Tencent | `true` | ✅ |
-| IBM | `true` | ✅ |
-| OpenStack | `false` | ❌ |
-| NCP | `false` | ❌ |
-| NHN | `false` | ❌ |
+| AWS | `true` | Yes |
+| Azure | `true` | Yes |
+| GCP | `true` | Yes |
+| Alibaba | `true` | Yes |
+| Tencent | `true` | Yes |
+| IBM | `true` | Yes |
+| OpenStack | `false` | No |
+| NCP | `false` | No |
+| NHN | `false` | No |
 
 ## Test Flow
 
-각 CSP에 대해 다음 순서로 Tag CRUD를 검증합니다:
+For each CSP, Tag CRUD is validated in this order:
 
-1. **AddTag(1)** — `POST /spider/tag` — 첫 번째 태그 추가 (`spider-rdbms-tag` / `rdbms-tag-value`)
-2. **ListTag** — `GET /spider/tag?...` — 목록에서 첫 번째 태그 존재 확인
-3. **GetTag** — `GET /spider/tag/{Key}?...` — 태그 값 일치 확인
-4. **AddTag(2)** — `POST /spider/tag` — 두 번째 태그 추가 (`spider-rdbms-tag2` / `rdbms-tag-value2`)
-5. **RemoveTag** — `DELETE /spider/tag/{Key}` — 첫 번째 태그 삭제
-6. **VerifyRemoved** — `GET /spider/tag?...` — 첫 번째 태그가 목록에서 제거되었는지 확인
-7. **Cleanup** — 두 번째 태그 삭제 (정리)
+1. **AddTag(1)** — `POST /spider/tag` — adds the first tag (`spider-rdbms-tag` / `rdbms-tag-value`)
+2. **ListTag** — `GET /spider/tag?...` — confirms the first tag is present in the list
+3. **GetTag** — `GET /spider/tag/{Key}?...` — confirms the tag value matches
+4. **AddTag(2)** — `POST /spider/tag` — adds a second tag (`spider-rdbms-tag2` / `rdbms-tag-value2`)
+5. **RemoveTag** — `DELETE /spider/tag/{Key}` — deletes the first tag
+6. **VerifyRemoved** — `GET /spider/tag?...` — confirms the first tag is gone from the list
+7. **Cleanup** — deletes the second tag (cleanup)
 
-모든 단계가 PASS여야 해당 CSP가 전체 PASS로 판정됩니다.
+A CSP is judged an overall PASS only if every step passes.
 
 ## Configuration
 
 ```bash
 export SPIDER_URL=http://localhost:1024   # CB-Spider REST API URL
-export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
+export SPIDER_AUTH=admin:****             # Basic auth (admin:<password>)
 ```
 
 ## How to Run Tests
@@ -71,8 +71,8 @@ export SPIDER_AUTH=admin:*****           # Basic auth (admin:<password>)
 ./run-all-csp-rdbms-tag-tests.sh
 ```
 
-- SupportsTag=true인 6개 CSP에 대해 병렬로 Tag CRUD 검증 실행
-- 완료 후 통합 결과 테이블 및 PASS/FAIL 집계 출력
+- Runs Tag CRUD validation in parallel on the 6 CSPs where SupportsTag=true
+- Prints a unified result table and a PASS/FAIL tally when done
 
 **Example output:**
 ```
@@ -94,7 +94,7 @@ Total: 6 PASS, 0 FAIL
 
 ### Individual CSP
 
-특정 CSP만 단독 실행:
+To run a single CSP on its own:
 
 ```bash
 ./aws-rdbms-tag-test.sh
@@ -105,14 +105,14 @@ Total: 6 PASS, 0 FAIL
 ./ibm-rdbms-tag-test.sh
 ```
 
-단독 실행 시 결과 파일은 `RESULT_DIR` 환경변수로 지정하거나 기본값(`/tmp/rdbms_tag_results`)이 사용됩니다.
+When run individually, the result file goes to the `RESULT_DIR` you specify, or to the default (`/tmp/rdbms_tag_results`).
 
 ## Script Structure
 
 ```
 tag-test/
-├── run-all-csp-rdbms-tag-tests.sh   # Orchestrator: 6개 CSP 병렬 실행, PASS/FAIL 집계
-├── common-rdbms-tag-test.sh         # Common: AddTag → ListTag → GetTag → AddTag2 → RemoveTag → VerifyRemoved
+├── run-all-csp-rdbms-tag-tests.sh   # Orchestrator: parallel run across the 6 CSPs, PASS/FAIL tally
+├── common-rdbms-tag-test.sh         # Common: AddTag -> ListTag -> GetTag -> AddTag2 -> RemoveTag -> VerifyRemoved
 ├── aws-rdbms-tag-test.sh
 ├── azure-rdbms-tag-test.sh
 ├── gcp-rdbms-tag-test.sh
@@ -126,9 +126,9 @@ tag-test/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SPIDER_URL` | `http://localhost:1024` | CB-Spider REST API URL |
-| `SPIDER_AUTH` | `admin:*****` | Basic auth credentials |
+| `SPIDER_AUTH` | `admin:****` | Basic auth credentials |
 | `RESULT_DIR` | `/tmp/rdbms_tag_results` | Result file output directory |
-| `VERBOSE` | `0` | `1`로 설정 시 per-CSP 전체 로그 덤프 출력 |
+| `VERBOSE` | `0` | Set to `1` for a per-CSP full log dump |
 
 ```bash
 # Example: verbose output
@@ -137,22 +137,22 @@ VERBOSE=1 ./run-all-csp-rdbms-tag-tests.sh
 
 ## Result Format
 
-결과 파일(`result_<csp>.txt`)은 파이프(|) 구분 8개 필드:
+Each result file (`result_<csp>.txt`) has 8 pipe-separated fields:
 
 ```
 CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
 ```
 
-| 필드 | 설명 |
+| Field | Description |
 |------|------|
-| `CSP` | CSP 이름 (예: AWS) |
-| `AddTag` | 첫 번째 태그 추가 결과 (`PASS` / `FAIL`) |
-| `ListTag` | 태그 목록 조회 및 존재 확인 결과 |
-| `GetTag` | 특정 태그 조회 및 값 일치 확인 결과 |
-| `AddTag2` | 두 번째 태그 추가 결과 |
-| `RemoveTag` | 첫 번째 태그 삭제 결과 |
-| `VerifyRemoved` | 삭제 후 목록에서 제거 확인 결과 |
-| `Elapsed` | 경과 시간 |
+| `CSP` | CSP name (e.g. AWS) |
+| `AddTag` | Result of adding the first tag (`PASS` / `FAIL`) |
+| `ListTag` | Result of listing tags and confirming presence |
+| `GetTag` | Result of fetching a specific tag and confirming its value |
+| `AddTag2` | Result of adding the second tag |
+| `RemoveTag` | Result of deleting the first tag |
+| `VerifyRemoved` | Result of confirming it's gone from the list after deletion |
+| `Elapsed` | Elapsed time |
 
 ## Logs & Results
 
@@ -161,7 +161,7 @@ CSP|AddTag|ListTag|GetTag|AddTag2|RemoveTag|VerifyRemoved|Elapsed
 /tmp/rdbms_tag_logs_<PID>/log_<csp>.txt
 ```
 
-실행 중 모니터링:
+To monitor a run in progress:
 
 ```bash
 tail -f /tmp/rdbms_tag_logs_<PID>/log_aws.txt
@@ -176,7 +176,7 @@ tail -f /tmp/rdbms_tag_logs_<PID>/log_aws.txt
 | GetTag | `GET` | `/spider/tag/{Key}?ConnectionName=&ResourceType=rdbms&ResourceName=` |
 | RemoveTag | `DELETE` | `/spider/tag/{Key}` |
 
-## 시험 결과
+## Test Results
 
 ### 2026-08-03
 

--- a/test/s3-test-json-format/README.md
+++ b/test/s3-test-json-format/README.md
@@ -4,6 +4,15 @@ Automated test suite for CB-Spider S3 API endpoints with JSON response format.
 
 ## Prerequisites
 
+### Basic Auth
+
+Tests authenticate to CB-Spider with HTTP Basic Auth. Set these before running (defaults shown):
+
+```bash
+export SPIDER_USERNAME=admin   # default: admin
+export SPIDER_PASSWORD=<your-password>
+```
+
 ### CSP Connection Configuration
 
 Before running tests, register connection names for each CSP in CB-Spider.
@@ -12,13 +21,14 @@ Before running tests, register connection names for each CSP in CB-Spider.
 |-----|----------------|
 | AWS | `aws-config01` |
 | GCP | `gcp-iowa-config` |
-| Alibaba | `alibaba-config` |
-| Tencent | `tencent-config` |
-| IBM | `ibm-config01` |
+| Azure | `azure-northeu-config` |
+| Alibaba | `alibaba-tokyo-config` |
+| Tencent | `tencent-tokyo-config` |
+| IBM | `ibm-us-south-1-config` |
 | OpenStack | `openstack-config01` |
-| NCP | `ncp-config01` |
-| NHN | `nhn-config01` |
-| KT | `kt-config` |
+| NCP | `ncp-korea1-config` |
+| NHN | `nhn-korea-pangyo1-config` |
+| KT | `kt-mokdong1-config` |
 
 ## CSP Test Coverage
 
@@ -33,10 +43,16 @@ Before running tests, register connection names for each CSP in CB-Spider.
 - **OpenStack**: 22 test cases
   - 6 Bucket + 6 Object + 0 Multipart + 0 Versioning + 4 CORS + 6 CB-Spider Special
   - Excluded: Multipart Upload (6 tests), Versioning (4 tests)
-  
+
 - **NCP, NHN**: 24 test cases
   - 6 Bucket + 6 Object + 6 Multipart + 0 Versioning + 0 CORS + 6 CB-Spider Special
   - Excluded: Versioning (4 tests), CORS (4 tests)
+
+- **Azure**: 18 test cases
+  - 6 Bucket + 6 Object + 0 Multipart + 0 Versioning + 0 CORS + 6 CB-Spider Special
+  - Excluded: Multipart Upload (6 tests), Versioning (4 tests), CORS (4 tests)
+  - Azure Blob Storage's S3-compatible layer does not support Versioning, CORS, Multipart Upload, or Delete Marker
+  - Uses `common-s3-api-test-except-versioning-cors.sh` with `SKIP_MULTIPART=true`, and adds the `x-ms-blob-type: BlockBlob` header required for PreSigned uploads via `PRESIGNED_UPLOAD_EXTRA_HEADER`
 
 ## How to Run Tests
 
@@ -49,7 +65,7 @@ Execute all CSP tests sequentially with summary report:
 ```
 
 This will:
-- Test all 9 CSPs (AWS, GCP, Alibaba, Tencent, IBM, OpenStack, NCP, NHN, KT)
+- Test all 10 CSPs (AWS, GCP, Azure, Alibaba, Tencent, IBM, OpenStack, NCP, NHN, KT)
 - Display detailed results for each CSP
 - Generate a comprehensive summary table
 
@@ -63,6 +79,9 @@ Execute test for a specific CSP:
 
 # GCP
 ./gcp-test.sh
+
+# Azure
+./azure-test.sh
 
 # Alibaba
 ./alibaba-test.sh
@@ -88,9 +107,22 @@ Execute test for a specific CSP:
 
 ## Test Scripts
 
-- `common-s3-full-api-test.sh`: Full API test (32 APIs)
-- `common-s3-api-test-except-multipart-versioning.sh`: Except Multipart & Versioning (21 APIs)
-- `common-s3-api-test-except-versioning-cors.sh`: Except Versioning & CORS (23 APIs)
+- `common-s3-full-api-test.sh`: Full API test — Bucket(6) + Object(6) + Multipart(6) + Versioning(4) + CORS(4) + Special(6) = 32 tests
+  - Used by: AWS, GCP, Alibaba, Tencent, IBM, KT
+- `common-s3-api-test-except-multipart-versioning.sh`: Skips Multipart Upload & Versioning — Bucket(6) + Object(6) + CORS(4) + Special(6) = 22 tests
+  - Used by: OpenStack
+- `common-s3-api-test-except-versioning-cors.sh`: Skips Versioning & CORS — Bucket(6) + Object(6) + Multipart(6) + Special(6) = 24 tests
+  - Used by: NCP, NHN
+  - Supports `SKIP_MULTIPART=true` to additionally skip Multipart Upload (used by Azure, 18 tests)
+
+### Common Environment Variables
+
+| Variable | Purpose | Used by |
+|----------|---------|---------|
+| `CONNECTION_NAME` | CB-Spider connection name for the target CSP | all |
+| `SPIDER_USERNAME` / `SPIDER_PASSWORD` | Basic Auth credentials for the CB-Spider API | all |
+| `SKIP_MULTIPART` | Skip Multipart Upload tests within `common-s3-api-test-except-versioning-cors.sh` | Azure |
+| `PRESIGNED_UPLOAD_EXTRA_HEADER` | Extra header appended to PreSigned upload `curl` calls | Azure |
 
 ## Notes
 

--- a/test/s3-test-xml-format-awscurl/README.md
+++ b/test/s3-test-xml-format-awscurl/README.md
@@ -40,6 +40,7 @@ Register connection names for each CSP before running tests.
 |-----|----------------|
 | AWS | `aws-config01` |
 | GCP | `gcp-iowa-config` |
+| Azure | `azure-northeu-config` |
 | Alibaba | `alibaba-tokyo-config` |
 | Tencent | `tencent-tokyo-config` |
 | IBM | `ibm-us-south-1-config` |
@@ -59,7 +60,7 @@ cd /path/to/cb-spider
 
 ## CSP Test Coverage
 
-### Full Test Suite (30 tests)
+### Full Test Suite (32 tests)
 
 Used for: **AWS, GCP, Alibaba, Tencent, IBM, KT**
 
@@ -74,11 +75,16 @@ Used for: **AWS, GCP, Alibaba, Tencent, IBM, KT**
 
 ### Partial Test Suites
 
-**OpenStack** (`common-s3-api-test-except-multipart-versioning.sh`) — 20 tests  
+**OpenStack** (`common-s3-api-test-except-multipart-versioning.sh`) — 22 tests  
 - Skipped: Multipart Upload (6) + Versioning (4)
 
-**NCP, NHN** (`common-s3-api-test-except-versioning-cors.sh`) — 22 tests  
+**NCP, NHN** (`common-s3-api-test-except-versioning-cors.sh`) — 24 tests  
 - Skipped: Versioning (4) + CORS (4)
+
+**Azure** (`common-s3-api-test-except-versioning-cors.sh` with `SKIP_MULTIPART=true`) — 18 tests  
+- Skipped: Multipart Upload (6) + Versioning (4) + CORS (4)
+- Azure Blob Storage's S3-compatible layer does not support Versioning, CORS, Multipart Upload, or Delete Marker
+- Also sets `PRESIGNED_UPLOAD_EXTRA_HEADER="x-ms-blob-type: BlockBlob"`, required by Azure for PreSigned uploads
 
 ---
 
@@ -104,13 +110,14 @@ chmod +x run-all-csp-tests.sh
 ./run-all-csp-tests.sh
 ```
 
-Runs all 9 CSPs and prints a consolidated pass/fail summary table.
+Runs all 10 CSPs and prints a consolidated pass/fail summary table.
 
 ### Run a single CSP
 
 ```bash
 ./aws-test.sh
 ./gcp-test.sh
+./azure-test.sh
 ./alibaba-test.sh
 ./tencent-test.sh
 ./ibm-test.sh
@@ -132,11 +139,12 @@ CONNECTION_NAME="my-custom-config" ./common-s3-full-api-test.sh
 
 | Script | Purpose |
 |---|---|
-| `common-s3-full-api-test.sh` | Full 30-test suite |
-| `common-s3-api-test-except-multipart-versioning.sh` | 20-test suite (no Multipart / Versioning) |
-| `common-s3-api-test-except-versioning-cors.sh` | 22-test suite (no Versioning / CORS) |
+| `common-s3-full-api-test.sh` | Full 32-test suite |
+| `common-s3-api-test-except-multipart-versioning.sh` | 22-test suite (no Multipart / Versioning) |
+| `common-s3-api-test-except-versioning-cors.sh` | 24-test suite (no Versioning / CORS); supports `SKIP_MULTIPART=true` for an 18-test suite (also no Multipart) |
 | `aws-test.sh` | AWS wrapper → full suite |
 | `gcp-test.sh` | GCP wrapper → full suite |
+| `azure-test.sh` | Azure wrapper → no Multipart/Versioning/CORS (`SKIP_MULTIPART=true`) |
 | `alibaba-test.sh` | Alibaba wrapper → full suite |
 | `tencent-test.sh` | Tencent wrapper → full suite |
 | `ibm-test.sh` | IBM wrapper → full suite |

--- a/test/s3-test-xml-format/README.md
+++ b/test/s3-test-xml-format/README.md
@@ -4,6 +4,15 @@ Automated test suite for CB-Spider S3 API endpoints with XML response format.
 
 ## Prerequisites
 
+### Basic Auth
+
+Tests authenticate to CB-Spider with HTTP Basic Auth. Set these before running (defaults shown):
+
+```bash
+export SPIDER_USERNAME=admin   # default: admin
+export SPIDER_PASSWORD=<your-password>
+```
+
 ### CSP Connection Configuration
 
 Before running tests, register connection names for each CSP in CB-Spider.
@@ -12,13 +21,14 @@ Before running tests, register connection names for each CSP in CB-Spider.
 |-----|----------------|
 | AWS | `aws-config01` |
 | GCP | `gcp-iowa-config` |
-| Alibaba | `alibaba-config` |
-| Tencent | `tencent-config` |
-| IBM | `ibm-config01` |
+| Azure | `azure-northeu-config` |
+| Alibaba | `alibaba-tokyo-config` |
+| Tencent | `tencent-tokyo-config` |
+| IBM | `ibm-us-south-1-config` |
 | OpenStack | `openstack-config01` |
-| NCP | `ncp-config01` |
-| NHN | `nhn-config01` |
-| KT | `kt-config` |
+| NCP | `ncp-korea1-config` |
+| NHN | `nhn-korea-pangyo1-config` |
+| KT | `kt-mokdong1-config` |
 
 ## CSP Test Coverage
 
@@ -33,10 +43,16 @@ Before running tests, register connection names for each CSP in CB-Spider.
 - **OpenStack**: 22 test cases
   - 6 Bucket + 6 Object + 0 Multipart + 0 Versioning + 4 CORS + 6 CB-Spider Special
   - Excluded: Multipart Upload (6 tests), Versioning (4 tests)
-  
+
 - **NCP, NHN**: 24 test cases
   - 6 Bucket + 6 Object + 6 Multipart + 0 Versioning + 0 CORS + 6 CB-Spider Special
   - Excluded: Versioning (4 tests), CORS (4 tests)
+
+- **Azure**: 18 test cases
+  - 6 Bucket + 6 Object + 0 Multipart + 0 Versioning + 0 CORS + 6 CB-Spider Special
+  - Excluded: Multipart Upload (6 tests), Versioning (4 tests), CORS (4 tests)
+  - Azure Blob Storage's S3-compatible layer does not support Versioning, CORS, Multipart Upload, or Delete Marker
+  - Uses `common-s3-api-test-except-versioning-cors.sh` with `SKIP_MULTIPART=true`, and adds the `x-ms-blob-type: BlockBlob` header required for PreSigned uploads via `PRESIGNED_UPLOAD_EXTRA_HEADER`
 
 ## How to Run Tests
 
@@ -49,7 +65,7 @@ Execute all CSP tests sequentially with summary report:
 ```
 
 This will:
-- Test all 9 CSPs (AWS, GCP, Alibaba, Tencent, IBM, OpenStack, NCP, NHN, KT)
+- Test all 10 CSPs (AWS, GCP, Azure, Alibaba, Tencent, IBM, OpenStack, NCP, NHN, KT)
 - Display detailed results for each CSP
 - Generate a comprehensive summary table
 
@@ -63,6 +79,9 @@ Execute test for a specific CSP:
 
 # GCP
 ./gcp-test.sh
+
+# Azure
+./azure-test.sh
 
 # Alibaba
 ./alibaba-test.sh
@@ -88,9 +107,22 @@ Execute test for a specific CSP:
 
 ## Test Scripts
 
-- `common-s3-full-api-test.sh`: Full API test (32 APIs)
-- `common-s3-api-test-except-multipart-versioning.sh`: Except Multipart & Versioning (21 APIs)
-- `common-s3-api-test-except-versioning-cors.sh`: Except Versioning & CORS (23 APIs)
+- `common-s3-full-api-test.sh`: Full API test — Bucket(6) + Object(6) + Multipart(6) + Versioning(4) + CORS(4) + Special(6) = 32 tests
+  - Used by: AWS, GCP, Alibaba, Tencent, IBM, KT
+- `common-s3-api-test-except-multipart-versioning.sh`: Skips Multipart Upload & Versioning — Bucket(6) + Object(6) + CORS(4) + Special(6) = 22 tests
+  - Used by: OpenStack
+- `common-s3-api-test-except-versioning-cors.sh`: Skips Versioning & CORS — Bucket(6) + Object(6) + Multipart(6) + Special(6) = 24 tests
+  - Used by: NCP, NHN
+  - Supports `SKIP_MULTIPART=true` to additionally skip Multipart Upload (used by Azure, 18 tests)
+
+### Common Environment Variables
+
+| Variable | Purpose | Used by |
+|----------|---------|---------|
+| `CONNECTION_NAME` | CB-Spider connection name for the target CSP | all |
+| `SPIDER_USERNAME` / `SPIDER_PASSWORD` | Basic Auth credentials for the CB-Spider API | all |
+| `SKIP_MULTIPART` | Skip Multipart Upload tests within `common-s3-api-test-except-versioning-cors.sh` | Azure |
+| `PRESIGNED_UPLOAD_EXTRA_HEADER` | Extra header appended to PreSigned upload `curl` calls | Azure |
 
 ## Notes
 


### PR DESCRIPTION
- Sync S3 test READMEs with scripts: add missing Azure entries, fix stale CSP counts and test-case numbers
- Sync RDBMS test READMEs with scripts: fix auth-default typo, undocumented all_test.sh, stale log paths
- Translate all 11 affected READMEs from Korean/English mix to English
- Documentation only, no script changes